### PR TITLE
[PI-101][test] Add regression tests for home-path scoping to file tools

### DIFF
--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -183,6 +183,31 @@ class TestSecretGuard:
         })
         assert out is None
 
+    def test_allows_home_path_in_bash_command(self):
+        """PI-101 regression: Bash commands referencing $HOME paths must not be blocked.
+
+        Home-path detection is scoped to file tools (Write/Edit/MultiEdit) only.
+        Blocking Bash broke legitimate MCP config reads and tool invocations.
+        """
+        home = os.environ.get("HOME", "/home/testuser")
+        out = run_secret_guard(self._script, {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"cat {home}/.claude/settings.json"},
+        })
+        assert out is None
+
+    def test_still_blocks_home_path_in_write(self):
+        """Companion to PI-101: home-path detection remains active for Write."""
+        home = os.environ.get("HOME", "/home/testuser")
+        out = run_secret_guard(self._script, {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": "/tmp/config.yaml",
+                "content": f"mcp_config: {home}/.claude/mcp.json",
+            },
+        })
+        assert out is not None and out["decision"] == "block"
+
 
 class TestShellLineEndings:
     """Regression: shell hook scripts must be LF-only.


### PR DESCRIPTION
## Summary

Adds two regression tests to `TestSecretGuard` covering the PI-101 fix (home-path check scoped to file tools only):

- `test_allows_home_path_in_bash_command` — Bash command referencing `$HOME` must not be blocked
- `test_still_blocks_home_path_in_write` — Write with `$HOME` path still blocked

The original fix landed via an earlier squash-merge. This PR adds the missing test coverage flagged in Copilot's review of #102.

Closes #101