### PR TITLE
[PI-106][fix] Guard against empty check list in CI wait loop

### DIFF
--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -117,8 +117,13 @@ _has_review_activity() {
 }
 
 # --- Wait for all CI checks (excludes review/decision commit status) ---
+# Guard: if checks haven't registered yet (empty list), keep polling.
+# An empty list is indistinguishable from "all done" without this guard,
+# which caused #104 to merge before CI even started.
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
+  CHECK_COUNT=$(echo "$CHECKS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+  [ "$CHECK_COUNT" -eq 0 ] && { sleep 10; continue; }
   PENDING=$(_count_pending "$CHECKS")
   [ "$PENDING" -eq 0 ] && break
   sleep 10

--- a/templates/base/dot_claude/scripts/monitor_pr.sh
+++ b/templates/base/dot_claude/scripts/monitor_pr.sh
@@ -137,8 +137,13 @@ _has_review_activity() {
 }
 
 # --- Wait for all CI checks (excludes review/decision commit status) ---
+# Guard: if checks haven't registered yet (empty list), keep polling.
+# An empty list is indistinguishable from "all done" without this guard,
+# which caused premature merges before CI even started.
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
+  CHECK_COUNT=$(echo "$CHECKS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+  [ "$CHECK_COUNT" -eq 0 ] && { sleep 10; continue; }
   PENDING=$(_count_pending "$CHECKS")
   [ "$PENDING" -eq 0 ] && break
   sleep 10

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -284,7 +284,7 @@ class TestGitHubWorkflowHooks:
         fake_gh.write_text(
             """#!/usr/bin/env bash
 if [ "$1 $2" = "pr checks" ]; then
-  echo '[]'
+  echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]'
   exit 0
 fi
 if [ "$1 $2" = "pr view" ]; then


### PR DESCRIPTION
## Summary

- Adds a `CHECK_COUNT == 0 → continue` guard to the CI wait loop in `monitor_pr.sh` (both the dev copy and the base template)

## Root cause

When `finish_pr.sh` runs immediately after `push_branch.sh`, GitHub Actions hasn't registered checks yet. `gh pr checks` returns `[]`, so `PENDING = 0`, the loop exits immediately, and the script merges before CI even starts. This caused #104 to merge with 4 failing tests.

## What the admin bypass does (and doesn't do)

The admin bypass only fires for `REVIEW_REQUIRED` / `CHANGES_REQUESTED` — i.e. the reviewer gate, not the CI gate. It is intentional for a solo-dev repo with no second reviewer and is unchanged.

Closes #106