### PR TITLE
chore(PI-144): Tagged releases, changelog, release-pinned install.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+# Release on tag push (ADR-008): build the wheel, generate the changelog
+# for the latest tag from Conventional Commits (ADR-006), publish a GitHub
+# Release with the artifacts.
+#
+# Cutting a release:
+#   1. Bump version in pyproject.toml AND src/project_init/__init__.py
+#   2. git tag vX.Y.Z && push the tag
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history — git-cliff needs prior tags to scope --latest.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Verify tag matches package version
+        run: |
+          PKG_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "v$PKG_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Generate changelog (latest tag)
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*
+          body_path: RELEASE_NOTES.md

--- a/README.md
+++ b/README.md
@@ -57,7 +57,22 @@ Two honest caveats:
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
 ```
 
-This installs [`uv`](https://docs.astral.sh/uv/) if missing, clones the repo to `~/.local/share/project-init` (override with `PROJECT_INIT_HOME=...`), and writes a user-level slash command at `~/.claude/commands/project-init.md`.
+This installs [`uv`](https://docs.astral.sh/uv/) if missing, clones the repo to `~/.local/share/project-init` (override with `PROJECT_INIT_HOME=...`) **pinned to the latest tagged release**, and writes a user-level slash command at `~/.claude/commands/project-init.md`.
+
+Pin a specific version, or opt into the unreleased development head:
+
+```bash
+PROJECT_INIT_REF=v0.2.0 bash -c "$(curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh)"
+PROJECT_INIT_REF=main   bash -c "$(curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh)"
+```
+
+Direct tool install without the slash command (any pinned tag):
+
+```bash
+uv tool install git+https://github.com/VytCepas/project-init@v0.2.0
+```
+
+Distribution is git-only by design — see [ADR-008](docs/adr/adr-008-distribution-channel.md).
 
 ## Use
 
@@ -110,9 +125,14 @@ The test suite validates this command works correctly — see `TestREADMEExample
 
 ## Update
 
+Re-run the installer — it moves the clone to the latest tagged release:
+
 ```bash
-git -C ~/.local/share/project-init pull
+curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
 ```
+
+(`PROJECT_INIT_REF=main` for the development head; releases are cut by
+tagging `vX.Y.Z`, which triggers the release workflow.)
 
 ## Uninstall
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,32 @@
+# git-cliff configuration (ADR-006/ADR-008): changelog from Conventional
+# Commits, rendered into GitHub Releases by .github/workflows/release.yml.
+
+[changelog]
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+          {% if commit.breaking %}[**breaking**] {% endif %}\
+          {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+]

--- a/docs/adr/adr-008-distribution-channel.md
+++ b/docs/adr/adr-008-distribution-channel.md
@@ -1,0 +1,45 @@
+# ADR-008: Distribution stays git-based with tagged releases; PyPI deferred
+
+- Status: Accepted
+- Date: 2026-06-11
+- Implements: distribution decision required by #144
+
+## Context
+
+`install.sh` cloned `main` and the documented update path was `git pull` —
+every user tracked an unreleased moving target, and version 0.1.0 was never
+followed by a tag. For colleagues to adopt project-init safely, installs
+must be reproducible and pinnable. The open question was the channel:
+git-only, or also publish to PyPI.
+
+## Considered Options
+
+1. **Git-only with tagged releases** — release workflow on tag push,
+   `install.sh` resolves the latest release tag, `PROJECT_INIT_REF` pins.
+2. **Also publish to PyPI** — `uv tool install project-init`.
+
+## Decision Outcome
+
+Chosen option 1, git-only with tagged releases:
+
+- Pinning works without PyPI: `install.sh` defaults to the latest GitHub
+  Release tag; `PROJECT_INIT_REF=vX.Y.Z` pins a version and
+  `PROJECT_INIT_REF=main` opts into the development head. Direct installs
+  work too: `uv tool install git+https://github.com/VytCepas/project-init@vX.Y.Z`.
+- PyPI adds real overhead (account/token custody, name claim, mandatory
+  version discipline for every fix) and its main benefit — frictionless org
+  rollout — has no current demand.
+- The decision is cheap to reverse: a `uv publish` step appended to the
+  existing release workflow is the entire migration.
+
+**Revisit trigger:** an org rollout that needs `uv tool install
+project-init` from an index (private mirrors, locked-down egress), or a
+second team adopting the tool.
+
+### Consequences
+
+- Good: reproducible installs now; no new infrastructure or secrets.
+- Good: the release workflow (wheel + git-cliff changelog from
+  Conventional Commits, ADR-006) is the single release path.
+- Bad: install still requires git + GitHub reachability; air-gapped
+  environments must mirror the repo.

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,9 @@ set -euo pipefail
 REPO_URL="${PROJECT_INIT_REPO:-https://github.com/VytCepas/project-init.git}"
 INSTALL_DIR="${PROJECT_INIT_HOME:-$HOME/.local/share/project-init}"
 COMMANDS_DIR="$HOME/.claude/commands"
+# Pin a version with PROJECT_INIT_REF=vX.Y.Z, or track the development head
+# with PROJECT_INIT_REF=main. Default: the latest GitHub Release (ADR-008).
+REQUESTED_REF="${PROJECT_INIT_REF:-}"
 
 say() { printf '\033[1;36m[project-init]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[project-init]\033[0m %s\n' "$*" >&2; }
@@ -38,19 +41,50 @@ ensure_uv() {
     command -v uv >/dev/null 2>&1 || die "uv install failed — check shell PATH"
 }
 
-# 2. repo
-ensure_repo() {
-    if [ -d "$INSTALL_DIR/.git" ]; then
-        say "updating existing clone at $INSTALL_DIR"
-        git -C "$INSTALL_DIR" pull --ff-only
+# 2. ref — latest release tag unless PROJECT_INIT_REF overrides
+resolve_ref() {
+    if [ -n "$REQUESTED_REF" ]; then
+        printf '%s\n' "$REQUESTED_REF"
+        return
+    fi
+    # Derive owner/repo from REPO_URL for the API query (github.com only).
+    local slug tag
+    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$#\1#p')
+    if [ -n "$slug" ]; then
+        tag=$(curl -fsSL "https://api.github.com/repos/$slug/releases/latest" 2>/dev/null \
+            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)
+    fi
+    if [ -n "${tag:-}" ]; then
+        printf '%s\n' "$tag"
     else
-        say "cloning $REPO_URL -> $INSTALL_DIR"
-        mkdir -p "$(dirname "$INSTALL_DIR")"
-        git clone "$REPO_URL" "$INSTALL_DIR"
+        warn "could not resolve the latest release (none published yet?) — falling back to main"
+        warn "pin explicitly with: PROJECT_INIT_REF=vX.Y.Z"
+        printf 'main\n'
     fi
 }
 
-# 3. slash command
+# 3. repo
+ensure_repo() {
+    REF="$(resolve_ref)"
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        say "updating existing clone at $INSTALL_DIR (ref: $REF)"
+        git -C "$INSTALL_DIR" fetch --tags --force origin
+    else
+        say "cloning $REPO_URL ($REF) -> $INSTALL_DIR"
+        mkdir -p "$(dirname "$INSTALL_DIR")"
+        git clone "$REPO_URL" "$INSTALL_DIR"
+    fi
+    if [ "$REF" = "main" ]; then
+        git -C "$INSTALL_DIR" checkout -q main
+        git -C "$INSTALL_DIR" pull --ff-only
+    else
+        # Release tags check out detached — exactly what a pinned install wants.
+        git -C "$INSTALL_DIR" checkout -q "$REF"
+    fi
+    say "installed: $(git -C "$INSTALL_DIR" describe --tags --always)"
+}
+
+# 4. slash command
 ensure_slash_command() {
     mkdir -p "$COMMANDS_DIR"
     cat >"$COMMANDS_DIR/project-init.md" <<CMD
@@ -79,7 +113,9 @@ $(printf '\033[1;32m[project-init]\033[0m done.')
 Next steps:
   • Inside any Claude Code session:        /project-init
   • From a shell (any project):            uvx --from $INSTALL_DIR project-init
-  • Update later:                          git -C $INSTALL_DIR pull
+  • Update to the latest release:          re-run this installer
+  • Pin a specific version:                PROJECT_INIT_REF=vX.Y.Z installer
+  • Track the development head:            PROJECT_INIT_REF=main installer
 
 EOF
 }

--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,10 @@ resolve_ref() {
         return
     fi
     # Derive owner/repo from REPO_URL for the API query (github.com only).
+    # POSIX ERE has no lazy quantifier, so strip the .git suffix separately.
     local slug tag
-    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$#\1#p')
+    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*github\.com[:/]([^/]+/[^/]+)$#\1#p')
+    slug="${slug%.git}"
     if [ -n "$slug" ]; then
         tag=$(curl -fsSL "https://api.github.com/repos/$slug/releases/latest" 2>/dev/null \
             | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.1.0"
+version = "0.2.0"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,4 +1,4 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -78,6 +78,7 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail if any {{...}} placeholder survives rendering (PI-17)",
     )
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p
 
 

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -64,6 +64,12 @@ class TestInstallScriptPinning:
         content = self._script()
         assert "falling back to main" in content
 
+    def test_strips_git_suffix_from_repo_slug(self):
+        """Codex review regression: POSIX ERE has no lazy quantifier, so the
+        .git suffix must be stripped separately or the API URL 404s."""
+        content = self._script()
+        assert '"${slug%.git}"' in content
+
     def test_no_unpinned_update_path(self):
         """The old `git pull` on whatever-was-checked-out update path is gone:
         pull only happens on an explicit main checkout."""

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -1,0 +1,85 @@
+"""PI-144: tagged releases, changelog, pinned installs (ADR-008).
+
+Contract checks on the release workflow, the git-cliff config, install.sh's
+ref resolution, and version consistency across the package.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestReleaseWorkflow:
+    def _workflow(self) -> str:
+        return (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    def test_triggers_on_version_tags(self):
+        content = self._workflow()
+        assert 'tags: ["v*"]' in content
+        assert "contents: write" in content
+
+    def test_builds_artifacts_and_publishes_release(self):
+        content = self._workflow()
+        assert "uv build" in content
+        assert "softprops/action-gh-release@v3" in content
+        assert "files: dist/*" in content
+
+    def test_changelog_generated_from_latest_tag(self):
+        content = self._workflow()
+        assert "orhun/git-cliff-action@v4" in content
+        assert "--latest" in content
+        assert "fetch-depth: 0" in content, "git-cliff needs full history for prior tags"
+
+    def test_guards_tag_version_consistency(self):
+        content = self._workflow()
+        assert "GITHUB_REF_NAME" in content
+        assert "pyproject.toml" in content
+
+
+class TestCliffConfig:
+    def test_parses_and_uses_conventional_commits(self):
+        config = tomllib.loads((_REPO_ROOT / "cliff.toml").read_text())
+        assert config["git"]["conventional_commits"] is True
+        groups = {p.get("group") for p in config["git"]["commit_parsers"]}
+        assert {"Features", "Bug Fixes"} <= groups
+
+
+class TestInstallScriptPinning:
+    def _script(self) -> str:
+        return (_REPO_ROOT / "install.sh").read_text()
+
+    def test_resolves_latest_release_by_default(self):
+        content = self._script()
+        assert "releases/latest" in content
+        assert "tag_name" in content
+
+    def test_ref_override_documented_and_used(self):
+        content = self._script()
+        assert "PROJECT_INIT_REF" in content
+
+    def test_falls_back_to_main_when_no_release(self):
+        content = self._script()
+        assert "falling back to main" in content
+
+    def test_no_unpinned_update_path(self):
+        """The old `git pull` on whatever-was-checked-out update path is gone:
+        pull only happens on an explicit main checkout."""
+        content = self._script()
+        assert "checkout -q main" in content
+        assert "checkout -q \"$REF\"" in content
+
+
+class TestVersionConsistency:
+    def test_package_dunder_matches_pyproject(self):
+        pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+        init = (_REPO_ROOT / "src" / "project_init" / "__init__.py").read_text()
+        version = pyproject["project"]["version"]
+        assert f'__version__ = "{version}"' in init
+
+    def test_readme_documents_pinning_and_update(self):
+        content = (_REPO_ROOT / "README.md").read_text()
+        assert "PROJECT_INIT_REF" in content
+        assert "adr-008" in content

--- a/tests/smoke/test_packaging.py
+++ b/tests/smoke/test_packaging.py
@@ -64,6 +64,18 @@ class TestInstalledWheel:
         if not venv_bin.exists():  # Windows fallback
             venv_bin = venv_dir / "Scripts" / "project-init.exe"
 
+        # PI-144: the installed release artifact must report its version —
+        # this is what install pinning and the upgrade path key off.
+        import tomllib
+        pkg_version = tomllib.loads(
+            (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
+        )["project"]["version"]
+        version_out = subprocess.run(
+            [str(venv_bin), "--version"], capture_output=True, text=True, timeout=30
+        )
+        assert version_out.returncode == 0
+        assert pkg_version in version_out.stdout
+
         # Scaffold using the installed binary, with --strict.
         result = subprocess.run(
             [

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Installation becomes reproducible: users get the latest tagged release instead of tracking an unreleased `main`.

- **Release workflow** (`release.yml`): on `v*` tag push — guard that the tag matches the pyproject version, `uv build`, git-cliff changelog scoped to the latest tag (Conventional Commits per ADR-006), GitHub Release with wheel + sdist. Action versions verified current: `softprops/action-gh-release@v3`, `orhun/git-cliff-action@v4` (with the required `fetch-depth: 0`).
- **`install.sh`**: resolves the latest GitHub Release tag via the API by default (owner/repo derived from `PROJECT_INIT_REPO`, so forks work); `PROJECT_INIT_REF=vX.Y.Z` pins, `PROJECT_INIT_REF=main` opts into the development head. While no release exists yet it falls back to `main` with a loud warning, so this PR is safe to merge before the first tag. Updates re-resolve the ref instead of blind `git pull`.
- **ADR-008**: distribution stays git-only (`uv tool install git+...@tag` covers pinned direct installs); PyPI deferred with an explicit revisit trigger — appending `uv publish` to the release workflow is the entire migration if that changes.
- **`--version` flag added**: the ticket assumed it existed; only `__version__` did. #142's upgrade path needs it. Version bumped to **0.2.0** for the first tagged release.
- **README**: install / pin / update documentation.

## Test plan

- `uv run pytest` — **367 passed, 4 skipped** (11 new tests)
- Contracts: release workflow triggers/guard/changelog/artifacts, cliff.toml parses with conventional commits, install.sh resolves `releases/latest` + override + fallback, `__version__` ↔ pyproject consistency, README documents pinning
- Wheel smoke now asserts the built artifact reports its version via `--version` (the value pinning and upgrades key off)
- `bash -n install.sh` clean

## After merge

Cut the first release with: bump nothing (already 0.2.0) — `git tag v0.2.0 && git push origin v0.2.0`. The workflow does the rest; `install.sh` then starts resolving v0.2.0 automatically.

Closes #144

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwE4JmKzyPiiwnHnHfb64L)_