### PR TITLE
[nojira][fix] Sync .claude/scripts from updated templates

### DIFF
--- a/.claude/scripts/finish-pr.sh
+++ b/.claude/scripts/finish-pr.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Push the current branch, mark the PR ready, then monitor checks/review and merge.
+#
+# Usage:
+#   .claude/scripts/finish-pr.sh [pr-number] [--review-cycle N]
+#
+# If pr-number is omitted, detects the PR from the current branch.
+
+set -euo pipefail
+
+PR_NUMBER=""
+CYCLE_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --review-cycle)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Missing value for --review-cycle" >&2
+        echo "Usage: finish-pr.sh [pr-number] [--review-cycle N]" >&2
+        exit 2
+      fi
+      CYCLE_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --review-cycle=*)
+      CYCLE_ARGS+=("$1")
+      shift
+      ;;
+    *)
+      if [ -z "$PR_NUMBER" ]; then
+        PR_NUMBER="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        echo "Usage: finish-pr.sh [pr-number] [--review-cycle N]" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/push-branch.sh"
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+  if [ -z "$PR_NUMBER" ]; then
+    echo "ERROR: no PR found for current branch. Pass a PR number explicitly." >&2
+    exit 1
+  fi
+fi
+
+"$SCRIPT_DIR/promote-review.sh" "$PR_NUMBER"
+
+set +e
+"$SCRIPT_DIR/monitor-pr.sh" "$PR_NUMBER" --merge "${CYCLE_ARGS[@]}"
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 2 ]; then
+  echo ""
+  echo "Review fixes are required before merge. Reply to each review comment, commit fixes, then rerun:"
+  if [ "${#CYCLE_ARGS[@]}" -gt 0 ]; then
+    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER <next review-cycle from monitor-pr output>"
+  else
+    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER --review-cycle 1"
+  fi
+fi
+
+exit "$STATUS"

--- a/.claude/scripts/monitor-pr.sh
+++ b/.claude/scripts/monitor-pr.sh
@@ -109,7 +109,7 @@ if _review_decision_failed "$CHECKS"; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
       echo ""
       echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — force-merging with admin override."
-      GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$"
+      GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$" || true
       echo "Merged PR #$PR_NUMBER (admin)"
       exit 0
     else
@@ -132,11 +132,24 @@ PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER passed: $PR_URL"
 
 if [ "$MODE" = "--merge" ]; then
-  # Try direct merge first; if branch protection blocks it, fall back to --auto
-  if ! GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch 2>/dev/null; then
-    GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --auto 2>&1 | grep -v "^$"
-    echo "Auto-merge enabled for PR #$PR_NUMBER — will merge once all requirements are met."
-  else
+  # Check merge state: CLEAN = mergeable now, BLOCKED = review/branch protection gating
+  MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
+
+  if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
+    GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch 2>&1 | grep -v "^$" || true
     echo "Merged PR #$PR_NUMBER"
+  elif [ "$MERGE_STATE" = "BLOCKED" ]; then
+    # CI passed but review protection is the only gate — admin merge (owner bypass)
+    echo "PR is blocked by review protection — merging with admin override."
+    GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$" || true
+    echo "Merged PR #$PR_NUMBER (admin)"
+  else
+    # Unknown state — try direct first, fall back to --auto
+    if ! GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch 2>/dev/null; then
+      GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --auto 2>&1 | grep -v "^$" || true
+      echo "Auto-merge enabled for PR #$PR_NUMBER — will merge once all requirements are met."
+    else
+      echo "Merged PR #$PR_NUMBER"
+    fi
   fi
 fi

--- a/.claude/scripts/promote-review.sh
+++ b/.claude/scripts/promote-review.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Mark the current draft PR ready for review.
+# board-automation.yml handles the board card move (In Progress → In Review) server-side.
+#
+# Usage:
+#   .claude/scripts/promote-review.sh [pr-number]
+#
+# If pr-number is omitted, detects from the current branch.
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+
+# --- Detect PR from current branch if not provided ---
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+  if [ -z "$PR_NUMBER" ]; then
+    echo "ERROR: no PR found for current branch. Pass a PR number explicitly." >&2
+    echo "Usage: promote-review.sh [pr-number]" >&2
+    exit 1
+  fi
+fi
+
+# --- Check current state ---
+IS_DRAFT=$(gh pr view "$PR_NUMBER" --json isDraft -q '.isDraft')
+if [ "$IS_DRAFT" = "false" ]; then
+  PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
+  echo "PR #$PR_NUMBER is already ready for review: $PR_URL"
+  exit 0
+fi
+
+# --- Mark ready ---
+gh pr ready "$PR_NUMBER"
+
+PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
+echo "PR #$PR_NUMBER is now ready for review: $PR_URL"
+echo "board-automation.yml will move the board card to In Review."
+echo ""
+echo "Next: wait for CI and review."
+echo "To merge when checks pass: .claude/scripts/monitor-pr.sh $PR_NUMBER --merge"


### PR DESCRIPTION
Sync operational scripts with the template fixes from PI-69.

- `monitor-pr.sh`: BLOCKED state detection + grep exit code fix
- `finish-pr.sh`: was missing from `.claude/scripts/` (operational copy)
- `promote-review.sh`: dependency of `finish-pr.sh`, also missing