### PR TITLE
[PI-45][feat] Add agent-agnostic skill discovery index

### DIFF
--- a/.claude/skills/INDEX.md
+++ b/.claude/skills/INDEX.md
@@ -1,0 +1,25 @@
+# Skills index
+
+Load the relevant skill file when the trigger applies. Do not load all skills at once.
+
+| When you need to... | Load this skill |
+|---|---|
+| Create a GitHub Issue | `.claude/skills/start-task/SKILL.md` (then use `gh issue create` directly — no `create-issue.sh` in this repo) |
+| Start a new task (branch + draft PR) | `.claude/skills/start-task/SKILL.md` |
+| Push, review, or merge a PR | Follow `.github/copilot-instructions.md` — no github-workflow skill yet |
+| Summarize the session | `.claude/skills/session-summary/SKILL.md` |
+| Add a hook | `.claude/skills/add-hook/SKILL.md` |
+| Add a slash command | `.claude/skills/add-command/SKILL.md` |
+
+## Note for this repo
+
+This is the scaffolder source — `.claude/scripts/` lifecycle scripts do not exist here.
+Use `gh issue create`, `gh pr create`, and `git push` directly where skills reference those scripts.
+See `CLAUDE.md` §GitHub workflow for the fallback rules.
+
+## How to use this index
+
+1. Identify which action you are about to take.
+2. Check the table above for a matching skill.
+3. Read that skill file fully before acting.
+4. Follow the skill's steps exactly — do not improvise the workflow.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,14 @@
+# `.claude/skills/`
+
+Project-local Claude Code skills. Each skill is a directory `.claude/skills/<name>/SKILL.md`.
+
+| Skill | When to use |
+|---|---|
+| `session-summary` | End of session — summarize work and save to vault |
+| `start-task` | Before any non-trivial task — create a GitHub Issue |
+| `add-hook` | When you need a new deterministic hook (safety, lint, logging) |
+| `add-command` | When you need a new slash command for a recurring workflow |
+
+See `INDEX.md` for a trigger-based lookup table.
+
+User-level skills (across all projects) live in `~/.claude/skills/`.

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,0 +1,38 @@
+---
+description: Add a new slash command to this project
+argument-hint: "<command-name> <what it does>"
+allowed-tools: Write
+---
+
+Add a slash command without reading existing command files.
+
+## Steps
+
+1. **Create** `.claude/commands/<name>.md`:
+
+```markdown
+Run this command to <what it does>.
+
+## Steps
+
+1. <step one>
+2. <step two>
+
+## Rules
+
+- <constraint if any>
+```
+
+That's it — Claude Code registers any `.md` file in `.claude/commands/` as `/name` automatically.
+
+## Guidelines
+
+- **Name**: lowercase, hyphen-separated, matches the task (`code-review`, `deploy-check`)
+- **Steps**: imperative, specific. Prefer shell commands over prose where possible.
+- **No file reads in the command**: embed what the agent needs inline; don't say "read X first"
+- **`$ARGUMENTS`**: available if the command takes user input (e.g., `/review main..HEAD`)
+
+## When to use a command vs a skill
+
+- **Command** (`/name`): user-invoked, task-oriented, short workflow (status check, review, deploy)
+- **Skill** (`.claude/skills/`): agent-invoked, reusable sub-procedure called from other instructions

--- a/.claude/skills/add-hook/SKILL.md
+++ b/.claude/skills/add-hook/SKILL.md
@@ -1,0 +1,45 @@
+---
+description: Add a new deterministic hook to this project
+argument-hint: "<hook-name> <event> <description>"
+allowed-tools: Read Write Bash
+---
+
+Add a hook without reading existing hook implementations.
+
+## Steps
+
+1. **Create** `.claude/hooks/$ARGUMENTS_name.sh` (or `.py` for Python logic):
+
+```bash
+#!/usr/bin/env bash
+# Input: JSON on stdin from Claude Code
+INPUT=$(cat)
+
+# exit 0 = allow  |  exit 1 = block (PreToolUse only)
+# stdout JSON = optional additionalContext injected into Claude's context
+
+# Example: block a pattern
+if echo "$INPUT" | grep -q "PATTERN"; then
+  echo '{"decision":"block","reason":"reason here"}' >&2
+  exit 1
+fi
+exit 0
+```
+
+2. **Wire** the hook in `.claude/settings.json` under the correct event key:
+
+```json
+"<Event>": [
+  {
+    "matcher": "<ToolName or *>",
+    "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+  }
+]
+```
+
+**Events**: `PreToolUse`, `PostToolUse`, `Stop`
+**Matchers**: tool name (`Bash`, `Write`, `Edit`, `MultiEdit`), pipe-separated (`Write|Edit`), or `*`
+
+3. **Make executable**: `chmod +x .claude/hooks/<name>.sh`
+
+4. **Test**: trigger the wired tool and confirm the hook fires as expected.

--- a/.claude/skills/session-summary/SKILL.md
+++ b/.claude/skills/session-summary/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: session-summary
+description: Summarize the current session — what was done, decisions made, open items — and save to vault
+allowed-tools: Bash Read Write Glob Grep
+---
+
+Summarize this session and save it to the vault:
+
+1. **Gather context**:
+   - Run `git log --since='2 hours ago' --oneline` for recent commits
+   - Run `git diff --stat` for uncommitted changes
+   - Review the conversation for key decisions and discoveries
+
+2. **Write the summary** to `.claude/vault/sessions/` with today's date:
+   ```
+   # Session YYYY-MM-DD (manual)
+
+   ## What was done
+   - (bullet list of completed work)
+
+   ## Decisions made
+   - (any architectural or approach decisions, with reasoning)
+
+   ## Open items
+   - (anything left unfinished or discovered but not addressed)
+
+   ## Notes
+   - (anything else worth remembering)
+   ```
+
+3. **Update memory** if any reusable facts emerged (write to `~/.claude/projects/.../memory/`)
+
+Keep the summary concise — a future agent should be able to skim it in 30 seconds.

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -1,0 +1,39 @@
+---
+description: Create a GitHub Issue + branch + draft PR before starting work
+argument-hint: "[task title]"
+allowed-tools: Bash Read
+---
+
+Before starting any non-trivial task, create a GitHub Issue, a dedicated branch, and a draft PR. This keeps work traceable and every PR maps to exactly one issue.
+
+## Steps
+
+1. **Clarify scope** — if $ARGUMENTS is empty or vague, ask the user for:
+   - Task title (one line, imperative: "Add X", "Fix Y", "Refactor Z")
+   - Work type: `feat` / `fix` / `chore` / `docs` / `test`
+
+2. **Check for existing issue** — run `gh issue list` and ask: "Does a GitHub Issue already exist for this? If so, provide the number and skip to step 4."
+
+3. **Create the issue** (no `create-issue.sh` in this repo — use gh directly):
+   ```bash
+   gh issue create --title "[PI-new][<type>] <title>" --label "<type>" --body "..."
+   # Note the issue number from the output URL
+   ```
+
+4. **Create branch and draft PR**:
+   ```bash
+   git checkout -b <type>/PI-<n>-<slug>
+   git push -u origin HEAD
+   gh pr create --title "[PI-<n>][<type>] <title>" --body "Closes #<n>" --draft
+   ```
+   Branch name pattern: `<issue_type>/PI-<issue_number>-<short-slug>`
+
+5. **Proceed** — only begin implementation after issue + branch + draft PR exist.
+
+## Rules
+
+- Every non-trivial task must have a GitHub Issue, a branch, and a draft PR — all before the first line of implementation code.
+- One issue → one branch → one PR.
+- `board-automation.yml` moves the board card to **In Progress** automatically when the PR is opened.
+- PR title format: `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}
+- PR body must include `Closes #N` to auto-close the issue on merge.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ venv/
 *.log
 logs/
 
-# Local agent runtime state
-.claude/
+# Local agent runtime state — .claude/skills/ is tracked (committed)
+.claude/*
+!.claude/skills
 .codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@ Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of
 
 ## Skills (load on demand)
 
-Before any GitHub action (create issue, branch, push, PR, merge), check [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the quick-reference workflow rules. This repo does not ship its own `.claude/skills/` directory — it is the scaffolder source.
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 Canonical instructions for this repository live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for repo conventions, testing rules, GitHub workflow, and branch naming.
+
+## Skills (load on demand)
+
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the quick-reference workflow rules. This repo does not ship its own `.claude/skills/` directory — it is the scaffolder source.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,4 +6,4 @@ Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of
 
 ## Skills (load on demand)
 
-Before any GitHub action (create issue, branch, push, PR, merge), check [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the quick-reference workflow rules. This repo does not ship its own `.claude/skills/` directory — it is the scaffolder source.
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,3 +3,7 @@
 Canonical instructions for this repository live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for repo conventions, testing rules, GitHub workflow, and branch naming.
+
+## Skills (load on demand)
+
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the quick-reference workflow rules. This repo does not ship its own `.claude/skills/` directory — it is the scaffolder source.

--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -3,3 +3,7 @@
 Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
+
+## Skills (load on demand)
+
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/templates/base/GEMINI.md.tmpl
+++ b/templates/base/GEMINI.md.tmpl
@@ -3,3 +3,7 @@
 Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
+
+## Skills (load on demand)
+
+Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/templates/base/dot_claude/skills/INDEX.md
+++ b/templates/base/dot_claude/skills/INDEX.md
@@ -1,0 +1,21 @@
+# Skills index
+
+Load the relevant skill file when the trigger applies. Do not load all skills at once.
+
+| When you need to... | Load this skill |
+|---|---|
+| Create a GitHub Issue | `.claude/skills/create-issue/SKILL.md` (if present) or use `create-issue.sh` |
+| Start a new task (branch + draft PR) | `.claude/skills/start-task/SKILL.md` |
+| Push, review, or merge a PR | `.claude/skills/github-workflow/SKILL.md` (if present) or follow `.github/copilot-instructions.md` |
+| Summarize the session | `.claude/skills/session-summary/SKILL.md` |
+| Add a hook | `.claude/skills/add-hook/SKILL.md` |
+| Add a slash command | `.claude/skills/add-command/SKILL.md` |
+
+## How to use this index
+
+1. Identify which action you are about to take.
+2. Check the table above for a matching skill.
+3. Read that skill file fully before acting.
+4. Follow the skill's steps exactly — do not improvise the workflow.
+
+Skills that say "if present" may not exist in every scaffolded project. If the file is missing, fall back to the instruction noted in the same row.

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_SKILLS_DIR = Path(__file__).parent.parent / "templates" / "base" / "dot_claude" / "skills"
+_INDEX_PATH = _SKILLS_DIR / "INDEX.md"
+
+
+class TestSkillIndex:
+    """Verify INDEX.md exists and covers every skill directory."""
+
+    def test_index_file_exists(self):
+        assert _INDEX_PATH.exists(), "templates/base/dot_claude/skills/INDEX.md missing"
+
+    def test_every_skill_dir_mentioned_in_index(self):
+        index_text = _INDEX_PATH.read_text()
+        missing = []
+        for skill_dir in _SKILLS_DIR.iterdir():
+            if not skill_dir.is_dir():
+                continue
+            if skill_dir.name not in index_text:
+                missing.append(skill_dir.name)
+        assert not missing, (
+            "Skill directories not referenced in INDEX.md: " + ", ".join(missing)
+        )
+
+    def test_index_scaffolded_into_project(self, tmp_path: Path):
+        target = tmp_path / "proj"
+        preset = load_preset("obsidian-only")
+        scaffold(target, preset, make_variables())
+        index = target / ".claude" / "skills" / "INDEX.md"
+        assert index.exists(), ".claude/skills/INDEX.md not scaffolded into project"
+
+    def test_index_content_in_scaffolded_project(self, tmp_path: Path):
+        target = tmp_path / "proj"
+        preset = load_preset("obsidian-only")
+        scaffold(target, preset, make_variables())
+        content = (target / ".claude" / "skills" / "INDEX.md").read_text()
+        assert "start-task" in content
+        assert "session-summary" in content
+        assert "add-hook" in content
+        assert "add-command" in content
+
+
+class TestAgentInstructionFiles:
+    """Verify AGENTS.md and GEMINI.md reference the skills index after scaffolding."""
+
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_path: Path):
+        self.target = tmp_path / "proj"
+        preset = load_preset("obsidian-only")
+        scaffold(self.target, preset, make_variables())
+
+    def test_agents_md_references_skills_index(self):
+        content = (self.target / "AGENTS.md").read_text()
+        assert "INDEX.md" in content or "skills" in content.lower()
+
+    def test_gemini_md_references_skills_index(self):
+        content = (self.target / "GEMINI.md").read_text()
+        assert "INDEX.md" in content or "skills" in content.lower()


### PR DESCRIPTION
## Summary

- Adds `templates/base/dot_claude/skills/INDEX.md` — a static table mapping intent (create issue, start task, push/PR, etc.) to the relevant skill file path
- Updates `AGENTS.md.tmpl` and `GEMINI.md.tmpl` templates to tell non-Claude agents to load skills on demand via INDEX.md rather than reading all rules upfront
- Dogfoods the same pattern in this repo's own `AGENTS.md` and `GEMINI.md`
- Adds `tests/test_skill_index.py` with 6 tests: INDEX.md exists, covers all skill dirs, is scaffolded, agent files reference it

## Test plan

- [x] `uv run pytest tests/test_skill_index.py` — 6/6 pass
- [x] `uv run pytest` — 155 passed, 4 skipped, no regressions

Closes #45