### PR TITLE
chore(PI-143): Renovate for this repo and scaffolded projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,15 @@
   "commitMessagePrefix": "[nojira][chore]",
   "lockFileMaintenance": {
     "enabled": true
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Action refs in scaffolded workflow templates: the github-actions manager cannot parse them ({{#if}} blocks break YAML), so match uses: lines directly. Keeps the scaffolder from shipping stale action pins.",
+      "managerFilePatterns": ["/^templates/.*\\.ya?ml\\.tmpl$/"],
+      "matchStrings": ["uses: (?<depName>[^/\\s]+/[^@/\\s]+)@(?<currentValue>v[\\d.]+)"],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "group:allNonMajor"
   ],
   "semanticCommits": "disabled",
-  "commitMessagePrefix": "[nojira][chore]",
+  "commitMessagePrefix": "chore:",
   "lockFileMaintenance": {
     "enabled": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "schedule:weekly",
+    "group:allNonMajor"
+  ],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "[nojira][chore]",
+  "lockFileMaintenance": {
+    "enabled": true
+  }
+}

--- a/templates/base/dot_claude/docs/guides/developer-onboarding.md
+++ b/templates/base/dot_claude/docs/guides/developer-onboarding.md
@@ -17,9 +17,10 @@ and CI catches leaks instead.
 
 The repo ships a `renovate.json` (weekly grouped updates, GitHub Actions
 pinned by digest, lockfile maintenance — managers activate automatically
-from the files present). Renovate PRs arrive as `[nojira][chore] …`, which
-the PR validators accept. One per-org step: install the
-[Renovate GitHub App](https://github.com/apps/renovate) on the repository.
+from the files present). Renovate PRs arrive as `chore: Update …`, the
+canonical no-issue title format the PR validators accept. One per-org
+step: install the [Renovate GitHub App](https://github.com/apps/renovate)
+on the repository.
 
 To centralize policy across an organization, replace the `extends` list
 with a shared preset and keep repo files minimal:

--- a/templates/base/dot_claude/docs/guides/developer-onboarding.md
+++ b/templates/base/dot_claude/docs/guides/developer-onboarding.md
@@ -23,10 +23,16 @@ step: install the [Renovate GitHub App](https://github.com/apps/renovate)
 on the repository.
 
 To centralize policy across an organization, replace the `extends` list
-with a shared preset and keep repo files minimal:
+with a shared preset. Keep the PR-title settings unless the org preset
+provides them — Renovate's defaults (`chore(deps): …`) fail this repo's
+PR-title validator:
 
 ```json
-{ "extends": ["github>your-org/renovate-config"] }
+{
+  "extends": ["github>your-org/renovate-config"],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "chore:"
+}
 ```
 
 ## Global gitignore

--- a/templates/base/dot_claude/docs/guides/developer-onboarding.md
+++ b/templates/base/dot_claude/docs/guides/developer-onboarding.md
@@ -13,6 +13,21 @@ automatically. Install [gitleaks](https://github.com/gitleaks/gitleaks#installin
 for fast local secret scanning; without it the pre-commit scan is skipped
 and CI catches leaks instead.
 
+## Dependency updates (Renovate)
+
+The repo ships a `renovate.json` (weekly grouped updates, GitHub Actions
+pinned by digest, lockfile maintenance — managers activate automatically
+from the files present). Renovate PRs arrive as `[nojira][chore] …`, which
+the PR validators accept. One per-org step: install the
+[Renovate GitHub App](https://github.com/apps/renovate) on the repository.
+
+To centralize policy across an organization, replace the `extends` list
+with a shared preset and keep repo files minimal:
+
+```json
+{ "extends": ["github>your-org/renovate-config"] }
+```
+
 ## Global gitignore
 
 Keep OS and editor junk out of every repo you touch, without bloating each

--- a/templates/base/renovate.json
+++ b/templates/base/renovate.json
@@ -7,7 +7,7 @@
     "group:allNonMajor"
   ],
   "semanticCommits": "disabled",
-  "commitMessagePrefix": "[nojira][chore]",
+  "commitMessagePrefix": "chore:",
   "lockFileMaintenance": {
     "enabled": true
   }

--- a/templates/base/renovate.json
+++ b/templates/base/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "schedule:weekly",
+    "group:allNonMajor"
+  ],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "[nojira][chore]",
+  "lockFileMaintenance": {
+    "enabled": true
+  }
+}

--- a/tests/contracts/test_renovate.py
+++ b/tests/contracts/test_renovate.py
@@ -18,8 +18,9 @@ from tests.helpers import make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Must match the legacy format accepted by validate-pr.yml and commit-msg.
-_LEGACY_TITLE_RE = re.compile(r"^\[(?:[A-Z][A-Z0-9]{1,9}-[0-9]+|nojira)\]\[(?:feat|fix|chore|docs|test)\]$")
+# The canonical no-issue title format from validate-pr.yml (ADR-006:
+# generators emit only the canonical format, never the legacy brackets).
+_CANONICAL_TITLE_RE = re.compile(r"^(feat|fix|chore|docs|test)!?: .+")
 
 
 def _assert_renovate_contract(config: dict) -> None:
@@ -28,8 +29,13 @@ def _assert_renovate_contract(config: dict) -> None:
     assert "schedule:weekly" in config["extends"]
     assert "group:allNonMajor" in config["extends"]
     assert config["semanticCommits"] == "disabled"
-    assert _LEGACY_TITLE_RE.match(config["commitMessagePrefix"]), (
-        "Renovate PR titles must pass the repo's legacy title validator"
+    # Renovate derives the PR title from the commit message's first line,
+    # which starts with commitMessagePrefix followed by a space-joined action
+    # ("Update dependency X..."). Validate the resulting title shape against
+    # the same pattern the validate-pr workflow enforces.
+    simulated_title = f"{config['commitMessagePrefix']} Update dependency foo to v9"
+    assert _CANONICAL_TITLE_RE.match(simulated_title), (
+        f"Renovate PR title {simulated_title!r} would fail the title validator"
     )
     assert config["lockFileMaintenance"]["enabled"] is True
 

--- a/tests/contracts/test_renovate.py
+++ b/tests/contracts/test_renovate.py
@@ -1,0 +1,57 @@
+"""PI-143: Renovate config for this repo and scaffolded projects.
+
+Renovate managers are file-detection based (pep621 sees pyproject.toml, bun
+sees bun.lock, gomod sees go.mod), so one config serves every language
+preset — the contract is validity plus the workflow-compatible PR format.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Must match the legacy format accepted by validate-pr.yml and commit-msg.
+_LEGACY_TITLE_RE = re.compile(r"^\[(?:[A-Z][A-Z0-9]{1,9}-[0-9]+|nojira)\]\[(?:feat|fix|chore|docs|test)\]$")
+
+
+def _assert_renovate_contract(config: dict) -> None:
+    assert "config:recommended" in config["extends"]
+    assert "helpers:pinGitHubActionDigests" in config["extends"], "Actions must pin by digest"
+    assert "schedule:weekly" in config["extends"]
+    assert "group:allNonMajor" in config["extends"]
+    assert config["semanticCommits"] == "disabled"
+    assert _LEGACY_TITLE_RE.match(config["commitMessagePrefix"]), (
+        "Renovate PR titles must pass the repo's legacy title validator"
+    )
+    assert config["lockFileMaintenance"]["enabled"] is True
+
+
+class TestRepoRenovateConfig:
+    def test_valid_json_with_required_policy(self):
+        config = json.loads((_REPO_ROOT / "renovate.json").read_text())
+        _assert_renovate_contract(config)
+
+
+class TestScaffoldedRenovateConfig:
+    @pytest.mark.parametrize("language", ["python", "node", "go", "none"])
+    def test_rendered_valid_for_every_language(self, tmp_path: Path, language: str):
+        target = tmp_path / language
+        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go")}
+        scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags))
+        config = json.loads((target / "renovate.json").read_text())
+        _assert_renovate_contract(config)
+
+    def test_onboarding_documents_org_preset(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, load_preset("obsidian-only"), make_variables())
+        guide = (target / ".claude" / "docs" / "guides" / "developer-onboarding.md").read_text()
+        assert "renovate-config" in guide
+        assert "github>your-org" in guide

--- a/tests/contracts/test_renovate.py
+++ b/tests/contracts/test_renovate.py
@@ -39,6 +39,22 @@ class TestRepoRenovateConfig:
         config = json.loads((_REPO_ROOT / "renovate.json").read_text())
         _assert_renovate_contract(config)
 
+    def test_custom_manager_covers_workflow_templates(self):
+        """Codex review (PI-143): .yml.tmpl workflows are not valid YAML
+        ({{#if}} blocks), so the github-actions manager skips them — a regex
+        custom manager must keep template action pins fresh instead."""
+        config = json.loads((_REPO_ROOT / "renovate.json").read_text())
+        manager = config["customManagers"][0]
+        assert manager["customType"] == "regex"
+        assert manager["datasourceTemplate"] == "github-tags"
+
+        # The regex must match every `uses:` ref in the template workflows.
+        pattern = re.compile(manager["matchStrings"][0].replace("(?<", "(?P<"))
+        for tmpl in (_REPO_ROOT / "templates").rglob("*.yml.tmpl"):
+            for line in tmpl.read_text().splitlines():
+                if "uses:" in line:
+                    assert pattern.search(line), f"unmatched action ref in {tmpl.name}: {line.strip()}"
+
 
 class TestScaffoldedRenovateConfig:
     @pytest.mark.parametrize("language", ["python", "node", "go", "none"])

--- a/tests/contracts/test_renovate.py
+++ b/tests/contracts/test_renovate.py
@@ -50,8 +50,11 @@ class TestRepoRenovateConfig:
         ({{#if}} blocks), so the github-actions manager skips them — a regex
         custom manager must keep template action pins fresh instead."""
         config = json.loads((_REPO_ROOT / "renovate.json").read_text())
-        manager = config["customManagers"][0]
-        assert manager["customType"] == "regex"
+        regex_managers = [
+            m for m in config["customManagers"] if m["customType"] == "regex"
+        ]
+        assert regex_managers, "regex custom manager for workflow templates missing"
+        manager = regex_managers[0]
         assert manager["datasourceTemplate"] == "github-tags"
 
         # The regex must match every `uses:` ref in the template workflows.


### PR DESCRIPTION
## Summary

Automated dependency maintenance for both this repo and every scaffolded project.

- **`renovate.json`** (identical baseline in the repo root and `templates/base/`): `config:recommended` + `helpers:pinGitHubActionDigests` (Actions pinned by digest) + `schedule:weekly` + `group:allNonMajor`, with `lockFileMaintenance` enabled. All preset names verified against current Renovate sources.
- **PR format compatibility**: `semanticCommits: "disabled"` + `commitMessagePrefix: "chore:"` — Renovate derives PR titles from the commit message's first line, so PRs arrive as `chore: Update dependency X`, the canonical no-issue format per ADR-006 (generators emit only the canonical format, never legacy brackets). The contract test simulates the full derived title against the validator's pattern.
- **Template workflow coverage** (Codex review): the `github-actions` manager can't parse `.yml.tmpl` files (`{{#if}}` blocks break YAML), so a regex `customManagers` entry (github-tags datasource) bumps the `uses:` refs under `templates/**` — verified to match all 22 action refs, locked in by a contract test.
- **One config for all languages**: Renovate managers are file-detection based (pep621 picks up `pyproject.toml`/`uv.lock`, bun picks up `bun.lock`/`bun.lockb`, gomod picks up `go.mod`), so the template needs no language conditionals.
- **Docs**: the scaffolded onboarding guide documents the Renovate App install step and the org-level shared-preset extension point, including which title settings must survive the move to an org preset.

## Test plan

- `uv run pytest` — **375 passed, 4 skipped** (7 new tests)
- Contract tests: both configs parse as valid JSON and carry the required policy; rendered config validated for python/node/go/none scaffolds; simulated Renovate PR title matched against the actual validator pattern; every `uses:` line in template workflows matched by the custom manager regex

## After merge

The acceptance item "first onboarding PR merged" needs the Renovate GitHub App installed on the repository (https://github.com/apps/renovate) — that's an account-level action left to the owner. Once installed, Renovate opens its onboarding PR automatically against the committed config.

Closes #143