### PR TITLE
[#22][feat] Pin ubuntu-24.04 and consolidate Python setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint-and-test:
     name: Lint and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -21,9 +21,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-
-      - name: Set up Python
-        run: uv python install 3.12
+          python-version: "3.12"
 
       - name: Sync dev dependencies
         run: uv sync --extra dev
@@ -37,7 +35,7 @@ jobs:
 
   wheel-smoke:
     name: Wheel smoke test (PI-18)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: lint-and-test
     steps:
       - uses: actions/checkout@v4
@@ -47,9 +45,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-
-      - name: Set up Python
-        run: uv python install 3.12
+          python-version: "3.12"
 
       - name: Build wheel
         run: uv build --wheel

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint-and-test:
     name: Lint and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -23,9 +23,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-
-      - name: Set up Python
-        run: uv python install 3.12
+          python-version: "3.12"
 
       - name: Sync dev dependencies
         run: uv sync --extra dev


### PR DESCRIPTION
Closes #22

## Changes

- **Pin runner**: `ubuntu-latest` → `ubuntu-24.04` in all CI jobs for reproducibility
- **Consolidate Python setup**: remove separate `uv python install 3.12` step; pass `python-version: "3.12"` to `astral-sh/setup-uv` instead — this also enables caching of the Python installation

Applied to both `ci.yml` (this repo) and `ci.yml.tmpl` (scaffolded projects).

## Notes on "slim Python"

`uv` downloads from `python-build-standalone`, which is already a minimal standalone binary — there's no separate slim variant. Moving the install into `setup-uv` is the right optimization: it caches Python alongside the uv cache and removes a step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)