### PR TITLE
docs: Clarify git-hook enforcement requires per-clone install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that is cheap, but it is not natively so — be explicit about what each agent g
 |---|---|---|
 | **Native (Claude Code)** | Everything: deterministic hooks (lifecycle guard, pre-commit gate), skills invoked as `/commands`, settings wiring | Claude Code only |
 | **Instructions-only** | `AGENTS.md` / `GEMINI.md` redirect to the canonical `CLAUDE.md`; agents read conventions but **no hook fires and nothing is enforced** for them | Codex, Gemini CLI, Cursor, and other AGENTS.md-aware tools |
-| **Portable regardless** | Lifecycle scripts (plain bash), memory and vault (plain markdown), git hooks (`commit-msg`, `pre-push`) — these bind every agent and every human | Everything, including Ollama-based agents |
+| **Portable regardless** | Lifecycle scripts (plain bash), memory and vault (plain markdown), git hooks (`commit-msg`, `pre-push`) — agent-independent by construction; git hooks bind once `install_hooks.sh` has run in the clone (server-side actions need branch protection) | Everything, including Ollama-based agents |
 
 Two honest caveats:
 


### PR DESCRIPTION
No linked issue (nojira) — one-line README follow-up from Copilot's post-merge review on #149.

The "Portable regardless" support-tier row implied git hooks automatically bind everyone; they bind only after `.claude/scripts/install_hooks.sh` runs in a clone, and server-side actions need branch protection. Row reworded accordingly.

https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP

---
_Generated by [Claude Code](https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP)_