### PR TITLE
[PI-103][fix] Drop stale session_end tests broken by #104

### DIFF
--- a/tests/contracts/test_scaffold_lightrag.py
+++ b/tests/contracts/test_scaffold_lightrag.py
@@ -32,13 +32,6 @@ class TestScaffoldLightRAG:
         content = rule.read_text()
         assert "ingest_sessions.py" in content
 
-    def test_settings_json_has_stop_hook(self):
-        import json
-
-        settings = self.target / ".claude" / "settings.json"
-        data = json.loads(settings.read_text())
-        assert "Stop" in data["hooks"]
-
     def test_more_files_than_obsidian_only(self):
         preset_small = load_preset("obsidian-only")
         variables = make_variables(lightrag="")

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -47,10 +47,6 @@ class TestScaffoldObsidianOnly:
         assert "my-project" in content
         assert "{{project_name}}" not in content
 
-    def test_session_end_hook_exists(self):
-        hook = self.target / ".claude" / "hooks" / "session_end.sh"
-        assert hook.is_file()
-
     def test_skills_created(self):
         skills = self.target / ".claude" / "skills"
         assert (skills / "status" / "SKILL.md").is_file()

--- a/tests/integration/test_memory_starters.py
+++ b/tests/integration/test_memory_starters.py
@@ -223,23 +223,6 @@ class TestLintMemoryScript:
         assert "user_role.md" in result.stderr
 
 
-class TestSessionEndUpdates:
-    @pytest.fixture(autouse=True)
-    def _scaffold(self, tmp_target: Path):
-        self.target = tmp_target
-        preset = load_preset("obsidian-only")
-        variables = make_variables(memory_stack="obsidian-only", lightrag="")
-        scaffold(tmp_target, preset, variables)
-
-    def test_session_end_appends_to_log(self):
-        content = (self.target / ".claude" / "hooks" / "session_end.sh").read_text()
-        assert "vault/log.md" in content
-
-    def test_session_end_runs_lint(self):
-        content = (self.target / ".claude" / "hooks" / "session_end.sh").read_text()
-        assert "lint_memory.sh" in content
-
-
 class TestLightRAGIncremental:
     @pytest.fixture(autouse=True)
     def _scaffold(self, tmp_target: Path):


### PR DESCRIPTION
## Summary

- Removes `test_session_end_hook_exists` from `test_scaffold_obsidian.py`
- Removes `test_settings_json_has_stop_hook` from `test_scaffold_lightrag.py`
- Removes `TestSessionEndUpdates` class from `test_memory_starters.py`

## Why

These tests were asserting the existence of `session_end.sh` and the `Stop` hook wiring removed in #104. CI failed on main after that merge because the tests weren't updated first.

Root cause of the ordering problem: `finish_pr.sh --review-cycle 1` admin-merges without waiting for CI to pass.

Closes #103