### PR TITLE
chore(PI-132): Make LightRAG model names template variables

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -61,12 +61,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--llm-model",
         default="claude-sonnet-4-6",
-        help="LLM model written to .claude/memory/lightrag.yaml (LightRAG presets)",
+        help="Anthropic model for lightrag.yaml (llm.provider is anthropic; LightRAG presets)",
     )
     p.add_argument(
         "--embedding-model",
         default="text-embedding-3-small",
-        help="Embedding model written to .claude/memory/lightrag.yaml (LightRAG presets)",
+        help="OpenAI embedding model for lightrag.yaml (embedding.provider is openai)",
     )
     p.add_argument(
         "--non-interactive",

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -59,6 +59,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Add Playwright browser-automation MCP",
     )
     p.add_argument(
+        "--llm-model",
+        default="claude-sonnet-4-6",
+        help="LLM model written to .claude/memory/lightrag.yaml (LightRAG presets)",
+    )
+    p.add_argument(
+        "--embedding-model",
+        default="text-embedding-3-small",
+        help="Embedding model written to .claude/memory/lightrag.yaml (LightRAG presets)",
+    )
+    p.add_argument(
         "--non-interactive",
         action="store_true",
         help="Skip all prompts (requires --preset, --name, --description)",
@@ -349,6 +359,9 @@ def main(argv: list[str] | None = None) -> int:
         "go": "true" if is_go else "",
         "lightrag": "true" if is_lightrag else "",
         "obsidian": "true" if has_obsidian else "",
+        # LightRAG model selection (PI-132) — rendered into lightrag.yaml
+        "llm_model": args.llm_model,
+        "embedding_model": args.embedding_model,
     }
 
     try:

--- a/templates/lightrag/dot_claude/memory/lightrag.yaml.tmpl
+++ b/templates/lightrag/dot_claude/memory/lightrag.yaml.tmpl
@@ -8,7 +8,7 @@ working_dir: .claude/memory/.lightrag
 
 llm:
   provider: anthropic
-  model: claude-sonnet-4-6
+  model: {{llm_model}}
 
 embedding:
   # Anthropic does not expose embedding APIs.
@@ -17,7 +17,7 @@ embedding:
   #   update the embedding_func in the scripts; no cloud key needed.
   # See https://github.com/hkuds/lightrag for all supported backends.
   provider: openai
-  model: text-embedding-3-small
+  model: {{embedding_model}}
 
 chunk:
   size: 1200

--- a/tests/contracts/test_scaffold_lightrag.py
+++ b/tests/contracts/test_scaffold_lightrag.py
@@ -37,3 +37,40 @@ class TestScaffoldLightRAG:
         variables = make_variables(lightrag="")
         small = scaffold(self.target.parent / "small", preset_small, variables)
         assert len(self.created) > len(small)
+
+
+class TestLightRAGModelVariables:
+    """PI-132: model names in lightrag.yaml are template variables, not hardcoded."""
+
+    def test_default_models_rendered(self, tmp_target: Path):
+        preset = load_preset("obsidian-lightrag")
+        variables = make_variables(memory_stack="obsidian-lightrag", lightrag="true")
+        scaffold(tmp_target, preset, variables, strict=True)
+        content = (tmp_target / ".claude" / "memory" / "lightrag.yaml").read_text()
+        assert "model: claude-sonnet-4-6" in content
+        assert "model: text-embedding-3-small" in content
+        assert "{{" not in content
+
+    def test_model_override_rendered(self, tmp_target: Path):
+        preset = load_preset("obsidian-lightrag")
+        variables = make_variables(
+            memory_stack="obsidian-lightrag",
+            lightrag="true",
+            llm_model="claude-opus-4-8",
+            embedding_model="nomic-embed-text",
+        )
+        scaffold(tmp_target, preset, variables, strict=True)
+        content = (tmp_target / ".claude" / "memory" / "lightrag.yaml").read_text()
+        assert "model: claude-opus-4-8" in content
+        assert "model: nomic-embed-text" in content
+        assert "claude-sonnet-4-6" not in content
+
+    def test_template_has_no_hardcoded_model(self):
+        tmpl = (
+            Path(__file__).resolve().parents[2]
+            / "templates" / "lightrag" / "dot_claude" / "memory" / "lightrag.yaml.tmpl"
+        )
+        content = tmpl.read_text()
+        assert "{{llm_model}}" in content
+        assert "{{embedding_model}}" in content
+        assert "model: claude-" not in content

--- a/tests/contracts/test_scaffold_lightrag.py
+++ b/tests/contracts/test_scaffold_lightrag.py
@@ -57,12 +57,12 @@ class TestLightRAGModelVariables:
             memory_stack="obsidian-lightrag",
             lightrag="true",
             llm_model="claude-opus-4-8",
-            embedding_model="nomic-embed-text",
+            embedding_model="text-embedding-3-large",
         )
         scaffold(tmp_target, preset, variables, strict=True)
         content = (tmp_target / ".claude" / "memory" / "lightrag.yaml").read_text()
         assert "model: claude-opus-4-8" in content
-        assert "model: nomic-embed-text" in content
+        assert "model: text-embedding-3-large" in content
         assert "claude-sonnet-4-6" not in content
 
     def test_template_has_no_hardcoded_model(self):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -54,6 +54,8 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "go": "",
         "lightrag": "",
         "obsidian": "true",
+        "llm_model": "claude-sonnet-4-6",
+        "embedding_model": "text-embedding-3-small",
     }
     defaults.update(overrides)
     return defaults

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -86,3 +86,26 @@ class TestCLINonInteractiveCommandVariables:
         config = (target / ".claude" / "config.yaml").read_text()
         assert 'lint_command: "golangci-lint run"' in config
         assert 'test_command: "go test ./..."' in config
+
+
+class TestLLMModelFlags:
+    """PI-132: --llm-model / --embedding-model flow into lightrag.yaml."""
+
+    def test_model_flags_override_lightrag_yaml(self, tmp_target: Path):
+        from project_init.__main__ import main
+
+        rc = main([
+            str(tmp_target),
+            "--non-interactive",
+            "--preset", "obsidian-lightrag",
+            "--name", "cli-test",
+            "--description", "testing cli",
+            "--language", "python",
+            "--llm-model", "claude-opus-4-8",
+            "--embedding-model", "nomic-embed-text",
+            "--strict",
+        ])
+        assert rc == 0
+        content = (tmp_target / ".claude" / "memory" / "lightrag.yaml").read_text()
+        assert "model: claude-opus-4-8" in content
+        assert "model: nomic-embed-text" in content

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -102,10 +102,10 @@ class TestLLMModelFlags:
             "--description", "testing cli",
             "--language", "python",
             "--llm-model", "claude-opus-4-8",
-            "--embedding-model", "nomic-embed-text",
+            "--embedding-model", "text-embedding-3-large",
             "--strict",
         ])
         assert rc == 0
         content = (tmp_target / ".claude" / "memory" / "lightrag.yaml").read_text()
         assert "model: claude-opus-4-8" in content
-        assert "model: nomic-embed-text" in content
+        assert "model: text-embedding-3-large" in content


### PR DESCRIPTION
Closes #132

## Summary

`lightrag.yaml.tmpl` rendered hardcoded model names; adopters had to hand-edit YAML when models rotate. The template now renders `{{llm_model}}` and `{{embedding_model}}`, with new CLI flags to override at scaffold time:

```
--llm-model         default: claude-sonnet-4-6
--embedding-model   default: text-embedding-3-small
```

## Changes

- `templates/lightrag/dot_claude/memory/lightrag.yaml.tmpl` — model values are variables
- `src/project_init/__main__.py` — `--llm-model` / `--embedding-model` flags wired into the variables dict
- `tests/helpers.py` — defaults added to `make_variables`
- Tests: `TestLightRAGModelVariables` (default render, override, no-hardcoded-model in template, strict mode) + CLI-level flag test

## Testing

- `uv run pytest -n auto` — 313 passed, 4 skipped (rebased on ADR-006 main)
- `uv run ruff check .` — clean

https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP

---
_Generated by [Claude Code](https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP)_