### PR TITLE
chore(PI-136): Make AGENTS.md canonical; CLAUDE.md and GEMINI.md redirect

### DIFF
--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -1,12 +1,46 @@
-# AGENTS.md
+# {{project_name}}
 
-Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
+{{project_description}}
 
-Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
+Canonical instructions for **all** coding agents (and humans pairing with
+them). Claude Code reads [CLAUDE.md](CLAUDE.md), which redirects here.
 
-{{#if lint_command}}Discover project commands with `just --list` — the justfile is the canonical, agent-agnostic command surface (lint, format, test, docs, ci).
-{{/if}}
+## Start here
+
+All agentic-development infrastructure lives under [`.claude/`](.claude/) —
+the directory name is historical; the contents are agent-neutral (bash
+scripts, markdown skills, memory, and docs):
+
+- [`.claude/project-init.md`](.claude/project-init.md) — workflow, conventions, task tracking
+- [`.claude/memory/MEMORY.md`](.claude/memory/MEMORY.md) — memory index (read first for context)
+- [`.claude/docs/`](.claude/docs/) — system of record: ADRs and development guides
+- [`.claude/vault/`](.claude/vault/) — human workspace (Obsidian vault)
 
 ## Skills (load on demand)
 
-Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.
+Before any GitHub action (create issue, branch, push, PR, merge), check
+[`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant
+skill file. Skills are plain markdown (SKILL.md) — load only the one that
+matches what you are about to do.
+
+> Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
+
+## Key rules for agents
+
+- **TDD** — write failing tests before any implementation.
+- **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue.
+- **GitHub workflow** — for any push, PR, review, or merge action, load `.claude/skills/github_workflow/SKILL.md`. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `type(KEY-N): desc` (no scope = no issue) | body includes `Closes #N`.
+{{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.
+- **Lint** — `just lint` must pass before closing a task. The linter config enforces docstrings and complexity caps on project code — fix the code, don't loosen the gate.
+{{/if}}- **Docs** — follow the Diátaxis layout in [`docs/`](docs/) (see `docs/index.md`). Record architectural decisions with the `add_adr` skill.
+- **No secrets in code** — never hardcode API keys, tokens, or personal data. Use `os.environ['KEY']` or a `.env` file (gitignored).
+- **Enforcement is agent-agnostic** — secret scanning (gitleaks) and lifecycle gating run as git hooks plus CI checks (`validate-pr`, `secret-scan`), binding every agent and human alike. Run `.claude/scripts/install_hooks.sh` once per clone to activate them.
+
+## Claude Code specifics
+
+This section applies only when the agent is Claude Code. Other agents get
+no automatic hooks — rely on the git/CI enforcement above.
+
+- Hooks in `.claude/settings.json` fire automatically: `pre_commit_gate` (lint gate on commit), `github_command_guard` (steers toward lifecycle scripts), `post_edit_lint`, `workflow_state_reminder`.
+- Skills are auto-discovered and invocable as `/command`s.
+- Review plugins: `pr-review-toolkit@claude-plugins-official` is pre-enabled in `.claude/settings.json`; also consider `/plugin install code-review@claude-plugins-official` for full PR reviews.

--- a/templates/base/CLAUDE.md.tmpl
+++ b/templates/base/CLAUDE.md.tmpl
@@ -1,29 +1,10 @@
-# {{project_name}}
+# {{project_name}} — Claude Code entry point
 
-{{project_description}}
-
-## For Claude Code (and other agents)
-
-All agentic-development infrastructure lives under [`.claude/`](.claude/). Start there:
-
-- [`.claude/project-init.md`](.claude/project-init.md) — workflow, conventions, task tracking
-- [`.claude/memory/MEMORY.md`](.claude/memory/MEMORY.md) — memory index (read first for context)
-- [`.claude/docs/`](.claude/docs/) — system of record: ADRs and development guides
-- [`.claude/vault/`](.claude/vault/) — human workspace (Obsidian vault; open this directory as the vault root in Obsidian for wikilinks and graph view)
-- [`AGENTS.md`](AGENTS.md) and [`GEMINI.md`](GEMINI.md) — thin redirects here for non-Claude agents
-
-> Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
-
-## Key rules for agents
-
-- **TDD** — write failing tests before any implementation. Use `/plan <task>` to generate acceptance tests first.
-- **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue. Use `/start_task` if one does not exist.
-- **GitHub workflow** — for any push, PR, review, or merge action, load `.claude/skills/github_workflow/SKILL.md`. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `type(KEY-N): desc` (no scope = no issue) | body includes `Closes #N`.
-{{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.
-- **Lint** — `just lint` must pass before closing a task. The `pre_commit_gate` hook enforces this on every commit. The linter config also enforces docstrings and complexity caps on project code — fix the code, don't loosen the gate.
-{{/if}}- **Review plugins** — `pr-review-toolkit@claude-plugins-official` is pre-enabled in `.claude/settings.json` (silent-failure-hunter, code-simplifier, type-design-analyzer agents). Also consider `/plugin install code-review@claude-plugins-official` for full PR reviews.
-- **Docs** — follow the Diátaxis layout in [`docs/`](docs/) (see `docs/index.md`). Record architectural decisions with the `add_adr` skill.
-- **No secrets in code** — never hardcode API keys, tokens, or personal data. Use `os.environ['KEY']` or a `.env` file (gitignored).
+Canonical agent instructions live in [AGENTS.md](AGENTS.md) — the
+Linux Foundation standard file most coding agents read natively. Read it
+before working in this codebase; it is the source of truth for workflow,
+conventions, memory, tools, and branch naming. Its "Claude Code specifics"
+section applies to this session.
 
 ## Compact Instructions
 

--- a/templates/base/GEMINI.md.tmpl
+++ b/templates/base/GEMINI.md.tmpl
@@ -1,12 +1,16 @@
 # Gemini Agent Instructions
 
-Canonical instructions for this project live in [CLAUDE.md](CLAUDE.md).
+Canonical instructions for this project live in [AGENTS.md](AGENTS.md).
 
-Read [CLAUDE.md](CLAUDE.md) before working in this codebase. It is the source of truth for workflow, conventions, memory, tools, and branch naming.
+Read [AGENTS.md](AGENTS.md) before working in this codebase. It is the
+source of truth for workflow, conventions, memory, tools, and branch
+naming. Ignore its "Claude Code specifics" section — enforcement that
+applies to you (git hooks, CI checks) is listed under "Key rules for
+agents".
+
+Before any GitHub action (create issue, branch, push, PR, merge), check
+[`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant
+skill file.
 
 {{#if lint_command}}Discover project commands with `just --list` — the justfile is the canonical, agent-agnostic command surface (lint, format, test, docs, ci).
 {{/if}}
-
-## Skills (load on demand)
-
-Before any GitHub action (create issue, branch, push, PR, merge), check [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant skill file. Do not read all skills upfront — load only the one that matches what you are about to do.

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -161,7 +161,7 @@ gh pr list                                            # open PRs
 ## Conventions
 
 - Hooks and scripts prefer bash/python. LLM calls only for generative steps.
-- `CLAUDE.md` is the canonical root instruction file. `AGENTS.md` and `GEMINI.md` are redirects to it.
+- `AGENTS.md` is the canonical root instruction file (the standard most agents read natively). `CLAUDE.md` and `GEMINI.md` redirect to it.
 - Everything else lives under `.claude/`.
 
 ## Compact Instructions

--- a/templates/base/dot_claude/skills/add_command/SKILL.md
+++ b/templates/base/dot_claude/skills/add_command/SKILL.md
@@ -6,6 +6,10 @@ argument-hint: "<command-name> <what it does>"
 allowed-tools: Write
 ---
 
+> **Claude Code specific**: this skill manages Claude Code configuration
+> (settings.json wiring). Other agents do not consume what it produces.
+
+
 ## Create a skill
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.

--- a/templates/base/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/base/dot_claude/skills/add_hook/SKILL.md
@@ -6,6 +6,10 @@ argument-hint: "<hook-name> <event> <description>"
 allowed-tools: Read Write Bash
 ---
 
+> **Claude Code specific**: this skill manages Claude Code configuration
+> (settings.json wiring). Other agents do not consume what it produces.
+
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/base/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/base/dot_claude/skills/github_workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github_workflow
-description: Guides Claude through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+description: Guides the agent through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
 when_to_use: Load before any push, PR creation, PR review response, merge, or release action — including when lifecycle scripts fail and a git/gh fallback is needed.
 user-invocable: false
 effort: high

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -1,6 +1,6 @@
 # GitHub Copilot Instructions — {{project_name}}
 
-Canonical agent rules: [CLAUDE.md](../CLAUDE.md) | Workflow: [.claude/project-init.md](../.claude/project-init.md)
+Canonical agent rules: [AGENTS.md](../AGENTS.md) | Workflow: [.claude/project-init.md](../.claude/project-init.md)
 
 ## Issue & project tracking
 

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -65,7 +65,8 @@ class TestPortableReferencesResolve:
     def test_referenced_paths_exist_in_scaffold(self, target: Path):
         """Every relative path AGENTS.md links or names must exist."""
         content = (target / "AGENTS.md").read_text()
-        referenced = set(re.findall(r"\]\((\.claude/[^)#]+|docs/[^)#]+|CLAUDE\.md)\)", content))
+        # * not +: bare directory links like (.claude/) must be checked too.
+        referenced = set(re.findall(r"\]\((\.claude/[^)#]*|docs/[^)#]*|CLAUDE\.md)\)", content))
         referenced |= set(re.findall(r"`(\.claude/(?:skills|scripts)/[\w./-]+)`", content))
         assert referenced, "expected path references in AGENTS.md"
         for rel in referenced:

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -1,0 +1,93 @@
+"""PI-136: AGENTS.md is canonical; the non-Claude instruction path must work.
+
+AGENTS.md is the Linux Foundation standard read natively by Codex, Gemini
+CLI, Cursor and most agents; Claude Code reads CLAUDE.md, which redirects.
+Claude-only capabilities are isolated in a marked section so other agents
+are not told to rely on enforcement they do not have.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+@pytest.fixture()
+def target(tmp_path: Path) -> Path:
+    t = tmp_path / "proj"
+    scaffold(t, load_preset("obsidian-only"), make_variables())
+    return t
+
+
+class TestCanonicality:
+    def test_agents_md_carries_full_instructions(self, target: Path):
+        content = (target / "AGENTS.md").read_text()
+        for marker in ("Key rules for agents", "TDD", "GitHub workflow", "Skills (load on demand)"):
+            assert marker in content, f"AGENTS.md missing canonical content: {marker}"
+
+    def test_claude_md_is_a_thin_redirect(self, target: Path):
+        content = (target / "CLAUDE.md").read_text()
+        assert "AGENTS.md" in content
+        # A redirect plus Claude-only operational content (compact
+        # instructions) — not a second copy of the rules.
+        assert "Key rules for agents" not in content
+        assert len(content.splitlines()) < 30
+
+    def test_gemini_md_redirects_to_agents(self, target: Path):
+        content = (target / "GEMINI.md").read_text()
+        assert "AGENTS.md" in content
+        assert "CLAUDE.md" not in content, "no two-hop indirection for Gemini"
+
+
+class TestClaudeOnlyIsolation:
+    def test_claude_capabilities_in_marked_section(self, target: Path):
+        content = (target / "AGENTS.md").read_text()
+        head, sep, claude_section = content.partition("## Claude Code specifics")
+        assert sep, "marked Claude Code section missing"
+        # Hook names and plugin wiring are Claude-only — they must not be
+        # presented as universal capabilities.
+        for claude_only in ("pre_commit_gate", "settings.json", "/plugin install"):
+            assert claude_only not in head, f"Claude-only reference outside marked section: {claude_only}"
+            assert claude_only in claude_section
+
+    def test_agent_agnostic_enforcement_documented_for_all(self, target: Path):
+        head = (target / "AGENTS.md").read_text().partition("## Claude Code specifics")[0]
+        assert "install_hooks.sh" in head, "git-level enforcement is universal — belongs before the Claude section"
+        assert "gitleaks" in head
+
+
+class TestPortableReferencesResolve:
+    def test_referenced_paths_exist_in_scaffold(self, target: Path):
+        """Every relative path AGENTS.md links or names must exist."""
+        content = (target / "AGENTS.md").read_text()
+        referenced = set(re.findall(r"\]\((\.claude/[^)#]+|docs/[^)#]+|CLAUDE\.md)\)", content))
+        referenced |= set(re.findall(r"`(\.claude/(?:skills|scripts)/[\w./-]+)`", content))
+        assert referenced, "expected path references in AGENTS.md"
+        for rel in referenced:
+            assert (target / rel).exists(), f"AGENTS.md references missing path: {rel}"
+
+    def test_no_unrendered_placeholders_in_instruction_files(self, target: Path):
+        placeholder = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
+        for name in ("AGENTS.md", "CLAUDE.md", "GEMINI.md"):
+            text = (target / name).read_text()
+            assert not placeholder.search(text), f"unrendered placeholder in {name}"
+
+
+class TestSkillNeutrality:
+    _SKILLS = Path(__file__).resolve().parents[2] / "templates" / "base" / "dot_claude" / "skills"
+
+    def test_claude_specific_skills_are_marked(self):
+        """Skills that manage Claude Code config must say so explicitly."""
+        for name in ("add_command", "add_hook"):
+            content = (self._SKILLS / name / "SKILL.md").read_text()
+            assert "Claude Code specific" in content, f"{name} missing scope marker"
+
+    def test_github_workflow_skill_is_agent_neutral(self):
+        content = (self._SKILLS / "github_workflow" / "SKILL.md").read_text()
+        frontmatter = content.split("---")[1]
+        assert "Claude" not in frontmatter, "lifecycle skill must not be Claude-scoped"

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -108,7 +108,9 @@ class TestRecipesAreTheSingleCallsite:
 
     def test_instruction_files_reference_just_list(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "p", "python")
-        for name in ("CLAUDE.md", "AGENTS.md", "GEMINI.md"):
+        # CLAUDE.md is a redirect (PI-136); the canonical and Gemini entry
+        # points carry the command-discovery pointer.
+        for name in ("AGENTS.md", "GEMINI.md"):
             assert "just --list" in (target / name).read_text(), f"{name} missing just --list"
 
     def test_no_just_reference_for_language_none(self, tmp_path: Path):

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -197,8 +197,8 @@ class TestQualityPlugins:
         settings = json.loads((target / ".claude" / "settings.json").read_text())
         assert settings["enabledPlugins"]["pr-review-toolkit@claude-plugins-official"] is True
 
-    def test_claude_md_recommends_review_plugins(self, tmp_target: Path):
+    def test_agents_md_recommends_review_plugins(self, tmp_target: Path):
         target = _scaffold_language(tmp_target, "python")
-        content = (target / "CLAUDE.md").read_text()
+        content = (target / "AGENTS.md").read_text()
         assert "pr-review-toolkit" in content
         assert "code-review@claude-plugins-official" in content

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -225,8 +225,8 @@ class TestScaffoldObsidianOnly:
         content = (self.target / ".claude" / "project-init.md").read_text()
         assert "premature abstraction" in content.lower() or "no premature" in content.lower()
 
-    def test_claude_md_has_tdd_rule(self):
-        content = (self.target / "CLAUDE.md").read_text()
+    def test_agents_md_has_tdd_rule(self):
+        content = (self.target / "AGENTS.md").read_text()
         assert "TDD" in content or "test" in content.lower()
 
     def test_no_lightrag_files(self):

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -68,16 +68,19 @@ class TestTemplateIdentifiers:
             project_init_url="https://github.com/example/project-init"
         ))
 
-    def test_agents_md_redirects_to_claude(self):
-        content = (self.target / "AGENTS.md").read_text()
-        assert "VytCepas" not in content
-        assert "CLAUDE.md" in content
-        assert "source of truth" in content
-
-    def test_claude_md_uses_template_url(self):
+    def test_claude_md_redirects_to_agents(self):
+        """PI-136: AGENTS.md is canonical; CLAUDE.md is the redirect."""
         content = (self.target / "CLAUDE.md").read_text()
         assert "VytCepas" not in content
+        assert "AGENTS.md" in content
+        assert "source of truth" in content
+
+    def test_agents_md_is_canonical_and_uses_template_url(self):
+        content = (self.target / "AGENTS.md").read_text()
+        assert "VytCepas" not in content
         assert "github.com/example/project-init" in content
+        assert "Key rules for agents" in content
+        assert "Claude Code specifics" in content
 
     def test_project_init_md_uses_template_url(self):
         content = (self.target / ".claude" / "project-init.md").read_text()
@@ -154,7 +157,7 @@ class TestScaffoldGitHubFiles:
         assert f.is_file()
         content = f.read_text()
         assert "GitHub Projects" in content
-        assert "CLAUDE.md" in content
+        assert "AGENTS.md" in content
         assert "<issue_type>/<project_abbr>-<issue_number>-<slug>" in content
         assert "type(PROJECT-123): description" in content
         assert "[#N][type] description" not in content
@@ -166,7 +169,7 @@ class TestScaffoldGitHubFiles:
         f = self.target / "GEMINI.md"
         assert f.is_file()
         content = f.read_text()
-        assert "CLAUDE.md" in content
+        assert "AGENTS.md" in content
         assert "source of truth" in content
         assert "GitHub Projects" not in content
         assert "[PROJECT-123][type] description" not in content

--- a/tests/unit/test_command_variables.py
+++ b/tests/unit/test_command_variables.py
@@ -18,9 +18,9 @@ class TestCommandVariables:
 
     def test_python_renders_uv_run_ruff(self, tmp_path: Path):
         target = self._scaffold_with_lang(tmp_path)
-        # PI-139: CLAUDE.md points at the justfile recipe — the raw command
-        # lives in exactly one place, the justfile itself.
-        content = (target / "CLAUDE.md").read_text()
+        # PI-139/PI-136: AGENTS.md (canonical) points at the justfile recipe —
+        # the raw command lives in exactly one place, the justfile itself.
+        content = (target / "AGENTS.md").read_text()
         assert "just lint" in content
         assert "uv run ruff check ." in (target / "justfile").read_text()
         config = (target / ".claude" / "config.yaml").read_text()
@@ -53,9 +53,9 @@ class TestCommandVariables:
             format_command="",
             test_command="",
         )
-        claude = (target / "CLAUDE.md").read_text()
+        agents = (target / "AGENTS.md").read_text()
         # Must not render the lint bullet at all
-        assert "must pass before closing a task" not in claude
+        assert "must pass before closing a task" not in agents
 
     def test_no_legacy_python_linter_variable(self, tmp_path: Path):
         """The old {{python_linter}} placeholder must be gone everywhere."""


### PR DESCRIPTION
## Summary

Inverts instruction-file canonicality in scaffolded projects to match the industry standard: AGENTS.md (read natively by Codex, Gemini CLI, Cursor, and most agents) now carries the full instructions; CLAUDE.md becomes the redirect (a plain redirect file, not a symlink — Windows-safe).

- **AGENTS.md (canonical)**: project intro, `.claude/` layout (with a note that the directory name is historical and the contents agent-neutral), skills index pointer, key rules — including an explicit "enforcement is agent-agnostic" rule pointing at the git/CI layers from #131 — and a marked **"Claude Code specifics"** section isolating `settings.json` hooks, slash invocation, and plugin wiring, so non-Claude agents are never told to rely on enforcement they don't have.
- **CLAUDE.md (redirect)**: points at AGENTS.md and keeps only Claude-operational content (compact instructions). Claude Code behavior is unchanged — it reads CLAUDE.md and follows the pointer, exactly as AGENTS.md-native agents had to do before, but now the indirection is on the one tool whose vendor hasn't adopted the standard yet (anthropics/claude-code#34235).
- **GEMINI.md**: redirects straight to AGENTS.md (no two-hop), keeping its skills-index and `just --list` pointers native.
- **Skill neutrality**: `github_workflow`'s description de-Claude-ified; `add_command`/`add_hook` explicitly marked as Claude Code-specific (they manage Claude Code configuration by nature — that's their scope, now stated).
- **References updated**: `copilot-instructions.md.tmpl` and `project-init.md.tmpl` name AGENTS.md as canonical.

## Test plan

- `uv run pytest` — **384 passed, 4 skipped** (9 new tests)
- New contracts (`test_agents_canonical.py`): canonical content placement; Claude-only isolation (hook/plugin references must not appear before the marked section — this is enforced, not just documented); every relative path AGENTS.md references resolves in the scaffold; no unrendered placeholders in any instruction file; skill scope markers
- Existing assertions flipped from CLAUDE.md to AGENTS.md across six test modules
- Strict-mode CLI scaffold verified end-to-end

This unblocks #137 (Phase 2 multi-agent overlays).

Closes #136

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwE4JmKzyPiiwnHnHfb64L)_