### PR TITLE
[PI-51][chore] Commit .claude/settings.json and track it in gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-ci-check.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,11 @@ venv/
 *.log
 logs/
 
-# Local agent runtime state — skills/, hooks/, scripts/ are tracked (committed)
+# Local agent runtime state — committed: skills/, hooks/, scripts/, settings.json
+# gitignored: vault/, settings.local.json, scheduled_tasks.lock (personal/runtime)
 .claude/*
 !.claude/skills
 !.claude/hooks
 !.claude/scripts
+!.claude/settings.json
 .codex


### PR DESCRIPTION
## Summary

- Adds `!.claude/settings.json` to `.gitignore` — the hook wiring is now shared on clone
- Commits `.claude/settings.json` activating `pre-merge-ci-check.sh` for all contributors

Without this, the hook scripts in `.claude/hooks/` were present but silently inactive on any fresh clone since `settings.json` was gitignored.

## Test plan

- [x] `uv run pytest` — 156 passed, 4 skipped
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` — valid

Closes #51