### PR TITLE
[PI-30][feat] Add memory starters, vault templates, Obsidian config, and lint script

### DIFF
--- a/templates/base/dot_claude/memory/MEMORY.md.tmpl
+++ b/templates/base/dot_claude/memory/MEMORY.md.tmpl
@@ -3,6 +3,9 @@
 
   One bullet per memory file. Keep lines under ~150 chars.
   Each referenced file has frontmatter: name, description, type (user | feedback | project | reference).
-  See README.md in this directory for the full convention.
+  See SCHEMA.md in this directory for the full convention.
 -->
 
+- [Project context](project_context.md) — goals, constraints, key decisions
+- [User role](user_role.md) — developer background and preferences
+- [Conventions](feedback_conventions.md) — agent behavior rules for this project

--- a/templates/base/dot_claude/memory/README.md
+++ b/templates/base/dot_claude/memory/README.md
@@ -2,6 +2,8 @@
 
 Small, grep-able, human-readable memory files. Intended for facts an agent should reuse across sessions.
 
+See [`SCHEMA.md`](SCHEMA.md) for the authoritative governance rules (types, frontmatter, naming, lint enforcement).
+
 ## Convention
 
 Every memory file has YAML frontmatter:

--- a/templates/base/dot_claude/memory/SCHEMA.md
+++ b/templates/base/dot_claude/memory/SCHEMA.md
@@ -1,0 +1,52 @@
+# Memory Schema
+
+Authoritative governance for `.claude/memory/` files. `lint-memory.sh` enforces these rules.
+
+## Required frontmatter
+
+Every memory file (except MEMORY.md, SCHEMA.md, README.md) must have:
+
+```yaml
+---
+name: <short title>
+description: <one-line summary used for relevance ranking>
+type: user | feedback | project | reference
+---
+```
+
+## Types
+
+| Type | Purpose | Body structure |
+|---|---|---|
+| `user` | About the human — role, preferences, expertise | Free-form |
+| `feedback` | Rules/corrections the user has given | **Why:** + **How to apply:** |
+| `project` | Current-state facts — goals, deadlines, decisions | **Why:** + **How to apply:** |
+| `reference` | Pointers to external systems — URLs, dashboards | Free-form |
+
+## File naming
+
+`<type>_<slug>.md` — lowercase, hyphenated slug.
+
+Examples: `user_role.md`, `feedback_testing.md`, `project_deadline.md`, `reference_api-docs.md`
+
+## Index
+
+Every memory file must appear in `MEMORY.md` as a one-line bullet:
+
+```markdown
+- [Title](filename.md) — short description
+```
+
+Keep lines under ~150 characters. `lint-memory.sh` checks for orphaned files and stale index entries.
+
+## What NOT to store
+
+- Code patterns or architecture (derivable from the repo)
+- Git history (`git log`)
+- Ephemeral task state (use TODOs)
+- Anything already in `CLAUDE.md` or `project-init.md`
+- Large documents (put those in `vault/`)
+
+## Relationship to vault
+
+`memory/` holds small structured facts for fast agent recall. `vault/` holds richer human-authored documentation (Obsidian). When a vault note distills into a reusable fact, create a memory file and link back to the vault note for context.

--- a/templates/base/dot_claude/memory/feedback_conventions.md
+++ b/templates/base/dot_claude/memory/feedback_conventions.md
@@ -1,0 +1,11 @@
+---
+name: Conventions feedback
+description: Rules about how agents should behave in this project
+type: feedback
+---
+
+<!-- Add corrections and confirmed approaches as they accumulate -->
+
+**Why:** <!-- why the convention matters -->
+
+**How to apply:** <!-- specific behavior change for agents -->

--- a/templates/base/dot_claude/memory/project_context.md.tmpl
+++ b/templates/base/dot_claude/memory/project_context.md.tmpl
@@ -1,0 +1,11 @@
+---
+name: Project context
+description: Goals, constraints, and key decisions for {{project_name}}
+type: project
+---
+
+<!-- Fill after scaffolding: why this project exists, key constraints, stakeholder goals -->
+
+**Why:** <!-- reason this project exists -->
+
+**How to apply:** <!-- how this context should shape agent suggestions -->

--- a/templates/base/dot_claude/memory/user_role.md
+++ b/templates/base/dot_claude/memory/user_role.md
@@ -1,0 +1,7 @@
+---
+name: User role
+description: Who the developer is, their background, how to tailor responses
+type: user
+---
+
+<!-- Fill in: role, experience level, preferred languages/tools, communication style -->

--- a/templates/lightrag/dot_claude/scripts/ingest_sessions.py
+++ b/templates/lightrag/dot_claude/scripts/ingest_sessions.py
@@ -6,11 +6,15 @@ the markdown to LightRAG. LightRAG internally uses an LLM for entity
 extraction, but this wrapper itself makes no model decisions.
 
 Usage:
-    uv run .claude/scripts/ingest_sessions.py
+    uv run .claude/scripts/ingest_sessions.py           # incremental (default)
+    uv run .claude/scripts/ingest_sessions.py --full     # re-ingest everything
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
+import json
 import os
 import sys
 from pathlib import Path
@@ -21,9 +25,7 @@ try:
     from lightrag.llm.openai import openai_embedding
     from lightrag.utils import EmbeddingFunc
 except ImportError:
-    sys.stderr.write(
-        "lightrag-hku not installed. Run: uv pip install lightrag-hku\n"
-    )
+    sys.stderr.write("lightrag-hku not installed. Run: uv pip install lightrag-hku\n")
     sys.exit(1)
 
 
@@ -31,6 +33,21 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKING_DIR = ROOT / ".claude" / "memory" / ".lightrag"
 VAULT_DIR = ROOT / ".claude" / "vault"
 MEMORY_DIR = ROOT / ".claude" / "memory"
+HASH_FILE = WORKING_DIR / "ingested.json"
+
+
+def _file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_hashes() -> dict[str, str]:
+    if HASH_FILE.exists():
+        return json.loads(HASH_FILE.read_text(encoding="utf-8"))
+    return {}
+
+
+def _save_hashes(hashes: dict[str, str]) -> None:
+    HASH_FILE.write_text(json.dumps(hashes, indent=2) + "\n", encoding="utf-8")
 
 
 def collect_markdown() -> list[tuple[str, str]]:
@@ -47,6 +64,14 @@ def collect_markdown() -> list[tuple[str, str]]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Re-ingest all files (ignore hash cache)",
+    )
+    args = parser.parse_args()
+
     WORKING_DIR.mkdir(parents=True, exist_ok=True)
 
     if not os.environ.get("ANTHROPIC_API_KEY"):
@@ -74,11 +99,36 @@ def main() -> int:
         print("no markdown found to ingest")
         return 0
 
+    stored_hashes = {} if args.full else _load_hashes()
+    new_hashes: dict[str, str] = {}
+    ingested = 0
+
     for source, content in docs:
+        file_path = ROOT / source
+        current_hash = _file_hash(file_path)
+        new_hashes[source] = current_hash
+
+        if not args.full and stored_hashes.get(source) == current_hash:
+            continue
+
         print(f"ingest: {source}")
         rag.insert(content)
+        ingested += 1
 
-    print(f"ingested {len(docs)} documents into {WORKING_DIR}")
+    _save_hashes(new_hashes)
+
+    skipped = len(docs) - ingested
+    print(f"ingested {ingested} documents ({skipped} unchanged) into {WORKING_DIR}")
+
+    # Append to operational log if it exists
+    ops_log = ROOT / ".claude" / "vault" / "log.md"
+    if ops_log.exists() and ingested > 0:
+        from datetime import UTC, datetime
+
+        stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S")
+        with ops_log.open("a", encoding="utf-8") as f:
+            f.write(f"## [{stamp}] lightrag-ingest | {ingested} document(s)\n")
+
     return 0
 
 

--- a/templates/obsidian/dot_claude/hooks/session-end.sh
+++ b/templates/obsidian/dot_claude/hooks/session-end.sh
@@ -33,4 +33,27 @@ LOG="$SESSIONS_DIR/$STAMP.md"
   echo "<!-- Add manual notes here; agents may append below. -->"
 } > "$LOG"
 
+# Append one-liner to operational log
+OPS_LOG="$ROOT/.claude/vault/log.md"
+if [ -f "$OPS_LOG" ]; then
+  COMMIT_COUNT="$(git -C "$ROOT" log --since='2 hours ago' --oneline 2>/dev/null | wc -l | tr -d ' ')"
+  echo "## [$STAMP] session-end | ${COMMIT_COUNT} commit(s)" >> "$OPS_LOG"
+fi
+
+# Run memory lint if available; append warnings to session log
+LINT_SCRIPT="$ROOT/.claude/scripts/lint-memory.sh"
+if [ -x "$LINT_SCRIPT" ]; then
+  LINT_OUTPUT="$("$LINT_SCRIPT" 2>&1)" || true
+  if [ -n "$LINT_OUTPUT" ]; then
+    {
+      echo
+      echo "## Memory lint"
+      echo
+      echo '```'
+      echo "$LINT_OUTPUT"
+      echo '```'
+    } >> "$LOG"
+  fi
+fi
+
 echo "[session-end] wrote $LOG" >&2

--- a/templates/obsidian/dot_claude/scripts/lint-memory.sh
+++ b/templates/obsidian/dot_claude/scripts/lint-memory.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# lint-memory.sh — validate memory files against SCHEMA.md conventions.
+# Agent-agnostic: any agent or hook can call this directly.
+# Exit 0 on clean, exit 1 with actionable messages.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MEMORY_DIR="$ROOT/.claude/memory"
+INDEX="$MEMORY_DIR/MEMORY.md"
+
+ERRORS=0
+WARNINGS=0
+
+error() { echo "ERROR: $1" >&2; ERRORS=$((ERRORS + 1)); }
+warn()  { echo "WARN:  $1" >&2; WARNINGS=$((WARNINGS + 1)); }
+
+SKIP_FILES="MEMORY.md SCHEMA.md README.md"
+
+is_skipped() {
+  local name="$1"
+  for skip in $SKIP_FILES; do
+    [ "$name" = "$skip" ] && return 0
+  done
+  return 1
+}
+
+# --- Validate memory file frontmatter ---
+
+for file in "$MEMORY_DIR"/*.md; do
+  [ -f "$file" ] || continue
+  name="$(basename "$file")"
+  is_skipped "$name" && continue
+
+  # Extract YAML frontmatter (between --- delimiters)
+  if ! head -1 "$file" | grep -q '^---$'; then
+    error "$name: missing YAML frontmatter (no opening ---)"
+    continue
+  fi
+
+  # Get frontmatter block
+  frontmatter="$(sed -n '2,/^---$/p' "$file" | head -n -1)"
+
+  # Check required fields
+  for field in name description type; do
+    if ! echo "$frontmatter" | grep -q "^${field}:"; then
+      error "$name: missing required field '$field'"
+    fi
+  done
+
+  # Validate type value
+  type_val="$(echo "$frontmatter" | grep '^type:' | sed 's/^type:[[:space:]]*//' | tr -d '[:space:]')"
+  if [ -n "$type_val" ]; then
+    case "$type_val" in
+      user|feedback|project|reference) ;;
+      *) error "$name: invalid type '$type_val' (must be user|feedback|project|reference)" ;;
+    esac
+  fi
+done
+
+# --- Check index completeness ---
+
+if [ ! -f "$INDEX" ]; then
+  error "MEMORY.md index not found"
+else
+  # Check every memory file appears in the index
+  for file in "$MEMORY_DIR"/*.md; do
+    [ -f "$file" ] || continue
+    name="$(basename "$file")"
+    is_skipped "$name" && continue
+
+    if ! grep -q "$name" "$INDEX"; then
+      error "$name: not listed in MEMORY.md index"
+    fi
+  done
+
+  # Check every file referenced in index actually exists
+  while read -r ref; do
+    if [ ! -f "$MEMORY_DIR/$ref" ]; then
+      error "MEMORY.md references '$ref' but file does not exist"
+    fi
+  done < <(grep -oP '\[.*?\]\(\K[^)]+' "$INDEX" 2>/dev/null || true)
+fi
+
+# --- Report orphaned vault notes (warnings only) ---
+
+VAULT_DIR="$ROOT/.claude/vault"
+if [ -d "$VAULT_DIR" ]; then
+  # Collect all wikilink targets from vault notes
+  all_links="$(grep -roh '\[\[[^]]*\]\]' "$VAULT_DIR" 2>/dev/null | sed 's/\[\[//;s/\]\]//' | sort -u || true)"
+
+  for file in $(find "$VAULT_DIR" -name '*.md' -not -path '*/.obsidian/*' -not -path '*/templates/*' -not -name 'README.md' -not -name 'log.md'); do
+    name="$(basename "$file" .md)"
+    # Check if any other note links to this one
+    if [ -n "$all_links" ]; then
+      if ! echo "$all_links" | grep -q "$name"; then
+        warn "$(basename "$file"): no inbound wikilinks (orphan note)"
+      fi
+    fi
+  done
+fi
+
+# --- Summary ---
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo >&2
+  echo "lint-memory: $ERRORS error(s), $WARNINGS warning(s)" >&2
+  exit 1
+fi
+
+if [ "$WARNINGS" -gt 0 ]; then
+  echo "lint-memory: clean ($WARNINGS warning(s))" >&2
+fi
+
+exit 0

--- a/templates/obsidian/dot_claude/vault/decisions/adr-000-project-setup.md.tmpl
+++ b/templates/obsidian/dot_claude/vault/decisions/adr-000-project-setup.md.tmpl
@@ -1,0 +1,22 @@
+---
+title: ADR-000 Project setup
+date: {{created_date}}
+status: accepted
+tags: [setup, scaffolding]
+---
+
+# ADR-000: Project setup with project-init
+
+## Context
+
+This project was scaffolded using [project-init]({{project_init_url}}).
+
+## Decision
+
+Preset: `{{memory_stack}}`
+
+## Consequences
+
+- Memory files live in `.claude/memory/` (agent-curated facts)
+- Vault notes live in `.claude/vault/` (human-authored, Obsidian-compatible)
+{{#if lightrag}}- LightRAG provides semantic search over both layers{{/if lightrag}}

--- a/templates/obsidian/dot_claude/vault/dot_obsidian/README.md
+++ b/templates/obsidian/dot_claude/vault/dot_obsidian/README.md
@@ -1,0 +1,31 @@
+# Obsidian Configuration
+
+These config stubs bootstrap a usable Obsidian vault. Open `.claude/vault/` as an Obsidian vault.
+
+## Recommended community plugins
+
+Install these from Obsidian Settings → Community plugins → Browse:
+
+| Plugin | Why | Config notes |
+|--------|-----|-------------|
+| **Templater** | Consistent note structure from `templates/` | Set template folder to `templates/` |
+| **Linter** | Auto-formats YAML frontmatter, enforces heading structure | Enable YAML sort, require title |
+| **Dataview** | Query notes by frontmatter (list accepted ADRs, open decisions) | No config needed |
+
+## Optional plugins
+
+| Plugin | Why |
+|--------|-----|
+| **Calendar** | Navigate session logs by date — point to `sessions/` |
+| **Git** | Auto-commit vault changes on interval (10-min auto-backup) |
+| **Kanban** | Visual task board from markdown |
+| **Graph Analysis** | Better graph metrics, find disconnected clusters |
+| **Tag Wrangler** | Rename/merge tags across vault |
+
+## What's pre-configured
+
+- `app.json` — wikilinks enabled, new notes default to `knowledge/`, attachments to `design/`
+- `core-plugins.json` — backlinks, graph view, tag pane, outline, templates, daily notes
+- `community-plugins.json` — Templater, Linter, Dataview (install required, config stubs only)
+
+Obsidian workspace state and cache are gitignored (see `.gitignore`).

--- a/templates/obsidian/dot_claude/vault/dot_obsidian/app.json
+++ b/templates/obsidian/dot_claude/vault/dot_obsidian/app.json
@@ -1,0 +1,6 @@
+{
+  "useMarkdownLinks": false,
+  "newFileLocation": "folder",
+  "newFileFolderPath": "knowledge",
+  "attachmentFolderPath": "design"
+}

--- a/templates/obsidian/dot_claude/vault/dot_obsidian/community-plugins.json
+++ b/templates/obsidian/dot_claude/vault/dot_obsidian/community-plugins.json
@@ -1,0 +1,1 @@
+["templater-obsidian", "obsidian-linter", "dataview"]

--- a/templates/obsidian/dot_claude/vault/dot_obsidian/core-plugins.json
+++ b/templates/obsidian/dot_claude/vault/dot_obsidian/core-plugins.json
@@ -1,0 +1,1 @@
+["backlink", "graph", "tag-pane", "outline", "templates", "daily-notes"]

--- a/templates/obsidian/dot_claude/vault/log.md
+++ b/templates/obsidian/dot_claude/vault/log.md
@@ -1,0 +1,6 @@
+# Operational Log
+
+Append-only record of significant operations. Format:
+`## [YYYY-MM-DD HH:MM] action | title`
+
+<!-- Agents and hooks append below this line -->

--- a/templates/obsidian/dot_claude/vault/templates/decision.md
+++ b/templates/obsidian/dot_claude/vault/templates/decision.md
@@ -1,0 +1,16 @@
+---
+title: <% tp.file.title %>
+date: <% tp.date.now("YYYY-MM-DD") %>
+status: proposed
+tags: []
+---
+
+# <% tp.file.title %>
+
+## Context
+
+## Options considered
+
+## Decision
+
+## Consequences

--- a/templates/obsidian/dot_claude/vault/templates/design-note.md
+++ b/templates/obsidian/dot_claude/vault/templates/design-note.md
@@ -1,0 +1,14 @@
+---
+title: <% tp.file.title %>
+date: <% tp.date.now("YYYY-MM-DD") %>
+status: draft
+tags: []
+---
+
+# <% tp.file.title %>
+
+## Context
+
+## Proposal
+
+## Trade-offs

--- a/templates/obsidian/dot_claude/vault/templates/knowledge-note.md
+++ b/templates/obsidian/dot_claude/vault/templates/knowledge-note.md
@@ -1,0 +1,12 @@
+---
+title: <% tp.file.title %>
+source: 
+tags: []
+confidence: high
+---
+
+# <% tp.file.title %>
+
+## Content
+
+## Related

--- a/templates/obsidian/dot_claude/vault/templates/session-note.md
+++ b/templates/obsidian/dot_claude/vault/templates/session-note.md
@@ -1,0 +1,16 @@
+---
+date: <% tp.date.now("YYYY-MM-DD") %>
+tags: [session]
+---
+
+# Session <% tp.date.now("YYYY-MM-DD") %>
+
+## Goals
+
+- 
+
+## Notes
+
+## Follow-ups
+
+- [ ] 

--- a/tests/test_memory_starters.py
+++ b/tests/test_memory_starters.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+class TestMemoryStarterFiles:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        variables = make_variables(memory_stack="obsidian-only", lightrag="")
+        scaffold(tmp_target, preset, variables)
+
+    def test_project_context_exists(self):
+        assert (self.target / ".claude" / "memory" / "project_context.md").is_file()
+
+    def test_user_role_exists(self):
+        assert (self.target / ".claude" / "memory" / "user_role.md").is_file()
+
+    def test_feedback_conventions_exists(self):
+        assert (self.target / ".claude" / "memory" / "feedback_conventions.md").is_file()
+
+    def test_schema_exists(self):
+        assert (self.target / ".claude" / "memory" / "SCHEMA.md").is_file()
+
+    def test_schema_defines_all_types(self):
+        content = (self.target / ".claude" / "memory" / "SCHEMA.md").read_text()
+        for t in ("user", "feedback", "project", "reference"):
+            assert t in content
+
+    def test_starter_files_have_valid_frontmatter(self):
+        fm_re = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+        for name in ("project_context.md", "user_role.md", "feedback_conventions.md"):
+            content = (self.target / ".claude" / "memory" / name).read_text()
+            match = fm_re.match(content)
+            assert match, f"{name}: no YAML frontmatter"
+            fm = match.group(1)
+            for field in ("name:", "description:", "type:"):
+                assert field in fm, f"{name}: missing {field}"
+
+    def test_starter_types_are_valid(self):
+        fm_re = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+        valid_types = {"user", "feedback", "project", "reference"}
+        for name in ("project_context.md", "user_role.md", "feedback_conventions.md"):
+            content = (self.target / ".claude" / "memory" / name).read_text()
+            match = fm_re.match(content)
+            type_line = [line for line in match.group(1).splitlines() if line.startswith("type:")]
+            assert type_line, f"{name}: no type field"
+            type_val = type_line[0].split(":", 1)[1].strip()
+            assert type_val in valid_types, f"{name}: invalid type '{type_val}'"
+
+    def test_memory_index_references_all_starters(self):
+        content = (self.target / ".claude" / "memory" / "MEMORY.md").read_text()
+        assert "project_context.md" in content
+        assert "user_role.md" in content
+        assert "feedback_conventions.md" in content
+
+    def test_project_context_renders_project_name(self):
+        content = (self.target / ".claude" / "memory" / "project_context.md").read_text()
+        assert "my-project" in content
+        assert "{{project_name}}" not in content
+
+    def test_readme_references_schema(self):
+        content = (self.target / ".claude" / "memory" / "README.md").read_text()
+        assert "SCHEMA.md" in content
+
+
+class TestVaultStarterContent:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        variables = make_variables(memory_stack="obsidian-only", lightrag="")
+        scaffold(tmp_target, preset, variables)
+
+    def test_log_md_exists(self):
+        assert (self.target / ".claude" / "vault" / "log.md").is_file()
+
+    def test_log_md_has_header(self):
+        content = (self.target / ".claude" / "vault" / "log.md").read_text()
+        assert "Operational Log" in content
+
+    def test_adr_000_exists(self):
+        adr = self.target / ".claude" / "vault" / "decisions" / "adr-000-project-setup.md"
+        assert adr.is_file()
+
+    def test_adr_000_renders_variables(self):
+        content = (
+            self.target / ".claude" / "vault" / "decisions" / "adr-000-project-setup.md"
+        ).read_text()
+        assert "{{created_date}}" not in content
+        assert "{{memory_stack}}" not in content
+        assert "obsidian-only" in content
+
+    def test_templater_templates_exist(self):
+        templates = self.target / ".claude" / "vault" / "templates"
+        for name in ("decision.md", "session-note.md", "knowledge-note.md", "design-note.md"):
+            assert (templates / name).is_file(), f"missing template: {name}"
+
+    def test_templater_templates_use_tp_syntax(self):
+        templates = self.target / ".claude" / "vault" / "templates"
+        for name in ("decision.md", "session-note.md", "knowledge-note.md", "design-note.md"):
+            content = (templates / name).read_text()
+            assert "tp." in content, f"{name}: should use Templater tp. syntax"
+
+    def test_templater_templates_no_scaffold_placeholders(self):
+        placeholder_re = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
+        templates = self.target / ".claude" / "vault" / "templates"
+        for name in ("decision.md", "session-note.md", "knowledge-note.md", "design-note.md"):
+            content = (templates / name).read_text()
+            matches = placeholder_re.findall(content)
+            assert not matches, f"{name}: scaffold placeholders found: {matches}"
+
+
+class TestObsidianConfig:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        variables = make_variables(memory_stack="obsidian-only", lightrag="")
+        scaffold(tmp_target, preset, variables)
+
+    def test_obsidian_dir_exists(self):
+        assert (self.target / ".claude" / "vault" / ".obsidian").is_dir()
+
+    def test_app_json_exists(self):
+        f = self.target / ".claude" / "vault" / ".obsidian" / "app.json"
+        assert f.is_file()
+        import json
+
+        data = json.loads(f.read_text())
+        assert data["useMarkdownLinks"] is False
+
+    def test_core_plugins_json_exists(self):
+        f = self.target / ".claude" / "vault" / ".obsidian" / "core-plugins.json"
+        assert f.is_file()
+        import json
+
+        plugins = json.loads(f.read_text())
+        assert "backlink" in plugins
+        assert "graph" in plugins
+
+    def test_community_plugins_json_exists(self):
+        f = self.target / ".claude" / "vault" / ".obsidian" / "community-plugins.json"
+        assert f.is_file()
+        import json
+
+        plugins = json.loads(f.read_text())
+        assert "templater-obsidian" in plugins
+
+    def test_obsidian_readme_exists(self):
+        assert (self.target / ".claude" / "vault" / ".obsidian" / "README.md").is_file()
+
+    def test_dot_rename_applied_to_obsidian(self):
+        assert not (self.target / ".claude" / "vault" / "dot_obsidian").exists()
+
+
+class TestLintMemoryScript:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        variables = make_variables(memory_stack="obsidian-only", lightrag="")
+        scaffold(tmp_target, preset, variables)
+
+    def test_lint_script_exists(self):
+        script = self.target / ".claude" / "scripts" / "lint-memory.sh"
+        assert script.is_file()
+
+    def test_lint_script_is_executable(self):
+        script = self.target / ".claude" / "scripts" / "lint-memory.sh"
+        assert script.stat().st_mode & 0o111
+
+    def test_lint_passes_on_clean_scaffold(self):
+        # Initialize a git repo so git rev-parse works
+        subprocess.run(["git", "init", str(self.target)], capture_output=True, check=True)
+        script = self.target / ".claude" / "scripts" / "lint-memory.sh"
+        result = subprocess.run(
+            ["bash", str(script)],
+            cwd=str(self.target),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"lint failed: {result.stderr}"
+
+    def test_lint_fails_on_missing_index_entry(self):
+        subprocess.run(["git", "init", str(self.target)], capture_output=True, check=True)
+        # Remove a file from the index but keep the file
+        index = self.target / ".claude" / "memory" / "MEMORY.md"
+        content = index.read_text()
+        index.write_text(content.replace("- [User role](user_role.md)", "").strip() + "\n")
+
+        script = self.target / ".claude" / "scripts" / "lint-memory.sh"
+        result = subprocess.run(
+            ["bash", str(script)],
+            cwd=str(self.target),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "user_role.md" in result.stderr
+
+    def test_lint_fails_on_stale_index_reference(self):
+        subprocess.run(["git", "init", str(self.target)], capture_output=True, check=True)
+        # Delete a memory file but leave its index entry
+        (self.target / ".claude" / "memory" / "user_role.md").unlink()
+
+        script = self.target / ".claude" / "scripts" / "lint-memory.sh"
+        result = subprocess.run(
+            ["bash", str(script)],
+            cwd=str(self.target),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "user_role.md" in result.stderr
+
+
+class TestSessionEndUpdates:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-only")
+        variables = make_variables(memory_stack="obsidian-only", lightrag="")
+        scaffold(tmp_target, preset, variables)
+
+    def test_session_end_appends_to_log(self):
+        content = (self.target / ".claude" / "hooks" / "session-end.sh").read_text()
+        assert "vault/log.md" in content
+
+    def test_session_end_runs_lint(self):
+        content = (self.target / ".claude" / "hooks" / "session-end.sh").read_text()
+        assert "lint-memory.sh" in content
+
+
+class TestLightRAGIncremental:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        self.target = tmp_target
+        preset = load_preset("obsidian-lightrag")
+        variables = make_variables(memory_stack="obsidian-lightrag", lightrag="true")
+        scaffold(tmp_target, preset, variables)
+
+    def test_ingest_script_has_full_flag(self):
+        content = (self.target / ".claude" / "scripts" / "ingest_sessions.py").read_text()
+        assert "--full" in content
+
+    def test_ingest_script_has_hash_tracking(self):
+        content = (self.target / ".claude" / "scripts" / "ingest_sessions.py").read_text()
+        assert "ingested.json" in content
+        assert "sha256" in content
+
+    def test_lightrag_adr_000_has_lightrag_note(self):
+        content = (
+            self.target / ".claude" / "vault" / "decisions" / "adr-000-project-setup.md"
+        ).read_text()
+        assert "LightRAG" in content


### PR DESCRIPTION
## Summary

- Adds 3 pre-populated memory starter files (`project_context`, `user_role`, `feedback_conventions`) with valid YAML frontmatter to `base` layer — both presets get them
- Adds `SCHEMA.md` governance doc defining types, naming convention, and lint rules
- Scaffolds `.obsidian/` config stubs (app.json, core-plugins.json, community-plugins.json) + README recommending Templater, Linter, Dataview
- Adds 4 Templater-syntax vault note templates (decision, session-note, knowledge-note, design-note)
- Adds `vault/log.md` append-only operational timeline (Karpathy LLM Wiki pattern)
- Adds `ADR-000` project setup note with LightRAG conditional block
- Adds `lint-memory.sh` — agent-agnostic standalone script that validates frontmatter, index consistency, and orphan notes; wired into `session-end.sh`
- Adds incremental LightRAG ingest with SHA-256 hash tracking and `--full` flag
- 33 new tests covering all of the above; full suite 212 pass, 4 skip (API key dependent)

## Test plan

- [x] `uv run pytest` — 212 passed, 4 skipped, 0 failures
- [x] `ruff check` — clean
- [x] Manual scaffold of `obsidian-only` preset verified: memory files render, Templater syntax preserved, lint exits 0 on clean scaffold, lint exits 1 on broken index
- [x] `.obsidian/` config stubs verified valid JSON
- [x] ADR-000 renders `{{created_date}}`, `{{memory_stack}}`, `{{project_init_url}}` correctly

## Obsidian plugin requirements

**Required** for full functionality:
- **Templater** — vault templates use `<% tp.file.title %>` / `<% tp.date.now() %>`; without it, templates show raw syntax

**Recommended**:
- **Linter** — auto-formats YAML frontmatter on save
- **Dataview** — query notes by frontmatter (e.g. list accepted ADRs)

`community-plugins.json` pre-registers all three so they activate immediately after installing from Obsidian Settings.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)