### PR TITLE
[PI-53][fix] monitor-pr.sh polls for pending reviews before merge

### DIFF
--- a/.claude/scripts/monitor-pr.sh
+++ b/.claude/scripts/monitor-pr.sh
@@ -49,25 +49,37 @@ sys.exit(len(bad))
 "
 }
 
-# Print all review comments — called when CHANGES_REQUESTED so the agent
-# sees exactly what needs fixing without a separate gh pr view call.
+# Print review feedback on CHANGES_REQUESTED.
+# Tries inline review comments first; falls back to full PR comments view
+# because review body / conversation feedback won't appear in the inline endpoint.
 _print_review_comments() {
-  gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
-    --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
-    2>/dev/null || true
+  local inline
+  inline=$(
+    gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+      --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
+      2>/dev/null || true
+  )
+  if [ -n "$inline" ]; then
+    printf '%s\n' "$inline"
+  else
+    gh pr view "$PR_NUMBER" --comments 2>/dev/null || true
+  fi
+  echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
 }
 
-# Safe gh pr view wrapper — retries up to 3 times on transient failures
-# so a brief API hiccup doesn't abort the whole poll loop.
+# Safe gh pr view wrapper — retries up to 3 times on transient failures.
+# Returns a distinct sentinel "UNKNOWN" after exhausting retries so the caller
+# can keep polling rather than treating repeated failures as no review required.
 _get_review_decision() {
   local attempts=0
   while [ "$attempts" -lt 3 ]; do
     local result
-    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) && echo "$result" && return
+    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) \
+      && echo "$result" && return
     attempts=$((attempts + 1))
     sleep 5
   done
-  echo ""  # treat as no decision on repeated failure — keep polling
+  echo "UNKNOWN"
 }
 
 # --- Phase 1: wait for CI ---
@@ -94,6 +106,7 @@ PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 #   CHANGES_REQUESTED — blocked, must address
 #   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
 #   ""               — no review requirement, proceed
+#   UNKNOWN          — transient gh failure after retries, keep polling
 _handle_changes_requested() {
   echo "Changes requested on PR #$PR_NUMBER — address the following before merging:"
   _print_review_comments
@@ -105,6 +118,7 @@ if [ "$MODE" = "--merge" ]; then
   while true; do
     REVIEW=$(_get_review_decision)
     [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
+    [ "$REVIEW" = "UNKNOWN" ] && { echo "Could not determine review state, retrying..."; sleep 30; continue; }
     [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
     echo "Waiting for review on PR #$PR_NUMBER (review required)..."
     sleep 30
@@ -112,7 +126,7 @@ if [ "$MODE" = "--merge" ]; then
 else
   REVIEW=$(_get_review_decision)
   [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
-  if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
+  if [ "$REVIEW" = "REVIEW_REQUIRED" ] || [ "$REVIEW" = "UNKNOWN" ]; then
     echo "PR #$PR_NUMBER: CI passed but review is still pending."
     echo "  $PR_URL"
     exit 0

--- a/.claude/scripts/monitor-pr.sh
+++ b/.claude/scripts/monitor-pr.sh
@@ -49,6 +49,27 @@ sys.exit(len(bad))
 "
 }
 
+# Print all review comments — called when CHANGES_REQUESTED so the agent
+# sees exactly what needs fixing without a separate gh pr view call.
+_print_review_comments() {
+  gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+    --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
+    2>/dev/null || true
+}
+
+# Safe gh pr view wrapper — retries up to 3 times on transient failures
+# so a brief API hiccup doesn't abort the whole poll loop.
+_get_review_decision() {
+  local attempts=0
+  while [ "$attempts" -lt 3 ]; do
+    local result
+    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) && echo "$result" && return
+    attempts=$((attempts + 1))
+    sleep 5
+  done
+  echo ""  # treat as no decision on repeated failure — keep polling
+}
+
 # --- Phase 1: wait for CI ---
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null) || CHECKS="[]"
@@ -73,25 +94,24 @@ PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 #   CHANGES_REQUESTED — blocked, must address
 #   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
 #   ""               — no review requirement, proceed
+_handle_changes_requested() {
+  echo "Changes requested on PR #$PR_NUMBER — address the following before merging:"
+  _print_review_comments
+  echo "  Re-run after pushing fixes: .claude/scripts/monitor-pr.sh $PR_NUMBER --merge"
+  exit 1
+}
+
 if [ "$MODE" = "--merge" ]; then
   while true; do
-    REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
-    if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-      echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-      echo "  gh pr view $PR_NUMBER --comments"
-      exit 1
-    fi
+    REVIEW=$(_get_review_decision)
+    [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
     [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
     echo "Waiting for review on PR #$PR_NUMBER (review required)..."
     sleep 30
   done
 else
-  REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
-  if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-    echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-    echo "  gh pr view $PR_NUMBER --comments"
-    exit 1
-  fi
+  REVIEW=$(_get_review_decision)
+  [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
   if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
     echo "PR #$PR_NUMBER: CI passed but review is still pending."
     echo "  $PR_URL"

--- a/.claude/scripts/monitor-pr.sh
+++ b/.claude/scripts/monitor-pr.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# Wait for all CI checks on a PR to complete, then optionally merge.
+# Wait for all CI checks and required reviews on a PR, then optionally merge.
 # Only prints failures or the final pass line — no per-refresh noise.
 # Requires: gh, python3 (stdlib only — no jq dependency).
 #
 # Usage:
 #   .claude/scripts/monitor-pr.sh <pr-number> [--merge]
 #
-# --merge: squash-merge and delete branch automatically when checks pass.
+# --merge: squash-merge and delete branch automatically when checks pass
+#          and any required review is approved.
 #
 # Agents: use this to complete the full PR lifecycle without manual steps.
 #   .claude/scripts/monitor-pr.sh <n> --merge
@@ -48,6 +49,7 @@ sys.exit(len(bad))
 "
 }
 
+# --- Phase 1: wait for CI ---
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null) || CHECKS="[]"
   PENDING=$(_count_pending "$CHECKS")
@@ -64,12 +66,37 @@ if [ "$FAIL_CODE" -gt 0 ]; then
 fi
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
-REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
 
-if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-  echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-  echo "  gh pr view $PR_NUMBER --comments"
-  exit 1
+# --- Phase 2: wait for required reviews (Copilot, human, etc.) ---
+# reviewDecision values:
+#   APPROVED         — green, proceed
+#   CHANGES_REQUESTED — blocked, must address
+#   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
+#   ""               — no review requirement, proceed
+if [ "$MODE" = "--merge" ]; then
+  while true; do
+    REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
+    if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+      echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
+      echo "  gh pr view $PR_NUMBER --comments"
+      exit 1
+    fi
+    [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
+    echo "Waiting for review on PR #$PR_NUMBER (review required)..."
+    sleep 30
+  done
+else
+  REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
+  if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+    echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
+    echo "  gh pr view $PR_NUMBER --comments"
+    exit 1
+  fi
+  if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
+    echo "PR #$PR_NUMBER: CI passed but review is still pending."
+    echo "  $PR_URL"
+    exit 0
+  fi
 fi
 
 echo "PR #$PR_NUMBER passed: $PR_URL"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,13 @@ Full agent rules and repo conventions are in [CLAUDE.md](../CLAUDE.md). [AGENTS.
 
 Read this file before any GitHub issue, branch, push, PR, review, CI, or merge work. These workflow rules are mandatory, not optional background context.
 
+## For Copilot code review
+
+- **Always read the current file state** before suggesting changes. Your training data may be outdated; the actual code in this PR is authoritative.
+- **Do not suggest patterns that contradict what is already in the file.** Read the full function/file context before commenting.
+- **Flag stale suggestions yourself** — if the issue you spotted is already handled elsewhere in the diff, say so rather than flagging it as an open problem.
+- Reference `.claude/skills/INDEX.md` for the list of available skills if you need to suggest workflow improvements.
+
 ## Quick reference (Copilot Workspace / inline chat)
 
 ### Issue & project tracking

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -49,25 +49,37 @@ sys.exit(len(bad))
 "
 }
 
-# Print all review comments — called when CHANGES_REQUESTED so the agent
-# sees exactly what needs fixing without a separate gh pr view call.
+# Print review feedback on CHANGES_REQUESTED.
+# Tries inline review comments first; falls back to full PR comments view
+# because review body / conversation feedback won't appear in the inline endpoint.
 _print_review_comments() {
-  gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
-    --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
-    2>/dev/null || true
+  local inline
+  inline=$(
+    gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+      --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
+      2>/dev/null || true
+  )
+  if [ -n "$inline" ]; then
+    printf '%s\n' "$inline"
+  else
+    gh pr view "$PR_NUMBER" --comments 2>/dev/null || true
+  fi
+  echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
 }
 
-# Safe gh pr view wrapper — retries up to 3 times on transient failures
-# so a brief API hiccup doesn't abort the whole poll loop.
+# Safe gh pr view wrapper — retries up to 3 times on transient failures.
+# Returns a distinct sentinel "UNKNOWN" after exhausting retries so the caller
+# can keep polling rather than treating repeated failures as no review required.
 _get_review_decision() {
   local attempts=0
   while [ "$attempts" -lt 3 ]; do
     local result
-    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) && echo "$result" && return
+    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) \
+      && echo "$result" && return
     attempts=$((attempts + 1))
     sleep 5
   done
-  echo ""  # treat as no decision on repeated failure — keep polling
+  echo "UNKNOWN"
 }
 
 # --- Phase 1: wait for CI ---
@@ -94,6 +106,7 @@ PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 #   CHANGES_REQUESTED — blocked, must address
 #   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
 #   ""               — no review requirement, proceed
+#   UNKNOWN          — transient gh failure after retries, keep polling
 _handle_changes_requested() {
   echo "Changes requested on PR #$PR_NUMBER — address the following before merging:"
   _print_review_comments
@@ -105,6 +118,7 @@ if [ "$MODE" = "--merge" ]; then
   while true; do
     REVIEW=$(_get_review_decision)
     [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
+    [ "$REVIEW" = "UNKNOWN" ] && { echo "Could not determine review state, retrying..."; sleep 30; continue; }
     [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
     echo "Waiting for review on PR #$PR_NUMBER (review required)..."
     sleep 30
@@ -112,7 +126,7 @@ if [ "$MODE" = "--merge" ]; then
 else
   REVIEW=$(_get_review_decision)
   [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
-  if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
+  if [ "$REVIEW" = "REVIEW_REQUIRED" ] || [ "$REVIEW" = "UNKNOWN" ]; then
     echo "PR #$PR_NUMBER: CI passed but review is still pending."
     echo "  $PR_URL"
     exit 0

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -49,6 +49,27 @@ sys.exit(len(bad))
 "
 }
 
+# Print all review comments — called when CHANGES_REQUESTED so the agent
+# sees exactly what needs fixing without a separate gh pr view call.
+_print_review_comments() {
+  gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+    --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]\n  \(.body)\n"' \
+    2>/dev/null || true
+}
+
+# Safe gh pr view wrapper — retries up to 3 times on transient failures
+# so a brief API hiccup doesn't abort the whole poll loop.
+_get_review_decision() {
+  local attempts=0
+  while [ "$attempts" -lt 3 ]; do
+    local result
+    result=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""' 2>/dev/null) && echo "$result" && return
+    attempts=$((attempts + 1))
+    sleep 5
+  done
+  echo ""  # treat as no decision on repeated failure — keep polling
+}
+
 # --- Phase 1: wait for CI ---
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null) || CHECKS="[]"
@@ -73,25 +94,24 @@ PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 #   CHANGES_REQUESTED — blocked, must address
 #   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
 #   ""               — no review requirement, proceed
+_handle_changes_requested() {
+  echo "Changes requested on PR #$PR_NUMBER — address the following before merging:"
+  _print_review_comments
+  echo "  Re-run after pushing fixes: .claude/scripts/monitor-pr.sh $PR_NUMBER --merge"
+  exit 1
+}
+
 if [ "$MODE" = "--merge" ]; then
   while true; do
-    REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
-    if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-      echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-      echo "  gh pr view $PR_NUMBER --comments"
-      exit 1
-    fi
+    REVIEW=$(_get_review_decision)
+    [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
     [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
     echo "Waiting for review on PR #$PR_NUMBER (review required)..."
     sleep 30
   done
 else
-  REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
-  if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-    echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-    echo "  gh pr view $PR_NUMBER --comments"
-    exit 1
-  fi
+  REVIEW=$(_get_review_decision)
+  [ "$REVIEW" = "CHANGES_REQUESTED" ] && _handle_changes_requested
   if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
     echo "PR #$PR_NUMBER: CI passed but review is still pending."
     echo "  $PR_URL"

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# Wait for all CI checks on a PR to complete, then optionally merge.
+# Wait for all CI checks and required reviews on a PR, then optionally merge.
 # Only prints failures or the final pass line — no per-refresh noise.
 # Requires: gh, python3 (stdlib only — no jq dependency).
 #
 # Usage:
 #   .claude/scripts/monitor-pr.sh <pr-number> [--merge]
 #
-# --merge: squash-merge and delete branch automatically when checks pass.
+# --merge: squash-merge and delete branch automatically when checks pass
+#          and any required review is approved.
 #
 # Agents: use this to complete the full PR lifecycle without manual steps.
 #   .claude/scripts/monitor-pr.sh <n> --merge
@@ -48,6 +49,7 @@ sys.exit(len(bad))
 "
 }
 
+# --- Phase 1: wait for CI ---
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion 2>/dev/null) || CHECKS="[]"
   PENDING=$(_count_pending "$CHECKS")
@@ -64,12 +66,37 @@ if [ "$FAIL_CODE" -gt 0 ]; then
 fi
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
-REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
 
-if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
-  echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
-  echo "  gh pr view $PR_NUMBER --comments"
-  exit 1
+# --- Phase 2: wait for required reviews (Copilot, human, etc.) ---
+# reviewDecision values:
+#   APPROVED         — green, proceed
+#   CHANGES_REQUESTED — blocked, must address
+#   REVIEW_REQUIRED  — waiting on a pending review (Copilot or human)
+#   ""               — no review requirement, proceed
+if [ "$MODE" = "--merge" ]; then
+  while true; do
+    REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
+    if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+      echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
+      echo "  gh pr view $PR_NUMBER --comments"
+      exit 1
+    fi
+    [ "$REVIEW" != "REVIEW_REQUIRED" ] && break
+    echo "Waiting for review on PR #$PR_NUMBER (review required)..."
+    sleep 30
+  done
+else
+  REVIEW=$(gh pr view "$PR_NUMBER" --json reviewDecision -q '.reviewDecision // ""')
+  if [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+    echo "Changes requested on PR #$PR_NUMBER — address review comments before merging."
+    echo "  gh pr view $PR_NUMBER --comments"
+    exit 1
+  fi
+  if [ "$REVIEW" = "REVIEW_REQUIRED" ]; then
+    echo "PR #$PR_NUMBER: CI passed but review is still pending."
+    echo "  $PR_URL"
+    exit 0
+  fi
 fi
 
 echo "PR #$PR_NUMBER passed: $PR_URL"


### PR DESCRIPTION
## Summary

- Replaces single `reviewDecision` check with a polling loop that waits while `REVIEW_REQUIRED`
- Exits 1 immediately on `CHANGES_REQUESTED` with actionable message pointing to `gh pr view --comments`
- Non-merge mode reports review state without blocking
- Both template and `.claude/scripts/` copies updated

## Why

With branch protection now requiring 1 approval, `monitor-pr.sh --merge` would fall through `REVIEW_REQUIRED` and crash at the merge step with a GitHub API error rather than waiting gracefully for Copilot or a human reviewer to finish.

## Test plan

- [x] `uv run pytest` — 156 passed, 4 skipped

Closes #53