### PR TITLE
feat(PI-145): governance starter files and branch protection bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ The wizard asks (interactive mode only):
 - Core MCPs (Context7)
 - Database MCP — none / Postgres / SQLite
 - Browser automation — Playwright (yes/no)
+- Owner/team (`--owner`) — default CODEOWNERS owner, SECURITY contact, and LICENSE copyright holder (e.g. `@org/team`)
+- License (`--license mit|apache-2.0|proprietary|none`) — renders a LICENSE with the current year and the owner (or project name); `none` skips the file
+
+Every preset also ships governance starters: `.github/CODEOWNERS`,
+`CONTRIBUTING.md` (setup, `just --list` command surface, branch/PR
+conventions, review flow), and `SECURITY.md`. After pushing to GitHub, run
+`.claude/scripts/setup_github.sh --protect` inside the project to apply
+baseline branch protection (require CI green, require PR review, block
+force-push) — unprotected default branches undermine the workflow
+enforcement everything else sets up.
 
 Your answers are recorded in `.claude/config.yaml`. Re-run any time — it reconciles, preserves existing project files, and never overwrites memory or vault notes. With `--strict`, templates are rendered and validated in a temporary directory first, then the validated scaffold files are merged into the target; strict mode is not a whole-directory replacement.
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -73,6 +73,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="OpenAI embedding model for lightrag.yaml (embedding.provider is openai)",
     )
     p.add_argument(
+        "--license",
+        choices=["mit", "apache-2.0", "proprietary", "none"],
+        default="none",
+        help="LICENSE file to render (default: none — no file)",
+    )
+    p.add_argument(
+        "--owner",
+        default="",
+        help=(
+            "Project owner/team: CODEOWNERS default owner (@user or "
+            "@org/team), SECURITY contact, and LICENSE copyright holder"
+        ),
+    )
+    p.add_argument(
         "--non-interactive",
         action="store_true",
         help="Skip all prompts (requires --preset, --name, --description)",
@@ -275,8 +289,10 @@ def _select_preset(
     return _choose_preset_interactive(presets)
 
 
-def _gather_inputs_interactive(default_name: str) -> tuple[str, str, str, list[dict]]:
-    """Prompt for name, description, language, and MCP selection."""
+def _gather_inputs_interactive(
+    default_name: str,
+) -> tuple[str, str, str, list[dict], str, str]:
+    """Prompt for name, description, language, MCPs, owner, and license."""
     project_name = _prompt("Project name", default=default_name)
     project_description = _prompt("Description", default="")
     language = _prompt("Language (python/node/go/none)", default="none")
@@ -290,7 +306,13 @@ def _gather_inputs_interactive(default_name: str) -> tuple[str, str, str, list[d
         selected_mcps = selected_mcps + [db_mcp]
     if _choose_browser_interactive():
         selected_mcps = selected_mcps + [PLAYWRIGHT_MCP]
-    return project_name, project_description, language, selected_mcps
+
+    # Governance (PI-145).
+    owner = _prompt("Owner/team for CODEOWNERS + LICENSE (e.g. @org/team)", default="")
+    license_choice = _prompt("License (mit/apache-2.0/proprietary/none)", default="none")
+    if license_choice not in {"mit", "apache-2.0", "proprietary", "none"}:
+        license_choice = "none"
+    return project_name, project_description, language, selected_mcps, owner, license_choice
 
 
 # Per-language tooling commands (PI-16): (lint, format, test). Empty strings
@@ -373,8 +395,10 @@ def main(argv: list[str] | None = None) -> int:
         project_name = args.name
         project_description = args.description
         language = args.language or "none"
+        owner = args.owner
+        license_choice = args.license
     else:
-        project_name, project_description, language, selected_mcps = (
+        project_name, project_description, language, selected_mcps, owner, license_choice = (
             _gather_inputs_interactive(default_name=target.name)
         )
 
@@ -397,12 +421,22 @@ def main(argv: list[str] | None = None) -> int:
         "lint_command": lint_command,
         "format_command": format_command,
         "test_command": test_command,
+        # Governance (PI-145). license_holder falls back to the project name
+        # so a LICENSE rendered without --owner still has a copyright line.
+        "project_owner": owner,
+        "license": license_choice,
+        "license_holder": owner or project_name,
+        "created_year": date.today().strftime("%Y"),
         # Conditional block flags (truthy/falsy strings).
         "python": "true" if language == "python" else "",
         "node": "true" if language == "node" else "",
         "go": "true" if language == "go" else "",
+        "justfile": "true" if language != "none" else "",
         "lightrag": "true" if is_lightrag else "",
         "obsidian": "true" if has_obsidian else "",
+        "license_mit": "true" if license_choice == "mit" else "",
+        "license_apache": "true" if license_choice == "apache-2.0" else "",
+        "license_proprietary": "true" if license_choice == "proprietary" else "",
         # LightRAG model selection (PI-132) — rendered into lightrag.yaml
         "llm_model": args.llm_model,
         "embedding_model": args.embedding_model,

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -236,6 +236,16 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "test_command": fields.get("tooling.test_command", ""),
         "lightrag": "true" if "lightrag" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
+        "justfile": "true" if language != "none" else "",
+        # Governance (PI-145) postdates pre-record configs: those projects
+        # were scaffolded without a license or owner, so these are faithful.
+        "project_owner": "",
+        "license": "none",
+        "license_holder": fields.get("project.name", ""),
+        "license_mit": "",
+        "license_apache": "",
+        "license_proprietary": "",
+        "created_year": fields.get("project.created", "").split("-")[0],
         **_MIGRATION_DEFAULTS,
     }
     for flag in _LANGUAGE_FLAGS:

--- a/templates/base/CONTRIBUTING.md.tmpl
+++ b/templates/base/CONTRIBUTING.md.tmpl
@@ -1,0 +1,55 @@
+# Contributing to {{project_name}}
+
+{{project_description}}
+
+This project was scaffolded with [project-init]({{project_init_url}}): agent
+instructions live in [AGENTS.md](AGENTS.md) (canonical; `CLAUDE.md` and
+`GEMINI.md` redirect there), and the conventions below bind humans and
+coding agents alike. Claude Code gets deterministic enforcement (hooks);
+other agents and humans get the same rules via git hooks and CI.
+
+## Setup
+{{#if justfile}}
+```bash
+just setup
+```
+{{/if justfile}}
+Install the repo git hooks once per clone — they enforce commit-message
+format, secret scanning, and branch naming locally:
+
+```bash
+.claude/scripts/install_hooks.sh
+```
+{{#if justfile}}
+## Commands
+
+The justfile is the canonical command surface — `just --list` shows every
+recipe. CI runs the same recipes, so if `just lint` and `just test` pass
+locally, CI agrees.
+{{/if justfile}}
+## Branches, commits, and PRs
+
+| What | Pattern | Example |
+|---|---|---|
+| Branch | `<type>/<KEY>-<n>-<slug>` | `feat/KEY-42-add-oauth` |
+| PR title | `type(KEY-N): description` | `feat(KEY-42): add OAuth login` |
+| No-issue PR | `type: description` | `chore: bump dev dependency` |
+| PR body | must include `Closes #N` (skip for no-issue PRs) | |
+
+`KEY` is the project issue key set in `.claude/config.yaml`
+(`project_key`). Types: `feat` `fix` `chore` `docs` `test`. Work starts
+from an issue — use `.claude/scripts/create_issue.sh` (or the
+`start_task` skill in Claude Code) so metadata lands on the project board.
+
+## Review flow
+
+1. Open a draft PR early; push with `.claude/scripts/push_branch.sh`.
+2. Mark ready when CI is green. Respond to every review comment —
+   including bot reviews — either by fixing or by explaining why not.
+3. Merges go through `.claude/scripts/monitor_pr.sh <n> --merge` so CI
+   and review gates are honored.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for how to report vulnerabilities —
+please do not open public issues for security problems.

--- a/templates/base/LICENSE.tmpl
+++ b/templates/base/LICENSE.tmpl
@@ -1,0 +1,220 @@
+{{#if license_mit}}MIT License
+
+Copyright (c) {{created_year}} {{license_holder}}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+{{/if license_mit}}{{#if license_apache}}                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright {{created_year}} {{license_holder}}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+{{/if license_apache}}{{#if license_proprietary}}Copyright (c) {{created_year}} {{license_holder}}. All rights reserved.
+
+This software and its documentation are proprietary and confidential.
+Internal use only: no part of this repository may be copied, modified,
+distributed, sublicensed, or disclosed outside the organization without
+prior written permission from the copyright holder.
+
+Provided "AS IS", without warranty of any kind.
+{{/if license_proprietary}}

--- a/templates/base/SECURITY.md.tmpl
+++ b/templates/base/SECURITY.md.tmpl
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security problems.
+
+- Preferred: use GitHub's private vulnerability reporting on this
+  repository (Security tab → "Report a vulnerability").
+{{#if project_owner}}
+- Or contact the maintainer directly: {{project_owner}}
+{{/if project_owner}}
+You should receive an acknowledgement within a few business days. Please
+include reproduction steps and the affected version or commit.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| latest release / `main` | ✅ |
+| older releases | ❌ |
+
+## Scope notes
+
+Secrets must never be committed — the scaffolded pre-commit hook runs a
+gitleaks scan, and CI re-checks. If you find a leaked credential in the
+history, report it privately first so it can be rotated before disclosure.

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -26,7 +26,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Command | `/request_review` | mark PR ready for review, optional agent review |
 | Script | `create_issue.sh <type> "desc"` | create typed issue, prints issue number |
 | Script | `create_nojira_pr.sh <type> "desc"` | branch + push + draft PR without an issue |
-| Script | `setup_github.sh [branch]` | configure branch protection and review governance |
+| Script | `setup_github.sh [branch] [--protect]` | provision board fields and review settings; `--protect` applies baseline branch protection |
 | Script | `start_issue.sh <n> <type>` | branch + draft PR |
 | Script | `promote_review.sh` | mark PR ready (board card moves automatically) |
 | Script | `monitor_pr.sh <n> [--merge]` | wait for CI; --merge squash-merges when clean |
@@ -94,7 +94,7 @@ Without GitHub-native auto-merge, `monitor_pr.sh --merge` still works by merging
 Run the scaffolded setup helper after creating the repository:
 
 ```bash
-.claude/scripts/setup_github.sh
+.claude/scripts/setup_github.sh --protect
 ```
 
 It attempts to configure branch protection, required checks, conversation resolution, and Copilot code review. If GitHub does not expose a setting through the API or your token lacks permission, it prints the manual setup step.
@@ -149,7 +149,7 @@ git add … && git commit -m "fix(<KEY>-<n>): Fix failing tests"
 .claude/scripts/create_issue.sh <type> "description" --priority high --area docs --size S --acceptance "Done when ..."  # new issue → prints issue number
 .claude/scripts/start_issue.sh <n> <type>             # branch + draft PR
 .claude/scripts/create_nojira_pr.sh fix "description" # no-issue branch + draft PR
-.claude/scripts/setup_github.sh                       # one-time branch protection/review setup
+.claude/scripts/setup_github.sh --protect            # one-time governance setup + branch protection
 .claude/scripts/promote_review.sh                     # mark PR ready for review
 .claude/scripts/monitor_pr.sh <n> --merge             # wait for CI, merge when clean
 .claude/scripts/finish_pr.sh <n>                      # push, ready, monitor, merge

--- a/templates/base/dot_claude/scripts/README.md
+++ b/templates/base/dot_claude/scripts/README.md
@@ -12,4 +12,4 @@ Helper scripts invoked by the user, by hooks, or by agents via the Bash tool. Pr
 - **`promote_review.sh`** — Mark a draft PR ready for review
 - **`monitor_pr.sh`** — Poll PR checks and optionally squash-merge with `--merge`
 - **`finish_pr.sh`** — Composite: push, mark ready, monitor checks/review, and merge
-- **`setup_github.sh`** — One-time GitHub repository governance setup (branch protection, review settings)
+- **`setup_github.sh`** — One-time GitHub repository governance setup (board fields, review settings; `--protect` applies baseline branch protection)

--- a/templates/base/dot_claude/scripts/setup_github.sh
+++ b/templates/base/dot_claude/scripts/setup_github.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 # Configure or check GitHub repository governance for the scaffolded workflow.
 #
+# Usage: setup_github.sh [branch] [--protect]
+#   --protect  apply baseline branch protection to the default branch
+#              (require CI green, require PR review, block force-push).
+#              Idempotent: the PUT endpoint replaces the existing config.
+#
 # Requires: gh and admin permission on the repository.
 
 set -euo pipefail
 
-BRANCH="${1:-main}"
+BRANCH="main"
+PROTECT=0
+for arg in "$@"; do
+  case "$arg" in
+    --protect) PROTECT=1 ;;
+    --*) echo "Unknown option: $arg" >&2; exit 1 ;;
+    *) BRANCH="$arg" ;;
+  esac
+done
 
 if ! gh auth status >/dev/null 2>&1; then
   echo "ERROR: gh is not authenticated. Run gh auth login first." >&2
@@ -19,6 +32,7 @@ NAME=${REPO#*/}
 echo "Configuring GitHub governance for $REPO ($BRANCH)"
 # Default endpoint: repos/$OWNER/$NAME/branches/main/protection
 
+if [ "$PROTECT" = 1 ]; then
 PROTECTION=$(mktemp)
 trap 'rm -f "$PROTECTION"' EXIT
 
@@ -49,6 +63,9 @@ if gh api "repos/$OWNER/$NAME/branches/$BRANCH/protection" -X PUT --input "$PROT
   echo "Branch protection applied to $BRANCH"
 else
   echo "WARNING: could not apply branch protection. Check admin permissions and repository plan." >&2
+fi
+else
+  echo "Skipping branch protection (pass --protect to apply: require CI green, require review, block force-push)"
 fi
 
 if gh api "repos/$OWNER/$NAME/code-review-settings" -X PUT -f copilot_code_review_enabled=true >/dev/null 2>&1; then

--- a/templates/base/dot_claude/scripts/setup_github.sh
+++ b/templates/base/dot_claude/scripts/setup_github.sh
@@ -36,11 +36,16 @@ if [ "$PROTECT" = 1 ]; then
 PROTECTION=$(mktemp)
 trap 'rm -f "$PROTECTION"' EXIT
 
+# Contexts must match the scaffolded workflows ("<workflow> / <job name>").
+# "CI / Integration tests" is omitted on purpose — that job is documented as
+# user-adjustable; add it here once your integration suite is stable.
 cat > "$PROTECTION" <<'JSON'
 {
   "required_status_checks": {
     "strict": true,
     "contexts": [
+      "CI / Lint and test",
+      "CI / Secret scan (gitleaks)",
       "Validate PR / Check PR title, branch, and linked issue",
       "review/decision"
     ]

--- a/templates/base/dot_github/CODEOWNERS.tmpl
+++ b/templates/base/dot_github/CODEOWNERS.tmpl
@@ -1,0 +1,12 @@
+# CODEOWNERS — reviewers auto-requested for matching paths (scaffolded by project-init).
+# Order matters: the last matching pattern wins.
+# Owners must be GitHub usernames (@user) or teams (@org/team) with write access.
+{{#if project_owner}}
+# Default owner for everything in the repository.
+*       {{project_owner}}
+{{/if project_owner}}
+# Per-area examples — uncomment and adjust:
+# /src/             @your-org/backend
+# /docs/            @your-org/docs
+# /.github/         @your-org/platform
+# /.claude/         @your-org/platform

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -118,3 +118,10 @@ class TestBranchProtectionBootstrap:
         assert "required_status_checks" in script
         assert "required_pull_request_reviews" in script
         assert '"allow_force_pushes": false' in script
+
+    def test_protection_requires_generated_ci_checks(self):
+        """The required contexts must cover the scaffolded CI workflow's
+        unconditional jobs, or 'require CI green' is an empty promise."""
+        script = _SETUP_GITHUB.read_text()
+        assert '"CI / Lint and test"' in script
+        assert '"CI / Secret scan (gitleaks)"' in script

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -1,0 +1,120 @@
+"""PI-145: governance starter files — CODEOWNERS, CONTRIBUTING, SECURITY,
+LICENSE picker, and the setup_github.sh --protect gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SETUP_GITHUB = (
+    _REPO_ROOT / "templates/base/dot_claude/scripts/setup_github.sh"
+)
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+class TestGovernanceFiles:
+    @pytest.mark.parametrize("preset", ["obsidian-only", "obsidian-lightrag"])
+    def test_rendered_for_every_preset(self, tmp_path: Path, preset: str):
+        """CODEOWNERS, CONTRIBUTING, SECURITY ship with every preset."""
+        target = tmp_path / preset
+        scaffold(target, load_preset(preset), make_variables(), strict=True)
+        assert (target / ".github" / "CODEOWNERS").exists()
+        assert (target / "CONTRIBUTING.md").exists()
+        assert (target / "SECURITY.md").exists()
+
+    def test_codeowners_renders_owner(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", project_owner="@acme/platform")
+        content = (target / ".github" / "CODEOWNERS").read_text()
+        assert "*       @acme/platform" in content
+
+    def test_codeowners_without_owner_keeps_examples_only(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        content = (target / ".github" / "CODEOWNERS").read_text()
+        assert "@your-org/backend" in content  # commented examples survive
+        # No uncommented ownership line without an owner.
+        active = [
+            ln for ln in content.splitlines() if ln.strip() and not ln.startswith("#")
+        ]
+        assert active == []
+
+    def test_contributing_references_command_surface(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        content = (target / "CONTRIBUTING.md").read_text()
+        assert "just --list" in content
+        assert "install_hooks.sh" in content
+        assert "type(KEY-N): description" in content
+        assert "AGENTS.md" in content, "must match the canonical-instructions framing"
+
+    def test_contributing_language_none_has_no_just(self, tmp_path: Path):
+        target = _scaffold(
+            tmp_path / "p", language="none", python="", justfile="",
+            lint_command="", format_command="", test_command="",
+        )
+        content = (target / "CONTRIBUTING.md").read_text()
+        assert "just --list" not in content
+        assert "just setup" not in content
+
+    def test_security_renders_contact(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", project_owner="@vyt")
+        content = (target / "SECURITY.md").read_text()
+        assert "@vyt" in content
+        assert "private vulnerability reporting" in content
+
+
+class TestLicensePicker:
+    def test_no_license_by_default(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert not (target / "LICENSE").exists()
+
+    @pytest.mark.parametrize(
+        ("flag", "marker"),
+        [
+            ("license_mit", "MIT License"),
+            ("license_apache", "Apache License"),
+            ("license_proprietary", "All rights reserved"),
+        ],
+    )
+    def test_each_license_renders_with_year_and_holder(
+        self, tmp_path: Path, flag: str, marker: str
+    ):
+        target = _scaffold(
+            tmp_path / flag,
+            license_holder="ACME Corp",
+            created_year="2026",
+            **{flag: "true"},
+        )
+        content = (target / "LICENSE").read_text()
+        assert marker in content
+        assert "2026 ACME Corp" in content
+        assert "{{" not in content
+
+    def test_licenses_are_mutually_exclusive_blocks(self, tmp_path: Path):
+        """Only the selected license text is rendered."""
+        target = _scaffold(tmp_path / "p", license_mit="true")
+        content = (target / "LICENSE").read_text()
+        assert "Apache License" not in content
+        assert "All rights reserved" not in content
+
+
+class TestBranchProtectionBootstrap:
+    def test_protect_flag_gates_protection(self):
+        script = _SETUP_GITHUB.read_text()
+        assert "--protect" in script
+        assert 'if [ "$PROTECT" = 1 ]' in script
+        assert "Skipping branch protection" in script
+
+    def test_protection_baseline_is_complete(self):
+        """CI green + PR review + no force-push: the documented baseline."""
+        script = _SETUP_GITHUB.read_text()
+        assert "required_status_checks" in script
+        assert "required_pull_request_reviews" in script
+        assert '"allow_force_pushes": false' in script

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,10 +49,18 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "python": "true",
         "node": "",
         "go": "",
+        "justfile": "true",
         "lightrag": "",
         "obsidian": "true",
         "llm_model": "claude-sonnet-4-6",
         "embedding_model": "text-embedding-3-small",
+        "project_owner": "",
+        "license": "none",
+        "license_holder": "my-project",
+        "license_mit": "",
+        "license_apache": "",
+        "license_proprietary": "",
+        "created_year": "2026",
     }
     defaults.update(overrides)
     return defaults

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -41,6 +41,48 @@ class TestCLI:
             main(["--non-interactive"])
 
 
+class TestCLIGovernanceFlags:
+    """PI-145: --license and --owner render governance files."""
+
+    def _run(self, target: Path, *extra: str) -> int:
+        from project_init.__main__ import main
+
+        return main([
+            str(target),
+            "--non-interactive",
+            "--preset", "obsidian-only",
+            "--name", "gov-cli",
+            "--description", "test",
+            "--language", "python",
+            *extra,
+        ])
+
+    def test_license_and_owner_render(self, tmp_path: Path):
+        from datetime import date
+
+        target = tmp_path / "p"
+        assert self._run(target, "--license", "mit", "--owner", "@acme/core") == 0
+        license_text = (target / "LICENSE").read_text()
+        assert "MIT License" in license_text
+        assert f"{date.today().year} @acme/core" in license_text
+        assert "*       @acme/core" in (target / ".github" / "CODEOWNERS").read_text()
+
+    def test_no_license_flag_renders_no_file(self, tmp_path: Path):
+        target = tmp_path / "p"
+        assert self._run(target) == 0
+        assert not (target / "LICENSE").exists()
+        assert (target / "CONTRIBUTING.md").exists()
+
+    def test_invalid_license_is_rejected(self, tmp_path: Path):
+        with pytest.raises(SystemExit):
+            self._run(tmp_path / "p", "--license", "gpl-3.0")
+
+    def test_license_holder_falls_back_to_project_name(self, tmp_path: Path):
+        target = tmp_path / "p"
+        assert self._run(target, "--license", "proprietary") == 0
+        assert "gov-cli. All rights reserved." in (target / "LICENSE").read_text()
+
+
 class TestCLINonInteractiveCommandVariables:
     """PI-16: CLI passes correct command variables based on --language."""
 


### PR DESCRIPTION
Closes #145

## Summary
- Every preset now ships `.github/CODEOWNERS`, `CONTRIBUTING.md` (setup, `just --list` command surface, branch/PR conventions, review flow — aligned with the AGENTS.md-canonical framing from PI-136), and `SECURITY.md` (GitHub private vulnerability reporting + supported-versions stub)
- LICENSE picker: `--license mit|apache-2.0|proprietary|none` (default none → no file) rendered with the current year and `--owner` (falls back to project name); wizard prompts added for both inputs
- `setup_github.sh` branch protection is now opt-in via `--protect` (idempotent PUT: require CI green, require PR review, block force-push); board-field provisioning unchanged; template docs updated
- Upgrade migration defaults extended so pre-PI-145 projects re-render faithfully (no license, no owner)

## Test plan
- `tests/contracts/test_governance.py`: rendering for both presets, owner substitution, license matrix (year + holder, mutual exclusion, none → skipped), --protect gating contract
- `tests/integration/test_cli.py`: new flags end-to-end incl. validation of bad `--license` and holder fallback
- Full suite: 420 passed