### PR TITLE
[#14] GitHub Project board — create board, automation workflow

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -1,0 +1,154 @@
+name: Board automation
+
+# Moves GitHub Project board cards based on issue and PR lifecycle events.
+#
+# Requirements:
+#   - PROJECT_TOKEN secret: a PAT with 'project' scope (GITHUB_TOKEN lacks this for user projects)
+#   - PROJECT_NUMBER variable (or hardcoded below): the numeric project board number
+#
+# Column transitions:
+#   issue opened          → To Do
+#   PR opened (draft)     → In Progress  (linked issue, via "Closes #N" in body)
+#   PR ready_for_review   → In Review    (linked issue)
+#   PR merged             → Done         (linked issue)
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, ready_for_review, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  board-move:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      OWNER: ${{ github.repository_owner }}
+      PROJECT_NUMBER: 2   # update if your project number differs
+
+    steps:
+      - name: Determine target status
+        id: status
+        run: |
+          EVENT="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
+
+          if [[ "$EVENT" == "issues" && "$ACTION" == "opened" ]]; then
+            echo "status=To Do" >> $GITHUB_OUTPUT
+            echo "item_type=issue" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "opened" ]]; then
+            echo "status=In Progress" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "ready_for_review" ]]; then
+            echo "status=In Review" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "status=Done" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          else
+            echo "status=skip" >> $GITHUB_OUTPUT
+            echo "item_type=skip" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve issue number
+        id: issue
+        if: steps.status.outputs.status != 'skip'
+        run: |
+          if [[ "${{ steps.status.outputs.item_type }}" == "issue" ]]; then
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            # Extract linked issue from PR body ("Closes #N", "Fixes #N", "Resolves #N")
+            PR_BODY="${{ github.event.pull_request.body }}"
+            ISSUE_NUM=$(echo "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1)
+            if [[ -z "$ISSUE_NUM" ]]; then
+              echo "No linked issue found in PR body — skipping board move" >&2
+              echo "number=" >> $GITHUB_OUTPUT
+            else
+              echo "number=$ISSUE_NUM" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Move card on board
+        if: steps.status.outputs.status != 'skip' && steps.issue.outputs.number != ''
+        run: |
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          TARGET_STATUS="${{ steps.status.outputs.status }}"
+
+          # Fetch project metadata
+          PROJECT_DATA=$(gh api graphql -f query='
+            query($owner: String!, $number: Int!) {
+              user(login: $owner) {
+                projectV2(number: $number) {
+                  id
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      options { id name }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue { number }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner="$OWNER" -F number=$PROJECT_NUMBER)
+
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id')
+          FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.field.id')
+          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg s "$TARGET_STATUS" \
+            '.data.user.projectV2.field.options[] | select(.name == $s) | .id')
+          ITEM_ID=$(echo "$PROJECT_DATA" | jq -r --argjson n $ISSUE_NUM \
+            '.data.user.projectV2.items.nodes[] | select(.content.number == $n) | .id')
+
+          if [[ -z "$ITEM_ID" ]]; then
+            echo "Issue #$ISSUE_NUM not found on board — adding it first"
+            # Get issue node ID
+            ISSUE_NODE_ID=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) { id }
+                }
+              }' -f owner="$OWNER" -f repo="${{ github.event.repository.name }}" \
+                 -F number=$ISSUE_NUM | jq -r '.data.repository.issue.id')
+
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($project: ID!, $content: ID!) {
+                addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
+                  item { id }
+                }
+              }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" \
+              | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+
+          if [[ -z "$ITEM_ID" || -z "$OPTION_ID" ]]; then
+            echo "Could not resolve item ($ITEM_ID) or option ($OPTION_ID) — skipping" >&2
+            exit 0
+          fi
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field
+                value: { singleSelectOptionId: $option }
+              }) { projectV2Item { id } }
+            }' \
+            -f project="$PROJECT_ID" \
+            -f item="$ITEM_ID" \
+            -f field="$FIELD_ID" \
+            -f option="$OPTION_ID"
+
+          echo "Moved issue #$ISSUE_NUM to '$TARGET_STATUS' on project board"

--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -60,12 +60,15 @@ jobs:
       - name: Resolve issue number
         id: issue
         if: steps.status.outputs.status != 'skip'
+        env:
+          ITEM_TYPE: ${{ steps.status.outputs.item_type }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if [[ "${{ steps.status.outputs.item_type }}" == "issue" ]]; then
-            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          if [[ "$ITEM_TYPE" == "issue" ]]; then
+            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           else
             # Extract linked issue from PR body ("Closes #N", "Fixes #N", "Resolves #N")
-            PR_BODY="${{ github.event.pull_request.body }}"
             ISSUE_NUM=$(echo "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1)
             if [[ -z "$ISSUE_NUM" ]]; then
               echo "No linked issue found in PR body — skipping board move" >&2
@@ -77,9 +80,11 @@ jobs:
 
       - name: Move card on board
         if: steps.status.outputs.status != 'skip' && steps.issue.outputs.number != ''
+        env:
+          ISSUE_NUM: ${{ steps.issue.outputs.number }}
+          TARGET_STATUS: ${{ steps.status.outputs.status }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          ISSUE_NUM="${{ steps.issue.outputs.number }}"
-          TARGET_STATUS="${{ steps.status.outputs.status }}"
 
           # Fetch project metadata
           PROJECT_DATA=$(gh api graphql -f query='
@@ -120,7 +125,7 @@ jobs:
                 repository(owner: $owner, name: $repo) {
                   issue(number: $number) { id }
                 }
-              }' -f owner="$OWNER" -f repo="${{ github.event.repository.name }}" \
+              }' -f owner="$OWNER" -f repo="$REPO_NAME" \
                  -F number=$ISSUE_NUM | jq -r '.data.repository.issue.id')
 
             ITEM_ID=$(gh api graphql -f query='

--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -1,0 +1,155 @@
+name: Board automation
+
+# Moves GitHub Project board cards based on issue and PR lifecycle events.
+#
+# Setup (one-time):
+#   1. Create a PAT with 'project' scope at https://github.com/settings/tokens
+#   2. Store it as a repository secret named PROJECT_TOKEN
+#   3. Create a GitHub Project board for this repo
+#   4. Set PROJECT_NUMBER below to match your board's number
+#
+# Column transitions:
+#   issue opened          → To Do
+#   PR opened (draft)     → In Progress  (linked issue, via "Closes #N" in PR body)
+#   PR ready_for_review   → In Review    (linked issue)
+#   PR merged             → Done         (linked issue)
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, ready_for_review, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  board-move:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      OWNER: ${{ github.repository_owner }}
+      PROJECT_NUMBER: 1   # replace with your project board number
+
+    steps:
+      - name: Determine target status
+        id: status
+        run: |
+          EVENT="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
+
+          if [[ "$EVENT" == "issues" && "$ACTION" == "opened" ]]; then
+            echo "status=To Do" >> $GITHUB_OUTPUT
+            echo "item_type=issue" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "opened" ]]; then
+            echo "status=In Progress" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "ready_for_review" ]]; then
+            echo "status=In Review" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "status=Done" >> $GITHUB_OUTPUT
+            echo "item_type=pr" >> $GITHUB_OUTPUT
+
+          else
+            echo "status=skip" >> $GITHUB_OUTPUT
+            echo "item_type=skip" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve issue number
+        id: issue
+        if: steps.status.outputs.status != 'skip'
+        run: |
+          if [[ "${{ steps.status.outputs.item_type }}" == "issue" ]]; then
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            # Extract linked issue from PR body ("Closes #N", "Fixes #N", "Resolves #N")
+            PR_BODY="${{ github.event.pull_request.body }}"
+            ISSUE_NUM=$(echo "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1)
+            if [[ -z "$ISSUE_NUM" ]]; then
+              echo "No linked issue found in PR body — skipping board move" >&2
+              echo "number=" >> $GITHUB_OUTPUT
+            else
+              echo "number=$ISSUE_NUM" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Move card on board
+        if: steps.status.outputs.status != 'skip' && steps.issue.outputs.number != ''
+        run: |
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          TARGET_STATUS="${{ steps.status.outputs.status }}"
+
+          # Fetch project metadata
+          PROJECT_DATA=$(gh api graphql -f query='
+            query($owner: String!, $number: Int!) {
+              user(login: $owner) {
+                projectV2(number: $number) {
+                  id
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      options { id name }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue { number }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner="$OWNER" -F number=$PROJECT_NUMBER)
+
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id')
+          FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.field.id')
+          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg s "$TARGET_STATUS" \
+            '.data.user.projectV2.field.options[] | select(.name == $s) | .id')
+          ITEM_ID=$(echo "$PROJECT_DATA" | jq -r --argjson n $ISSUE_NUM \
+            '.data.user.projectV2.items.nodes[] | select(.content.number == $n) | .id')
+
+          if [[ -z "$ITEM_ID" ]]; then
+            echo "Issue #$ISSUE_NUM not found on board — adding it first"
+            ISSUE_NODE_ID=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) { id }
+                }
+              }' -f owner="$OWNER" -f repo="${{ github.event.repository.name }}" \
+                 -F number=$ISSUE_NUM | jq -r '.data.repository.issue.id')
+
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($project: ID!, $content: ID!) {
+                addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
+                  item { id }
+                }
+              }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" \
+              | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+
+          if [[ -z "$ITEM_ID" || -z "$OPTION_ID" ]]; then
+            echo "Could not resolve item ($ITEM_ID) or option ($OPTION_ID) — skipping" >&2
+            exit 0
+          fi
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field
+                value: { singleSelectOptionId: $option }
+              }) { projectV2Item { id } }
+            }' \
+            -f project="$PROJECT_ID" \
+            -f item="$ITEM_ID" \
+            -f field="$FIELD_ID" \
+            -f option="$OPTION_ID"
+
+          echo "Moved issue #$ISSUE_NUM to '$TARGET_STATUS' on project board"

--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -62,12 +62,15 @@ jobs:
       - name: Resolve issue number
         id: issue
         if: steps.status.outputs.status != 'skip'
+        env:
+          ITEM_TYPE: ${{ steps.status.outputs.item_type }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if [[ "${{ steps.status.outputs.item_type }}" == "issue" ]]; then
-            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          if [[ "$ITEM_TYPE" == "issue" ]]; then
+            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           else
             # Extract linked issue from PR body ("Closes #N", "Fixes #N", "Resolves #N")
-            PR_BODY="${{ github.event.pull_request.body }}"
             ISSUE_NUM=$(echo "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1)
             if [[ -z "$ISSUE_NUM" ]]; then
               echo "No linked issue found in PR body — skipping board move" >&2
@@ -79,9 +82,11 @@ jobs:
 
       - name: Move card on board
         if: steps.status.outputs.status != 'skip' && steps.issue.outputs.number != ''
+        env:
+          ISSUE_NUM: ${{ steps.issue.outputs.number }}
+          TARGET_STATUS: ${{ steps.status.outputs.status }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          ISSUE_NUM="${{ steps.issue.outputs.number }}"
-          TARGET_STATUS="${{ steps.status.outputs.status }}"
 
           # Fetch project metadata
           PROJECT_DATA=$(gh api graphql -f query='
@@ -121,7 +126,7 @@ jobs:
                 repository(owner: $owner, name: $repo) {
                   issue(number: $number) { id }
                 }
-              }' -f owner="$OWNER" -f repo="${{ github.event.repository.name }}" \
+              }' -f owner="$OWNER" -f repo="$REPO_NAME" \
                  -F number=$ISSUE_NUM | jq -r '.data.repository.issue.id')
 
             ITEM_ID=$(gh api graphql -f query='

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -887,7 +887,8 @@ class TestScaffoldIntegrity:
         """{{var}} or {{#if var}} surviving means a template wasn't named .tmpl
         or a variable wasn't wired up in __main__.py."""
         import re
-        placeholder_re = re.compile(r"\{\{[^}]+\}\}")
+        # Match {{...}} but not ${{...}} (GitHub Actions expression syntax)
+        placeholder_re = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
         offenders: list[str] = []
         for preset_name, lightrag_flag in [
             ("obsidian-only", ""),


### PR DESCRIPTION
## Summary

Closes #14

Creates the GitHub Project board for project-init and adds a GitHub Actions workflow that automatically moves board cards through the lifecycle — eliminating manual card management.

## Changes

- `.github/workflows/board-automation.yml` — board automation for this repo (PROJECT_NUMBER=2)
- `templates/base/dot_github/workflows/board-automation.yml` — same workflow in scaffold template (PROJECT_NUMBER=1, with setup instructions)
- `tests/test_scaffold.py` — fix placeholder regex to not flag `${{ }}` GitHub Actions syntax as unrendered template vars

## Board

https://github.com/users/VytCepas/projects/2

Columns: Backlog → To Do → In Progress → In Review → Done

Transitions fired by the workflow:
| Event | Column |
|---|---|
| Issue opened | To Do |
| PR opened (draft) | In Progress |
| PR ready for review | In Review |
| PR merged | Done |

## Test plan

- [x] `uv run pytest` — 114 passed, 4 skipped
- [x] Board created with 5 columns verified via GraphQL
- [x] `PROJECT_TOKEN` secret set on repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)