### PR TITLE
[PI-101][fix] Fix secret-guard falsely blocking Bash commands with HOME paths

### DIFF
--- a/templates/base/dot_claude/hooks/secret-guard.py
+++ b/templates/base/dot_claude/hooks/secret-guard.py
@@ -65,12 +65,16 @@ def _home_path_patterns() -> list[tuple[re.Pattern[str], str]]:
     escaped = re.escape(home.rstrip("/\\"))
     return [(re.compile(escaped + r"[/\\]\S+"), f"Personal home-directory path ({home}/...)")]
 
+# Patterns checked on all tools (Write, Edit, MultiEdit, Bash)
 ALL_PATTERNS: list[tuple[re.Pattern[str], str]] = (
     _API_KEY_PATTERNS
     + [(_SECRET_ASSIGNMENT, "Hardcoded secret assignment")]
     + _PII_PATTERNS
-    + _home_path_patterns()
 )
+
+# Home-path patterns checked on file writes/edits only — not Bash commands,
+# which legitimately reference $HOME paths (MCP configs, tool binaries, etc.)
+FILE_ONLY_PATTERNS: list[tuple[re.Pattern[str], str]] = _home_path_patterns()
 
 # ---------------------------------------------------------------------------
 # Exemptions
@@ -89,10 +93,11 @@ def _is_exempt_file(file_path: str) -> bool:
     return name in _EXEMPT_BASENAMES or name.endswith(".example")
 
 
-def _scan(text: str, source: str) -> list[str]:
+def _scan(text: str, source: str, extra_patterns: list[tuple[re.Pattern[str], str]] | None = None) -> list[str]:
     """Return list of finding descriptions, empty if clean."""
     findings: list[str] = []
-    for pattern, label in ALL_PATTERNS:
+    patterns = ALL_PATTERNS + (extra_patterns or [])
+    for pattern, label in patterns:
         match = pattern.search(text)
         if match:
             # Skip if the matched value is adjacent to a placeholder marker
@@ -122,6 +127,8 @@ def main() -> int:
 
     texts: list[tuple[str, str]] = []  # (text, source_label)
 
+    is_file_tool = tool_name in ("Write", "Edit", "MultiEdit")
+
     if tool_name == "Write":
         texts.append((tool_input.get("content", ""), file_path or "file content"))
     elif tool_name == "Edit":
@@ -134,9 +141,10 @@ def main() -> int:
     else:
         return 0
 
+    extra = FILE_ONLY_PATTERNS if is_file_tool else None
     all_findings: list[str] = []
     for text, source in texts:
-        all_findings.extend(_scan(text, source))
+        all_findings.extend(_scan(text, source, extra))
 
     if all_findings:
         unique = list(dict.fromkeys(all_findings))  # deduplicate, preserve order


### PR DESCRIPTION
## Summary

- `secret-guard.py` template was flagging any Bash command containing `$HOME` paths as a privacy violation
- This blocks legitimate access to WSL-level MCP configs (e.g. `~/.claude/`) and tool binaries in all scaffolded projects
- Home-directory path detection is now scoped to `Write`/`Edit`/`MultiEdit` only — where hardcoding `$HOME` in project files is the actual risk

## Changes

- `templates/base/dot_claude/hooks/secret-guard.py`: extracted `FILE_ONLY_PATTERNS`, updated `_scan()` signature, conditioned home-path check on file tools only

## References

- Downstream fix: VytCepas/zarija#3 / VytCepas/zarija#4

Closes #101