### PR TITLE
[PI-41][feat] Rich issue metadata — sub-issues, Backlog flow, typed templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,6 +24,29 @@ body:
       label: Expected behaviour
     validations:
       required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. auth, scaffold, templates, ci"
+  - type: input
+    id: source_project
+    attributes:
+      label: Source project
+      description: If this bug was reported from another project or repo, record it here.
+      placeholder: "owner/repo or owner/repo#N"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: If this bug is tracked under a larger epic. Use #N or owner/repo#N.
+      placeholder: "#42 or VytCepas/other-repo#7"
   - type: textarea
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -13,3 +13,32 @@ body:
     attributes:
       label: Why now?
       description: What breaks or degrades if this is skipped?
+  - type: dropdown
+    id: scale
+    attributes:
+      label: Scale
+      description: Is this a standalone task or a parent grouping sub-tasks?
+      options: [task, epic]
+      default: 0
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Size estimate
+      options: [XS, S, M, L, XL]
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. ci, deps, scaffold, templates"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -15,6 +15,23 @@ body:
       label: Audience
       description: Who needs this documentation?
       placeholder: "Users, maintainers, agents, contributors, operators..."
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. install, scaffold, templates, scripts, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"
   - type: textarea
     id: references
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -27,7 +27,37 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: scale
+    attributes:
+      label: Scale
+      description: Is this a standalone task or a parent epic broken into sub-issues?
+      options: [task, epic]
+      default: 0
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: dropdown
     id: effort
     attributes:
-      label: Effort estimate
+      label: Size estimate
       options: [XS, S, M, L, XL]
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. auth, scaffold, templates, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: If this is a sub-task of a larger epic. Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, external links, or cross-project context
+      placeholder: "- #N\n- owner/repo#N\n- https://..."

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -21,3 +21,20 @@ body:
     attributes:
       label: Suggested approach
       placeholder: "Unit test, scaffold-output diff, CLI test, workflow validation..."
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. scaffold, templates, scripts, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,8 @@ Read this file before any GitHub issue, branch, push, PR, review, CI, or merge w
 - Create issues: `gh issue create` — pick the right template (bug / feature / chore / docs / test)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
 - Branch names use `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, e.g. `chore/PI-40-split-scaffold-tests`
-- Issue and PR names use the Project Init key: `PI-<issue-number>`, e.g. `PI-42`
-- PR titles must follow: `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
+- **Issue titles**: plain description only — no prefix. Type is carried by the label (`feature`, `bug`, etc.) which GitHub shows everywhere. E.g. `Add OAuth login`, not `[feat] Add OAuth login`.
+- **PR titles** must follow `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`. The type prefix is kept here because PR titles become merge commit messages in `git log`, where labels are invisible. This enables changelog generation and quick log scanning.
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
 - PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 - When asked to push/finish a PR, continue autonomously using the review cycle protocol below.

--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -7,7 +7,7 @@ name: Board automation
 #   - PROJECT_NUMBER variable (or hardcoded below): the numeric project board number
 #
 # Column transitions:
-#   issue opened          → To Do
+#   issue opened          → Backlog
 #   PR opened (draft)     → In Progress  (linked issue, via "Closes #N" in body)
 #   PR ready_for_review   → In Review    (linked issue)
 #   PR merged             → Done         (linked issue)
@@ -37,7 +37,7 @@ jobs:
           ACTION="${{ github.event.action }}"
 
           if [[ "$EVENT" == "issues" && "$ACTION" == "opened" ]]; then
-            echo "status=To Do" >> $GITHUB_OUTPUT
+            echo "status=Backlog" >> $GITHUB_OUTPUT
             echo "item_type=issue" >> $GITHUB_OUTPUT
 
           elif [[ "$EVENT" == "pull_request" && "$ACTION" == "opened" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Template naming convention: directories stored as `dot_claude/`, `dot_gitignore`
 - Work is tracked in GitHub Projects backed by GitHub Issues.
 - Branch names must follow `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, for example `chore/PI-40-split-scaffold-tests`.
 - Project Init uses `PI` as the project abbreviation.
-- PR titles must follow `[PI-IssueNumber][type] description` where type is one of `feat`, `fix`, `chore`, `docs`, or `test`.
+- Issue titles: plain description only — type is carried by the label, not the title.
+- PR titles must follow `[PI-IssueNumber][type] description` where type ∈ {feat, fix, chore, docs, test} — the type prefix is kept because PR titles become merge commit messages in git log where labels are invisible.
 - PR bodies must include `Closes #<number>` to auto-link the issue and move the board card on merge.
 - This repo may not have root `.claude/scripts/` files because it is the scaffolder source. Do not run files under `templates/` as this repo's operational automation; those are scaffolded-project artifacts. If a referenced lifecycle script is absent in the root `.claude/scripts/`, use the equivalent `git` / `gh` commands directly.
 

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -6,7 +6,8 @@ project:
   description: "{{project_description}}"
   created: {{created_date}}
   project_init_version: {{project_init_version}}
-  project_key: ""   # e.g. "PI" -> branches use feat/PI-42-slug and PR titles use [PI-42][feat]; blank derives from repo name
+  project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use [PI-42][feat], issue titles use [PI][feat]
+  github_project_number: 1 # numeric GitHub Project V2 board number (used by board-automation.yml and create-issue.sh)
 
 language: {{language}}            # python | node | go | none
 

--- a/templates/base/dot_claude/docs/guides/issue-metadata.md
+++ b/templates/base/dot_claude/docs/guides/issue-metadata.md
@@ -1,0 +1,27 @@
+# Issue metadata
+
+Issues carry planning metadata in two places.
+
+## GitHub labels
+
+Use labels for values that workflows and project boards can read.
+
+- Type labels: `feature`, `bug`, `chore`, `documentation`, `test`
+- Priority labels: `priority:high`, `priority:medium`, `priority:low`
+- Size labels: `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+- Area labels are repository-specific. Use existing labels only; do not invent new area labels from agent context.
+
+`create-issue.sh` creates missing priority and size labels when the token has permission. If label creation fails, the issue is still created and the value remains in the markdown body.
+
+## Markdown body
+
+Use the markdown body for context GitHub does not model portably:
+
+- references to issues, PRs, ADRs, docs, designs, logs, or external links
+- dependencies, blocked-by, parent, and follow-up relationships
+- acceptance criteria
+- implementation notes and affected areas
+- Definition of Ready
+- Definition of Done
+
+GitHub Projects fields are synced opportunistically by `board-automation.yml`. Missing fields or options are logged and skipped so issue creation does not fail in a new repository.

--- a/templates/base/dot_claude/hooks/github-command-guard.sh
+++ b/templates/base/dot_claude/hooks/github-command-guard.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# github-command-guard.sh - steer agents toward the project GitHub workflow.
+# PreToolUse hook on Bash. Receives tool input JSON on stdin.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+CMD=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((data.get('tool_input', {}) or {}).get('command', '') or '')
+" 2>/dev/null || true)
+
+[ -z "$CMD" ] && exit 0
+
+block() {
+  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" "$1"
+  exit 0
+}
+
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])gh[[:space:]]+issue[[:space:]]+create\b'; then
+  if [ -x ".claude/scripts/create-issue.sh" ] || [ -f ".claude/scripts/create-issue.sh" ]; then
+    block "Use .claude/skills/create-issue/SKILL.md and .claude/scripts/create-issue.sh instead of raw gh issue create so priority, references, and acceptance criteria are captured."
+  fi
+fi
+
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+merge\b'; then
+  if ! printf '%s' "$CMD" | grep -q -- '--auto'; then
+    block "Use .claude/scripts/monitor-pr.sh <pr-number> --merge instead of raw gh pr merge so CI and review checks are handled."
+  fi
+fi
+
+if printf '%s' "$CMD" | grep -qE 'git[[:space:]]+push([^|;&]*[[:space:]])?(origin[[:space:]]+)?(main|master)\b'; then
+  block "Direct pushes to main/master are blocked. Use an issue branch and pull request."
+fi
+
+exit 0

--- a/templates/base/dot_claude/hooks/workflow-state-reminder.sh
+++ b/templates/base/dot_claude/hooks/workflow-state-reminder.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-python3 -c '
+printf '%s' "$INPUT" | python3 -c '
 import json
 import re
 import sys

--- a/templates/base/dot_claude/hooks/workflow-state-reminder.sh
+++ b/templates/base/dot_claude/hooks/workflow-state-reminder.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# workflow-state-reminder.sh - inject concise lifecycle reminders for workflow prompts.
+# UserPromptSubmit hook. Receives prompt JSON on stdin.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+python3 -c '
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+prompt = (
+    data.get("prompt")
+    or data.get("user_prompt")
+    or data.get("message")
+    or ""
+)
+
+if not re.search(r"\b(start work|implement|push|merge|finish|create issue|new issue)\b", prompt, re.I):
+    sys.exit(0)
+
+print(json.dumps({
+    "additionalContext": (
+        "Workflow reminder: before GitHub issue, branch, push, PR, review, or merge work, "
+        "check .claude/skills/INDEX.md and load the relevant skill. Use issue -> branch -> "
+        "draft PR -> checks/review -> monitor-pr lifecycle scripts."
+    )
+}))
+'

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -25,6 +25,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Command | `/plan <task>` | acceptance tests first, then implementation plan |
 | Command | `/request-review` | mark PR ready for review, optional agent review |
 | Script | `create-issue.sh <type> "desc"` | create typed issue, prints issue number |
+| Script | `setup-github.sh [branch]` | configure branch protection and review governance |
 | Script | `start-issue.sh <n> <type>` | branch + draft PR |
 | Script | `promote-review.sh` | mark PR ready (board card moves automatically) |
 | Script | `monitor-pr.sh <n> [--merge]` | wait for CI; --merge squash-merges when clean |
@@ -34,7 +35,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Agent | `reviewer` | code review specialist |
 | Agent | `researcher` | codebase explorer |
 
-Hooks run automatically via `settings.json`: `bash-safety-guard`, `pre-commit-gate`, `post-edit-lint`{{#if obsidian}}, `session-end`{{/if}}.
+Hooks run automatically via `settings.json`: `bash-safety-guard`, `github-command-guard`, `workflow-state-reminder`, `pre-commit-gate`, `post-edit-lint`{{#if obsidian}}, `session-end`{{/if}}.
 
 **Rules** (`.claude/rules/`): per-filetype conventions loaded automatically by Claude Code when you open a matching file.
 
@@ -70,7 +71,7 @@ Every non-trivial task follows this exact sequence. Run the scripts; the LLM's o
 
 | Step | Command | What happens automatically |
 |------|---------|---------------------------|
-| 1. Create issue | `.claude/scripts/create-issue.sh <type> "description"` | Issue created, board card → **To Do** |
+| 1. Create issue | `.claude/scripts/create-issue.sh <type> "description" --priority <priority> --area "<area>" --size <size> --acceptance "<criterion>"` | Issue created with metadata, board card → **To Do** |
 | 2. Start work | `.claude/scripts/start-issue.sh <issue-n> <type>` | Branch (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) + push + draft PR, board → **In Progress** |
 | 3. Commit | `git add … && git commit -m "[#n][type] message"` | `commit-msg` hook validates format; `pre-commit-gate` auto-lints |
 | 4. Push | `git push` | CI runs; if it fails a comment is posted on the PR with `gh run view --log-failed` |
@@ -87,6 +88,14 @@ Automated completion via `monitor-pr.sh --merge` works after checks pass. GitHub
 2. **Branch protection rule on `main`** — require CI status checks to pass
 
 Without GitHub-native auto-merge, `monitor-pr.sh --merge` still works by merging explicitly after CI passes.
+
+Run the scaffolded setup helper after creating the repository:
+
+```bash
+.claude/scripts/setup-github.sh
+```
+
+It attempts to configure branch protection, required checks, conversation resolution, and Copilot code review. If GitHub does not expose a setting through the API or your token lacks permission, it prints the manual setup step.
 
 ### Commit and PR format
 
@@ -129,8 +138,9 @@ Run `/request-review` to also invoke the `reviewer` agent (~500 extra tokens). S
 ### Quick reference
 
 ```bash
-.claude/scripts/create-issue.sh <type> "description"  # new issue → prints issue number
+.claude/scripts/create-issue.sh <type> "description" --priority high --area docs --size S --acceptance "Done when ..."  # new issue → prints issue number
 .claude/scripts/start-issue.sh <n> <type>             # branch + draft PR
+.claude/scripts/setup-github.sh                       # one-time branch protection/review setup
 .claude/scripts/promote-review.sh                     # mark PR ready for review
 .claude/scripts/monitor-pr.sh <n> --merge             # wait for CI, merge when clean
 gh run view --log-failed                              # see what CI failed

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -29,7 +29,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Script | `start-issue.sh <n> <type>` | branch + draft PR |
 | Script | `promote-review.sh` | mark PR ready (board card moves automatically) |
 | Script | `monitor-pr.sh <n> [--merge]` | wait for CI; --merge squash-merges when clean |
-| Script | `finish-pr.sh [n]` | push branch, mark ready, monitor checks/review, and merge |
+| Script | `finish-pr.sh [n] [--review-cycle N]` | push branch, mark ready, monitor checks/review, and merge |
 | Skill | `session-summary` | summarise session and save to vault |
 | Skill | `add-hook` | add a new deterministic hook |
 | Skill | `add-command` | add a new slash command |

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -29,6 +29,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Script | `start-issue.sh <n> <type>` | branch + draft PR |
 | Script | `promote-review.sh` | mark PR ready (board card moves automatically) |
 | Script | `monitor-pr.sh <n> [--merge]` | wait for CI; --merge squash-merges when clean |
+| Script | `finish-pr.sh [n]` | push branch, mark ready, monitor checks/review, and merge |
 | Skill | `session-summary` | summarise session and save to vault |
 | Skill | `add-hook` | add a new deterministic hook |
 | Skill | `add-command` | add a new slash command |
@@ -75,10 +76,9 @@ Every non-trivial task follows this exact sequence. Run the scripts; the LLM's o
 | 2. Start work | `.claude/scripts/start-issue.sh <issue-n> <type>` | Branch (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) + push + draft PR, board → **In Progress** |
 | 3. Commit | `git add … && git commit -m "[#n][type] message"` | `commit-msg` hook validates format; `pre-commit-gate` auto-lints |
 | 4. Push | `git push` | CI runs; if it fails a comment is posted on the PR with `gh run view --log-failed` |
-| 5. Mark ready | `.claude/scripts/promote-review.sh` | PR marked ready for review, board → **In Review** |
-| 6. Monitor & merge | `.claude/scripts/monitor-pr.sh <n> --merge` | Blocks until CI passes, then squash-merges; board → **Done** |
+| 5. Finish PR | `.claude/scripts/finish-pr.sh <n>` | Pushes, marks ready, monitors CI/review, and merges when clean |
 
-Steps 3–4 repeat until the work is complete. **When asked to push or finish a PR, keep going until the lifecycle is complete**: push → promote → `monitor-pr.sh --merge` → fix any CI failures → repeat until merged.
+Steps 3–4 repeat until the work is complete. **When asked to push or finish a PR, keep going until the lifecycle is complete**: `finish-pr.sh` → fix any CI or review failures → rerun with the next review cycle until merged.
 
 ### Merge setup (one-time per repo)
 
@@ -143,6 +143,7 @@ Run `/request-review` to also invoke the `reviewer` agent (~500 extra tokens). S
 .claude/scripts/setup-github.sh                       # one-time branch protection/review setup
 .claude/scripts/promote-review.sh                     # mark PR ready for review
 .claude/scripts/monitor-pr.sh <n> --merge             # wait for CI, merge when clean
+.claude/scripts/finish-pr.sh <n>                      # push, ready, monitor, merge
 gh run view --log-failed                              # see what CI failed
 gh issue list                                         # open issues
 gh pr list                                            # open PRs

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -75,42 +75,61 @@ contains_word() {
   echo "$haystack" | grep -qw "$needle"
 }
 
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [ -z "$value" ]; then
+    echo "ERROR: missing value for '$option'" >&2
+    usage >&2
+    exit 1
+  fi
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --priority)
-      PRIORITY="${2:-}"
+      require_option_value "$1" "${2:-}"
+      PRIORITY="$2"
       shift 2
       ;;
     --area)
-      AREA="${2:-}"
+      require_option_value "$1" "${2:-}"
+      AREA="$2"
       shift 2
       ;;
     --size)
-      SIZE="${2:-}"
+      require_option_value "$1" "${2:-}"
+      SIZE="$2"
       shift 2
       ;;
     --reference)
-      REFERENCES+=("${2:-}")
+      require_option_value "$1" "${2:-}"
+      REFERENCES+=("$2")
       shift 2
       ;;
     --dependency)
-      DEPENDENCIES+=("${2:-}")
+      require_option_value "$1" "${2:-}"
+      DEPENDENCIES+=("$2")
       shift 2
       ;;
     --acceptance)
-      ACCEPTANCE+=("${2:-}")
+      require_option_value "$1" "${2:-}"
+      ACCEPTANCE+=("$2")
       shift 2
       ;;
     --assignee)
-      ASSIGNEE="${2:-}"
+      require_option_value "$1" "${2:-}"
+      ASSIGNEE="$2"
       shift 2
       ;;
     --milestone)
-      MILESTONE="${2:-}"
+      require_option_value "$1" "${2:-}"
+      MILESTONE="$2"
       shift 2
       ;;
     --body-file)
-      BODY_FILE="${2:-}"
+      require_option_value "$1" "${2:-}"
+      BODY_FILE="$2"
       shift 2
       ;;
     -h|--help)

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -11,17 +11,6 @@
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Project config — read from .claude/config.yaml when present.
-# project_key: if set (e.g. "PI"), the issue title becomes [PI][feat] description.
-# ---------------------------------------------------------------------------
-PROJECT_KEY=""
-if [ -f ".claude/config.yaml" ]; then
-  PROJECT_KEY=$(grep -m1 'project_key:' .claude/config.yaml \
-    | sed 's/.*project_key:[[:space:]]*//' \
-    | tr -d '"'"'"'[:space:]')
-fi
-
 VALID_TYPES="feat fix chore docs test"
 VALID_PRIORITIES="high medium low"
 VALID_SIZES="XS S M L XL"
@@ -48,11 +37,6 @@ Options:
   --milestone NAME                Set milestone by name
   --body-file FILE                Append extra markdown body content
   -h, --help                      Show this help
-
-Project key:
-  If .claude/config.yaml has a non-empty project_key, the title becomes
-  [KEY][type] description (e.g. [PI][feat] Add OAuth login). This makes issues
-  identifiable when viewed from a cross-repo GitHub Project board.
 
 Sub-issues:
   --parent links the new issue as a native GitHub sub-issue of the given parent.
@@ -252,11 +236,7 @@ case "$TYPE" in
   test)  TYPE_LABEL="test" ;;
 esac
 
-if [ -n "$PROJECT_KEY" ]; then
-  TITLE="[$PROJECT_KEY][$TYPE] $DESCRIPTION"
-else
-  TITLE="[$TYPE] $DESCRIPTION"
-fi
+TITLE="$DESCRIPTION"
 
 BODY_PATH=$(mktemp)
 trap 'rm -f "$BODY_PATH"' EXIT

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -1,39 +1,131 @@
 #!/bin/bash
-# Create a GitHub issue with enforced type prefix and body template.
+# Create a GitHub issue with typed labels and planning metadata.
 #
 # Usage:
-#   .claude/scripts/create-issue.sh <type> "Short description"
+#   .claude/scripts/create-issue.sh <type> "Short description" [metadata flags]
 #
 # Types: feat  fix  chore  docs  test
 #
 # Prints the created issue number to stdout so it can be piped:
-#   .claude/scripts/create-issue.sh feat "Add OAuth login" | xargs -I{} .claude/scripts/start-issue.sh {} feat
+#   .claude/scripts/create-issue.sh feat "Add OAuth login" --priority high | xargs -I{} .claude/scripts/start-issue.sh {} feat
 
 set -euo pipefail
 
 VALID_TYPES="feat fix chore docs test"
+VALID_PRIORITIES="high medium low"
+VALID_SIZES="XS S M L XL"
 
 usage() {
-  echo "Usage: create-issue.sh <type> \"Short description\""
-  echo ""
-  echo "Types: $VALID_TYPES"
-  echo ""
-  echo "Examples:"
-  echo "  create-issue.sh feat \"Add OAuth login\""
-  echo "  create-issue.sh fix \"Handle null pointer in auth\""
-  echo "  create-issue.sh chore \"Bump dev dependencies\""
-  exit 1
+  cat <<'EOF'
+Usage: create-issue.sh <type> "Short description" [options]
+
+Types:
+  feat  fix  chore  docs  test
+
+Options:
+  --priority high|medium|low      Apply priority label and body metadata
+  --area VALUE                    Record affected area in body metadata
+  --size XS|S|M|L|XL              Apply size label and body metadata
+  --reference VALUE               Add a reference; repeatable
+  --dependency VALUE              Add a dependency; repeatable
+  --acceptance VALUE              Add an acceptance criterion; repeatable
+  --assignee USER                 Assign the issue
+  --milestone NAME                Set milestone by name
+  --body-file FILE                Append extra markdown body content
+  -h, --help                      Show this help
+
+Metadata model:
+  GitHub labels: type, priority, and size when labels exist or can be created.
+  Markdown body: area, references, dependencies, acceptance criteria, notes,
+  Definition of Ready, and Definition of Done.
+
+Missing label fallback:
+  If a label is missing and cannot be created, issue creation continues without
+  that label because the same metadata is still stored in the markdown body.
+EOF
 }
 
-# --- Validate args ---
-if [ $# -lt 2 ]; then
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
   usage
+  exit 0
+fi
+
+if [ $# -lt 2 ]; then
+  usage >&2
+  exit 1
 fi
 
 TYPE="$1"
 DESCRIPTION="$2"
+shift 2
 
-if ! echo "$VALID_TYPES" | grep -qw "$TYPE"; then
+PRIORITY=""
+AREA=""
+SIZE=""
+ASSIGNEE=""
+MILESTONE=""
+BODY_FILE=""
+REFERENCES=()
+DEPENDENCIES=()
+ACCEPTANCE=()
+
+contains_word() {
+  local needle="$1"
+  local haystack="$2"
+  echo "$haystack" | grep -qw "$needle"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --priority)
+      PRIORITY="${2:-}"
+      shift 2
+      ;;
+    --area)
+      AREA="${2:-}"
+      shift 2
+      ;;
+    --size)
+      SIZE="${2:-}"
+      shift 2
+      ;;
+    --reference)
+      REFERENCES+=("${2:-}")
+      shift 2
+      ;;
+    --dependency)
+      DEPENDENCIES+=("${2:-}")
+      shift 2
+      ;;
+    --acceptance)
+      ACCEPTANCE+=("${2:-}")
+      shift 2
+      ;;
+    --assignee)
+      ASSIGNEE="${2:-}"
+      shift 2
+      ;;
+    --milestone)
+      MILESTONE="${2:-}"
+      shift 2
+      ;;
+    --body-file)
+      BODY_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! contains_word "$TYPE" "$VALID_TYPES"; then
   echo "ERROR: invalid type '$TYPE'. Valid types: $VALID_TYPES" >&2
   exit 1
 fi
@@ -43,99 +135,150 @@ if [ -z "$DESCRIPTION" ]; then
   exit 1
 fi
 
-# --- Map type to label ---
+if [ -n "$PRIORITY" ] && ! contains_word "$PRIORITY" "$VALID_PRIORITIES"; then
+  echo "ERROR: invalid priority '$PRIORITY'. Valid priorities: $VALID_PRIORITIES" >&2
+  exit 1
+fi
+
+if [ -n "$SIZE" ] && ! contains_word "$SIZE" "$VALID_SIZES"; then
+  echo "ERROR: invalid size '$SIZE'. Valid sizes: $VALID_SIZES" >&2
+  exit 1
+fi
+
+if [ -n "$BODY_FILE" ] && [ ! -f "$BODY_FILE" ]; then
+  echo "ERROR: body file not found: $BODY_FILE" >&2
+  exit 1
+fi
+
 case "$TYPE" in
-  feat)  LABEL="feature" ;;
-  fix)   LABEL="bug" ;;
-  chore) LABEL="chore" ;;
-  docs)  LABEL="documentation" ;;
-  test)  LABEL="test" ;;
+  feat)  TYPE_LABEL="feature" ;;
+  fix)   TYPE_LABEL="bug" ;;
+  chore) TYPE_LABEL="chore" ;;
+  docs)  TYPE_LABEL="documentation" ;;
+  test)  TYPE_LABEL="test" ;;
 esac
 
 TITLE="[$TYPE] $DESCRIPTION"
+BODY_PATH=$(mktemp)
+trap 'rm -f "$BODY_PATH"' EXIT
 
-# --- Body template per type ---
-case "$TYPE" in
-  feat)
-    BODY="$(cat <<'TMPL'
-## Problem
+write_list() {
+  local fallback="$1"
+  shift
+  if [ "$#" -eq 0 ]; then
+    echo "- [ ] $fallback"
+    return
+  fi
+  for item in "$@"; do
+    [ -n "$item" ] && echo "- [ ] $item"
+  done
+}
 
-<!-- What gap or friction does this address? -->
+write_bullets() {
+  local fallback="$1"
+  shift
+  if [ "$#" -eq 0 ]; then
+    echo "- $fallback"
+    return
+  fi
+  for item in "$@"; do
+    [ -n "$item" ] && echo "- $item"
+  done
+}
 
-## Solution
+{
+  echo "## Summary"
+  echo
+  echo "$DESCRIPTION"
+  echo
+  echo "## Metadata"
+  echo
+  echo "- Type: $TYPE"
+  echo "- Priority: ${PRIORITY:-unset}"
+  echo "- Area: ${AREA:-unset}"
+  echo "- Size: ${SIZE:-unset}"
+  if [ -n "$ASSIGNEE" ]; then
+    echo "- Assignee: @$ASSIGNEE"
+  fi
+  if [ -n "$MILESTONE" ]; then
+    echo "- Milestone: $MILESTONE"
+  fi
+  echo
+  echo "## References"
+  echo
+  write_bullets "None" "${REFERENCES[@]}"
+  echo
+  echo "## Dependencies"
+  echo
+  write_bullets "None" "${DEPENDENCIES[@]}"
+  echo
+  echo "## Acceptance criteria"
+  echo
+  write_list "Define acceptance criteria before implementation" "${ACCEPTANCE[@]}"
+  echo
+  echo "## Implementation notes"
+  echo
+  echo "- Affected area: ${AREA:-unset}"
+  echo
+  echo "## Definition of Ready"
+  echo
+  echo "- [ ] Priority, area, size, and acceptance criteria are set"
+  echo "- [ ] Dependencies and references are captured or marked none"
+  echo
+  echo "## Definition of Done"
+  echo
+  echo "- [ ] Acceptance criteria are met"
+  echo "- [ ] Tests and documentation are updated where needed"
+} > "$BODY_PATH"
 
-<!-- High-level description of the approach -->
+if [ -n "$BODY_FILE" ]; then
+  {
+    echo
+    echo "## Additional context"
+    echo
+    cat "$BODY_FILE"
+  } >> "$BODY_PATH"
+fi
 
-## Acceptance criteria
+ensure_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+  if gh label list --search "$name" --json name -q '.[].name' 2>/dev/null | grep -Fxq "$name"; then
+    echo "$name"
+    return
+  fi
+  if gh label create "$name" --color "$color" --description "$description" >/dev/null 2>&1; then
+    echo "$name"
+    return
+  fi
+  echo "Warning: label missing and could not be created: $name" >&2
+}
 
-- [ ] ...
-TMPL
-)"
-    ;;
-  fix)
-    BODY="$(cat <<'TMPL'
-## Steps to reproduce
+LABEL_ARGS=()
+if LABEL=$(ensure_label "$TYPE_LABEL" "0075ca" "Issue type"); then
+  [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
+fi
+if [ -n "$PRIORITY" ]; then
+  if LABEL=$(ensure_label "priority:$PRIORITY" "d93f0b" "Issue priority"); then
+    [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
+  fi
+fi
+if [ -n "$SIZE" ]; then
+  if LABEL=$(ensure_label "size:$SIZE" "5319e7" "Issue size"); then
+    [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
+  fi
+fi
 
-1. ...
+CREATE_ARGS=(--title "$TITLE" --body-file "$BODY_PATH")
+if [ -n "$ASSIGNEE" ]; then
+  CREATE_ARGS+=(--assignee "$ASSIGNEE")
+fi
+if [ -n "$MILESTONE" ]; then
+  CREATE_ARGS+=(--milestone "$MILESTONE")
+fi
 
-## Expected behaviour
-
-...
-
-## Actual behaviour
-
-...
-
-## Root cause (if known)
-
-...
-TMPL
-)"
-    ;;
-  chore)
-    BODY="$(cat <<'TMPL'
-## What and why
-
-<!-- What is changing and why it's needed -->
-
-## Notes
-
-...
-TMPL
-)"
-    ;;
-  docs)
-    BODY="$(cat <<'TMPL'
-## What to document
-
-<!-- Which area needs documentation and why it's currently lacking -->
-TMPL
-)"
-    ;;
-  test)
-    BODY="$(cat <<'TMPL'
-## What to test
-
-<!-- Which behaviour is currently untested and why it matters -->
-
-## Approach
-
-...
-TMPL
-)"
-    ;;
-esac
-
-# --- Create issue (gracefully skip label if it doesn't exist) ---
-ISSUE_URL=$(gh issue create \
-  --title "$TITLE" \
-  --body "$BODY" \
-  --label "$LABEL" 2>/dev/null \
-  || gh issue create \
-       --title "$TITLE" \
-       --body "$BODY")
-
-# Extract issue number from URL (e.g. https://github.com/owner/repo/issues/42)
+ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" "${LABEL_ARGS[@]}")
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
 echo "$ISSUE_NUMBER"

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -11,9 +11,21 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Project config — read from .claude/config.yaml when present.
+# project_key: if set (e.g. "PI"), the issue title becomes [PI][feat] description.
+# ---------------------------------------------------------------------------
+PROJECT_KEY=""
+if [ -f ".claude/config.yaml" ]; then
+  PROJECT_KEY=$(grep -m1 'project_key:' .claude/config.yaml \
+    | sed 's/.*project_key:[[:space:]]*//' \
+    | tr -d '"'"'"'[:space:]')
+fi
+
 VALID_TYPES="feat fix chore docs test"
 VALID_PRIORITIES="high medium low"
 VALID_SIZES="XS S M L XL"
+VALID_SCALES="epic task"
 
 usage() {
   cat <<'EOF'
@@ -26,6 +38,9 @@ Options:
   --priority high|medium|low      Apply priority label and body metadata
   --area VALUE                    Record affected area in body metadata
   --size XS|S|M|L|XL              Apply size label and body metadata
+  --scale epic|task               Mark as epic (parent) or task (leaf); adds scale label
+  --parent VALUE                  Link new issue as sub-issue of VALUE
+                                  Formats: 42, #42, owner/repo#42, or full issue URL
   --reference VALUE               Add a reference; repeatable
   --dependency VALUE              Add a dependency; repeatable
   --acceptance VALUE              Add an acceptance criterion; repeatable
@@ -34,9 +49,19 @@ Options:
   --body-file FILE                Append extra markdown body content
   -h, --help                      Show this help
 
+Project key:
+  If .claude/config.yaml has a non-empty project_key, the title becomes
+  [KEY][type] description (e.g. [PI][feat] Add OAuth login). This makes issues
+  identifiable when viewed from a cross-repo GitHub Project board.
+
+Sub-issues:
+  --parent links the new issue as a native GitHub sub-issue of the given parent.
+  Cross-repo parents use owner/repo#42 or the full issue URL.
+  --scale epic marks this issue as a parent work item (adds scale:epic label).
+
 Metadata model:
-  GitHub labels: type, priority, and size when labels exist or can be created.
-  Markdown body: area, references, dependencies, acceptance criteria, notes,
+  GitHub labels: type, priority, size, and scale when labels exist or can be created.
+  Markdown body: area, scale, parent, references, dependencies, acceptance criteria,
   Definition of Ready, and Definition of Done.
 
 Missing label fallback:
@@ -62,6 +87,8 @@ shift 2
 PRIORITY=""
 AREA=""
 SIZE=""
+SCALE=""
+PARENT=""
 ASSIGNEE=""
 MILESTONE=""
 BODY_FILE=""
@@ -100,6 +127,16 @@ while [ $# -gt 0 ]; do
     --size)
       require_option_value "$1" "${2:-}"
       SIZE="$2"
+      shift 2
+      ;;
+    --scale)
+      require_option_value "$1" "${2:-}"
+      SCALE="$2"
+      shift 2
+      ;;
+    --parent)
+      require_option_value "$1" "${2:-}"
+      PARENT="$2"
       shift 2
       ;;
     --reference)
@@ -164,9 +201,47 @@ if [ -n "$SIZE" ] && ! contains_word "$SIZE" "$VALID_SIZES"; then
   exit 1
 fi
 
+if [ -n "$SCALE" ] && ! contains_word "$SCALE" "$VALID_SCALES"; then
+  echo "ERROR: invalid scale '$SCALE'. Valid scales: $VALID_SCALES" >&2
+  exit 1
+fi
+
 if [ -n "$BODY_FILE" ] && [ ! -f "$BODY_FILE" ]; then
   echo "ERROR: body file not found: $BODY_FILE" >&2
   exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Parse --parent reference into owner / repo / number.
+# Accepts: 42, #42, owner/repo#42, or full GitHub issue URL.
+# Sets globals PARENT_OWNER, PARENT_REPO, PARENT_NUMBER.
+# ---------------------------------------------------------------------------
+PARENT_OWNER=""
+PARENT_REPO=""
+PARENT_NUMBER=""
+
+parse_parent() {
+  local raw="${1#\#}"   # strip leading #
+  if [[ "$raw" =~ ^https://github\.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
+    PARENT_OWNER="${BASH_REMATCH[1]}"
+    PARENT_REPO="${BASH_REMATCH[2]}"
+    PARENT_NUMBER="${BASH_REMATCH[3]}"
+  elif [[ "$raw" =~ ^([^/#]+)/([^#]+)#([0-9]+)$ ]]; then
+    PARENT_OWNER="${BASH_REMATCH[1]}"
+    PARENT_REPO="${BASH_REMATCH[2]}"
+    PARENT_NUMBER="${BASH_REMATCH[3]}"
+  elif [[ "$raw" =~ ^[0-9]+$ ]]; then
+    PARENT_OWNER=$(gh repo view --json owner -q .owner.login)
+    PARENT_REPO=$(gh repo view --json name -q .name)
+    PARENT_NUMBER="$raw"
+  else
+    echo "ERROR: cannot parse parent '$1'. Use: 42, #42, owner/repo#42, or full URL" >&2
+    exit 1
+  fi
+}
+
+if [ -n "$PARENT" ]; then
+  parse_parent "$PARENT"
 fi
 
 case "$TYPE" in
@@ -177,7 +252,12 @@ case "$TYPE" in
   test)  TYPE_LABEL="test" ;;
 esac
 
-TITLE="[$TYPE] $DESCRIPTION"
+if [ -n "$PROJECT_KEY" ]; then
+  TITLE="[$PROJECT_KEY][$TYPE] $DESCRIPTION"
+else
+  TITLE="[$TYPE] $DESCRIPTION"
+fi
+
 BODY_PATH=$(mktemp)
 trap 'rm -f "$BODY_PATH"' EXIT
 
@@ -213,9 +293,13 @@ write_bullets() {
   echo "## Metadata"
   echo
   echo "- Type: $TYPE"
+  echo "- Scale: ${SCALE:-task}"
   echo "- Priority: ${PRIORITY:-unset}"
   echo "- Area: ${AREA:-unset}"
   echo "- Size: ${SIZE:-unset}"
+  if [ -n "$PARENT" ]; then
+    echo "- Parent: $PARENT_OWNER/$PARENT_REPO#$PARENT_NUMBER"
+  fi
   if [ -n "$ASSIGNEE" ]; then
     echo "- Assignee: @$ASSIGNEE"
   fi
@@ -288,6 +372,11 @@ if [ -n "$SIZE" ]; then
     [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
   fi
 fi
+if [ -n "$SCALE" ]; then
+  if LABEL=$(ensure_label "scale:$SCALE" "f9d0c4" "Issue scale"); then
+    [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
+  fi
+fi
 
 CREATE_ARGS=(--title "$TITLE" --body-file "$BODY_PATH")
 if [ -n "$ASSIGNEE" ]; then
@@ -299,5 +388,36 @@ fi
 
 ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" "${LABEL_ARGS[@]}")
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
+# ---------------------------------------------------------------------------
+# Link as a native GitHub sub-issue when --parent was specified.
+# Uses the addSubIssue GraphQL mutation (supports cross-repo parents via URL).
+# ---------------------------------------------------------------------------
+if [ -n "$PARENT" ]; then
+  PARENT_NODE_ID=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) { id }
+      }
+    }' \
+    -f owner="$PARENT_OWNER" \
+    -f repo="$PARENT_REPO" \
+    -F number="$PARENT_NUMBER" \
+    --jq '.data.repository.issue.id')
+
+  CHILD_NODE_ID=$(gh api "repos/:owner/:repo/issues/$ISSUE_NUMBER" --jq '.node_id')
+
+  gh api graphql -f query='
+    mutation($parent: ID!, $child: ID!) {
+      addSubIssue(input: { issueId: $parent, subIssueId: $child }) {
+        issue { number }
+        subIssue { number }
+      }
+    }' \
+    -f parent="$PARENT_NODE_ID" \
+    -f child="$CHILD_NODE_ID" > /dev/null
+
+  echo "Linked #$ISSUE_NUMBER as sub-issue of $PARENT_OWNER/$PARENT_REPO#$PARENT_NUMBER" >&2
+fi
 
 echo "$ISSUE_NUMBER"

--- a/templates/base/dot_claude/scripts/finish-pr.sh
+++ b/templates/base/dot_claude/scripts/finish-pr.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Push the current branch, mark the PR ready, then monitor checks/review and merge.
+#
+# Usage:
+#   .claude/scripts/finish-pr.sh [pr-number] [--review-cycle N]
+#
+# If pr-number is omitted, detects the PR from the current branch.
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+CYCLE_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --review-cycle)
+      CYCLE_ARGS+=("$1" "${2:-0}")
+      shift 2
+      ;;
+    --review-cycle=*)
+      CYCLE_ARGS+=("$1")
+      shift
+      ;;
+    *)
+      if [ -z "$PR_NUMBER" ]; then
+        PR_NUMBER="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        echo "Usage: finish-pr.sh [pr-number] [--review-cycle N]" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/push-branch.sh"
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+  if [ -z "$PR_NUMBER" ]; then
+    echo "ERROR: no PR found for current branch. Pass a PR number explicitly." >&2
+    exit 1
+  fi
+fi
+
+"$SCRIPT_DIR/promote-review.sh" "$PR_NUMBER"
+
+set +e
+"$SCRIPT_DIR/monitor-pr.sh" "$PR_NUMBER" --merge "${CYCLE_ARGS[@]}"
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 2 ]; then
+  echo ""
+  echo "Review fixes are required before merge. Reply to each review comment, commit fixes, then rerun:"
+  if [ "${#CYCLE_ARGS[@]}" -gt 0 ]; then
+    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER <next review-cycle from monitor-pr output>"
+  else
+    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER --review-cycle 1"
+  fi
+fi
+
+exit "$STATUS"

--- a/templates/base/dot_claude/scripts/finish-pr.sh
+++ b/templates/base/dot_claude/scripts/finish-pr.sh
@@ -14,7 +14,12 @@ CYCLE_ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --review-cycle)
-      CYCLE_ARGS+=("$1" "${2:-0}")
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Missing value for --review-cycle" >&2
+        echo "Usage: finish-pr.sh [pr-number] [--review-cycle N]" >&2
+        exit 2
+      fi
+      CYCLE_ARGS+=("$1" "$2")
       shift 2
       ;;
     --review-cycle=*)

--- a/templates/base/dot_claude/scripts/finish-pr.sh
+++ b/templates/base/dot_claude/scripts/finish-pr.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-PR_NUMBER="${1:-}"
+PR_NUMBER=""
 CYCLE_ARGS=()
 
 while [ $# -gt 0 ]; do

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -109,7 +109,7 @@ if _review_decision_failed "$CHECKS"; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
       echo ""
       echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — force-merging with admin override."
-      GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$"
+      GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$" || true
       echo "Merged PR #$PR_NUMBER (admin)"
       exit 0
     else
@@ -134,7 +134,7 @@ echo "PR #$PR_NUMBER passed: $PR_URL"
 if [ "$MODE" = "--merge" ]; then
   # Try direct merge first; if branch protection blocks it, fall back to --auto
   if ! GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch 2>/dev/null; then
-    GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --auto 2>&1 | grep -v "^$"
+    GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --auto 2>&1 | grep -v "^$" || true
     echo "Auto-merge enabled for PR #$PR_NUMBER — will merge once all requirements are met."
   else
     echo "Merged PR #$PR_NUMBER"

--- a/templates/base/dot_claude/scripts/setup-github.sh
+++ b/templates/base/dot_claude/scripts/setup-github.sh
@@ -27,7 +27,7 @@ cat > "$PROTECTION" <<'JSON'
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "Validate PR",
+      "Validate PR / Check PR title, branch, and linked issue",
       "review/decision"
     ]
   },

--- a/templates/base/dot_claude/scripts/setup-github.sh
+++ b/templates/base/dot_claude/scripts/setup-github.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Configure or check GitHub repository governance for the scaffolded workflow.
+#
+# Requires: gh and admin permission on the repository.
+
+set -euo pipefail
+
+BRANCH="${1:-main}"
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated. Run gh auth login first." >&2
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+
+echo "Configuring GitHub governance for $REPO ($BRANCH)"
+# Default endpoint: repos/$OWNER/$NAME/branches/main/protection
+
+PROTECTION=$(mktemp)
+trap 'rm -f "$PROTECTION"' EXIT
+
+cat > "$PROTECTION" <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Validate PR",
+      "review/decision"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+
+if gh api "repos/$OWNER/$NAME/branches/$BRANCH/protection" -X PUT --input "$PROTECTION" >/dev/null; then
+  echo "Branch protection applied to $BRANCH"
+else
+  echo "WARNING: could not apply branch protection. Check admin permissions and repository plan." >&2
+fi
+
+if gh api "repos/$OWNER/$NAME/code-review-settings" -X PUT -f copilot_code_review_enabled=true >/dev/null 2>&1; then
+  echo "Copilot code review enabled"
+else
+  echo "WARNING: Enable Copilot code review manually if your plan supports it:" >&2
+  echo "  https://github.com/$OWNER/$NAME/settings/code_review" >&2
+fi
+
+echo "GitHub governance setup complete."

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -32,6 +32,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-ci-check.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/github-command-guard.sh",
+            "timeout": 10
           }
         ]
       }
@@ -44,6 +49,17 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-lint.sh",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/workflow-state-reminder.sh",
+            "timeout": 10
           }
         ]
       }

--- a/templates/base/dot_claude/skills/INDEX.md
+++ b/templates/base/dot_claude/skills/INDEX.md
@@ -4,7 +4,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 
 | When you need to... | Load this skill |
 |---|---|
-| Create a GitHub Issue | `.claude/skills/create-issue/SKILL.md` (if present) or use `create-issue.sh` |
+| Create a GitHub Issue | `.claude/skills/create-issue/SKILL.md` |
 | Start a new task (branch + draft PR) | `.claude/skills/start-task/SKILL.md` |
 | Push, review, or merge a PR | `.claude/skills/github-workflow/SKILL.md` (if present) or follow `.github/copilot-instructions.md` |
 | Summarize the session | `.claude/skills/session-summary/SKILL.md` |

--- a/templates/base/dot_claude/skills/create-issue/SKILL.md
+++ b/templates/base/dot_claude/skills/create-issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+description: Create a GitHub Issue with planning metadata
+argument-hint: "[type] [title]"
+allowed-tools: Bash Read
+---
+
+Use this skill whenever creating a GitHub Issue.
+
+## Metadata to gather
+
+Before creating the issue, determine:
+
+- type: `feat`, `fix`, `chore`, `docs`, or `test`
+- title: short imperative description
+- priority: `high`, `medium`, or `low`
+- area: existing repo area label or plain body metadata
+- size: `XS`, `S`, `M`, `L`, or `XL`
+- references: related issues, PRs, ADRs, docs, designs, logs, or external links
+- dependencies: blocked-by, parent, or follow-up relationships
+- acceptance criteria: concrete checklist items
+
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+
+## Rules
+
+- Use `.claude/scripts/create-issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
+- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Store relationships that GitHub does not support portably in markdown sections.
+- Check for duplicate issues before creating a new one:
+  ```bash
+  gh issue list --state open --search "<keywords>"
+  ```
+
+## Create
+
+Run:
+
+```bash
+.claude/scripts/create-issue.sh <type> "<title>" \
+  --priority <high|medium|low> \
+  --area "<area>" \
+  --size <XS|S|M|L|XL> \
+  --reference "<reference>" \
+  --dependency "<dependency>" \
+  --acceptance "<criterion>"
+```
+
+Repeat `--reference`, `--dependency`, and `--acceptance` as needed.
+
+## Report
+
+After creation, report the issue number and URL:
+
+```bash
+gh issue view <number> --json url -q .url
+```

--- a/templates/base/dot_claude/skills/start-task/SKILL.md
+++ b/templates/base/dot_claude/skills/start-task/SKILL.md
@@ -14,9 +14,9 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
 
 2. **Check for existing issue** — run `gh issue list` and ask: "Does a GitHub Issue already exist for this? If so, provide the number and skip to step 4."
 
-3. **Create the issue**:
+3. **Create the issue** — load `.claude/skills/create-issue/SKILL.md` and follow it. It gathers priority, area, size, references, dependencies, and acceptance criteria before running:
    ```bash
-   ISSUE_NUMBER=$(.claude/scripts/create-issue.sh <type> "<title>")
+   ISSUE_NUMBER=$(.claude/scripts/create-issue.sh <type> "<title>" --priority <priority> --area "<area>" --size <size> --acceptance "<criterion>")
    echo "Created issue #$ISSUE_NUMBER"
    ```
 

--- a/templates/base/dot_github/ISSUE_TEMPLATE/bug.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/bug.yml
@@ -2,6 +2,27 @@ name: Bug
 description: Something is broken
 labels: [bug]
 body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: frontend, backend, docs, devops, product
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: [XS, S, M, L, XL]
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
@@ -29,3 +50,35 @@ body:
     attributes:
       label: Environment
       placeholder: "OS, runtime version, dependency versions"
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, docs, designs, logs, or external links.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by, parent, or follow-up relationships.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: ready
+    attributes:
+      label: Definition of Ready
+      placeholder: What must be true before implementation starts?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: What must be true before this can close?
+    validations:
+      required: true

--- a/templates/base/dot_github/ISSUE_TEMPLATE/chore.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/chore.yml
@@ -2,6 +2,27 @@ name: Chore
 description: Maintenance, refactor, dependency update, or CI change
 labels: [chore]
 body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: frontend, backend, docs, devops, product
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: [XS, S, M, L, XL]
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
@@ -13,3 +34,35 @@ body:
     attributes:
       label: Why now?
       description: What breaks or degrades if this is skipped?
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, docs, designs, or external links.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by, parent, or follow-up relationships.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: ready
+    attributes:
+      label: Definition of Ready
+      placeholder: What must be true before implementation starts?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: What must be true before this can close?
+    validations:
+      required: true

--- a/templates/base/dot_github/ISSUE_TEMPLATE/config.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Planning discussion
+    url: https://github.com
+    about: Use discussions for exploratory ideas that are not ready for issue tracking.

--- a/templates/base/dot_github/ISSUE_TEMPLATE/docs.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/docs.yml
@@ -2,6 +2,27 @@ name: Docs
 description: Documentation addition or correction
 labels: [documentation]
 body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: docs, product, devops, frontend, backend
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: [XS, S, M, L, XL]
+    validations:
+      required: true
   - type: textarea
     id: scope
     attributes:
@@ -20,3 +41,30 @@ body:
     attributes:
       label: References
       description: Related issues, PRs, ADRs, files, or external links
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by, parent, or follow-up relationships.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: ready
+    attributes:
+      label: Definition of Ready
+      placeholder: What must be true before implementation starts?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: What must be true before this can close?
+    validations:
+      required: true

--- a/templates/base/dot_github/ISSUE_TEMPLATE/feature.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/feature.yml
@@ -2,6 +2,27 @@ name: Feature
 description: New feature or enhancement
 labels: [feature]
 body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: frontend, backend, docs, devops, product
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: [XS, S, M, L, XL]
+    validations:
+      required: true
   - type: input
     id: title
     attributes:
@@ -24,6 +45,30 @@ body:
       placeholder: |
         - [ ] Criterion 1
         - [ ] Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, docs, designs, or external links.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by, parent, or follow-up relationships.
+  - type: textarea
+    id: ready
+    attributes:
+      label: Definition of Ready
+      placeholder: What must be true before implementation starts?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: What must be true before this can close?
     validations:
       required: true
   - type: dropdown

--- a/templates/base/dot_github/ISSUE_TEMPLATE/test.yml
+++ b/templates/base/dot_github/ISSUE_TEMPLATE/test.yml
@@ -2,6 +2,27 @@ name: Test
 description: Missing or insufficient test coverage
 labels: [test]
 body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: frontend, backend, docs, devops, product
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      options: [XS, S, M, L, XL]
+    validations:
+      required: true
   - type: textarea
     id: behavior
     attributes:
@@ -21,3 +42,35 @@ body:
     attributes:
       label: Suggested approach
       placeholder: "Unit test, scaffold-output diff, CLI test, workflow validation..."
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, docs, designs, or external links.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by, parent, or follow-up relationships.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: ready
+    attributes:
+      label: Definition of Ready
+      placeholder: What must be true before implementation starts?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: What must be true before this can close?
+    validations:
+      required: true

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -15,6 +15,7 @@ Canonical agent rules: [CLAUDE.md](../CLAUDE.md) | Workflow: [.claude/project-in
 - Draft PRs are opened immediately when work starts, not when done
 - When asked to push/finish a PR, continue autonomously using the review cycle protocol below.
 - Never use bare `git push` for branch publishing — always use `.claude/scripts/push-branch.sh` so transient GitHub errors don't silently fail.
+- Prefer `.claude/scripts/finish-pr.sh <pr-number>` when the user asks to finish a PR; it pushes, marks ready, runs `monitor-pr.sh --merge`, and preserves the review-cycle behavior.
 - No direct commits to `main`
 
 ### Review cycle protocol (max 2 rounds, then admin merge)

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -5,7 +5,7 @@ Canonical agent rules: [CLAUDE.md](../CLAUDE.md) | Workflow: [.claude/project-in
 ## Issue & project tracking
 
 - Tracking system: **GitHub Projects** (kanban board) + **GitHub Issues** (tickets)
-- Create issues: `gh issue create` — use the right template (bug / feature / chore / docs / test)
+- Create issues: load `.claude/skills/create-issue/SKILL.md` and use `.claude/scripts/create-issue.sh`; it handles metadata gathering, priority labels, and acceptance criteria
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
 - Use a dedicated branch for each issue; format it as `<issue_type>/<project_abbr>-<issue_number>-<slug>`, e.g. `feat/PI-42-add-auth`; no direct commits to `main`
 - Issue and PR names use a project key: `<PROJECT-KEY>-<issue-number>`, e.g. `PI-42`

--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -1,103 +1,85 @@
 name: Board automation
 
-# Moves GitHub Project board cards based on issue and PR lifecycle events.
+# Syncs issue and PR lifecycle state to GitHub Projects v2.
 #
-# Setup (one-time):
-#   1. Create a PAT with 'project' scope at https://github.com/settings/tokens
-#   2. Store it as a repository secret named PROJECT_TOKEN
-#   3. Create a GitHub Project board for this repo
-#   4. Set PROJECT_NUMBER below to match your board's number
-#
-# Column transitions:
-#   issue opened          → To Do
-#   PR opened (draft)     → In Progress  (linked issue, via "Closes #N" in PR body)
-#   PR ready_for_review   → In Review    (linked issue)
-#   PR merged             → Done         (linked issue)
+# Setup:
+#   1. Create a PAT with Projects access.
+#   2. Store it as PROJECT_TOKEN.
+#   3. Set PROJECT_NUMBER to the target project number.
+#   4. Optional project fields: Status, Priority, Area, Size.
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited, reopened, labeled, unlabeled]
   pull_request:
     types: [opened, ready_for_review, closed]
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
-  board-move:
+  board-sync:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
       OWNER: ${{ github.repository_owner }}
-      PROJECT_NUMBER: 1   # replace with your project board number
+      REPO_NAME: ${{ github.event.repository.name }}
+      PROJECT_NUMBER: 1
 
     steps:
-      - name: Determine target status
-        id: status
-        run: |
-          EVENT="${{ github.event_name }}"
-          ACTION="${{ github.event.action }}"
-
-          if [[ "$EVENT" == "issues" && "$ACTION" == "opened" ]]; then
-            echo "status=To Do" >> $GITHUB_OUTPUT
-            echo "item_type=issue" >> $GITHUB_OUTPUT
-
-          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "opened" ]]; then
-            echo "status=In Progress" >> $GITHUB_OUTPUT
-            echo "item_type=pr" >> $GITHUB_OUTPUT
-
-          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "ready_for_review" ]]; then
-            echo "status=In Review" >> $GITHUB_OUTPUT
-            echo "item_type=pr" >> $GITHUB_OUTPUT
-
-          elif [[ "$EVENT" == "pull_request" && "$ACTION" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            echo "status=Done" >> $GITHUB_OUTPUT
-            echo "item_type=pr" >> $GITHUB_OUTPUT
-
-          else
-            echo "status=skip" >> $GITHUB_OUTPUT
-            echo "item_type=skip" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve issue number
-        id: issue
-        if: steps.status.outputs.status != 'skip'
+      - name: Determine issue and status
+        id: context
         env:
-          ITEM_TYPE: ${{ steps.status.outputs.item_type }}
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          if [[ "$ITEM_TYPE" == "issue" ]]; then
-            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-          else
-            # Extract linked issue from PR body ("Closes #N", "Fixes #N", "Resolves #N")
-            ISSUE_NUM=$(echo "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1)
-            if [[ -z "$ISSUE_NUM" ]]; then
-              echo "No linked issue found in PR body — skipping board move" >&2
-              echo "number=" >> $GITHUB_OUTPUT
-            else
-              echo "number=$ISSUE_NUM" >> $GITHUB_OUTPUT
-            fi
+          set -euo pipefail
+
+          status="skip"
+          issue=""
+
+          if [ "$EVENT" = "issues" ]; then
+            issue="$ISSUE_NUMBER"
+            status="To Do"
+          elif [ "$EVENT" = "pull_request" ] && [ "$ACTION" = "opened" ]; then
+            issue=$(printf '%s\n' "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1 || true)
+            status="In Progress"
+          elif [ "$EVENT" = "pull_request" ] && [ "$ACTION" = "ready_for_review" ]; then
+            issue=$(printf '%s\n' "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1 || true)
+            status="In Review"
+          elif [ "$EVENT" = "pull_request" ] && [ "$ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
+            issue=$(printf '%s\n' "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1 || true)
+            status="Done"
           fi
 
-      - name: Move card on board
-        if: steps.status.outputs.status != 'skip' && steps.issue.outputs.number != ''
-        env:
-          ISSUE_NUM: ${{ steps.issue.outputs.number }}
-          TARGET_STATUS: ${{ steps.status.outputs.status }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
+          echo "issue=$issue" >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
 
-          # Fetch project metadata
+      - name: Sync project item fields
+        if: steps.context.outputs.issue != '' && steps.context.outputs.status != 'skip'
+        env:
+          ISSUE_NUM: ${{ steps.context.outputs.issue }}
+          TARGET_STATUS: ${{ steps.context.outputs.status }}
+        run: |
+          set -euo pipefail
+
           PROJECT_DATA=$(gh api graphql -f query='
             query($owner: String!, $number: Int!) {
               user(login: $owner) {
                 projectV2(number: $number) {
                   id
-                  field(name: "Status") {
-                    ... on ProjectV2SingleSelectField {
-                      id
-                      options { id name }
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options { id name }
+                      }
                     }
                   }
                   items(first: 100) {
@@ -110,51 +92,71 @@ jobs:
                   }
                 }
               }
-            }' -f owner="$OWNER" -F number=$PROJECT_NUMBER)
+            }' -f owner="$OWNER" -F number="$PROJECT_NUMBER")
 
-          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id')
-          FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.field.id')
-          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg s "$TARGET_STATUS" \
-            '.data.user.projectV2.field.options[] | select(.name == $s) | .id')
-          ITEM_ID=$(echo "$PROJECT_DATA" | jq -r --argjson n $ISSUE_NUM \
-            '.data.user.projectV2.items.nodes[] | select(.content.number == $n) | .id')
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id // empty')
+          ITEM_ID=$(echo "$PROJECT_DATA" | jq -r --argjson n "$ISSUE_NUM" '.data.user.projectV2.items.nodes[] | select(.content.number == $n) | .id')
 
-          if [[ -z "$ITEM_ID" ]]; then
-            echo "Issue #$ISSUE_NUM not found on board — adding it first"
+          if [ -z "$PROJECT_ID" ]; then
+            echo "Skipping project sync: project not found or PROJECT_TOKEN lacks access"
+            exit 0
+          fi
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue #$ISSUE_NUM not found on board; adding it first"
             ISSUE_NODE_ID=$(gh api graphql -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   issue(number: $number) { id }
                 }
-              }' -f owner="$OWNER" -f repo="$REPO_NAME" \
-                 -F number=$ISSUE_NUM | jq -r '.data.repository.issue.id')
+              }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number="$ISSUE_NUM" | jq -r '.data.repository.issue.id')
 
             ITEM_ID=$(gh api graphql -f query='
               mutation($project: ID!, $content: ID!) {
                 addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
                   item { id }
                 }
-              }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" \
-              | jq -r '.data.addProjectV2ItemById.item.id')
+              }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id')
           fi
 
-          if [[ -z "$ITEM_ID" || -z "$OPTION_ID" ]]; then
-            echo "Could not resolve item ($ITEM_ID) or option ($OPTION_ID) — skipping" >&2
-            exit 0
-          fi
+          ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --json labels,body)
+          PRIORITY=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name | select(startswith("priority:"))][0] // empty' | sed 's/^priority://')
+          SIZE=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name | select(startswith("size:"))][0] // empty' | sed 's/^size://')
+          AREA=$(echo "$ISSUE_DATA" | jq -r '.body' | sed -n 's/^- Area: //Ip' | head -1)
 
-          gh api graphql -f query='
-            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $field
-                value: { singleSelectOptionId: $option }
-              }) { projectV2Item { id } }
-            }' \
-            -f project="$PROJECT_ID" \
-            -f item="$ITEM_ID" \
-            -f field="$FIELD_ID" \
-            -f option="$OPTION_ID"
+          update_single_select() {
+            local field_name="$1"
+            local option_name="$2"
+            [ -n "$option_name" ] || return 0
 
-          echo "Moved issue #$ISSUE_NUM to '$TARGET_STATUS' on project board"
+            local field_id
+            local option_id
+            field_id=$(echo "$PROJECT_DATA" | jq -r --arg f "$field_name" '.data.user.projectV2.fields.nodes[] | select(.name == $f) | .id')
+            if [ -z "$field_id" ]; then
+              echo "Skipping missing project field: $field_name"
+              return 0
+            fi
+
+            option_id=$(echo "$PROJECT_DATA" | jq -r --arg f "$field_name" --arg o "$option_name" '.data.user.projectV2.fields.nodes[] | select(.name == $f) | .options[] | select(.name == $o) | .id')
+            if [ -z "$option_id" ]; then
+              echo "Skipping missing project option: $field_name=$option_name"
+              return 0
+            fi
+
+            gh api graphql -f query='
+              mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { projectV2Item { id } }
+              }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f option="$option_id"
+          }
+
+          update_single_select "Status" "$TARGET_STATUS"
+          update_single_select "Priority" "$PRIORITY"
+          update_single_select "Area" "$AREA"
+          update_single_select "Size" "$SIZE"
+
+          echo "Synced issue #$ISSUE_NUM to GitHub Project metadata fields"

--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -45,7 +45,11 @@ jobs:
 
           if [ "$EVENT" = "issues" ]; then
             issue="$ISSUE_NUMBER"
-            status="To Do"
+            if [ "$ACTION" = "opened" ] || [ "$ACTION" = "reopened" ]; then
+              status="To Do"
+            else
+              status="metadata"
+            fi
           elif [ "$EVENT" = "pull_request" ] && [ "$ACTION" = "opened" ]; then
             issue=$(printf '%s\n' "$PR_BODY" | grep -oiP '(closes|fixes|resolves)\s+#\K[0-9]+' | head -1 || true)
             status="In Progress"
@@ -92,15 +96,39 @@ jobs:
                   }
                 }
               }
+              organization(login: $owner) {
+                projectV2(number: $number) {
+                  id
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options { id name }
+                      }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue { number }
+                      }
+                    }
+                  }
+                }
+              }
             }' -f owner="$OWNER" -F number="$PROJECT_NUMBER")
 
-          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id // empty')
-          ITEM_ID=$(echo "$PROJECT_DATA" | jq -r --argjson n "$ISSUE_NUM" '.data.user.projectV2.items.nodes[] | select(.content.number == $n) | .id')
+          PROJECT=$(echo "$PROJECT_DATA" | jq -c '.data.user.projectV2 // .data.organization.projectV2 // empty')
+          PROJECT_ID=$(echo "$PROJECT" | jq -r '.id // empty')
 
           if [ -z "$PROJECT_ID" ]; then
             echo "Skipping project sync: project not found or PROJECT_TOKEN lacks access"
             exit 0
           fi
+
+          ITEM_ID=$(echo "$PROJECT" | jq -r --argjson n "$ISSUE_NUM" '(.items.nodes // [])[] | select(.content.number == $n) | .id')
 
           if [ -z "$ITEM_ID" ]; then
             echo "Issue #$ISSUE_NUM not found on board; adding it first"
@@ -122,7 +150,30 @@ jobs:
           ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --json labels,body)
           PRIORITY=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name | select(startswith("priority:"))][0] // empty' | sed 's/^priority://')
           SIZE=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name | select(startswith("size:"))][0] // empty' | sed 's/^size://')
-          AREA=$(echo "$ISSUE_DATA" | jq -r '.body' | sed -n 's/^- Area: //Ip' | head -1)
+          parse_area() {
+            local body="$1"
+            local area
+
+            area=$(printf '%s\n' "$body" | sed -n 's/^- Area: //Ip' | head -1)
+            if [ -n "$area" ]; then
+              printf '%s\n' "$area"
+              return 0
+            fi
+
+            printf '%s\n' "$body" | awk '
+              BEGIN { in_area = 0 }
+              /^[[:space:]]*###[[:space:]]+Area[[:space:]]*$/ {
+                in_area = 1
+                next
+              }
+              in_area && /^[[:space:]]*$/ { next }
+              in_area {
+                print
+                exit
+              }
+            '
+          }
+          AREA=$(parse_area "$(echo "$ISSUE_DATA" | jq -r '.body')")
 
           update_single_select() {
             local field_name="$1"
@@ -131,13 +182,13 @@ jobs:
 
             local field_id
             local option_id
-            field_id=$(echo "$PROJECT_DATA" | jq -r --arg f "$field_name" '.data.user.projectV2.fields.nodes[] | select(.name == $f) | .id')
+            field_id=$(echo "$PROJECT" | jq -r --arg f "$field_name" '(.fields.nodes // [])[] | select(.name == $f) | .id')
             if [ -z "$field_id" ]; then
               echo "Skipping missing project field: $field_name"
               return 0
             fi
 
-            option_id=$(echo "$PROJECT_DATA" | jq -r --arg f "$field_name" --arg o "$option_name" '.data.user.projectV2.fields.nodes[] | select(.name == $f) | .options[] | select(.name == $o) | .id')
+            option_id=$(echo "$PROJECT" | jq -r --arg f "$field_name" --arg o "$option_name" '(.fields.nodes // [])[] | select(.name == $f) | (.options // [])[] | select(.name == $o) | .id')
             if [ -z "$option_id" ]; then
               echo "Skipping missing project option: $field_name=$option_name"
               return 0
@@ -154,7 +205,9 @@ jobs:
               }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f option="$option_id"
           }
 
-          update_single_select "Status" "$TARGET_STATUS"
+          if [ "$TARGET_STATUS" != "metadata" ]; then
+            update_single_select "Status" "$TARGET_STATUS"
+          fi
           update_single_select "Priority" "$PRIORITY"
           update_single_select "Area" "$AREA"
           update_single_select "Size" "$SIZE"

--- a/templates/base/dot_github/workflows/issue-validation.yml
+++ b/templates/base/dot_github/workflows/issue-validation.yml
@@ -1,0 +1,67 @@
+name: Validate issue metadata
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  validate-issue:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate required planning metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          LABELS_JSON: ${{ toJson(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+
+          require_text() {
+            local name="$1"
+            local pattern="$2"
+            if ! printf '%s\n' "$ISSUE_BODY" | grep -qiE "$pattern"; then
+              missing+=("$name")
+            fi
+          }
+
+          require_label_prefix() {
+            local name="$1"
+            local prefix="$2"
+            if ! printf '%s\n' "$LABELS_JSON" | grep -q "\"name\":\"$prefix"; then
+              missing+=("$name")
+            fi
+          }
+
+          require_text "Priority" 'Priority'
+          require_text "Area" 'Area'
+          require_text "Size" 'Size'
+          require_text "References" 'References'
+          require_text "Dependencies" 'Dependencies'
+          require_text "Acceptance criteria" 'Acceptance criteria'
+          require_text "Definition of Ready" 'Definition of Ready'
+          require_text "Definition of Done" 'Definition of Done'
+          require_label_prefix "type label" ""
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            gh issue edit "$ISSUE_NUMBER" --add-label "status:needs-info" || true
+            {
+              echo "This issue is missing required planning metadata:"
+              echo
+              for item in "${missing[@]}"; do
+                echo "- $item"
+              done
+              echo
+              echo "Update the issue body or labels, then the status:needs-info label will be removed automatically."
+            } > /tmp/issue-validation-comment.md
+            gh issue comment "$ISSUE_NUMBER" --body-file /tmp/issue-validation-comment.md
+            exit 1
+          fi
+
+          gh issue edit "$ISSUE_NUMBER" --remove-label "status:needs-info" || true
+          echo "Issue metadata is complete."

--- a/templates/base/dot_github/workflows/issue-validation.yml
+++ b/templates/base/dot_github/workflows/issue-validation.yml
@@ -2,7 +2,7 @@ name: Validate issue metadata
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, labeled, unlabeled]
 
 permissions:
   issues: write
@@ -22,33 +22,43 @@ jobs:
 
           missing=()
 
-          require_text() {
+          has_body_value() {
             local name="$1"
-            local pattern="$2"
-            if ! printf '%s\n' "$ISSUE_BODY" | grep -qiE "$pattern"; then
+            local bullet_pattern="^- ${name}: (unset|[[:space:]]*)$"
+            if ! printf '%s\n' "$ISSUE_BODY" | grep -qiE "$name"; then
+              missing+=("$name")
+              return
+            fi
+            if printf '%s\n' "$ISSUE_BODY" | grep -qiE "$bullet_pattern"; then
               missing+=("$name")
             fi
           }
 
-          require_label_prefix() {
-            local name="$1"
-            local prefix="$2"
-            if ! printf '%s\n' "$LABELS_JSON" | grep -q "\"name\":\"$prefix"; then
-              missing+=("$name")
+          has_type_label() {
+            if ! printf '%s\n' "$LABELS_JSON" | jq -e 'any(.[].name; . == "feature" or . == "bug" or . == "chore" or . == "documentation" or . == "test")' >/dev/null; then
+              missing+=("type label")
             fi
           }
 
-          require_text "Priority" 'Priority'
-          require_text "Area" 'Area'
-          require_text "Size" 'Size'
-          require_text "References" 'References'
-          require_text "Dependencies" 'Dependencies'
-          require_text "Acceptance criteria" 'Acceptance criteria'
-          require_text "Definition of Ready" 'Definition of Ready'
-          require_text "Definition of Done" 'Definition of Done'
-          require_label_prefix "type label" ""
+          has_priority_label() {
+            if ! printf '%s\n' "$LABELS_JSON" | jq -e 'any(.[].name; . == "priority:high" or . == "priority:medium" or . == "priority:low")' >/dev/null; then
+              missing+=("priority label")
+            fi
+          }
+
+          has_body_value "Priority"
+          has_body_value "Area"
+          has_body_value "Size"
+          has_body_value "References"
+          has_body_value "Dependencies"
+          has_body_value "Acceptance criteria"
+          has_body_value "Definition of Ready"
+          has_body_value "Definition of Done"
+          has_type_label
+          has_priority_label
 
           if [ "${#missing[@]}" -gt 0 ]; then
+            gh label create "status:needs-info" --color "d93f0b" --description "Issue is missing required planning metadata" 2>/dev/null || true
             gh issue edit "$ISSUE_NUMBER" --add-label "status:needs-info" || true
             {
               echo "This issue is missing required planning metadata:"

--- a/templates/base/dot_github/workflows/validate-pr.yml
+++ b/templates/base/dot_github/workflows/validate-pr.yml
@@ -6,47 +6,82 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
+  issues: read
   pull-requests: read
 
 jobs:
-  pr-title:
-    name: Check PR title format
+  pr-format-and-issue:
+    name: Check PR title, branch, and linked issue
     runs-on: ubuntu-24.04
     steps:
-      - name: Validate title format with type
+      - name: Validate PR workflow metadata
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          if echo "$PR_TITLE" | grep -qE '^\[([A-Z][A-Z0-9]{1,9}-[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
-            echo "PR title format OK: $PR_TITLE"
-          else
+          set -euo pipefail
+
+          if ! echo "$PR_TITLE" | grep -qE '^\[([A-Z][A-Z0-9]{1,9}-[0-9]+|nojira)\]\[(feat|fix|chore|docs|test)\]'; then
             echo "ERROR: PR title must match format: [PROJECT-123][type] or [nojira][type]"
             echo "Valid types: feat, fix, chore, docs, test"
-            echo "Examples:"
-            echo "  [PI-42][feat] Add OAuth login"
-            echo "  [APP-99][fix] Handle null pointer in auth"
-            echo "  [nojira][fix] Fix typo in README"
             exit 1
           fi
 
-  closes-keyword:
-    name: Check for Closes keyword in PR body
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Validate Closes keyword
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          # Skip Closes check for nojira PRs (no linked issue)
+          if [ "$PR_BRANCH" = "main" ] || [ "$PR_BRANCH" = "master" ]; then
+            echo "ERROR: PR branch must not be main or master"
+            exit 1
+          fi
+
           if echo "$PR_TITLE" | grep -qE '^\[nojira\]'; then
-            echo "nojira PR — skipping Closes keyword check"
+            echo "nojira PR - skipping Closes keyword check"
             exit 0
           fi
-          # For issue PRs, require Closes keyword
-          if echo "$PR_BODY" | grep -qiE 'closes\s+#[0-9]+'; then
-            echo "Closes keyword found"
-          else
+
+          if ! echo "$PR_BODY" | grep -qiE 'closes\s+#[0-9]+'; then
             echo "ERROR: PR body must include 'Closes #<number>' to auto-close the linked issue"
             exit 1
           fi
+
+          ISSUE_NUM=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | head -1 | grep -oE '[0-9]+')
+          ISSUE_KEY=$(echo "$PR_TITLE" | grep -oE '^\[[A-Z][A-Z0-9]{1,9}-[0-9]+\]' | tr -d '[]')
+          PR_TYPE=$(echo "$PR_TITLE" | grep -oE '\]\[(feat|fix|chore|docs|test)\]' | tr -d '[]')
+
+          if ! echo "$PR_BRANCH" | grep -qE '^(feat|fix|chore|docs|test)/[A-Z][A-Z0-9]{1,9}-[0-9]+-[a-z0-9][a-z0-9-]*$'; then
+            echo "ERROR: branch must match <type>/<PROJECT>-<issue-number>-<slug>"
+            exit 1
+          fi
+
+          BRANCH_KEY=$(echo "$PR_BRANCH" | grep -oE '[A-Z][A-Z0-9]{1,9}-[0-9]+')
+          if [ "$BRANCH_KEY" != "$ISSUE_KEY" ]; then
+            echo "ERROR: branch issue key ($BRANCH_KEY) must match PR title issue key ($ISSUE_KEY)"
+            exit 1
+          fi
+
+          ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --json state,labels)
+          ISSUE_STATE=$(echo "$ISSUE_DATA" | jq -r '.state')
+          if [ "$ISSUE_STATE" = "CLOSED" ]; then
+            echo "Linked issue is closed: #$ISSUE_NUM"
+            exit 1
+          fi
+
+          if echo "$ISSUE_DATA" | jq -e '.labels[].name == "status:needs-info"' >/dev/null; then
+            echo "ERROR: linked issue #$ISSUE_NUM is labeled status:needs-info"
+            exit 1
+          fi
+
+          case "$PR_TYPE" in
+            feat) EXPECTED_LABEL="feature" ;;
+            fix) EXPECTED_LABEL="bug" ;;
+            chore) EXPECTED_LABEL="chore" ;;
+            docs) EXPECTED_LABEL="documentation" ;;
+            test) EXPECTED_LABEL="test" ;;
+          esac
+
+          if ! echo "$ISSUE_DATA" | jq -e --arg label "$EXPECTED_LABEL" '.labels[].name == $label' >/dev/null; then
+            echo "ERROR: PR type '$PR_TYPE' does not match linked issue label '$EXPECTED_LABEL'"
+            exit 1
+          fi
+
+          echo "PR metadata is valid."

--- a/templates/base/dot_github/workflows/validate-pr.yml
+++ b/templates/base/dot_github/workflows/validate-pr.yml
@@ -39,12 +39,13 @@ jobs:
             exit 0
           fi
 
-          if ! echo "$PR_BODY" | grep -qiE 'closes\s+#[0-9]+'; then
-            echo "ERROR: PR body must include 'Closes #<number>' to auto-close the linked issue"
+          ISSUE_REF_REGEX='(closes|fixes|resolves)\s+#[0-9]+'
+          if ! echo "$PR_BODY" | grep -qiE "$ISSUE_REF_REGEX"; then
+            echo "ERROR: PR body must include 'Closes #<number>', 'Fixes #<number>', or 'Resolves #<number>' to auto-close the linked issue"
             exit 1
           fi
 
-          ISSUE_NUM=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | head -1 | grep -oE '[0-9]+')
+          ISSUE_NUM=$(echo "$PR_BODY" | grep -oiE "$ISSUE_REF_REGEX" | head -1 | grep -oE '[0-9]+')
           ISSUE_KEY=$(echo "$PR_TITLE" | grep -oE '^\[[A-Z][A-Z0-9]{1,9}-[0-9]+\]' | tr -d '[]')
           PR_TYPE=$(echo "$PR_TITLE" | grep -oE '\]\[(feat|fix|chore|docs|test)\]' | tr -d '[]')
 
@@ -66,7 +67,7 @@ jobs:
             exit 1
           fi
 
-          if echo "$ISSUE_DATA" | jq -e '.labels[].name == "status:needs-info"' >/dev/null; then
+          if echo "$ISSUE_DATA" | jq -e 'any(.labels[].name; . == "status:needs-info")' >/dev/null; then
             echo "ERROR: linked issue #$ISSUE_NUM is labeled status:needs-info"
             exit 1
           fi
@@ -79,7 +80,7 @@ jobs:
             test) EXPECTED_LABEL="test" ;;
           esac
 
-          if ! echo "$ISSUE_DATA" | jq -e --arg label "$EXPECTED_LABEL" '.labels[].name == $label' >/dev/null; then
+          if ! echo "$ISSUE_DATA" | jq -e --arg label "$EXPECTED_LABEL" 'any(.labels[].name; . == $label)' >/dev/null; then
             echo "ERROR: PR type '$PR_TYPE' does not match linked issue label '$EXPECTED_LABEL'"
             exit 1
           fi

--- a/templates/obsidian/dot_claude/settings.json.tmpl
+++ b/templates/obsidian/dot_claude/settings.json.tmpl
@@ -27,6 +27,16 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-gate.sh",
             "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-ci-check.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/github-command-guard.sh",
+            "timeout": 10
           }
         ]
       }
@@ -39,6 +49,17 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-lint.sh",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/workflow-state-reminder.sh",
+            "timeout": 10
           }
         ]
       }

--- a/tests/test_issue_metadata_workflow.py
+++ b/tests/test_issue_metadata_workflow.py
@@ -46,6 +46,10 @@ class TestIssueMetadataScaffold:
         assert "runs-on: ubuntu-24.04" in content
         assert "status:needs-info" in content
         assert "issues:" in content
+        assert "labeled, unlabeled" in content
+        assert "priority label" in content
+        assert "gh label create \"status:needs-info\"" in content
+        assert "unset" in content
 
     def test_board_automation_syncs_metadata_fields(self):
         content = (
@@ -58,12 +62,18 @@ class TestIssueMetadataScaffold:
         assert "Area" in content
         assert "Size" in content
         assert "Skipping missing project field" in content
+        assert "organization(login: $owner)" in content
+        assert "parse_area()" in content
+        assert "metadata" in content
+        assert "(.items.nodes // [])[]" in content
 
     def test_validate_pr_checks_issue_readiness(self):
         content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()
         assert "status:needs-info" in content
         assert "<type>/<PROJECT>-<issue-number>-<slug>" in content
         assert "Linked issue is closed" in content
+        assert "ISSUE_REF_REGEX" in content
+        assert "any(.labels[].name" in content
 
     def test_issue_metadata_docs_created(self):
         doc = self.target / ".claude" / "docs" / "guides" / "issue-metadata.md"
@@ -76,6 +86,7 @@ class TestIssueMetadataScaffold:
         content = script.read_text()
         assert "branches/main/protection" in content
         assert "Copilot code review" in content
+        assert "Validate PR / Check PR title, branch, and linked issue" in content
 
     def test_project_init_references_github_setup(self):
         content = (self.target / ".claude" / "project-init.md").read_text()
@@ -126,6 +137,15 @@ class TestCreateIssueScript:
     def test_script_documents_missing_label_fallback(self):
         content = self.script.read_text()
         assert "label missing" in content.lower() or "missing label" in content.lower()
+
+    def test_script_reports_missing_option_value(self):
+        result = subprocess.run(
+            [str(self.script), "feat", "Example", "--priority"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "missing value for '--priority'" in result.stderr
 
 
 class TestCreateIssueSkill:
@@ -198,3 +218,17 @@ class TestGitHubWorkflowHooks:
         ]
         assert any("github-command-guard.sh" in command for command in pre_commands)
         assert "UserPromptSubmit" in data["hooks"]
+
+    def test_workflow_state_reminder_reads_prompt_stdin(self):
+        hook = self.target / ".claude" / "hooks" / "workflow-state-reminder.sh"
+        payload = json.dumps({"prompt": "please finish this PR"})
+        result = subprocess.run(
+            [str(hook)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=self.target,
+        )
+        out = json.loads(result.stdout)
+        assert "additionalContext" in out

--- a/tests/test_issue_metadata_workflow.py
+++ b/tests/test_issue_metadata_workflow.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+class TestIssueMetadataScaffold:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        scaffold(tmp_target, preset, make_variables())
+
+    def test_issue_template_config_disables_blank_issues(self):
+        content = (
+            self.target / ".github" / "ISSUE_TEMPLATE" / "config.yml"
+        ).read_text()
+        assert "blank_issues_enabled: false" in content
+
+    def test_issue_forms_have_shared_metadata_fields(self):
+        required = [
+            "Priority",
+            "Area",
+            "Size",
+            "References",
+            "Dependencies",
+            "Acceptance criteria",
+            "Definition of Ready",
+            "Definition of Done",
+        ]
+        templates = self.target / ".github" / "ISSUE_TEMPLATE"
+        for name in ("bug.yml", "feature.yml", "chore.yml", "docs.yml", "test.yml"):
+            content = (templates / name).read_text()
+            for label in required:
+                assert label in content, f"{name} missing {label}"
+
+    def test_issue_validation_workflow_created(self):
+        workflow = self.target / ".github" / "workflows" / "issue-validation.yml"
+        content = workflow.read_text()
+        assert "runs-on: ubuntu-24.04" in content
+        assert "status:needs-info" in content
+        assert "issues:" in content
+
+    def test_board_automation_syncs_metadata_fields(self):
+        content = (
+            self.target / ".github" / "workflows" / "board-automation.yml"
+        ).read_text()
+        assert "PROJECT_TOKEN" in content
+        assert "addProjectV2ItemById" in content
+        assert "updateProjectV2ItemFieldValue" in content
+        assert "Priority" in content
+        assert "Area" in content
+        assert "Size" in content
+        assert "Skipping missing project field" in content
+
+    def test_validate_pr_checks_issue_readiness(self):
+        content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()
+        assert "status:needs-info" in content
+        assert "<type>/<PROJECT>-<issue-number>-<slug>" in content
+        assert "Linked issue is closed" in content
+
+    def test_issue_metadata_docs_created(self):
+        doc = self.target / ".claude" / "docs" / "guides" / "issue-metadata.md"
+        content = doc.read_text()
+        assert "GitHub labels" in content
+        assert "markdown body" in content
+
+    def test_setup_github_script_created(self):
+        script = self.target / ".claude" / "scripts" / "setup-github.sh"
+        content = script.read_text()
+        assert "branches/main/protection" in content
+        assert "Copilot code review" in content
+
+    def test_project_init_references_github_setup(self):
+        content = (self.target / ".claude" / "project-init.md").read_text()
+        assert ".claude/scripts/setup-github.sh" in content
+
+
+class TestCreateIssueScript:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        scaffold(tmp_target, preset, make_variables())
+        self.script = self.target / ".claude" / "scripts" / "create-issue.sh"
+
+    def test_help_documents_metadata_flags(self):
+        result = subprocess.run(
+            [str(self.script), "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        help_text = result.stdout
+        for flag in (
+            "--priority",
+            "--area",
+            "--size",
+            "--reference",
+            "--dependency",
+            "--acceptance",
+            "--assignee",
+            "--milestone",
+            "--body-file",
+        ):
+            assert flag in help_text
+
+    def test_script_generates_metadata_body_sections(self):
+        content = self.script.read_text()
+        for section in (
+            "## Metadata",
+            "## References",
+            "## Dependencies",
+            "## Acceptance criteria",
+            "## Definition of Ready",
+            "## Definition of Done",
+        ):
+            assert section in content
+
+    def test_script_documents_missing_label_fallback(self):
+        content = self.script.read_text()
+        assert "label missing" in content.lower() or "missing label" in content.lower()
+
+
+class TestCreateIssueSkill:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        scaffold(tmp_target, preset, make_variables())
+
+    def test_create_issue_skill_scaffolded(self):
+        skill = self.target / ".claude" / "skills" / "create-issue" / "SKILL.md"
+        content = skill.read_text()
+        assert "priority" in content.lower()
+        assert ".claude/scripts/create-issue.sh" in content
+
+    def test_skill_index_references_create_issue_skill(self):
+        content = (self.target / ".claude" / "skills" / "INDEX.md").read_text()
+        assert ".claude/skills/create-issue/SKILL.md" in content
+
+    def test_start_task_delegates_issue_creation_to_skill(self):
+        content = (
+            self.target / ".claude" / "skills" / "start-task" / "SKILL.md"
+        ).read_text()
+        assert ".claude/skills/create-issue/SKILL.md" in content
+
+
+class TestGitHubWorkflowHooks:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        scaffold(tmp_target, preset, make_variables())
+
+    def _run_hook(self, name: str, command: str) -> dict[str, str] | None:
+        hook = self.target / ".claude" / "hooks" / name
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        result = subprocess.run(
+            [str(hook)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=self.target,
+        )
+        if not result.stdout.strip():
+            return None
+        return json.loads(result.stdout)
+
+    def test_github_command_guard_blocks_raw_issue_create(self):
+        out = self._run_hook("github-command-guard.sh", "gh issue create --title X")
+        assert out is not None and out["decision"] == "block"
+
+    def test_github_command_guard_blocks_raw_pr_merge(self):
+        out = self._run_hook("github-command-guard.sh", "gh pr merge 42 --squash")
+        assert out is not None and out["decision"] == "block"
+
+    def test_github_command_guard_allows_monitor_pr_merge(self):
+        out = self._run_hook(
+            "github-command-guard.sh",
+            ".claude/scripts/monitor-pr.sh 42 --merge",
+        )
+        assert out is None
+
+    def test_settings_wire_workflow_hooks(self):
+        data = json.loads((self.target / ".claude" / "settings.json").read_text())
+        pre_commands = [
+            hook["command"]
+            for group in data["hooks"]["PreToolUse"]
+            for hook in group["hooks"]
+        ]
+        assert any("github-command-guard.sh" in command for command in pre_commands)
+        assert "UserPromptSubmit" in data["hooks"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -182,6 +182,16 @@ class TestScaffoldGitHubFiles:
         assert "--json" in content  # uses json polling, not --watch, to suppress noise
         assert "--delete-branch" in content
 
+    def test_finish_pr_wraps_push_ready_monitor_flow(self):
+        script = self.target / ".claude" / "scripts" / "finish-pr.sh"
+        assert script.is_file()
+        assert script.stat().st_mode & 0o111, "finish-pr.sh must be executable"
+        content = script.read_text()
+        assert "push-branch.sh" in content
+        assert "promote-review.sh" in content
+        assert "monitor-pr.sh" in content
+        assert "--review-cycle" in content
+
     def test_validate_pr_enforces_project_key_title_format(self):
         """PR title must match [PROJECT-123][type] or [nojira][type] format."""
         content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -192,6 +192,7 @@ class TestScaffoldGitHubFiles:
         assert "promote-review.sh" in content
         assert "monitor-pr.sh" in content
         assert 'PR_NUMBER=""' in content
+        assert "Missing value for --review-cycle" in content
         assert "--review-cycle" in content
 
     def test_validate_pr_enforces_project_key_title_format(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -181,6 +181,7 @@ class TestScaffoldGitHubFiles:
         assert "gh pr checks" in content
         assert "--json" in content  # uses json polling, not --watch, to suppress noise
         assert "--delete-branch" in content
+        assert 'grep -v "^$" || true' in content
 
     def test_finish_pr_wraps_push_ready_monitor_flow(self):
         script = self.target / ".claude" / "scripts" / "finish-pr.sh"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -190,6 +190,7 @@ class TestScaffoldGitHubFiles:
         assert "push-branch.sh" in content
         assert "promote-review.sh" in content
         assert "monitor-pr.sh" in content
+        assert 'PR_NUMBER=""' in content
         assert "--review-cycle" in content
 
     def test_validate_pr_enforces_project_key_title_format(self):


### PR DESCRIPTION
## Summary

- Native GitHub sub-issue linking via `--parent` flag using `addSubIssue` GraphQL mutation (cross-repo supported)
- `--scale epic|task` flag with `scale:` label
- New issues land in **Backlog** (was To Do) in board automation
- All 5 issue templates gain priority, area, scale, and parent fields; bug template adds source project field
- `config.yaml.tmpl` documents `github_project_number` alongside `project_key`
- Issue titles use plain descriptions — type carried by label, not title prefix
- PR titles keep `[PI-N][type]` (they become merge commit messages where labels are invisible)

Closes #61
Closes #62
Closes #63
Closes #64
Closes #65