### PR TITLE
feat(PI-139): Justfile as canonical command interface in templates and this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Template naming convention: directories stored as `dot_claude/`, `dot_gitignore`
 - **Deterministic** — copy/render logic is pure file ops; never call an LLM from the scaffolder itself.
 - **uv everywhere** — `uv run …`, never `pip install` or `python -m venv`.
 - **ruff only** — no black / isort / mypy.
+- **justfile is the command surface** — `just --list` shows the canonical recipes (`setup`, `lint`, `format`, `test`, `docs`, `ci`); prefer `just <recipe>` over raw tool invocations. Recipes stay thin wrappers — no logic in the justfile.
 - **Templates are tested by scaffolding into a temp dir** — any change to `templates/` should have a corresponding test in the focused `tests/test_*.py` module for that behavior. Create a new focused file if no existing module fits.
 
 ## Settings

--- a/justfile
+++ b/justfile
@@ -1,0 +1,26 @@
+# justfile — canonical command interface for this repo (PI-139 dogfood).
+# `just --list` shows every recipe. Recipes are thin wrappers — logic lives
+# in the tools and their configs, never in this file.
+
+# install/sync dev dependencies
+setup:
+    uv sync --extra dev
+
+# lint (docstring + complexity gates per pyproject.toml)
+lint:
+    uv run ruff check .
+
+# auto-format
+format:
+    uv run ruff format .
+
+# run the test suite
+test:
+    uv run pytest -n auto --tb=short -q
+
+# serve the docs site locally
+docs:
+    uv run --extra docs mkdocs serve
+
+# what CI runs
+ci: lint test

--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -4,6 +4,9 @@ Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
 
+{{#if lint_command}}Discover project commands with `just --list` — the justfile is the canonical, agent-agnostic command surface (lint, format, test, docs, ci).
+{{/if}}
+
 ## Skills (load on demand)
 
 Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/templates/base/CLAUDE.md.tmpl
+++ b/templates/base/CLAUDE.md.tmpl
@@ -19,7 +19,8 @@ All agentic-development infrastructure lives under [`.claude/`](.claude/). Start
 - **TDD** — write failing tests before any implementation. Use `/plan <task>` to generate acceptance tests first.
 - **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue. Use `/start_task` if one does not exist.
 - **GitHub workflow** — for any push, PR, review, or merge action, load `.claude/skills/github_workflow/SKILL.md`. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `type(KEY-N): desc` (no scope = no issue) | body includes `Closes #N`.
-{{#if lint_command}}- **Lint** — `{{lint_command}}` must pass before closing a task. The `pre_commit_gate` hook enforces this on every commit. The linter config also enforces docstrings and complexity caps on project code — fix the code, don't loosen the gate.
+{{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.
+- **Lint** — `just lint` must pass before closing a task. The `pre_commit_gate` hook enforces this on every commit. The linter config also enforces docstrings and complexity caps on project code — fix the code, don't loosen the gate.
 {{/if}}- **Review plugins** — `pr-review-toolkit@claude-plugins-official` is pre-enabled in `.claude/settings.json` (silent-failure-hunter, code-simplifier, type-design-analyzer agents). Also consider `/plugin install code-review@claude-plugins-official` for full PR reviews.
 - **Docs** — follow the Diátaxis layout in [`docs/`](docs/) (see `docs/index.md`). Record architectural decisions with the `add_adr` skill.
 - **No secrets in code** — never hardcode API keys, tokens, or personal data. Use `os.environ['KEY']` or a `.env` file (gitignored).

--- a/templates/base/GEMINI.md.tmpl
+++ b/templates/base/GEMINI.md.tmpl
@@ -4,6 +4,9 @@ Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
 
 Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
 
+{{#if lint_command}}Discover project commands with `just --list` — the justfile is the canonical, agent-agnostic command surface (lint, format, test, docs, ci).
+{{/if}}
+
 ## Skills (load on demand)
 
 Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/templates/base/dot_claude/docs/development/conventions.md.tmpl
+++ b/templates/base/dot_claude/docs/development/conventions.md.tmpl
@@ -3,12 +3,12 @@
 ## Code style
 
 {{#if python}}
-- Formatter/linter: `ruff` (`{{lint_command}}`)
+- Lint/format/test via `just` recipes — `just --list` shows them; linter is `ruff`
+- Docstrings required on public functions (Google style — enforced by the ruff `D` rules in `ruff.toml`, with complexity caps)
 - No type annotations required unless they clarify non-obvious interfaces
-- No docstrings unless the function name is insufficient
 {{/if}}
 {{#if node}}
-- Formatter/linter: configured in `package.json` (`{{lint_command}}`)
+- Lint/format/test via `just` recipes — `just --list` shows them; linter is ESLint (`eslint.config.mjs`, jsdoc/tsdoc + complexity gates)
 - TypeScript preferred for non-trivial modules
 {{/if}}
 

--- a/templates/base/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/base/dot_claude/hooks/pre_commit_gate.sh
@@ -59,10 +59,13 @@ if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
     git add "${STAGED_JS[@]}" 2>/dev/null || true
 fi
 
-# PI-139: when the project ships a justfile and just is installed, the final
-# gate is `just lint` — the single definition of "lint passes" shared with CI
-# and every agent. The per-file auto-fixes above still ran and re-staged.
-if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ]; then
+# PI-139: when the project ships a justfile with a lint recipe and just is
+# installed, the final gate is `just lint` — the single definition of "lint
+# passes" shared with CI and every agent. The per-file auto-fixes above still
+# ran and re-staged. A pre-existing justfile without a lint recipe (or no
+# just on PATH) keeps the per-file checks as the gate.
+if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ] \
+   && (cd "$ROOT" && just --show lint >/dev/null 2>&1); then
     ERRORS=""
     JUST_OUT=$(cd "$ROOT" && just lint 2>&1) || ERRORS="Lint errors (just lint):\n${JUST_OUT}\n"
 fi

--- a/templates/base/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/base/dot_claude/hooks/pre_commit_gate.sh
@@ -60,14 +60,13 @@ if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
 fi
 
 # PI-139: when the project ships a justfile with a lint recipe and just is
-# installed, the final gate is `just lint` — the single definition of "lint
-# passes" shared with CI and every agent. The per-file auto-fixes above still
-# ran and re-staged. A pre-existing justfile without a lint recipe (or no
-# just on PATH) keeps the per-file checks as the gate.
+# installed, additionally gate on `just lint` — the same definition of "lint
+# passes" CI and every agent use. Per-file findings above are preserved: the
+# recipe is language-specific, so in a mixed repo it may not cover everything
+# the per-file checks caught (a passing recipe must not wash those out).
 if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ] \
    && (cd "$ROOT" && just --show lint >/dev/null 2>&1); then
-    ERRORS=""
-    JUST_OUT=$(cd "$ROOT" && just lint 2>&1) || ERRORS="Lint errors (just lint):\n${JUST_OUT}\n"
+    JUST_OUT=$(cd "$ROOT" && just lint 2>&1) || ERRORS="${ERRORS}Lint errors (just lint):\n${JUST_OUT}\n"
 fi
 
 if [ -n "$ERRORS" ]; then

--- a/templates/base/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/base/dot_claude/hooks/pre_commit_gate.sh
@@ -59,6 +59,14 @@ if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
     git add "${STAGED_JS[@]}" 2>/dev/null || true
 fi
 
+# PI-139: when the project ships a justfile and just is installed, the final
+# gate is `just lint` — the single definition of "lint passes" shared with CI
+# and every agent. The per-file auto-fixes above still ran and re-staged.
+if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ]; then
+    ERRORS=""
+    JUST_OUT=$(cd "$ROOT" && just lint 2>&1) || ERRORS="Lint errors (just lint):\n${JUST_OUT}\n"
+fi
+
 if [ -n "$ERRORS" ]; then
     python3 -c "
 import json, sys

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -49,7 +49,7 @@ Hooks run automatically via `settings.json`: `github_command_guard`, `workflow_s
 - No error handling for impossible scenarios.
 - No backwards-compatibility shims — delete removed code.
 - Prefer editing existing files over creating new ones.
-{{#if lint_command}}- `{{lint_command}}` must pass before closing a task.
+{{#if lint_command}}- `just lint` must pass before closing a task (`just --list` shows all recipes).
 {{/if}}
 
 ## TDD

--- a/templates/base/dot_claude/skills/plan/SKILL.md.tmpl
+++ b/templates/base/dot_claude/skills/plan/SKILL.md.tmpl
@@ -15,9 +15,7 @@ Ask clarifying questions if needed. Answer: What is the core change? Why now? Wh
 
 Write the test assertions **before** implementation code:
 
-```{{#if lint_command}}
-{{lint_command}}
-{{/if}}bash
+```bash
 # Example: test that a function returns X when given Y
 assert_equals(parse_config("key=val"), {"key": "val"})
 assert_throws(parse_config("broken"), ParseError)

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -20,6 +20,6 @@ Canonical agent rules: [CLAUDE.md](../CLAUDE.md) | Workflow: [.claude/project-in
 
 - Write failing tests before implementation (TDD)
 - No secrets in code — use `os.environ` or `.env` (gitignored)
-{{#if lint_command}}- `{{lint_command}}` must pass before closing a task
+{{#if lint_command}}- `just lint` must pass before closing a task (`just --list` shows all recipes)
 {{/if}}- Prefer deterministic bash/python over LLM calls for hooks and scripts
 - Permanent decisions → `.claude/docs/adr/`; exploratory notes → `.claude/vault/`; reusable facts → `.claude/memory/`

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -28,27 +28,28 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
           python-version: "3.12"
 
+      # CI invokes the same justfile recipes agents and humans use (PI-139),
+      # so the command surface is defined exactly once.
+      - name: Install just
+        uses: extractions/setup-just@v4
+
       - name: Sync dev dependencies
-        run: uv sync --extra dev
+        run: just setup
 
-      - name: Lint (ruff)
-        run: {{lint_command}}
+      - name: Lint
+        run: just lint
 
-      # Optimization #1: Run tests in parallel mode
-      # Requires pytest-xdist in dev dependencies
-      # Can reduce test time by 30-50% on multi-core machines
-      #
       # Coverage gate (PI-138): activates automatically once pytest-cov is in
-      # dev dependencies; runs plain pytest until then. Tune --cov-fail-under
-      # to your project's baseline.
-      - name: Tests (pytest) — parallel, coverage-gated
+      # dev dependencies; runs plain tests until then. Tune --cov-fail-under
+      # in the justfile's test-cov recipe to your project's baseline.
+      - name: Tests — parallel, coverage-gated
         run: |
           if uv run python -c "import pytest_cov" 2>/dev/null; then
-            uv run pytest -n auto --tb=short -q --cov --cov-fail-under=70
+            just test-cov
           else
             echo "pytest-cov not installed — running without the coverage gate."
             echo "Add pytest-cov to dev dependencies to enable it."
-            uv run pytest -n auto --tb=short -q
+            just test
           fi
 {{/if python}}
 {{#if node}}
@@ -56,6 +57,10 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # CI invokes the same justfile recipes agents and humans use (PI-139).
+      - name: Install just
+        uses: extractions/setup-just@v4
 
       # Fresh scaffolds have no lockfile yet — fall back to a plain install.
       - name: Install dependencies
@@ -67,10 +72,10 @@ jobs:
           fi
 
       - name: Lint
-        run: {{lint_command}}
+        run: just lint
 
       - name: Tests
-        run: {{test_command}}
+        run: just test
 {{/if node}}
 {{#if go}}
       - name: Set up Go
@@ -78,11 +83,17 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The action installs + caches golangci-lint on CI; locally `just lint`
+      # runs the same `golangci-lint run` against the same .golangci.yml.
       - name: Lint (golangci-lint)
         uses: golangci/golangci-lint-action@v6
 
+      # CI invokes the same justfile recipes agents and humans use (PI-139).
+      - name: Install just
+        uses: extractions/setup-just@v4
+
       - name: Tests
-        run: {{test_command}}
+        run: just test
 {{/if go}}
 
       - name: Post failure summary

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -58,7 +58,9 @@ jobs:
         with:
           bun-version: latest
 
-      # CI invokes the same justfile recipes agents and humans use (PI-139).
+      # Lint/test invoke the same justfile recipes agents and humans use
+      # (PI-139). Dependency install stays inline: the frozen-lockfile
+      # fallback below is CI-specific logic that doesn't belong in a recipe.
       - name: Install just
         uses: extractions/setup-just@v4
 
@@ -88,7 +90,8 @@ jobs:
       - name: Lint (golangci-lint)
         uses: golangci/golangci-lint-action@v6
 
-      # CI invokes the same justfile recipes agents and humans use (PI-139).
+      # Tests run via the justfile recipe agents and humans use (PI-139);
+      # lint stays on the action above, which installs and caches the binary.
       - name: Install just
         uses: extractions/setup-just@v4
 

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -1,0 +1,95 @@
+{{#if python}}# justfile — the canonical command interface (scaffolded by project-init).
+# `just --list` shows every recipe. Recipes are thin wrappers — logic lives
+# in the tools and their configs, never in this file.
+
+# install/sync dev dependencies
+setup:
+    uv sync --extra dev
+
+# lint project code (docstring + complexity gates per ruff.toml)
+lint:
+    uv run ruff check .
+
+# auto-format project code
+format:
+    uv run ruff format .
+
+# run the test suite
+test:
+    uv run pytest -n auto --tb=short -q
+
+# tests with the coverage gate (what CI runs when pytest-cov is installed)
+test-cov:
+    uv run pytest -n auto --tb=short -q --cov --cov-fail-under=70
+
+# serve the docs site locally
+docs:
+    uv run --with mkdocs-material --with "mkdocstrings[python]" mkdocs serve
+
+# scan staged changes for secrets (same scan as the pre-commit git hook)
+scan:
+    gitleaks git --pre-commit --staged --redact --no-banner --verbose
+
+# what CI runs
+ci: lint test
+{{/if python}}{{#if node}}# justfile — the canonical command interface (scaffolded by project-init).
+# `just --list` shows every recipe. Recipes are thin wrappers — logic lives
+# in the tools and their configs, never in this file.
+
+# install dependencies
+setup:
+    bun install
+
+# lint project code (jsdoc/tsdoc + complexity gates per eslint.config.mjs)
+lint:
+    bun run lint
+
+# auto-format project code
+format:
+    bun run format
+
+# run the test suite
+test:
+    bun test
+
+# build the API docs (TypeDoc)
+docs:
+    bunx typedoc
+
+# scan staged changes for secrets (same scan as the pre-commit git hook)
+scan:
+    gitleaks git --pre-commit --staged --redact --no-banner --verbose
+
+# what CI runs
+ci: lint test
+{{/if node}}{{#if go}}# justfile — the canonical command interface (scaffolded by project-init).
+# `just --list` shows every recipe. Recipes are thin wrappers — logic lives
+# in the tools and their configs, never in this file.
+
+# download module dependencies
+setup:
+    go mod download
+
+# lint project code (revive/godoclint/gocognit gates per .golangci.yml)
+lint:
+    golangci-lint run
+
+# auto-format project code
+format:
+    gofmt -w .
+
+# run the test suite
+test:
+    go test ./...
+
+# docs: nothing to build — pkg.go.dev renders doc comments
+docs:
+    @echo "pkg.go.dev renders Go doc comments — nothing to build locally"
+
+# scan staged changes for secrets (same scan as the pre-commit git hook)
+scan:
+    gitleaks git --pre-commit --staged --redact --no-banner --verbose
+
+# what CI runs
+ci: lint test
+{{/if go}}

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -113,8 +113,8 @@ class TestRecipesAreTheSingleCallsite:
 
     def test_no_just_reference_for_language_none(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "none")
-        for name in ("AGENTS.md", "GEMINI.md"):
-            assert "just --list" not in (target / name).read_text()
+        for name in ("CLAUDE.md", "AGENTS.md", "GEMINI.md"):
+            assert "just --list" not in (target / name).read_text(), name
 
 
 class TestDogfoodJustfile:

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -102,6 +102,9 @@ class TestRecipesAreTheSingleCallsite:
         hook = (target / ".claude" / "hooks" / "pre_commit_gate.sh").read_text()
         assert "just lint" in hook
         assert "command -v just" in hook, "must fall back when just is not installed"
+        assert "just --show lint" in hook, (
+            "must fall back when a pre-existing justfile has no lint recipe"
+        )
 
     def test_instruction_files_reference_just_list(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "p", "python")

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -1,0 +1,123 @@
+"""PI-139: the justfile is the canonical command interface per language.
+
+Recipes must be thin wrappers matching the preset's toolchain, hooks and CI
+must call recipes instead of inline commands, and language=none scaffolds
+get no justfile at all.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RECIPES = ("setup", "lint", "format", "test", "docs", "ci", "scan")
+
+
+# Mirrors _LANGUAGE_COMMANDS in __main__.py: empty commands for language=none.
+_COMMANDS = {
+    "python": ("uv run ruff check .", "uv run ruff format .", "uv run pytest"),
+    "node": ("bun run lint", "bun run format", "bun test"),
+    "go": ("golangci-lint run", "gofmt -w .", "go test ./..."),
+}
+
+
+def _scaffold_language(target: Path, language: str) -> Path:
+    flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go")}
+    lint, fmt, test = _COMMANDS.get(language, ("", "", ""))
+    variables = make_variables(
+        language=language, lint_command=lint, format_command=fmt, test_command=test, **flags
+    )
+    scaffold(target, load_preset("obsidian-only"), variables)
+    return target
+
+
+def _recipe_body(justfile_text: str, name: str) -> str:
+    match = re.search(rf"^{name}:.*\n((?:[ \t]+.*\n?)*)", justfile_text, re.MULTILINE)
+    assert match, f"recipe {name!r} not found"
+    return match.group(1)
+
+
+class TestJustfilePerLanguage:
+    @pytest.mark.parametrize(
+        ("language", "lint_cmd", "test_cmd"),
+        [
+            ("python", "uv run ruff check .", "uv run pytest"),
+            ("node", "bun run lint", "bun test"),
+            ("go", "golangci-lint run", "go test ./..."),
+        ],
+    )
+    def test_recipes_match_toolchain(self, tmp_path: Path, language, lint_cmd, test_cmd):
+        target = _scaffold_language(tmp_path / language, language)
+        text = (target / "justfile").read_text()
+        for recipe in _RECIPES:
+            assert re.search(rf"^{recipe}:", text, re.MULTILINE), f"{recipe} missing ({language})"
+        assert lint_cmd in _recipe_body(text, "lint")
+        assert test_cmd in _recipe_body(text, "test")
+        assert "gitleaks git --pre-commit" in _recipe_body(text, "scan")
+
+    def test_ci_recipe_is_pure_dependency(self, tmp_path: Path):
+        """`ci: lint test` — recipes referencing recipes, no duplicated commands."""
+        target = _scaffold_language(tmp_path / "p", "python")
+        text = (target / "justfile").read_text()
+        assert re.search(r"^ci: lint test\s*$", text, re.MULTILINE)
+
+    def test_python_coverage_recipe(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "p", "python")
+        text = (target / "justfile").read_text()
+        assert "--cov-fail-under" in _recipe_body(text, "test-cov")
+
+    def test_no_justfile_for_language_none(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "n", "none")
+        assert not (target / "justfile").exists()
+
+    def test_no_just_interpolation_braces(self, tmp_path: Path):
+        """Recipes stay parameterless: just's own {{...}} interpolation would
+        collide with the template engine and trip strict mode."""
+        target = _scaffold_language(tmp_path / "p", "python")
+        assert "{{" not in (target / "justfile").read_text()
+
+
+class TestRecipesAreTheSingleCallsite:
+    def test_ci_workflow_calls_just(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "p", "python")
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "extractions/setup-just@v4" in ci
+        assert "just lint" in ci
+        assert "just test-cov" in ci
+
+    def test_node_ci_calls_just(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "n", "node")
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just lint" in ci
+        assert "just test" in ci
+
+    def test_pre_commit_gate_uses_just_lint(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "p", "python")
+        hook = (target / ".claude" / "hooks" / "pre_commit_gate.sh").read_text()
+        assert "just lint" in hook
+        assert "command -v just" in hook, "must fall back when just is not installed"
+
+    def test_instruction_files_reference_just_list(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "p", "python")
+        for name in ("CLAUDE.md", "AGENTS.md", "GEMINI.md"):
+            assert "just --list" in (target / name).read_text(), f"{name} missing just --list"
+
+    def test_no_just_reference_for_language_none(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "n", "none")
+        for name in ("AGENTS.md", "GEMINI.md"):
+            assert "just --list" not in (target / name).read_text()
+
+
+class TestDogfoodJustfile:
+    def test_repo_has_justfile_with_core_recipes(self):
+        text = (_REPO_ROOT / "justfile").read_text()
+        for recipe in ("setup", "lint", "format", "test", "docs", "ci"):
+            assert re.search(rf"^{recipe}:", text, re.MULTILINE), f"{recipe} missing"
+        assert "uv run ruff check ." in text
+        assert "uv run pytest" in text

--- a/tests/unit/test_command_variables.py
+++ b/tests/unit/test_command_variables.py
@@ -18,8 +18,11 @@ class TestCommandVariables:
 
     def test_python_renders_uv_run_ruff(self, tmp_path: Path):
         target = self._scaffold_with_lang(tmp_path)
+        # PI-139: CLAUDE.md points at the justfile recipe — the raw command
+        # lives in exactly one place, the justfile itself.
         content = (target / "CLAUDE.md").read_text()
-        assert "uv run ruff check ." in content
+        assert "just lint" in content
+        assert "uv run ruff check ." in (target / "justfile").read_text()
         config = (target / ".claude" / "config.yaml").read_text()
         assert 'lint_command: "uv run ruff check ."' in config
         assert 'test_command: "uv run pytest"' in config


### PR DESCRIPTION
## Summary

Collapses the smeared command surface (template variables, CLAUDE.md prose, hook scripts, `ci.yml.tmpl`) into one definition: the justfile. `just lint` now means the same thing for Claude Code, any other agent, CI, and humans — prerequisite-grade for the multi-agent work in #137.

- **`justfile.tmpl` per language** (python/node/go; `language=none` scaffolds get no justfile via the empty-render skip): `setup`, `lint`, `format`, `test`, `docs`, `ci`, `scan` — plus `test-cov` wrapping the Python coverage gate. `ci: lint test` is a pure recipe dependency. The `scan` recipe wraps the same gitleaks command as the pre-commit git hook (#131 coordination).
- **Thin wrappers enforced by construction**: recipes are deliberately parameterless — just's own `{{...}}` interpolation would collide with the scaffolder's template syntax and trip `--strict` mode, so any future urge to add logic to the justfile hits a guardrail (and a contract test asserts no `{{` survives).
- **CI calls recipes**: `ci.yml.tmpl` installs just (`extractions/setup-just@v4`, verified current) and runs `just lint` / `just test-cov` / `just test`. Go lint keeps `golangci-lint-action` (it's the canonical CI installer/cacher) with a comment noting `just lint` runs the identical command locally.
- **Hooks**: `pre_commit_gate.sh` gates on `just lint` when just and a justfile are present (single definition of "lint passes"), falling back to the existing per-file checks otherwise. `post_edit_lint.sh` intentionally stays per-file — it's fast UX feedback on the edited file, not the gate.
- **Instructions**: scaffolded CLAUDE.md/AGENTS.md/GEMINI.md point agents at `just --list` as the command-discovery mechanism.
- **Dogfooding**: this repo ships its own justfile (`setup`/`lint`/`format`/`test`/`docs`/`ci`) documented in CLAUDE.md.

## Test plan

- `uv run pytest` — **356 passed, 4 skipped** (13 new tests)
- Contract tests: recipes match each preset's toolchain (commands parsed out of recipe bodies, not just substring-matched), `ci` is a pure dependency recipe, CI workflow/hook/instruction files reference recipes, no justfile or `just --list` reference for `language=none`
- Strict-mode CLI scaffold verified end-to-end for python
- One pre-existing test updated: PI-16's assertion that the raw lint command appears in CLAUDE.md now asserts the `just lint` pointer instead — the raw command living only in the justfile is the point of this ticket

Closes #139

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwE4JmKzyPiiwnHnHfb64L)_