### PR TITLE
[PI-41][feat] Rich issue metadata — sub-issues, Backlog flow, typed templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,6 +24,29 @@ body:
       label: Expected behaviour
     validations:
       required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. auth, scaffold, templates, ci"
+  - type: input
+    id: source_project
+    attributes:
+      label: Source project
+      description: If this bug was reported from another project or repo, record it here.
+      placeholder: "owner/repo or owner/repo#N"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: If this bug is tracked under a larger epic. Use #N or owner/repo#N.
+      placeholder: "#42 or VytCepas/other-repo#7"
   - type: textarea
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -13,3 +13,32 @@ body:
     attributes:
       label: Why now?
       description: What breaks or degrades if this is skipped?
+  - type: dropdown
+    id: scale
+    attributes:
+      label: Scale
+      description: Is this a standalone task or a parent grouping sub-tasks?
+      options: [task, epic]
+      default: 0
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Size estimate
+      options: [XS, S, M, L, XL]
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. ci, deps, scaffold, templates"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -15,6 +15,23 @@ body:
       label: Audience
       description: Who needs this documentation?
       placeholder: "Users, maintainers, agents, contributors, operators..."
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. install, scaffold, templates, scripts, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"
   - type: textarea
     id: references
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -27,7 +27,37 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: scale
+    attributes:
+      label: Scale
+      description: Is this a standalone task or a parent epic broken into sub-issues?
+      options: [task, epic]
+      default: 0
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: dropdown
     id: effort
     attributes:
-      label: Effort estimate
+      label: Size estimate
       options: [XS, S, M, L, XL]
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. auth, scaffold, templates, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: If this is a sub-task of a larger epic. Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related issues, PRs, ADRs, external links, or cross-project context
+      placeholder: "- #N\n- owner/repo#N\n- https://..."

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -21,3 +21,20 @@ body:
     attributes:
       label: Suggested approach
       placeholder: "Unit test, scaffold-output diff, CLI test, workflow validation..."
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [high, medium, low, unset]
+      default: 3
+  - type: input
+    id: area
+    attributes:
+      label: Area / component
+      placeholder: "e.g. scaffold, templates, scripts, ci"
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Use #N (same repo) or owner/repo#N (cross-repo).
+      placeholder: "#42 or VytCepas/other-repo#7"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,8 @@ Read this file before any GitHub issue, branch, push, PR, review, CI, or merge w
 - Create issues: `gh issue create` — pick the right template (bug / feature / chore / docs / test)
 - Board cards move automatically via `board-automation.yml` — no manual updates needed
 - Branch names use `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, e.g. `chore/PI-40-split-scaffold-tests`
-- Issue and PR names use the Project Init key: `PI-<issue-number>`, e.g. `PI-42`
-- PR titles must follow: `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`
+- **Issue titles**: plain description only — no prefix. Type is carried by the label (`feature`, `bug`, etc.) which GitHub shows everywhere. E.g. `Add OAuth login`, not `[feat] Add OAuth login`.
+- **PR titles** must follow `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`. The type prefix is kept here because PR titles become merge commit messages in `git log`, where labels are invisible. This enables changelog generation and quick log scanning.
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
 - PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 - When asked to push/finish a PR, continue autonomously using the review cycle protocol below.

--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -7,7 +7,7 @@ name: Board automation
 #   - PROJECT_NUMBER variable (or hardcoded below): the numeric project board number
 #
 # Column transitions:
-#   issue opened          → To Do
+#   issue opened          → Backlog
 #   PR opened (draft)     → In Progress  (linked issue, via "Closes #N" in body)
 #   PR ready_for_review   → In Review    (linked issue)
 #   PR merged             → Done         (linked issue)
@@ -37,7 +37,7 @@ jobs:
           ACTION="${{ github.event.action }}"
 
           if [[ "$EVENT" == "issues" && "$ACTION" == "opened" ]]; then
-            echo "status=To Do" >> $GITHUB_OUTPUT
+            echo "status=Backlog" >> $GITHUB_OUTPUT
             echo "item_type=issue" >> $GITHUB_OUTPUT
 
           elif [[ "$EVENT" == "pull_request" && "$ACTION" == "opened" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Template naming convention: directories stored as `dot_claude/`, `dot_gitignore`
 - Work is tracked in GitHub Projects backed by GitHub Issues.
 - Branch names must follow `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, for example `chore/PI-40-split-scaffold-tests`.
 - Project Init uses `PI` as the project abbreviation.
-- PR titles must follow `[PI-IssueNumber][type] description` where type is one of `feat`, `fix`, `chore`, `docs`, or `test`.
+- Issue titles: plain description only — type is carried by the label, not the title.
+- PR titles must follow `[PI-IssueNumber][type] description` where type ∈ {feat, fix, chore, docs, test} — the type prefix is kept because PR titles become merge commit messages in git log where labels are invisible.
 - PR bodies must include `Closes #<number>` to auto-link the issue and move the board card on merge.
 - This repo may not have root `.claude/scripts/` files because it is the scaffolder source. Do not run files under `templates/` as this repo's operational automation; those are scaffolded-project artifacts. If a referenced lifecycle script is absent in the root `.claude/scripts/`, use the equivalent `git` / `gh` commands directly.
 

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -6,7 +6,8 @@ project:
   description: "{{project_description}}"
   created: {{created_date}}
   project_init_version: {{project_init_version}}
-  project_key: ""   # e.g. "PI" -> branches use feat/PI-42-slug and PR titles use [PI-42][feat]; blank derives from repo name
+  project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use [PI-42][feat], issue titles use [PI][feat]
+  github_project_number: 1 # numeric GitHub Project V2 board number (used by board-automation.yml and create-issue.sh)
 
 language: {{language}}            # python | node | go | none
 

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -11,17 +11,6 @@
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Project config — read from .claude/config.yaml when present.
-# project_key: if set (e.g. "PI"), the issue title becomes [PI][feat] description.
-# ---------------------------------------------------------------------------
-PROJECT_KEY=""
-if [ -f ".claude/config.yaml" ]; then
-  PROJECT_KEY=$(grep -m1 'project_key:' .claude/config.yaml \
-    | sed 's/.*project_key:[[:space:]]*//' \
-    | tr -d '"'"'"'[:space:]')
-fi
-
 VALID_TYPES="feat fix chore docs test"
 VALID_PRIORITIES="high medium low"
 VALID_SIZES="XS S M L XL"
@@ -48,11 +37,6 @@ Options:
   --milestone NAME                Set milestone by name
   --body-file FILE                Append extra markdown body content
   -h, --help                      Show this help
-
-Project key:
-  If .claude/config.yaml has a non-empty project_key, the title becomes
-  [KEY][type] description (e.g. [PI][feat] Add OAuth login). This makes issues
-  identifiable when viewed from a cross-repo GitHub Project board.
 
 Sub-issues:
   --parent links the new issue as a native GitHub sub-issue of the given parent.
@@ -252,11 +236,7 @@ case "$TYPE" in
   test)  TYPE_LABEL="test" ;;
 esac
 
-if [ -n "$PROJECT_KEY" ]; then
-  TITLE="[$PROJECT_KEY][$TYPE] $DESCRIPTION"
-else
-  TITLE="[$TYPE] $DESCRIPTION"
-fi
+TITLE="$DESCRIPTION"
 
 BODY_PATH=$(mktemp)
 trap 'rm -f "$BODY_PATH"' EXIT

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -11,9 +11,21 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Project config — read from .claude/config.yaml when present.
+# project_key: if set (e.g. "PI"), the issue title becomes [PI][feat] description.
+# ---------------------------------------------------------------------------
+PROJECT_KEY=""
+if [ -f ".claude/config.yaml" ]; then
+  PROJECT_KEY=$(grep -m1 'project_key:' .claude/config.yaml \
+    | sed 's/.*project_key:[[:space:]]*//' \
+    | tr -d '"'"'"'[:space:]')
+fi
+
 VALID_TYPES="feat fix chore docs test"
 VALID_PRIORITIES="high medium low"
 VALID_SIZES="XS S M L XL"
+VALID_SCALES="epic task"
 
 usage() {
   cat <<'EOF'
@@ -26,6 +38,9 @@ Options:
   --priority high|medium|low      Apply priority label and body metadata
   --area VALUE                    Record affected area in body metadata
   --size XS|S|M|L|XL              Apply size label and body metadata
+  --scale epic|task               Mark as epic (parent) or task (leaf); adds scale label
+  --parent VALUE                  Link new issue as sub-issue of VALUE
+                                  Formats: 42, #42, owner/repo#42, or full issue URL
   --reference VALUE               Add a reference; repeatable
   --dependency VALUE              Add a dependency; repeatable
   --acceptance VALUE              Add an acceptance criterion; repeatable
@@ -34,9 +49,19 @@ Options:
   --body-file FILE                Append extra markdown body content
   -h, --help                      Show this help
 
+Project key:
+  If .claude/config.yaml has a non-empty project_key, the title becomes
+  [KEY][type] description (e.g. [PI][feat] Add OAuth login). This makes issues
+  identifiable when viewed from a cross-repo GitHub Project board.
+
+Sub-issues:
+  --parent links the new issue as a native GitHub sub-issue of the given parent.
+  Cross-repo parents use owner/repo#42 or the full issue URL.
+  --scale epic marks this issue as a parent work item (adds scale:epic label).
+
 Metadata model:
-  GitHub labels: type, priority, and size when labels exist or can be created.
-  Markdown body: area, references, dependencies, acceptance criteria, notes,
+  GitHub labels: type, priority, size, and scale when labels exist or can be created.
+  Markdown body: area, scale, parent, references, dependencies, acceptance criteria,
   Definition of Ready, and Definition of Done.
 
 Missing label fallback:
@@ -62,6 +87,8 @@ shift 2
 PRIORITY=""
 AREA=""
 SIZE=""
+SCALE=""
+PARENT=""
 ASSIGNEE=""
 MILESTONE=""
 BODY_FILE=""
@@ -100,6 +127,16 @@ while [ $# -gt 0 ]; do
     --size)
       require_option_value "$1" "${2:-}"
       SIZE="$2"
+      shift 2
+      ;;
+    --scale)
+      require_option_value "$1" "${2:-}"
+      SCALE="$2"
+      shift 2
+      ;;
+    --parent)
+      require_option_value "$1" "${2:-}"
+      PARENT="$2"
       shift 2
       ;;
     --reference)
@@ -164,9 +201,47 @@ if [ -n "$SIZE" ] && ! contains_word "$SIZE" "$VALID_SIZES"; then
   exit 1
 fi
 
+if [ -n "$SCALE" ] && ! contains_word "$SCALE" "$VALID_SCALES"; then
+  echo "ERROR: invalid scale '$SCALE'. Valid scales: $VALID_SCALES" >&2
+  exit 1
+fi
+
 if [ -n "$BODY_FILE" ] && [ ! -f "$BODY_FILE" ]; then
   echo "ERROR: body file not found: $BODY_FILE" >&2
   exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Parse --parent reference into owner / repo / number.
+# Accepts: 42, #42, owner/repo#42, or full GitHub issue URL.
+# Sets globals PARENT_OWNER, PARENT_REPO, PARENT_NUMBER.
+# ---------------------------------------------------------------------------
+PARENT_OWNER=""
+PARENT_REPO=""
+PARENT_NUMBER=""
+
+parse_parent() {
+  local raw="${1#\#}"   # strip leading #
+  if [[ "$raw" =~ ^https://github\.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
+    PARENT_OWNER="${BASH_REMATCH[1]}"
+    PARENT_REPO="${BASH_REMATCH[2]}"
+    PARENT_NUMBER="${BASH_REMATCH[3]}"
+  elif [[ "$raw" =~ ^([^/#]+)/([^#]+)#([0-9]+)$ ]]; then
+    PARENT_OWNER="${BASH_REMATCH[1]}"
+    PARENT_REPO="${BASH_REMATCH[2]}"
+    PARENT_NUMBER="${BASH_REMATCH[3]}"
+  elif [[ "$raw" =~ ^[0-9]+$ ]]; then
+    PARENT_OWNER=$(gh repo view --json owner -q .owner.login)
+    PARENT_REPO=$(gh repo view --json name -q .name)
+    PARENT_NUMBER="$raw"
+  else
+    echo "ERROR: cannot parse parent '$1'. Use: 42, #42, owner/repo#42, or full URL" >&2
+    exit 1
+  fi
+}
+
+if [ -n "$PARENT" ]; then
+  parse_parent "$PARENT"
 fi
 
 case "$TYPE" in
@@ -177,7 +252,12 @@ case "$TYPE" in
   test)  TYPE_LABEL="test" ;;
 esac
 
-TITLE="[$TYPE] $DESCRIPTION"
+if [ -n "$PROJECT_KEY" ]; then
+  TITLE="[$PROJECT_KEY][$TYPE] $DESCRIPTION"
+else
+  TITLE="[$TYPE] $DESCRIPTION"
+fi
+
 BODY_PATH=$(mktemp)
 trap 'rm -f "$BODY_PATH"' EXIT
 
@@ -213,9 +293,13 @@ write_bullets() {
   echo "## Metadata"
   echo
   echo "- Type: $TYPE"
+  echo "- Scale: ${SCALE:-task}"
   echo "- Priority: ${PRIORITY:-unset}"
   echo "- Area: ${AREA:-unset}"
   echo "- Size: ${SIZE:-unset}"
+  if [ -n "$PARENT" ]; then
+    echo "- Parent: $PARENT_OWNER/$PARENT_REPO#$PARENT_NUMBER"
+  fi
   if [ -n "$ASSIGNEE" ]; then
     echo "- Assignee: @$ASSIGNEE"
   fi
@@ -288,6 +372,11 @@ if [ -n "$SIZE" ]; then
     [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
   fi
 fi
+if [ -n "$SCALE" ]; then
+  if LABEL=$(ensure_label "scale:$SCALE" "f9d0c4" "Issue scale"); then
+    [ -n "$LABEL" ] && LABEL_ARGS+=(--label "$LABEL")
+  fi
+fi
 
 CREATE_ARGS=(--title "$TITLE" --body-file "$BODY_PATH")
 if [ -n "$ASSIGNEE" ]; then
@@ -299,5 +388,36 @@ fi
 
 ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" "${LABEL_ARGS[@]}")
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
+# ---------------------------------------------------------------------------
+# Link as a native GitHub sub-issue when --parent was specified.
+# Uses the addSubIssue GraphQL mutation (supports cross-repo parents via URL).
+# ---------------------------------------------------------------------------
+if [ -n "$PARENT" ]; then
+  PARENT_NODE_ID=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) { id }
+      }
+    }' \
+    -f owner="$PARENT_OWNER" \
+    -f repo="$PARENT_REPO" \
+    -F number="$PARENT_NUMBER" \
+    --jq '.data.repository.issue.id')
+
+  CHILD_NODE_ID=$(gh api "repos/:owner/:repo/issues/$ISSUE_NUMBER" --jq '.node_id')
+
+  gh api graphql -f query='
+    mutation($parent: ID!, $child: ID!) {
+      addSubIssue(input: { issueId: $parent, subIssueId: $child }) {
+        issue { number }
+        subIssue { number }
+      }
+    }' \
+    -f parent="$PARENT_NODE_ID" \
+    -f child="$CHILD_NODE_ID" > /dev/null
+
+  echo "Linked #$ISSUE_NUMBER as sub-issue of $PARENT_OWNER/$PARENT_REPO#$PARENT_NUMBER" >&2
+fi
 
 echo "$ISSUE_NUMBER"


### PR DESCRIPTION
## Summary

- Native GitHub sub-issue linking via `--parent` flag using `addSubIssue` GraphQL mutation (cross-repo supported)
- `--scale epic|task` flag with `scale:` label
- New issues land in **Backlog** (was To Do) in board automation
- All 5 issue templates gain priority, area, scale, and parent fields; bug template adds source project field
- `config.yaml.tmpl` documents `github_project_number` alongside `project_key`
- Issue titles use plain descriptions — type carried by label, not title prefix
- PR titles keep `[PI-N][type]` (they become merge commit messages where labels are invisible)

Closes #61
Closes #62
Closes #63
Closes #64
Closes #65