### PR TITLE
[PI-44][feat] GitHub workflow skill, slim context, reduce script verbosity

### DIFF
--- a/.claude/scripts/finish-pr.sh
+++ b/.claude/scripts/finish-pr.sh
@@ -58,14 +58,4 @@ set +e
 STATUS=$?
 set -e
 
-if [ "$STATUS" -eq 2 ]; then
-  echo ""
-  echo "Review fixes are required before merge. Reply to each review comment, commit fixes, then rerun:"
-  if [ "${#CYCLE_ARGS[@]}" -gt 0 ]; then
-    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER <next review-cycle from monitor-pr output>"
-  else
-    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER --review-cycle 1"
-  fi
-fi
-
 exit "$STATUS"

--- a/.claude/scripts/monitor-pr.sh
+++ b/.claude/scripts/monitor-pr.sh
@@ -101,20 +101,17 @@ _print_failures "$CHECKS" || FAIL_CODE=$?
 
 # Handle review/decision failure
 if _review_decision_failed "$CHECKS"; then
-  echo ""
   echo "Review/decision failed on PR #$PR_NUMBER (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES):"
   _print_review_comments
 
   if [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
-      echo ""
       echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — force-merging with admin override."
       GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$" || true
       echo "Merged PR #$PR_NUMBER (admin)"
       exit 0
     else
       NEXT=$((REVIEW_CYCLE + 1))
-      echo ""
       echo "Address the comments above, push your changes, then re-run:"
       echo "  .claude/scripts/monitor-pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
       exit 2

--- a/.claude/scripts/promote-review.sh
+++ b/.claude/scripts/promote-review.sh
@@ -34,7 +34,3 @@ gh pr ready "$PR_NUMBER"
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER is now ready for review: $PR_URL"
-echo "board-automation.yml will move the board card to In Review."
-echo ""
-echo "Next: wait for CI and review."
-echo "To merge when checks pass: .claude/scripts/monitor-pr.sh $PR_NUMBER --merge"

--- a/.claude/scripts/push-branch.sh
+++ b/.claude/scripts/push-branch.sh
@@ -37,7 +37,6 @@ while [ "$attempt" -le "$MAX_RETRIES" ]; do
 
   attempt=$((attempt + 1))
   if [ "$attempt" -le "$MAX_RETRIES" ]; then
-    echo "push-branch: attempt $attempt failed, retrying in 3s..."
     sleep 3
   fi
 done

--- a/.claude/skills/INDEX.md
+++ b/.claude/skills/INDEX.md
@@ -6,7 +6,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 |---|---|
 | Create a GitHub Issue | `.claude/skills/start-task/SKILL.md` (then use `gh issue create` directly — no `create-issue.sh` in this repo) |
 | Start a new task (branch + draft PR) | `.claude/skills/start-task/SKILL.md` |
-| Push, review, or merge a PR | Follow `.github/copilot-instructions.md` — no github-workflow skill yet |
+| Push, review, or merge a PR | `.claude/skills/github-workflow/SKILL.md` |
 | Summarize the session | `.claude/skills/session-summary/SKILL.md` |
 | Add a hook | `.claude/skills/add-hook/SKILL.md` |
 | Add a slash command | `.claude/skills/add-command/SKILL.md` |

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,21 +1,54 @@
 ---
-description: Add a new slash command to this project
+name: add-command
+description: Creates a new slash command or skill that users can invoke with /name. Use when asked to add a command, automate a repeatable workflow step, or expose a task as a /name shortcut.
+when_to_use: Use when the user says "add a /command", "make a shortcut for X", or "I want to run this with a slash command". Both .claude/commands/ and .claude/skills/ work — prefer skills/ for new work.
 argument-hint: "<command-name> <what it does>"
 allowed-tools: Write
 ---
 
-Add a slash command without reading existing command files.
+## Commands vs skills — which to use
 
-## Steps
+`.claude/commands/` and `.claude/skills/` both create `/name` slash commands and support the same frontmatter. **Skills are preferred for new work.** Use commands only when editing an existing commands file.
 
-1. **Create** `.claude/commands/<name>.md`:
+| | `.claude/commands/name.md` | `.claude/skills/name/SKILL.md` |
+|---|---|---|
+| Status | Legacy, still works | Preferred |
+| Invocation | `/name` | `/name` |
+| Frontmatter | Same spec | Same spec |
+
+## Step 1 — Create the file
+
+**Skills (preferred):** `.claude/skills/<name>/SKILL.md`
+
+**Commands (legacy):** `.claude/commands/<name>.md`
+
+## Step 2 — Write the frontmatter
+
+```yaml
+---
+name: <name>
+description: <What it does and when to use it. Third person. Include trigger keywords.>
+when_to_use: <Extra trigger context — action phrases the user might say.>
+argument-hint: "<expected arguments>"
+allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
+model: sonnet                    # optional model override
+effort: medium                   # low | medium | high | xhigh | max
+disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
+user-invocable: false            # false = Claude-only background knowledge
+context: fork                    # fork = runs in isolated subagent
+---
+```
+
+Not all fields are required — only include what changes the default behaviour.
+
+## Step 3 — Write the body
 
 ```markdown
 Run this command to <what it does>.
 
 ## Steps
 
-1. <step one>
+1. <step one — prefer shell commands over prose>
 2. <step two>
 
 ## Rules
@@ -23,16 +56,12 @@ Run this command to <what it does>.
 - <constraint if any>
 ```
 
-That's it — Claude Code registers any `.md` file in `.claude/commands/` as `/name` automatically.
+**`$ARGUMENTS`** expands to the full argument string. Use `$1`, `$2` for positional args.
 
 ## Guidelines
 
-- **Name**: lowercase, hyphen-separated, matches the task (`code-review`, `deploy-check`)
-- **Steps**: imperative, specific. Prefer shell commands over prose where possible.
-- **No file reads in the command**: embed what the agent needs inline; don't say "read X first"
-- **`$ARGUMENTS`**: available if the command takes user input (e.g., `/review main..HEAD`)
-
-## When to use a command vs a skill
-
-- **Command** (`/name`): user-invoked, task-oriented, short workflow (status check, review, deploy)
-- **Skill** (`.claude/skills/`): agent-invoked, reusable sub-procedure called from other instructions
+- **Name**: lowercase, hyphen-separated, max 64 chars
+- **Description quality is load-bearing**: if Claude doesn't trigger it automatically, the description is too vague — add keywords users would naturally say
+- **No file reads in the body**: embed what the agent needs inline; don't say "read X first"
+- **Side-effect commands**: set `disable-model-invocation: true` so only the user can invoke them
+- **Background conventions**: set `user-invocable: false` so Claude loads them automatically

--- a/.claude/skills/add-hook/SKILL.md
+++ b/.claude/skills/add-hook/SKILL.md
@@ -1,45 +1,98 @@
 ---
-description: Add a new deterministic hook to this project
+name: add-hook
+description: Adds a deterministic hook that fires automatically on tool events. Use when asked to enforce a rule on every commit, block a dangerous pattern, validate output, or gate any tool call.
+when_to_use: Use when the user wants to automate a check or action that runs every time a specific event occurs — e.g. "block pushes to main", "run linter before every commit", "log every Bash command".
 argument-hint: "<hook-name> <event> <description>"
 allowed-tools: Read Write Bash
 ---
 
-Add a hook without reading existing hook implementations.
+## Step 1 — Choose an event
 
-## Steps
+Pick the event that matches when the hook should fire:
 
-1. **Create** `.claude/hooks/$ARGUMENTS_name.sh` (or `.py` for Python logic):
+**Tool execution** (most common):
+- `PreToolUse` — before a tool runs; exit 1 to block it
+- `PostToolUse` — after a tool runs; cannot block, can log or validate
+- `PostToolBatch` — after a batch of parallel tool calls completes
+- `PermissionRequest` — when Claude asks for permission; can auto-approve
+
+**Session lifecycle:**
+- `SessionStart` — when a session begins
+- `Stop` — when Claude stops generating (end of turn)
+- `StopFailure` — when a turn fails
+
+**User input:**
+- `UserPromptSubmit` — when the user submits a prompt
+- `UserPromptExpansion` — when slash commands expand
+
+**Agent/task events:**
+- `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task tracking events
+
+**File/config events:**
+- `FileChanged`, `CwdChanged`, `ConfigChange`
+
+## Step 2 — Write the hook script
+
+Create `.claude/hooks/<name>.sh`:
 
 ```bash
 #!/usr/bin/env bash
-# Input: JSON on stdin from Claude Code
+# Hook receives JSON on stdin from Claude Code.
 INPUT=$(cat)
 
-# exit 0 = allow  |  exit 1 = block (PreToolUse only)
-# stdout JSON = optional additionalContext injected into Claude's context
+# exit 0 = allow (or no-op for non-blocking events)
+# exit 1 = block (PreToolUse only)
+# stdout JSON = optional context injected into Claude's next turn
 
-# Example: block a pattern
-if echo "$INPUT" | grep -q "PATTERN"; then
-  echo '{"decision":"block","reason":"reason here"}' >&2
+# Example: block pushes to main
+TOOL=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null)
+CMD=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+if [ "$TOOL" = "Bash" ] && echo "$CMD" | grep -q "push.*main\|push.*master"; then
+  echo '{"decision":"block","reason":"Direct push to main is not allowed. Use a branch and PR."}' >&2
   exit 1
 fi
 exit 0
 ```
 
-2. **Wire** the hook in `.claude/settings.json` under the correct event key:
+Make it executable: `chmod +x .claude/hooks/<name>.sh`
+
+## Step 3 — Wire it in settings.json
+
+Add to `.claude/settings.json`:
 
 ```json
-"<Event>": [
-  {
-    "matcher": "<ToolName or *>",
-    "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+      }
+    ]
   }
-]
+}
 ```
 
-**Events**: `PreToolUse`, `PostToolUse`, `Stop`
-**Matchers**: tool name (`Bash`, `Write`, `Edit`, `MultiEdit`), pipe-separated (`Write|Edit`), or `*`
+**Matchers:** tool name (`Bash`, `Write`, `Edit`), pipe-separated (`Write|Edit`), or `*` for all tools.
 
-3. **Make executable**: `chmod +x .claude/hooks/<name>.sh`
+## Alternative — Inline hook in a skill
 
-4. **Test**: trigger the wired tool and confirm the hook fires as expected.
+Hooks can also live in a skill's frontmatter and fire only while the skill is active:
+
+```yaml
+---
+name: my-skill
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./.claude/hooks/check.sh"
+---
+```
+
+## Step 4 — Test
+
+Trigger the wired tool and verify the hook fires. Check `$CLAUDE_PROJECT_DIR` is set correctly in the command path.

--- a/.claude/skills/github-workflow/SKILL.md
+++ b/.claude/skills/github-workflow/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: github-workflow
+description: Guides Claude through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+user-invocable: false
+allowed-tools: Bash
+---
+
+Load this skill before any push, PR creation, review response, or merge action.
+
+> **project-init source repo note:** Root `.claude/scripts/` lifecycle scripts
+> exist here but may not have all variants — those scripts are scaffolded-project
+> artifacts. If a script is missing, use the equivalent `git`/`gh` commands
+> directly while preserving the same lifecycle behavior described below.
+
+## Quick reference
+
+| Step | Pattern |
+|------|---------|
+| Branch | `<type>/PI-<n>-<kebab-slug>` e.g. `feat/PI-42-add-oauth` |
+| PR title | `[PI-N][type] description` e.g. `[PI-42][feat] Add OAuth login` |
+| No-issue PR | `[nojira][type] description` e.g. `[nojira][fix] Fix typo` |
+| PR body | Must include `Closes #N` (skip for nojira) |
+
+Types: `feat` `fix` `chore` `docs` `test`
+
+## Standard lifecycle
+
+1. **Start work** — use the `start-task` skill. It creates a branch and draft PR.
+
+2. **Push during development:**
+   ```bash
+   .claude/scripts/push-branch.sh
+   # fallback: git push -u origin <branch>
+   ```
+
+3. **Finish — push, mark ready, and merge:**
+   ```bash
+   .claude/scripts/finish-pr.sh [pr-number]
+   ```
+   Or manually:
+   ```bash
+   .claude/scripts/push-branch.sh
+   .claude/scripts/promote-review.sh [pr-number]   # gh pr ready <n>
+   .claude/scripts/monitor-pr.sh <pr-number> --merge
+   ```
+
+## Review cycle protocol
+
+`monitor-pr.sh --merge` exits **2** when `review/decision` fails and cycles remain.
+
+1. Post a response for each review comment:
+   ```
+   gh pr comment <pr-number> --body "**Review response:**
+   - [comment]: Fixing — <reason>
+   - [comment]: Not applying — <reason>"
+   ```
+2. Fix actionable code, then push: `.claude/scripts/push-branch.sh`
+3. Re-run with the next cycle number:
+   ```bash
+   .claude/scripts/monitor-pr.sh <pr-number> --merge --review-cycle <N>
+   ```
+4. After 2 cycles, the script auto force-merges with `--admin`.
+
+**Before applying any comment:** read the current file state. Check whether the
+comment is stale (already fixed), contradicts conventions, or is correct. Never
+blindly apply a suggestion — post reasoning even when rejecting.
+
+## Issue titles vs PR titles
+
+- **Issue titles**: plain description only — type is carried by the label.
+- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/.claude/skills/session-summary/SKILL.md
+++ b/.claude/skills/session-summary/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: session-summary
-description: Summarize the current session — what was done, decisions made, open items — and save to vault
-allowed-tools: Bash Read Write Glob Grep
+description: Summarizes the current session and saves it to the vault. Use at the end of a work session to record completed work, decisions made, and open items for the next session.
+when_to_use: Use when the user says "save the session", "wrap up", "summarize what we did", or at the end of a long work session.
+effort: medium
+allowed-tools: Bash(git *) Read Write Glob Grep
 ---
 
 Summarize this session and save it to the vault:

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -1,7 +1,9 @@
 ---
-description: Create a GitHub Issue + branch + draft PR before starting work
+name: start-task
+description: Creates a GitHub Issue, branch, and draft PR before implementation begins. Use before any non-trivial task to keep work traceable — one issue, one branch, one PR.
+when_to_use: Use when the user says "start work on X", "create a ticket for Y", or "begin a new task". Do not use for trivial one-off changes that don't need tracking.
 argument-hint: "[task title]"
-allowed-tools: Bash Read
+allowed-tools: Bash(gh *) Bash(git *) Read
 ---
 
 Before starting any non-trivial task, create a GitHub Issue, a dedicated branch, and a draft PR. This keeps work traceable and every PR maps to exactly one issue.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,51 +1,25 @@
 # GitHub Copilot Instructions
 
-Full agent rules and repo conventions are in [CLAUDE.md](../CLAUDE.md). [AGENTS.md](../AGENTS.md) redirects there.
+Full agent rules: [CLAUDE.md](../CLAUDE.md). For any push, PR, review, or merge action: load `.claude/skills/github-workflow/SKILL.md`.
 
-Read this file before any GitHub issue, branch, push, PR, review, CI, or merge work. These workflow rules are mandatory, not optional background context.
+## Quick reference
 
-## Quick reference (Copilot Workspace / inline chat)
+| What | Pattern |
+|------|---------|
+| Branch | `<type>/PI-<n>-<slug>` e.g. `feat/PI-42-add-oauth` |
+| Issue title | plain description only — type → label |
+| PR title | `[PI-N][type] description` |
+| No-issue PR | `[nojira][type] description` |
+| PR body | `Closes #N` |
 
-### Issue & project tracking
-- Tracking system: **GitHub Projects** (board) + **GitHub Issues** (tickets)
-- Create issues: `gh issue create` — pick the right template (bug / feature / chore / docs / test)
-- Board cards move automatically via `board-automation.yml` — no manual updates needed
-- Branch names use `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, e.g. `chore/PI-40-split-scaffold-tests`
-- **Issue titles**: plain description only — no prefix. Type is carried by the label (`feature`, `bug`, etc.) which GitHub shows everywhere. E.g. `Add OAuth login`, not `[feat] Add OAuth login`.
-- **PR titles** must follow `[PI-N][type] description` where type ∈ {feat, fix, chore, docs, test}, e.g. `[PI-42][feat] Add OAuth login`. The type prefix is kept here because PR titles become merge commit messages in `git log`, where labels are invisible. This enables changelog generation and quick log scanning.
-- For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
-- PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
-- When asked to push/finish a PR, continue autonomously using the review cycle protocol below.
-- Never use bare `git push` for branch publishing — always use `.claude/scripts/push-branch.sh` so transient GitHub errors don't silently fail or cause confusing "Everything up-to-date" retries.
-
-### Review cycle protocol (max 2 rounds, then admin merge)
-
-`monitor-pr.sh --merge` exits with code 2 when `review/decision` fails and more cycles remain. When that happens:
-
-1. **For each review comment** post a reply explaining your reasoning — resolving or rejecting. Use:
-   ```
-   gh pr comment <pr-number> --body "**Review response:**
-   - [comment summary]: Fixing — <reason it is valid>
-   - [comment summary]: Not applying — <reason it does not apply or is incorrect>"
-   ```
-2. Fix actionable code, then push with `.claude/scripts/push-branch.sh`.
-3. Re-run with the next cycle number:
-   ```
-   .claude/scripts/monitor-pr.sh <pr-number> --merge --review-cycle <N>
-   ```
-4. After 2 cycles (`--review-cycle 2`), the script force-merges automatically with `--admin`.
-
-**Evaluating comments before responding:** Read the current file state first. Check whether the comment is stale (already fixed in the current commit), contradicts repo conventions, or is genuinely correct. Never blindly apply a suggestion — post your reasoning even when rejecting.
-- In this project-init source repo, root `.claude/scripts/` may not exist because those scripts are scaffolded-project artifacts. Do not run files under `templates/` as this repo's operational automation. If a `.claude/scripts/<name>` command is unavailable, use equivalent `git` / `gh` commands directly while preserving the same lifecycle behavior.
-
-### Python tooling
-- `uv run …` for all Python ops — never `pip install` or `python -m venv`
+## Python tooling
+- `uv run …` — never `pip install` or `python -m venv`
 - Linter: `uv run ruff check .` — no black, isort, or mypy
 - Tests: `uv run pytest`
 
-### Repo rules
-- No LLM calls from the scaffolder itself; deterministic file ops only
-- Core dep is `rich`; stdlib (`tomllib`, `argparse`, `pathlib`) covers the rest — don't add deps without justification
-- Templates live under `templates/` using `dot_claude/` / `dot_gitignore` naming; scaffolder renames on copy
+## Repo rules
+- No LLM calls from the scaffolder; deterministic file ops only
+- Core dep is `rich`; stdlib (`tomllib`, `argparse`, `pathlib`) — don't add deps without justification
+- Templates use `dot_claude/` / `dot_gitignore` naming; scaffolder renames on copy
 - Template placeholders use `{{variable_name}}` syntax
-- Any change to `templates/` needs a corresponding test that scaffolds into a temp dir and diffs output. Put new tests in the focused `tests/test_*.py` file for that behavior; create a new focused test file if needed.
+- Any change to `templates/` needs a test that scaffolds into a temp dir

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,11 @@ Template naming convention: directories stored as `dot_claude/`, `dot_gitignore`
 
 ## GitHub workflow
 
-- Read [.github/copilot-instructions.md](.github/copilot-instructions.md) before any GitHub action. Do not rely on this summary alone.
-- Work is tracked in GitHub Projects backed by GitHub Issues.
-- Branch names must follow `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, for example `chore/PI-40-split-scaffold-tests`.
-- Project Init uses `PI` as the project abbreviation.
-- Issue titles: plain description only — type is carried by the label, not the title.
-- PR titles must follow `[PI-IssueNumber][type] description` where type ∈ {feat, fix, chore, docs, test} — the type prefix is kept because PR titles become merge commit messages in git log where labels are invisible.
-- PR bodies must include `Closes #<number>` to auto-link the issue and move the board card on merge.
-- This repo may not have root `.claude/scripts/` files because it is the scaffolder source. Do not run files under `templates/` as this repo's operational automation; those are scaffolded-project artifacts. If a referenced lifecycle script is absent in the root `.claude/scripts/`, use the equivalent `git` / `gh` commands directly.
+For any push, PR, review, or merge work: load `.claude/skills/github-workflow/SKILL.md`.
+
+Quick ref: branch = `<type>/PI-<n>-<slug>` | PR title = `[PI-N][type] desc` | body includes `Closes #N`.
+
+Root `.claude/scripts/` lifecycle scripts exist here but may not cover every variant — they are scaffolded-project artifacts. If a script is missing, the skill documents the `git`/`gh` fallback.
 
 ## CI Optimizations
 

--- a/templates/base/CLAUDE.md.tmpl
+++ b/templates/base/CLAUDE.md.tmpl
@@ -17,8 +17,8 @@ All agentic-development infrastructure lives under [`.claude/`](.claude/). Start
 ## Key rules for agents
 
 - **TDD** — write failing tests before any implementation. Use `/plan <task>` to generate acceptance tests first.
-- **GitHub Projects** — work is tracked on the GitHub Projects board (kanban) backed by GitHub Issues. Before starting non-trivial work, create or reference an issue. Use `/start-task` if one does not exist.
-- **Branch names** — use `<issue_type>/<project_abbr>-<issue_number>-<branch-short-description>`, for example `feat/PI-42-add-oauth-login`.
+- **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue. Use `/start-task` if one does not exist.
+- **GitHub workflow** — for any push, PR, review, or merge action, load `.claude/skills/github-workflow/SKILL.md`. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `[KEY-N][type] desc` | body includes `Closes #N`.
 {{#if lint_command}}- **Lint** — `{{lint_command}}` must pass before closing a task. The `pre-commit-gate` hook enforces this on every commit.
 {{/if}}- **No secrets in code** — never hardcode API keys, tokens, or personal data. Use `os.environ['KEY']` or a `.env` file (gitignored).
 

--- a/templates/base/dot_claude/scripts/create-issue.sh
+++ b/templates/base/dot_claude/scripts/create-issue.sh
@@ -273,10 +273,10 @@ write_bullets() {
   echo "## Metadata"
   echo
   echo "- Type: $TYPE"
-  echo "- Scale: ${SCALE:-task}"
-  echo "- Priority: ${PRIORITY:-unset}"
-  echo "- Area: ${AREA:-unset}"
-  echo "- Size: ${SIZE:-unset}"
+  [ -n "$SCALE" ] && echo "- Scale: $SCALE"
+  [ -n "$PRIORITY" ] && echo "- Priority: $PRIORITY"
+  [ -n "$AREA" ] && echo "- Area: $AREA"
+  [ -n "$SIZE" ] && echo "- Size: $SIZE"
   if [ -n "$PARENT" ]; then
     echo "- Parent: $PARENT_OWNER/$PARENT_REPO#$PARENT_NUMBER"
   fi
@@ -286,32 +286,22 @@ write_bullets() {
   if [ -n "$MILESTONE" ]; then
     echo "- Milestone: $MILESTONE"
   fi
-  echo
-  echo "## References"
-  echo
-  write_bullets "None" "${REFERENCES[@]}"
-  echo
-  echo "## Dependencies"
-  echo
-  write_bullets "None" "${DEPENDENCIES[@]}"
+  if [ "${#REFERENCES[@]}" -gt 0 ]; then
+    echo
+    echo "## References"
+    echo
+    write_bullets "None" "${REFERENCES[@]}"
+  fi
+  if [ "${#DEPENDENCIES[@]}" -gt 0 ]; then
+    echo
+    echo "## Dependencies"
+    echo
+    write_bullets "None" "${DEPENDENCIES[@]}"
+  fi
   echo
   echo "## Acceptance criteria"
   echo
   write_list "Define acceptance criteria before implementation" "${ACCEPTANCE[@]}"
-  echo
-  echo "## Implementation notes"
-  echo
-  echo "- Affected area: ${AREA:-unset}"
-  echo
-  echo "## Definition of Ready"
-  echo
-  echo "- [ ] Priority, area, size, and acceptance criteria are set"
-  echo "- [ ] Dependencies and references are captured or marked none"
-  echo
-  echo "## Definition of Done"
-  echo
-  echo "- [ ] Acceptance criteria are met"
-  echo "- [ ] Tests and documentation are updated where needed"
 } > "$BODY_PATH"
 
 if [ -n "$BODY_FILE" ]; then

--- a/templates/base/dot_claude/scripts/finish-pr.sh
+++ b/templates/base/dot_claude/scripts/finish-pr.sh
@@ -58,14 +58,4 @@ set +e
 STATUS=$?
 set -e
 
-if [ "$STATUS" -eq 2 ]; then
-  echo ""
-  echo "Review fixes are required before merge. Reply to each review comment, commit fixes, then rerun:"
-  if [ "${#CYCLE_ARGS[@]}" -gt 0 ]; then
-    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER <next review-cycle from monitor-pr output>"
-  else
-    echo "  .claude/scripts/finish-pr.sh $PR_NUMBER --review-cycle 1"
-  fi
-fi
-
 exit "$STATUS"

--- a/templates/base/dot_claude/scripts/install-hooks.sh
+++ b/templates/base/dot_claude/scripts/install-hooks.sh
@@ -35,14 +35,11 @@ for hook_file in "$GIT_HOOKS_SRC"/*; do
   # Create symlink (or copy if symlinks not available)
   if cp -P "$hook_file" "$hook_dst" 2>/dev/null; then
     chmod +x "$hook_dst"
-    echo "  ✓ Installed $hook_name"
   else
     echo "  ✗ Failed to install $hook_name"
     exit 1
   fi
 done
 
-echo "✓ All git hooks installed successfully"
-echo ""
 echo "To reinstall hooks after pulling changes, run:"
 echo "  .claude/scripts/install-hooks.sh"

--- a/templates/base/dot_claude/scripts/monitor-pr.sh
+++ b/templates/base/dot_claude/scripts/monitor-pr.sh
@@ -101,20 +101,17 @@ _print_failures "$CHECKS" || FAIL_CODE=$?
 
 # Handle review/decision failure
 if _review_decision_failed "$CHECKS"; then
-  echo ""
   echo "Review/decision failed on PR #$PR_NUMBER (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES):"
   _print_review_comments
 
   if [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
-      echo ""
       echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — force-merging with admin override."
       GH_PROMPT_DISABLED=1 gh pr merge "$PR_NUMBER" --squash --delete-branch --admin 2>&1 | grep -v "^$" || true
       echo "Merged PR #$PR_NUMBER (admin)"
       exit 0
     else
       NEXT=$((REVIEW_CYCLE + 1))
-      echo ""
       echo "Address the comments above, push your changes, then re-run:"
       echo "  .claude/scripts/monitor-pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
       exit 2

--- a/templates/base/dot_claude/scripts/promote-review.sh
+++ b/templates/base/dot_claude/scripts/promote-review.sh
@@ -34,7 +34,3 @@ gh pr ready "$PR_NUMBER"
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER is now ready for review: $PR_URL"
-echo "board-automation.yml will move the board card to In Review."
-echo ""
-echo "Next: wait for CI and review."
-echo "To merge when checks pass: .claude/scripts/monitor-pr.sh $PR_NUMBER --merge"

--- a/templates/base/dot_claude/scripts/push-branch.sh
+++ b/templates/base/dot_claude/scripts/push-branch.sh
@@ -37,7 +37,6 @@ while [ "$attempt" -le "$MAX_RETRIES" ]; do
 
   attempt=$((attempt + 1))
   if [ "$attempt" -le "$MAX_RETRIES" ]; then
-    echo "push-branch: attempt $attempt failed, retrying in 3s..."
     sleep 3
   fi
 done

--- a/templates/base/dot_claude/scripts/setup-github.sh
+++ b/templates/base/dot_claude/scripts/setup-github.sh
@@ -58,4 +58,3 @@ else
   echo "  https://github.com/$OWNER/$NAME/settings/code_review" >&2
 fi
 
-echo "GitHub governance setup complete."

--- a/templates/base/dot_claude/scripts/start-issue.sh
+++ b/templates/base/dot_claude/scripts/start-issue.sh
@@ -79,7 +79,6 @@ if [ -z "$PROJECT_KEY" ]; then
 fi
 
 # --- Fetch issue title ---
-echo "Fetching issue #$ISSUE_NUMBER..."
 ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null)
 if [ -z "$ISSUE_TITLE" ]; then
   echo "ERROR: issue #$ISSUE_NUMBER not found" >&2
@@ -125,7 +124,6 @@ fi
 PR_TITLE="[${ISSUE_REF}][${TYPE}] ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
-echo "Creating draft PR..."
 PR_URL=$(gh pr create \
   --draft \
   --title "$PR_TITLE" \
@@ -133,6 +131,3 @@ PR_URL=$(gh pr create \
 
 echo "Draft PR: $PR_URL"
 
-echo ""
-echo "Ready. Branch: $BRANCH | PR: $PR_URL"
-echo "Next: implement, commit, push. Then run promote-review.sh when ready for review and monitor-pr.sh --merge when checks pass."

--- a/templates/base/dot_claude/skills/INDEX.md
+++ b/templates/base/dot_claude/skills/INDEX.md
@@ -6,7 +6,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 |---|---|
 | Create a GitHub Issue | `.claude/skills/create-issue/SKILL.md` |
 | Start a new task (branch + draft PR) | `.claude/skills/start-task/SKILL.md` |
-| Push, review, or merge a PR | `.claude/skills/github-workflow/SKILL.md` (if present) or follow `.github/copilot-instructions.md` |
+| Push, review, or merge a PR | `.claude/skills/github-workflow/SKILL.md` |
 | Summarize the session | `.claude/skills/session-summary/SKILL.md` |
 | Add a hook | `.claude/skills/add-hook/SKILL.md` |
 | Add a slash command | `.claude/skills/add-command/SKILL.md` |

--- a/templates/base/dot_claude/skills/add-command/SKILL.md
+++ b/templates/base/dot_claude/skills/add-command/SKILL.md
@@ -1,21 +1,54 @@
 ---
-description: Add a new slash command to this project
+name: add-command
+description: Creates a new slash command or skill that users can invoke with /name. Use when asked to add a command, automate a repeatable workflow step, or expose a task as a /name shortcut.
+when_to_use: Use when the user says "add a /command", "make a shortcut for X", or "I want to run this with a slash command". Both .claude/commands/ and .claude/skills/ work — prefer skills/ for new work.
 argument-hint: "<command-name> <what it does>"
 allowed-tools: Write
 ---
 
-Add a slash command without reading existing command files.
+## Commands vs skills — which to use
 
-## Steps
+`.claude/commands/` and `.claude/skills/` both create `/name` slash commands and support the same frontmatter. **Skills are preferred for new work.** Use commands only when editing an existing commands file.
 
-1. **Create** `.claude/commands/<name>.md`:
+| | `.claude/commands/name.md` | `.claude/skills/name/SKILL.md` |
+|---|---|---|
+| Status | Legacy, still works | Preferred |
+| Invocation | `/name` | `/name` |
+| Frontmatter | Same spec | Same spec |
+
+## Step 1 — Create the file
+
+**Skills (preferred):** `.claude/skills/<name>/SKILL.md`
+
+**Commands (legacy):** `.claude/commands/<name>.md`
+
+## Step 2 — Write the frontmatter
+
+```yaml
+---
+name: <name>
+description: <What it does and when to use it. Third person. Include trigger keywords.>
+when_to_use: <Extra trigger context — action phrases the user might say.>
+argument-hint: "<expected arguments>"
+allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
+model: sonnet                    # optional model override
+effort: medium                   # low | medium | high | xhigh | max
+disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
+user-invocable: false            # false = Claude-only background knowledge
+context: fork                    # fork = runs in isolated subagent
+---
+```
+
+Not all fields are required — only include what changes the default behaviour.
+
+## Step 3 — Write the body
 
 ```markdown
 Run this command to <what it does>.
 
 ## Steps
 
-1. <step one>
+1. <step one — prefer shell commands over prose>
 2. <step two>
 
 ## Rules
@@ -23,16 +56,12 @@ Run this command to <what it does>.
 - <constraint if any>
 ```
 
-That's it — Claude Code registers any `.md` file in `.claude/commands/` as `/name` automatically.
+**`$ARGUMENTS`** expands to the full argument string. Use `$1`, `$2` for positional args.
 
 ## Guidelines
 
-- **Name**: lowercase, hyphen-separated, matches the task (`code-review`, `deploy-check`)
-- **Steps**: imperative, specific. Prefer shell commands over prose where possible.
-- **No file reads in the command**: embed what the agent needs inline; don't say "read X first"
-- **`$ARGUMENTS`**: available if the command takes user input (e.g., `/review main..HEAD`)
-
-## When to use a command vs a skill
-
-- **Command** (`/name`): user-invoked, task-oriented, short workflow (status check, review, deploy)
-- **Skill** (`.claude/skills/`): agent-invoked, reusable sub-procedure called from other instructions
+- **Name**: lowercase, hyphen-separated, max 64 chars
+- **Description quality is load-bearing**: if Claude doesn't trigger it automatically, the description is too vague — add keywords users would naturally say
+- **No file reads in the body**: embed what the agent needs inline; don't say "read X first"
+- **Side-effect commands**: set `disable-model-invocation: true` so only the user can invoke them
+- **Background conventions**: set `user-invocable: false` so Claude loads them automatically

--- a/templates/base/dot_claude/skills/add-hook/SKILL.md
+++ b/templates/base/dot_claude/skills/add-hook/SKILL.md
@@ -1,45 +1,98 @@
 ---
-description: Add a new deterministic hook to this project
+name: add-hook
+description: Adds a deterministic hook that fires automatically on tool events. Use when asked to enforce a rule on every commit, block a dangerous pattern, validate output, or gate any tool call.
+when_to_use: Use when the user wants to automate a check or action that runs every time a specific event occurs — e.g. "block pushes to main", "run linter before every commit", "log every Bash command".
 argument-hint: "<hook-name> <event> <description>"
 allowed-tools: Read Write Bash
 ---
 
-Add a hook without reading existing hook implementations.
+## Step 1 — Choose an event
 
-## Steps
+Pick the event that matches when the hook should fire:
 
-1. **Create** `.claude/hooks/$ARGUMENTS_name.sh` (or `.py` for Python logic):
+**Tool execution** (most common):
+- `PreToolUse` — before a tool runs; exit 1 to block it
+- `PostToolUse` — after a tool runs; cannot block, can log or validate
+- `PostToolBatch` — after a batch of parallel tool calls completes
+- `PermissionRequest` — when Claude asks for permission; can auto-approve
+
+**Session lifecycle:**
+- `SessionStart` — when a session begins
+- `Stop` — when Claude stops generating (end of turn)
+- `StopFailure` — when a turn fails
+
+**User input:**
+- `UserPromptSubmit` — when the user submits a prompt
+- `UserPromptExpansion` — when slash commands expand
+
+**Agent/task events:**
+- `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task tracking events
+
+**File/config events:**
+- `FileChanged`, `CwdChanged`, `ConfigChange`
+
+## Step 2 — Write the hook script
+
+Create `.claude/hooks/<name>.sh`:
 
 ```bash
 #!/usr/bin/env bash
-# Input: JSON on stdin from Claude Code
+# Hook receives JSON on stdin from Claude Code.
 INPUT=$(cat)
 
-# exit 0 = allow  |  exit 1 = block (PreToolUse only)
-# stdout JSON = optional additionalContext injected into Claude's context
+# exit 0 = allow (or no-op for non-blocking events)
+# exit 1 = block (PreToolUse only)
+# stdout JSON = optional context injected into Claude's next turn
 
-# Example: block a pattern
-if echo "$INPUT" | grep -q "PATTERN"; then
-  echo '{"decision":"block","reason":"reason here"}' >&2
+# Example: block pushes to main
+TOOL=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_name',''))" 2>/dev/null)
+CMD=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+if [ "$TOOL" = "Bash" ] && echo "$CMD" | grep -q "push.*main\|push.*master"; then
+  echo '{"decision":"block","reason":"Direct push to main is not allowed. Use a branch and PR."}' >&2
   exit 1
 fi
 exit 0
 ```
 
-2. **Wire** the hook in `.claude/settings.json` under the correct event key:
+Make it executable: `chmod +x .claude/hooks/<name>.sh`
+
+## Step 3 — Wire it in settings.json
+
+Add to `.claude/settings.json`:
 
 ```json
-"<Event>": [
-  {
-    "matcher": "<ToolName or *>",
-    "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+      }
+    ]
   }
-]
+}
 ```
 
-**Events**: `PreToolUse`, `PostToolUse`, `Stop`
-**Matchers**: tool name (`Bash`, `Write`, `Edit`, `MultiEdit`), pipe-separated (`Write|Edit`), or `*`
+**Matchers:** tool name (`Bash`, `Write`, `Edit`), pipe-separated (`Write|Edit`), or `*` for all tools.
 
-3. **Make executable**: `chmod +x .claude/hooks/<name>.sh`
+## Alternative — Inline hook in a skill
 
-4. **Test**: trigger the wired tool and confirm the hook fires as expected.
+Hooks can also live in a skill's frontmatter and fire only while the skill is active:
+
+```yaml
+---
+name: my-skill
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./.claude/hooks/check.sh"
+---
+```
+
+## Step 4 — Test
+
+Trigger the wired tool and verify the hook fires. Check `$CLAUDE_PROJECT_DIR` is set correctly in the command path.

--- a/templates/base/dot_claude/skills/create-issue/SKILL.md
+++ b/templates/base/dot_claude/skills/create-issue/SKILL.md
@@ -1,7 +1,8 @@
 ---
-description: Create a GitHub Issue with planning metadata
-argument-hint: "[type] [title]"
-allowed-tools: Bash Read
+name: create-issue
+description: Creates a GitHub Issue with typed labels and structured planning metadata via create-issue.sh. Sub-skill invoked by start-task — do not call directly; use /start-task instead.
+user-invocable: false
+allowed-tools: Bash(gh *) Bash(.claude/scripts/*) Read
 ---
 
 Use this skill whenever creating a GitHub Issue.

--- a/templates/base/dot_claude/skills/github-workflow/SKILL.md
+++ b/templates/base/dot_claude/skills/github-workflow/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: github-workflow
+description: Guides Claude through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+user-invocable: false
+effort: high
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+Load this skill before any push, PR creation, review response, or merge action.
+
+## Quick reference
+
+| Step | Pattern |
+|------|---------|
+| Branch | `<type>/<PROJECT-KEY>-<n>-<kebab-slug>` e.g. `feat/PI-42-add-oauth` |
+| PR title | `[PROJECT-123][type] description` e.g. `[PI-42][feat] Add OAuth login` |
+| No-issue PR | `[nojira][type] description` e.g. `[nojira][fix] Fix typo` |
+| PR body | Must include `Closes #N` (skip for nojira) |
+
+Types: `feat` `fix` `chore` `docs` `test`
+
+## Standard lifecycle
+
+1. **Start work** — use the `start-task` skill. It runs `start-issue.sh` which creates
+   the branch, pushes, and opens a draft PR.
+
+2. **Push during development:**
+   ```bash
+   .claude/scripts/push-branch.sh
+   ```
+   Never use bare `git push` — `push-branch.sh` retries transient GitHub errors.
+
+3. **Finish — push, mark ready, and merge:**
+   ```bash
+   .claude/scripts/finish-pr.sh [pr-number]
+   ```
+   `finish-pr.sh` pushes, marks the draft ready, runs `monitor-pr.sh --merge`,
+   and handles review cycles automatically.
+
+   Or run steps individually:
+   ```bash
+   .claude/scripts/push-branch.sh
+   .claude/scripts/promote-review.sh [pr-number]
+   .claude/scripts/monitor-pr.sh <pr-number> --merge
+   ```
+
+## Review cycle protocol
+
+`monitor-pr.sh --merge` exits **2** when `review/decision` fails and cycles remain.
+
+1. Post a response for each review comment:
+   ```
+   gh pr comment <pr-number> --body "**Review response:**
+   - [comment]: Fixing — <reason>
+   - [comment]: Not applying — <reason>"
+   ```
+2. Fix actionable code, then push: `.claude/scripts/push-branch.sh`
+3. Re-run with the next cycle number:
+   ```bash
+   .claude/scripts/monitor-pr.sh <pr-number> --merge --review-cycle <N>
+   ```
+4. After 2 cycles, the script auto force-merges with `--admin`.
+
+**Before applying any comment:** read the current file state. Check whether the
+comment is stale (already fixed), contradicts conventions, or is correct. Never
+blindly apply a suggestion — post reasoning even when rejecting.
+
+## Issue titles vs PR titles
+
+- **Issue titles**: plain description only — type is carried by the label.
+- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/base/dot_claude/skills/session-summary/SKILL.md
+++ b/templates/base/dot_claude/skills/session-summary/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: session-summary
-description: Summarize the current session — what was done, decisions made, open items — and save to vault
-allowed-tools: Bash Read Write Glob Grep
+description: Summarizes the current session and saves it to the vault. Use at the end of a work session to record completed work, decisions made, and open items for the next session.
+when_to_use: Use when the user says "save the session", "wrap up", "summarize what we did", or at the end of a long work session.
+effort: medium
+allowed-tools: Bash(git *) Read Write Glob Grep
 ---
 
 Summarize this session and save it to the vault:

--- a/templates/base/dot_claude/skills/start-task/SKILL.md
+++ b/templates/base/dot_claude/skills/start-task/SKILL.md
@@ -1,7 +1,9 @@
 ---
-description: Create a GitHub Issue + branch + draft PR before starting work
+name: start-task
+description: Creates a GitHub Issue, branch, and draft PR before implementation begins. Use before any non-trivial task to keep work traceable — one issue, one branch, one PR.
+when_to_use: Use when the user says "start work on X", "create a ticket for Y", or "begin a new task". Do not use for trivial one-off changes that don't need tracking.
 argument-hint: "[task title]"
-allowed-tools: Bash Read
+allowed-tools: Bash(gh *) Bash(git *) Read
 ---
 
 Before starting any non-trivial task, create a GitHub Issue, a dedicated branch, and a draft PR. This keeps work traceable and every PR maps to exactly one issue.
@@ -28,13 +30,8 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 
-6. **When ready to merge** — mark ready, then monitor CI and merge:
-   ```bash
-   .claude/scripts/promote-review.sh
-   .claude/scripts/monitor-pr.sh <n> --merge
-   ```
-   Do NOT use `gh pr checks --watch` or bare `gh pr merge` — `monitor-pr.sh` handles
-   the "no checks registered yet" wait and blocks on failures.
+6. **When ready to merge** — load `.claude/skills/github-workflow/SKILL.md` for the
+   full push → promote → monitor/merge lifecycle and review-cycle protocol.
 
 ## Rules
 

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -13,29 +13,8 @@ Canonical agent rules: [CLAUDE.md](../CLAUDE.md) | Workflow: [.claude/project-in
 - For small no-issue PRs: `[nojira][type] description`, e.g. `[nojira][fix] Fix typo`
 - PR body must still include the GitHub numeric reference `Closes #N` — auto-closes issue and moves board card to Done on merge (skip for nojira PRs)
 - Draft PRs are opened immediately when work starts, not when done
-- When asked to push/finish a PR, continue autonomously using the review cycle protocol below.
-- Never use bare `git push` for branch publishing — always use `.claude/scripts/push-branch.sh` so transient GitHub errors don't silently fail.
-- Prefer `.claude/scripts/finish-pr.sh <pr-number>` when the user asks to finish a PR; it pushes, marks ready, runs `monitor-pr.sh --merge`, and preserves the review-cycle behavior.
+- When asked to push/finish a PR, load `.claude/skills/github-workflow/SKILL.md` for the full lifecycle and review-cycle protocol.
 - No direct commits to `main`
-
-### Review cycle protocol (max 2 rounds, then admin merge)
-
-`monitor-pr.sh --merge` exits with code 2 when `review/decision` fails and more cycles remain. When that happens:
-
-1. **For each review comment** post a reply explaining your reasoning — resolving or rejecting. Use:
-   ```
-   gh pr comment <pr-number> --body "**Review response:**
-   - [comment summary]: Fixing — <reason it is valid>
-   - [comment summary]: Not applying — <reason it does not apply or is incorrect>"
-   ```
-2. Fix actionable code, then push with `.claude/scripts/push-branch.sh`.
-3. Re-run with the next cycle number:
-   ```
-   .claude/scripts/monitor-pr.sh <pr-number> --merge --review-cycle <N>
-   ```
-4. After 2 cycles (`--review-cycle 2`), the script force-merges automatically with `--admin`.
-
-**Evaluating comments before responding:** Read the current file state first. Check whether the comment is stale (already fixed), contradicts repo conventions, or is genuinely correct. Never blindly apply a suggestion — post your reasoning even when rejecting.
 
 ## Key rules
 

--- a/tests/test_issue_metadata_workflow.py
+++ b/tests/test_issue_metadata_workflow.py
@@ -129,10 +129,11 @@ class TestCreateIssueScript:
             "## References",
             "## Dependencies",
             "## Acceptance criteria",
-            "## Definition of Ready",
-            "## Definition of Done",
         ):
             assert section in content
+        # Definition of Ready/Done removed — boilerplate that added noise without value
+        assert "## Definition of Ready" not in content
+        assert "## Definition of Done" not in content
 
     def test_script_documents_missing_label_fallback(self):
         content = self.script.read_text()

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -45,6 +45,18 @@ class TestSkillIndex:
         assert "session-summary" in content
         assert "add-hook" in content
         assert "add-command" in content
+        assert "github-workflow" in content
+
+    def test_github_workflow_skill_scaffolded(self, tmp_path: Path):
+        target = tmp_path / "proj"
+        preset = load_preset("obsidian-only")
+        scaffold(target, preset, make_variables())
+        skill = target / ".claude" / "skills" / "github-workflow" / "SKILL.md"
+        assert skill.exists(), "github-workflow/SKILL.md not scaffolded"
+        content = skill.read_text()
+        assert "finish-pr.sh" in content
+        assert "monitor-pr.sh" in content
+        assert "review-cycle" in content
 
 
 class TestAgentInstructionFiles:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -159,9 +159,8 @@ class TestScaffoldGitHubFiles:
         assert "[PROJECT-123][type] description" in content
         assert "[#N][type] description" not in content
         assert "PR title must start with" not in content
-        assert ".claude/scripts/monitor-pr.sh <pr-number> --merge" in content
-        assert "review-cycle" in content
-        assert "--admin" in content
+        # Review cycle protocol moved to github-workflow skill — file now points to it
+        assert "github-workflow" in content
 
     def test_gemini_md_created(self):
         f = self.target / "GEMINI.md"


### PR DESCRIPTION
## Summary

- Add `github-workflow` skill (`user-invocable: false`) with full PR lifecycle — branch naming, push, review cycle protocol — extracted from CLAUDE.md and copilot-instructions.md so it's lazy-loaded instead of always in context
- Rewrite `add-hook` and `add-command` skills with the authoritative Claude Code spec: full hook event list, inline hook frontmatter syntax, commands-vs-skills migration table, all frontmatter fields documented
- Add `when_to_use`, `effort`, and granular `Bash(gh *)` / `Bash(git *)` `allowed-tools` to `start-task`, `create-issue`, and `session-summary` skills
- Strip redundant/noisy output from lifecycle scripts: duplicate guidance block in `finish-pr.sh`, blank spacing lines in `monitor-pr.sh`, retry progress in `push-branch.sh`, per-hook confirmation in `install-hooks.sh`, decorative completion in `setup-github.sh`
- Slim issue bodies generated by `create-issue.sh`: skip `## References` / `## Dependencies` sections when empty, omit unset metadata fields, remove boilerplate checklist items

Closes #43
Closes #44