### PR TITLE
chore(PI-133): Modernize skill frontmatter and add validation tests

### DIFF
--- a/.claude/skills/github_workflow/SKILL.md
+++ b/.claude/skills/github_workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github_workflow
 description: Guides Claude through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+when_to_use: Load before any push, PR creation, PR review response, merge, or release action — including when lifecycle scripts fail and a git/gh fallback is needed.
 user-invocable: false
 effort: high
 allowed-tools: Bash(git *) Bash(gh *) Bash(.claude/scripts/*) Read

--- a/templates/base/dot_claude/skills/audit/SKILL.md
+++ b/templates/base/dot_claude/skills/audit/SKILL.md
@@ -5,6 +5,7 @@ when_to_use: Use when the user says "audit the project", "health check", "scan f
 argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
+context: fork
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/base/dot_claude/skills/create_issue/SKILL.md
+++ b/templates/base/dot_claude/skills/create_issue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create_issue
 description: Creates a GitHub Issue with typed labels and structured planning metadata via create_issue.sh. Sub-skill invoked by start_task — do not call directly; use /start_task instead.
+when_to_use: Invoked by the start_task skill whenever a GitHub Issue must be created; never called directly by users.
 user-invocable: false
 allowed-tools: Bash(gh *) Bash(.claude/scripts/*) Read
 ---

--- a/templates/base/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/base/dot_claude/skills/github_workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github_workflow
 description: Guides Claude through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+when_to_use: Load before any push, PR creation, PR review response, merge, or release action — including when lifecycle scripts fail and a git/gh fallback is needed.
 user-invocable: false
 effort: high
 allowed-tools: Bash(git *) Bash(gh *) Bash(.claude/scripts/*) Read

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -93,14 +93,18 @@ class TestSkillFrontmatter:
                 fields[key.strip()] = value.strip()
         raise AssertionError(f"{path}: frontmatter never closed")
 
+    # Template skills and this repo's own skills both follow the standard.
+    _SKILL_ROOTS = (_SKILLS_DIR, _REPO_ROOT / ".claude" / "skills")
+
     def _skill_files(self):
-        for skill_dir in sorted(_SKILLS_DIR.iterdir()):
-            if not skill_dir.is_dir():
-                continue
-            for name in ("SKILL.md", "SKILL.md.tmpl"):
-                p = skill_dir / name
-                if p.exists():
-                    yield p
+        for root in self._SKILL_ROOTS:
+            for skill_dir in sorted(root.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                for name in ("SKILL.md", "SKILL.md.tmpl"):
+                    p = skill_dir / name
+                    if p.exists():
+                        yield p
 
     def test_all_skills_have_name_and_description(self):
         for path in self._skill_files():
@@ -116,11 +120,15 @@ class TestSkillFrontmatter:
 
     def test_sub_skills_marked_not_user_invocable(self):
         """Skills documented as indirectly invoked must not be /command-visible."""
-        for skill in ("create_issue", "github_workflow"):
-            fm = self._frontmatter(_SKILLS_DIR / skill / "SKILL.md")
-            assert fm.get("user-invocable") == "false", (
-                f"{skill}: expected user-invocable: false"
-            )
+        for root in self._SKILL_ROOTS:
+            for skill in ("create_issue", "github_workflow"):
+                path = root / skill / "SKILL.md"
+                if not path.exists():
+                    continue
+                fm = self._frontmatter(path)
+                assert fm.get("user-invocable") == "false", (
+                    f"{path}: expected user-invocable: false"
+                )
 
     def test_audit_runs_in_forked_context(self):
         """Heavyweight scan isolates its context; findings land in a GitHub issue."""

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -76,3 +76,53 @@ class TestAgentInstructionFiles:
     def test_gemini_md_references_skills_index(self):
         content = (self.target / "GEMINI.md").read_text()
         assert "INDEX.md" in content or "skills" in content.lower()
+
+
+class TestSkillFrontmatter:
+    """PI-133: every skill carries valid, discovery-friendly frontmatter."""
+
+    def _frontmatter(self, path: Path) -> dict[str, str]:
+        lines = path.read_text().splitlines()
+        assert lines and lines[0] == "---", f"{path}: missing frontmatter open"
+        fields: dict[str, str] = {}
+        for line in lines[1:]:
+            if line == "---":
+                return fields
+            if ":" in line and not line.startswith((" ", "\t", "-")):
+                key, value = line.split(":", 1)
+                fields[key.strip()] = value.strip()
+        raise AssertionError(f"{path}: frontmatter never closed")
+
+    def _skill_files(self):
+        for skill_dir in sorted(_SKILLS_DIR.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            for name in ("SKILL.md", "SKILL.md.tmpl"):
+                p = skill_dir / name
+                if p.exists():
+                    yield p
+
+    def test_all_skills_have_name_and_description(self):
+        for path in self._skill_files():
+            fm = self._frontmatter(path)
+            assert fm.get("name"), f"{path}: frontmatter missing name"
+            assert fm.get("description"), f"{path}: frontmatter missing description"
+
+    def test_all_skills_have_when_to_use(self):
+        """when_to_use drives discovery for both users and model invocation."""
+        for path in self._skill_files():
+            fm = self._frontmatter(path)
+            assert fm.get("when_to_use"), f"{path}: frontmatter missing when_to_use"
+
+    def test_sub_skills_marked_not_user_invocable(self):
+        """Skills documented as indirectly invoked must not be /command-visible."""
+        for skill in ("create_issue", "github_workflow"):
+            fm = self._frontmatter(_SKILLS_DIR / skill / "SKILL.md")
+            assert fm.get("user-invocable") == "false", (
+                f"{skill}: expected user-invocable: false"
+            )
+
+    def test_audit_runs_in_forked_context(self):
+        """Heavyweight scan isolates its context; findings land in a GitHub issue."""
+        fm = self._frontmatter(_SKILLS_DIR / "audit" / "SKILL.md")
+        assert fm.get("context") == "fork"


### PR DESCRIPTION
Closes #133

## Summary

Per-skill review of all 12 template skills (plus this repo's own copies) against the current SKILL.md frontmatter spec. Most were already modern (`when_to_use`, `argument-hint`, `effort`, `user-invocable`); this PR closes the remaining gaps and locks the standard in with validation tests.

## Per-skill changes

| Skill | Change | Rationale |
|---|---|---|
| `audit` | + `context: fork` | Heavyweight whole-project scan; findings land in a GitHub issue, so the main thread doesn't need its context |
| `github_workflow` (template + repo copy) | + `when_to_use` | Model-invocation discovery for push/PR/merge/fallback situations |
| `create_issue` | + `when_to_use` | Documents indirect invocation via start_task |

All other skills reviewed and left unchanged — already conformant. `context: fork` was deliberately NOT applied to `session_summary`/`plan`/`review` (they need conversation context or deliver their output into the main thread).

## Validation (new `TestSkillFrontmatter`)

- Every skill (incl. `.tmpl`) has `name`, `description`, `when_to_use`
- Sub-skills (`create_issue`, `github_workflow`) carry `user-invocable: false`
- `audit` runs in forked context

INDEX.md unchanged — still matches the skill set (covered by existing tests).

## Testing

- `uv run pytest -n auto` — 317 passed, 4 skipped
- `uv run ruff check .` — clean

https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP

---
_Generated by [Claude Code](https://claude.ai/code/session_012b88XRnavc8jdn1te2FYtP)_