### PR TITLE
[nojira][docs] Use monitor-pr script in PR completion guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,10 +8,11 @@ Full agent rules are in [AGENTS.md](../AGENTS.md) and repo conventions in [CLAUD
 - Tracking system: **GitHub Projects** (board) + **GitHub Issues** (tickets)
 - Create issues: `gh issue create` — pick the right template (bug / feature / chore)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
-- PR titles must follow: `[#N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[#42][feat] Add OAuth login`
+- Issue, branch, and PR names use the Project Init key: `PI-<issue-number>`, e.g. `PI-42`
+- PR titles must follow: `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
-- PR body must include `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
-- When asked to push/finish a PR, continue autonomously: push, wait for checks, inspect review comments, fix actionable feedback, push again, repeat until clean, then merge if the user requested completion.
+- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
+- When asked to push/finish a PR, continue autonomously: push, run `.claude/scripts/monitor-pr.sh <pr-number> --merge`, inspect any failed checks or review comments it reports, fix actionable feedback, push again, and rerun the script until it merges cleanly.
 
 ### Python tooling
 - `uv run …` for all Python ops — never `pip install` or `python -m venv`

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,14 +17,14 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qE '^\[(#[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
+          if echo "$PR_TITLE" | grep -qE '^\[(PI-[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
             echo "PR title format OK: $PR_TITLE"
           else
-            echo "ERROR: PR title must match format: [#IssueNumber][type] or [nojira][type]"
+            echo "ERROR: PR title must match format: [PI-IssueNumber][type] or [nojira][type]"
             echo "Valid types: feat, fix, chore, docs, test"
             echo "Examples:"
-            echo "  [#42][feat] Add OAuth login"
-            echo "  [#99][fix] Handle null pointer in auth"
+            echo "  [PI-42][feat] Add OAuth login"
+            echo "  [PI-99][fix] Handle null pointer in auth"
             echo "  [nojira][fix] Fix typo in README"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@ Work is tracked in **GitHub Projects** (board) backed by **GitHub Issues** (tick
 
 For GitHub Issues, PR titles, PR bodies, and board behavior, read [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-**PR title format:** `[#IssueNumber][type] description` where type ∈ {feat, fix, chore, docs, test}  
+**Issue/branch/PR key format:** `PI-<issue-number>` for this repo (Project Init).  
+**PR title format:** `[PI-IssueNumber][type] description` where type ∈ {feat, fix, chore, docs, test}  
 **No-issue PRs:** `[nojira][type] description` for trivial changes  
 **PR body:** must include `Closes #<number>` to auto-link issue and move board card on merge
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,9 +10,10 @@ Source of truth: [.github/copilot-instructions.md](.github/copilot-instructions.
 - Tracking system: **GitHub Projects** (board) + **GitHub Issues** (tickets)
 - Create issues: `gh issue create` — pick the right template (bug / feature / chore)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
-- PR titles must follow: `[#N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[#42][feat] Add OAuth login`
+- Issue, branch, and PR names use the Project Init key: `PI-<issue-number>`, e.g. `PI-42`
+- PR titles must follow: `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
-- PR body must include `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
+- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 
 ### Python tooling
 - `uv run …` for all Python ops — never `pip install` or `python -m venv`

--- a/docs/adr/adr-003-github-native-workflow.md
+++ b/docs/adr/adr-003-github-native-workflow.md
@@ -16,7 +16,7 @@ Issues were tracked in Linear alongside GitHub Issues and PRs, requiring two sys
 - `board-automation.yml` workflow automates card movement triggered by issue/PR lifecycle events.
 - **No Linear MCP** in `MCP_CATALOG` (removed in PI-26)
 - **No GitHub MCP** — `gh` CLI covers all needs with zero token overhead
-- PR title format: `[#IssueNumber][type] Short description` where type ∈ {feat, fix, chore, docs, test}
+- PR title format: `[PI-IssueNumber][type] Short description` where type ∈ {feat, fix, chore, docs, test}
 - PR body must include `Closes #<number>` for auto-close on merge and board card movement (skip for `[nojira]` PRs)
 
 ## Consequences

--- a/docs/adr/adr-005-github-pr-board-workflow.md
+++ b/docs/adr/adr-005-github-pr-board-workflow.md
@@ -30,14 +30,14 @@ Each step maps to a GitHub Projects board column:
 | In Review | `/request-review` run — PR marked ready-for-review |
 | Done | PR merged with `Closes #<n>` in body |
 
-### Branch naming
+### Ticket, branch, and PR naming
 
-Use a dedicated branch for each issue. Keep branch names short and descriptive; the enforced public format is the PR title, not the branch name.
+Use the Project Init key `PI-<issue-number>` in issue titles, branch names, and PR titles. Keep branch names short and descriptive after the key.
 
 ### PR rules
 
 - Created as **draft** immediately when work starts (not when it's done).
-- Title format: `[#<issue>][<type>] Short description` or `[nojira][<type>] Short description`
+- Title format: `[PI-<issue>][<type>] Short description` or `[nojira][<type>] Short description`
 - Valid types: `feat` (feature), `fix` (bugfix), `chore` (maintenance/refactor), `docs` (doc-only), `test` (test-only)
 - Body must include `Closes #<issue>` to auto-close the issue and trigger the board move on merge (skip for `[nojira]` PRs)
 - One issue → one branch → one PR. Stacked PRs allowed only for dependency chains, never for convenience.
@@ -47,11 +47,11 @@ Use a dedicated branch for each issue. Keep branch names short and descriptive; 
 
 | Type | Use case | Example |
 |---|---|---|
-| `feat` | New feature or enhancement | `[#42][feat] Add OAuth login` |
-| `fix` | Bug fix | `[#99][fix] Handle null pointer` |
-| `chore` | Maintenance, refactor, deps, CI | `[#16][chore] Remove Linear remnants` |
-| `docs` | Documentation-only change | `[#20][docs] Update API guide` |
-| `test` | Test-only change | `[#55][test] Add auth unit tests` |
+| `feat` | New feature or enhancement | `[PI-42][feat] Add OAuth login` |
+| `fix` | Bug fix | `[PI-99][fix] Handle null pointer` |
+| `chore` | Maintenance, refactor, deps, CI | `[PI-16][chore] Remove Linear remnants` |
+| `docs` | Documentation-only change | `[PI-20][docs] Update API guide` |
+| `test` | Test-only change | `[PI-55][test] Add auth unit tests` |
 
 ### No-issue PRs (nojira)
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -11,7 +11,7 @@ uv sync --extra dev
 ## Workflow
 
 1. `gh issue list` — pick or create an issue
-2. Create a branch for the issue work
+2. Create a branch for the issue work using `PI-<issue-number>` in the name
 3. Write failing tests first (TDD)
 4. Implement until tests pass
 5. `uv run ruff check . && uv run ruff format .` — lint and format
@@ -20,7 +20,7 @@ uv sync --extra dev
 
 ## PR checklist
 
-- [ ] Title: `[#IssueNumber][type] description`
+- [ ] Title: `[PI-IssueNumber][type] description`
 - [ ] Body includes `Closes #<number>`
 - [ ] New template files have a corresponding test
 - [ ] No unrendered `{{...}}` placeholders in template output

--- a/templates/base/CLAUDE.md.tmpl
+++ b/templates/base/CLAUDE.md.tmpl
@@ -24,7 +24,7 @@ All agentic-development infrastructure lives under [`.claude/`](.claude/). Start
 ## Compact Instructions
 
 When compacting this conversation, preserve:
-- The GitHub Issue number being worked on (e.g. `#42`)
+- The project ticket key and GitHub issue number being worked on (e.g. `PI-42`, GitHub `#42`)
 - Files modified in this session (list by path)
 - Test results: pass/fail count and any failing test names
 - Unresolved errors or lint failures

--- a/templates/base/GEMINI.md.tmpl
+++ b/templates/base/GEMINI.md.tmpl
@@ -13,12 +13,13 @@ See [AGENTS.md](AGENTS.md) for full agent rules and layout spec, and [CLAUDE.md]
 - Tracking system: **GitHub Projects** (kanban board) + **GitHub Issues** (tickets)
 - Create issues: `gh issue create` — use the right template (bug / feature / chore)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
-- Use a dedicated branch for each issue; no direct commits to `main`
-- PR titles must follow: `[#N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[#42][feat] Add OAuth login`
+- Use a dedicated branch for each issue; include the project key, e.g. `PI-42-add-auth`; no direct commits to `main`
+- Issue, branch, and PR names use a project key: `<PROJECT-KEY>-<issue-number>`, e.g. `PI-42`
+- PR titles must follow: `[PROJECT-123][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
-- PR body must include `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
+- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 - Draft PRs are opened immediately when work starts, not when done
-- When asked to push/finish a PR, continue autonomously: push, wait for checks, inspect review comments, fix actionable feedback, push again, repeat until clean, then merge if the user requested completion.
+- When asked to push/finish a PR, continue autonomously: push, run `.claude/scripts/monitor-pr.sh <pr-number> --merge`, inspect any failed checks or review comments it reports, fix actionable feedback, push again, and rerun the script until it merges cleanly.
 
 ### Key rules
 - One issue → one branch → one PR.

--- a/templates/base/dot_claude/docs/development/conventions.md.tmpl
+++ b/templates/base/dot_claude/docs/development/conventions.md.tmpl
@@ -18,11 +18,11 @@ Format: `type: short description (#issue-number)`
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 
-Example: `feat: add OAuth login (#42)`
+Example: `feat: add OAuth login (PI-42)`
 
 ## Pull requests
 
-- Title: `[#IssueNumber] Short description`
+- Title: `[PROJECT-123][type] Short description`
 - Body must include `Closes #<number>` for auto-close on merge
 - All tests must pass before merging
 

--- a/templates/base/dot_claude/hooks/bash-safety-guard.sh
+++ b/templates/base/dot_claude/hooks/bash-safety-guard.sh
@@ -27,7 +27,7 @@ fi
 # Force push to protected branches
 if printf '%s' "$CMD" | grep -qE 'git push.*(--force|-f)' && \
    printf '%s' "$CMD" | grep -qE '(main|master|production|prod|release)'; then
-    block "Blocked: force push to a protected branch (main/master/production). Use a feature branch, or ask the user to confirm explicitly."
+    block "Blocked: force push to a protected branch (main/master/production). Use a project-key branch like PI-42-short-title, or ask the user to confirm explicitly."
 fi
 
 # Hard reset without an explicit path (blanket discard of working tree)

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -68,7 +68,7 @@ Every non-trivial task follows this exact sequence:
 | Step | Action | Board column |
 |------|--------|-------------|
 | 1 | Run `/start-task` — creates issue, branch, draft PR | **To Do → In Progress** |
-| 2 | Implement on the branch; commit with `#<issue>` references | In Progress |
+| 2 | Implement on the branch; use `<PROJECT-KEY>-<issue>` in human names and `#<issue>` where GitHub linking is needed | In Progress |
 | 3 | Run `/request-review` — marks PR ready, optional reviewer agent | **In Progress → In Review** |
 | 4 | Tests pass on CI; PR merged with `Closes #<issue>` in body | **In Review → Done** |
 
@@ -80,23 +80,24 @@ Every non-trivial task follows this exact sequence:
   ```
   This installs enforceable conventions: pre-push hook prevents accidental main branch commits.
 - One issue → one branch → one PR.
-- Use a dedicated branch for each issue.
-- **PR title:** `[#N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[#42][feat] Add OAuth login`
+- Use a dedicated branch for each issue; include the project key, e.g. `PI-42-add-auth`.
+- Issue, branch, and PR names use a project key: `<PROJECT-KEY>-<issue-number>`, e.g. `PI-42`.
+- **PR title:** `[PROJECT-123][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
   - For small no-issue PRs: `[nojira][type] description` (e.g. `[nojira][fix] Fix typo`)
-- PR body must include `Closes #N` — auto-closes issue and moves board card on merge (skip for nojira PRs).
+- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card on merge (skip for nojira PRs).
 - Draft PRs created immediately when work starts — not when it's done.
 - PRs must pass CI (tests + lint) before merging.
-- When asked to push or finish a PR, keep going until the lifecycle is complete: push, wait for CI, inspect review comments, fix actionable feedback, push again, repeat until checks and comments are clean, then merge if the user requested completion.
+- When asked to push or finish a PR, keep going until the lifecycle is complete: push, run `.claude/scripts/monitor-pr.sh <pr-number> --merge`, inspect any failed checks or review comments it reports, fix actionable feedback, push again, and rerun the script until it merges cleanly.
 
 ### PR Types
 
 | Type | Use case | Example |
 |---|---|---|
-| `feat` | New feature or enhancement | `[#42][feat] Add OAuth login` |
-| `fix` | Bug fix | `[#99][fix] Handle null pointer` |
-| `chore` | Maintenance, refactor, deps, CI | `[#16][chore] Update dependencies` |
-| `docs` | Documentation-only change | `[#20][docs] Update API guide` |
-| `test` | Test-only change | `[#55][test] Add unit tests` |
+| `feat` | New feature or enhancement | `[PI-42][feat] Add OAuth login` |
+| `fix` | Bug fix | `[PI-99][fix] Handle null pointer` |
+| `chore` | Maintenance, refactor, deps, CI | `[PI-16][chore] Update dependencies` |
+| `docs` | Documentation-only change | `[PI-20][docs] Update API guide` |
+| `test` | Test-only change | `[PI-55][test] Add unit tests` |
 
 ### Code review (optional)
 

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -33,9 +33,9 @@ for attempt in {1..5}; do
   # Parse with simple grep/sed (no jq or python needed)
   merge_status=$(echo "$pr_json" | grep -oP '"mergeStateStatus":"\K[^"]*' || echo "")
   review=$(echo "$pr_json" | grep -oP '"reviewDecision":"\K[^"]*' || echo "")
-  checks_failed=$(echo "$pr_json" | grep -o '"conclusion":"FAILURE"' | wc -l)
-  checks_pending=$(echo "$pr_json" | grep -o '"status":"\(IN_PROGRESS\|QUEUED\|PENDING\)"' | wc -l)
-  comment_count=$(echo "$pr_json" | grep -o '"author":' | wc -l)
+  checks_failed=$(echo "$pr_json" | { grep -o '"conclusion":"FAILURE"' || true; } | wc -l)
+  checks_pending=$(echo "$pr_json" | { grep -o '"status":"\(IN_PROGRESS\|QUEUED\|PENDING\)"' || true; } | wc -l)
+  comment_count=$(echo "$pr_json" | { grep -o '"author":' || true; } | wc -l)
 
   # Default values if not found
   merge_status="${merge_status:-UNKNOWN}"

--- a/templates/base/dot_claude/skills/start-task/SKILL.md
+++ b/templates/base/dot_claude/skills/start-task/SKILL.md
@@ -32,22 +32,30 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```
    Capture the issue number from the returned URL (last path segment).
 
-4. **Create a dedicated branch** for the issue:
-   ```bash
-   git checkout -b <short-branch-name>
-   ```
-   Keep the branch name short and descriptive; PR title format is defined separately below.
+4. **Assign the project key** — use the repository's configured key if one exists; otherwise derive short uppercase initials from the project name. Example: Project Init → `PI`.
 
-5. **Push an initial empty commit** — GitHub requires at least one commit ahead of base before a PR can be opened:
+5. **Rename the issue title** so the ticket is visibly keyed:
    ```bash
-   git commit --allow-empty -m "WIP: start #<issue-number> — <title>"
+   gh issue edit <issue-number> --title "<PROJECT-KEY>-<issue-number>: <title>"
+   ```
+
+6. **Create a dedicated branch** for the issue:
+   ```bash
+   git checkout -b <PROJECT-KEY>-<issue-number>-<slug>
+   # e.g. PI-42-add-auth
+   ```
+   Keep the branch name short and descriptive after the project key.
+
+7. **Push an initial empty commit** — GitHub requires at least one commit ahead of base before a PR can be opened:
+   ```bash
+   git commit --allow-empty -m "WIP: start <PROJECT-KEY>-<issue-number> - <title>"
    git push -u origin <branch-name>
    ```
 
-6. **Create a draft PR** with type in title:
+8. **Create a draft PR** with type in title:
    ```bash
    gh pr create \
-     --title "[#<issue-number>][<type>] <title>" \
+     --title "[<PROJECT-KEY>-<issue-number>][<type>] <title>" \
      --body "$(cat <<'EOF'
    ## Summary
 
@@ -67,7 +75,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```
    Valid types: feat, fix, chore, docs, test
 
-7. **Move the board card to In Progress** — if a GitHub Project board exists:
+9. **Move the board card to In Progress** — if a GitHub Project board exists:
    ```bash
    # Fetch project ID (the GraphQL node ID, not the numeric number)
    PROJECT_NUM=<number>   # from gh project list --owner <repo-owner>
@@ -84,16 +92,16 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```
    Skip silently if no project board is configured.
 
-8. **Record the issue number** for this session:
+10. **Record the issue number** for this session:
    ```bash
-   echo "Current task: #<number> — <title>" > .claude/memory/current-task.md
+   echo "Current task: <PROJECT-KEY>-<number> — <title> (GitHub #<number>)" > .claude/memory/current-task.md
    ```
 
-9. **Proceed** — only begin implementation after the issue, branch, and draft PR exist.
+11. **Proceed** — only begin implementation after the issue, branch, and draft PR exist.
 
 ## Rules
 
 > Every non-trivial task must have: a GitHub Issue, a dedicated branch, and a draft PR — all created before the first line of implementation code is written.
 
-> PR titles must follow the format: `[#N][type] description` or `[nojira][type] description`
+> PR titles must follow the format: `[PROJECT-123][type] description` or `[nojira][type] description`
 > Valid types: `feat`, `fix`, `chore`, `docs`, `test`

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -7,12 +7,13 @@ Full agent rules: [AGENTS.md](../AGENTS.md) | Project conventions: [CLAUDE.md](.
 - Tracking system: **GitHub Projects** (kanban board) + **GitHub Issues** (tickets)
 - Create issues: `gh issue create` — use the right template (bug / feature / chore)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
-- Use a dedicated branch for each issue; no direct commits to `main`
-- PR titles must follow: `[#N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[#42][feat] Add OAuth login`
+- Use a dedicated branch for each issue; include the project key, e.g. `PI-42-add-auth`; no direct commits to `main`
+- Issue, branch, and PR names use a project key: `<PROJECT-KEY>-<issue-number>`, e.g. `PI-42`
+- PR titles must follow: `[PROJECT-123][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
-- PR body must include `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
+- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 - Draft PRs are opened immediately when work starts, not when done
-- When asked to push/finish a PR, continue autonomously: push, wait for checks, inspect review comments, fix actionable feedback, push again, repeat until clean, then merge if the user requested completion.
+- When asked to push/finish a PR, continue autonomously: push, run `.claude/scripts/monitor-pr.sh <pr-number> --merge`, inspect any failed checks or review comments it reports, fix actionable feedback, push again, and rerun the script until it merges cleanly.
 - No direct commits to `main`
 
 ## Key rules

--- a/templates/base/dot_github/hooks/pre-push
+++ b/templates/base/dot_github/hooks/pre-push
@@ -10,7 +10,7 @@ while read local_ref local_sha remote_ref remote_sha; do
     echo "❌ ERROR: Direct push to main/master is not allowed"
     echo ""
     echo "To contribute:"
-    echo "  1. Create a new branch: git checkout -b <branch-name>"
+    echo "  1. Create a new branch with the project key: git checkout -b <PROJECT-KEY>-<issue-number>-<slug>"
     echo "  2. Make your changes and push: git push origin <branch-name>"
     echo "  3. Open a PR on GitHub"
     echo ""

--- a/templates/base/dot_github/pull_request_template.md
+++ b/templates/base/dot_github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- PR Title Format: [#IssueNumber][type] description  OR  [nojira][type] description -->
+<!-- PR Title Format: [PROJECT-123][type] description  OR  [nojira][type] description -->
 <!-- Valid types: feat | fix | chore | docs | test -->
 
 ## Summary

--- a/templates/base/dot_github/workflows/validate-pr.yml
+++ b/templates/base/dot_github/workflows/validate-pr.yml
@@ -17,14 +17,14 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qE '^\[(#[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
+          if echo "$PR_TITLE" | grep -qE '^\[([A-Z][A-Z0-9]{1,9}-[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
             echo "PR title format OK: $PR_TITLE"
           else
-            echo "ERROR: PR title must match format: [#IssueNumber][type] or [nojira][type]"
+            echo "ERROR: PR title must match format: [PROJECT-123][type] or [nojira][type]"
             echo "Valid types: feat, fix, chore, docs, test"
             echo "Examples:"
-            echo "  [#42][feat] Add OAuth login"
-            echo "  [#99][fix] Handle null pointer in auth"
+            echo "  [PI-42][feat] Add OAuth login"
+            echo "  [APP-99][fix] Handle null pointer in auth"
             echo "  [nojira][fix] Fix typo in README"
             exit 1
           fi

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1339,9 +1339,10 @@ class TestScaffoldGitHubFiles:
         content = f.read_text()
         assert "GitHub Projects" in content
         assert "AGENTS.md" in content
-        assert "[#N][type] description" in content
+        assert "[PROJECT-123][type] description" in content
+        assert "[#N][type] description" not in content
         assert "PR title must start with" not in content
-        assert "wait for checks" in content
+        assert ".claude/scripts/monitor-pr.sh <pr-number> --merge" in content
         assert "fix actionable feedback" in content
 
     def test_gemini_md_created(self):
@@ -1350,8 +1351,9 @@ class TestScaffoldGitHubFiles:
         content = f.read_text()
         assert "GitHub Projects" in content
         assert "AGENTS.md" in content
-        assert "[#N][type] description" in content
-        assert "wait for checks" in content
+        assert "[PROJECT-123][type] description" in content
+        assert "[#N][type] description" not in content
+        assert ".claude/scripts/monitor-pr.sh <pr-number> --merge" in content
 
     def test_monitor_pr_can_merge_when_clean(self):
         script = self.target / ".claude" / "scripts" / "monitor-pr.sh"
@@ -1361,11 +1363,13 @@ class TestScaffoldGitHubFiles:
         assert "gh pr merge" in content
         assert "gh pr checks" in content
         assert "--delete-branch" in content
+        assert "grep -o '\"conclusion\":\"FAILURE\"' || true" in content
 
-    def test_validate_pr_enforces_title_format(self):
-        """PR title must match [#N][type] or [nojira][type] format."""
+    def test_validate_pr_enforces_project_key_title_format(self):
+        """PR title must match [PROJECT-123][type] or [nojira][type] format."""
         content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()
         # Check for the new regex pattern with type validation
+        assert "[A-Z][A-Z0-9]{1,9}-[0-9]+" in content
         assert "(feat|fix|chore|docs|test)" in content
         assert "nojira" in content
         # Ensure old format is not present (should have been updated)
@@ -1395,6 +1399,7 @@ class TestScaffoldGitHubFiles:
         # Verify the hook prevents pushing to main
         assert "refs/heads/main" in content or "refs/heads/master" in content
         assert "ERROR" in content or "not allowed" in content
+        assert "<PROJECT-KEY>-<issue-number>-<slug>" in content
 
     def test_gemini_no_unrendered_placeholders(self):
         import re
@@ -1402,6 +1407,14 @@ class TestScaffoldGitHubFiles:
         text = (self.target / "GEMINI.md").read_text()
         matches = placeholder_re.findall(text)
         assert not matches, f"Unrendered placeholders in GEMINI.md: {matches}"
+
+
+def test_project_validate_pr_workflow_uses_pi_key():
+    content = (
+        Path(__file__).resolve().parent.parent / ".github" / "workflows" / "validate-pr.yml"
+    ).read_text()
+    assert "PI-[0-9]+" in content
+    assert "[PI-IssueNumber][type]" in content
 
 
 class TestREADMEExampleCommand:


### PR DESCRIPTION
## Summary

- Point autonomous PR completion guidance at .claude/scripts/monitor-pr.sh <pr-number> --merge.
- Keep scaffolded Copilot, Gemini, and project-init guidance aligned.
- Update scaffold tests to assert the script-based guidance.

## Test plan

- uv run ruff check .
- uv lock --check
- uv run pytest
- uv run --extra docs mkdocs build --strict