### PR TITLE
[PI-30][test] Inject project_name into MEMORY.md.tmpl header

### DIFF
--- a/templates/base/dot_claude/memory/MEMORY.md.tmpl
+++ b/templates/base/dot_claude/memory/MEMORY.md.tmpl
@@ -1,5 +1,5 @@
 <!--
-  MEMORY.md — project-level memory index.
+  MEMORY.md — project-level memory index for {{project_name}}.
 
   One bullet per memory file. Keep lines under ~150 chars.
   Each referenced file has frontmatter: name, description, type (user | feedback | project | reference).


### PR DESCRIPTION
## Summary

- Adds `{{project_name}}` to the MEMORY.md comment header so agents can identify which project the index belongs to without opening other files
- Mocked change used to exercise the full PR lifecycle end-to-end

## Test plan

- [ ] CI lint-and-test passes
- [ ] CI wheel-smoke passes
- [ ] validate-pr title format check passes
- [ ] validate-pr Closes keyword check passes
- [ ] Board automation moves PI-30 card to "In Progress"

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)