### PR TITLE
docs(PI-135): Document Claude-first positioning and add developer onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,28 @@ Principles:
 - **One folder, `.claude/`**, for everything agentic. Project root stays clean.
 - **Obsidian vault for humans, LightRAG (optional) for agents** — separated on disk.
 - **Deterministic-first** — hooks and scripts are bash/python. LLM calls only where generative.
-- **Model-agnostic** — `AGENTS.md` and `GEMINI.md` redirect non-Claude agents to the canonical `CLAUDE.md` instructions.
+- **Claude-first, portable core** — built and tested for Claude Code; other agents get instructions, not enforcement. See [Agent support tiers](#agent-support-tiers).
 - **`bun` and `uv` only** — no `npm`/`npx`/`pip`/`venv` anywhere in scaffolded projects.
+
+## Agent support tiers
+
+This is **firstly a Claude Code scaffolder**. It aims to be agent-agnostic where
+that is cheap, but it is not natively so — be explicit about what each agent gets:
+
+| Tier | What you get | Applies to |
+|---|---|---|
+| **Native (Claude Code)** | Everything: deterministic hooks (lifecycle guard, pre-commit gate), skills invoked as `/commands`, settings wiring | Claude Code only |
+| **Instructions-only** | `AGENTS.md` / `GEMINI.md` redirect to the canonical `CLAUDE.md`; agents read conventions but **no hook fires and nothing is enforced** for them | Codex, Gemini CLI, Cursor, and other AGENTS.md-aware tools |
+| **Portable regardless** | Lifecycle scripts (plain bash), memory and vault (plain markdown), git hooks (`commit-msg`, `pre-push`) — these bind every agent and every human | Everything, including Ollama-based agents |
+
+Two honest caveats:
+
+- Hook enforcement and skill invocation **do not exist outside Claude Code**. An
+  agent reading `AGENTS.md` is asked to follow the rules; nothing makes it.
+  The git hooks and CI checks are the only enforcement that binds all agents.
+- **Automated testing covers the Claude Code artifacts only.** The test suite
+  validates settings schema, skills, hooks, and rendered files; no other agent
+  is exercised in CI.
 
 ## Install (one-time)
 

--- a/templates/base/dot_claude/docs/guides/developer-onboarding.md
+++ b/templates/base/dot_claude/docs/guides/developer-onboarding.md
@@ -1,0 +1,67 @@
+# Developer onboarding — personal machine setup
+
+This page covers **per-developer machine state** that the scaffolder
+deliberately does not manage: global git configuration and editor sync are
+personal, not repository state, so they are documented here instead of being
+scaffolded (see the project-init decision in PI-140).
+
+Everything repo-level (hooks, linting, commands, env examples) is already in
+the repository — you do not need to configure any of that by hand.
+
+## Global gitignore
+
+Keep OS and editor junk out of every repo you touch, without bloating each
+project's `.gitignore`:
+
+```bash
+git config --global core.excludesFile ~/.gitignore_global
+cat >> ~/.gitignore_global <<'EOF'
+.DS_Store
+Thumbs.db
+*.swp
+.idea/
+EOF
+```
+
+Project `.gitignore` files stay focused on project artifacts (build output,
+env files, caches) — never add personal editor noise to them.
+
+## Recommended global git config
+
+```bash
+git config --global init.defaultBranch main
+git config --global pull.rebase true          # no accidental merge commits on pull
+git config --global push.autoSetupRemote true # first push sets upstream
+git config --global fetch.prune true          # drop deleted remote branches
+```
+
+Identity (use your work email on work machines):
+
+```bash
+git config --global user.name  "Your Name"
+git config --global user.email "you@example.com"
+```
+
+## Commit signing (if your org requires it)
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+## Editor settings
+
+- **VS Code Settings Sync** is an account-level feature — enable it in VS Code
+  itself (`Settings Sync: Turn On`). It is intentionally not configured by the
+  repository.
+- Repo-level editor settings (format-on-save, recommended extensions) live in
+  the repository's `.vscode/` directory when the project opted into that
+  overlay — personal themes and keybindings never belong there.
+
+## Checklist
+
+- [ ] Global gitignore configured
+- [ ] Global git config applied (rebase pulls, pruning, identity)
+- [ ] Commit signing set up, if required
+- [ ] Repo hooks installed: run `.claude/scripts/install_hooks.sh` once per clone

--- a/templates/base/dot_claude/docs/guides/developer-onboarding.md
+++ b/templates/base/dot_claude/docs/guides/developer-onboarding.md
@@ -5,8 +5,10 @@ deliberately does not manage: global git configuration and editor sync are
 personal, not repository state, so they are documented here instead of being
 scaffolded (see the project-init decision in PI-140).
 
-Everything repo-level (hooks, linting, commands, env examples) is already in
-the repository — you do not need to configure any of that by hand.
+Everything repo-level (linting, commands, env examples) ships with the
+repository. The one per-clone step: run `.claude/scripts/install_hooks.sh`
+once to activate the `commit-msg` and `pre-push` git hooks — git does not
+enable repository hooks automatically.
 
 ## Global gitignore
 

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -199,6 +199,12 @@ class TestScaffoldObsidianOnly:
         assert (docs / "development" / "conventions.md").is_file()
         assert (docs / "development" / "testing.md").is_file()
         assert (docs / "guides" / "using-memory.md").is_file()
+        # PI-135: per-developer git hygiene lives in docs, not as scaffolder features
+        onboarding = docs / "guides" / "developer-onboarding.md"
+        assert onboarding.is_file()
+        content = onboarding.read_text()
+        assert "core.excludesFile" in content
+        assert "Settings Sync" in content
 
     def test_plan_skill_is_tdd_first(self):
         plan = self.target / ".claude" / "skills" / "plan" / "SKILL.md"


### PR DESCRIPTION
Closes #135

## Summary

The README claimed "Model-agnostic" — overstated, since all deterministic enforcement (hooks, DAG gating) and skill invocation exist only in Claude Code, and CI tests only Claude artifacts. This documents the reality honestly for workplace adopters.

## Changes

- **README**: principle reworded to "Claude-first, portable core"; new **Agent support tiers** section (native / instructions-only / portable-regardless) with explicit caveats that nothing is enforced outside Claude Code and other agents are not CI-tested
- **New scaffolded guide** `docs/guides/developer-onboarding.md`: per-developer git hygiene (global gitignore, recommended global config, commit signing, Settings Sync) — the items rejected as scaffolder features in PI-140, documented instead
- Contract test extended: onboarding guide presence + content assertions

## Testing

- `uv run pytest -n auto` — 309 passed, 4 skipped
- `uv run ruff check .` — clean

https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP

---
_Generated by [Claude Code](https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP)_