### PR TITLE
feat(PI-146): SessionStart bootstrap hook and opt-in devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The wizard asks (interactive mode only):
 - Browser automation — Playwright (yes/no)
 - Owner/team (`--owner`) — default CODEOWNERS owner, SECURITY contact, and LICENSE copyright holder (e.g. `@org/team`)
 - License (`--license mit|apache-2.0|proprietary|none`) — renders a LICENSE with the current year and the owner (or project name); `none` skips the file
+- Devcontainer (`--devcontainer`) — renders `.devcontainer/` for Codespaces, fresh clones, and remote agent containers (see below)
 
 Every preset also ships governance starters: `.github/CODEOWNERS`,
 `CONTRIBUTING.md` (setup, `just --list` command surface, branch/PR
@@ -119,6 +120,22 @@ force-push) — unprotected default branches undermine the workflow
 enforcement everything else sets up.
 
 Your answers are recorded in `.claude/config.yaml`. Re-run any time — it reconciles, preserves existing project files, and never overwrites memory or vault notes. With `--strict`, templates are rendered and validated in a temporary directory first, then the validated scaffold files are merged into the target; strict mode is not a whole-directory replacement.
+
+### Remote and web agent sessions
+
+Scaffolded projects bootstrap themselves in ephemeral environments
+(Claude Code on the web, CI agents, fresh clones):
+
+- A **SessionStart hook** (`.claude/hooks/session_setup.sh`) syncs
+  dependencies when a session opens in a cold environment — `just setup`
+  when available, falling back to `uv sync` / `bun install` /
+  `go mod download`. Warm sessions are a no-op: a content stamp of the
+  dependency manifests short-circuits before any tool runs, and a failed
+  bootstrap warns without blocking the session.
+- The opt-in **`--devcontainer`** flag renders a minimal
+  `.devcontainer/` (Ubuntu base image; post-create installs `just` plus
+  the language toolchain and reuses the same bootstrap) — one consistent
+  environment for new colleagues, Codespaces, and agent containers.
 
 ## Example command
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -87,6 +87,14 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--devcontainer",
+        action="store_true",
+        help=(
+            "Render .devcontainer/ (base image + toolchain bootstrap) for "
+            "Codespaces, fresh clones, and remote agent sessions"
+        ),
+    )
+    p.add_argument(
         "--non-interactive",
         action="store_true",
         help="Skip all prompts (requires --preset, --name, --description)",
@@ -291,8 +299,8 @@ def _select_preset(
 
 def _gather_inputs_interactive(
     default_name: str,
-) -> tuple[str, str, str, list[dict], str, str]:
-    """Prompt for name, description, language, MCPs, owner, and license."""
+) -> tuple[str, str, str, list[dict], str, str, bool]:
+    """Prompt for name, description, language, MCPs, owner, license, devcontainer."""
     project_name = _prompt("Project name", default=default_name)
     project_description = _prompt("Description", default="")
     language = _prompt("Language (python/node/go/none)", default="none")
@@ -312,7 +320,21 @@ def _gather_inputs_interactive(
     license_choice = _prompt("License (mit/apache-2.0/proprietary/none)", default="none")
     if license_choice not in {"mit", "apache-2.0", "proprietary", "none"}:
         license_choice = "none"
-    return project_name, project_description, language, selected_mcps, owner, license_choice
+
+    from rich.prompt import Confirm
+
+    devcontainer = Confirm.ask(
+        "Add a devcontainer (Codespaces / remote agent sessions)?", default=False
+    )
+    return (
+        project_name,
+        project_description,
+        language,
+        selected_mcps,
+        owner,
+        license_choice,
+        devcontainer,
+    )
 
 
 # Per-language tooling commands (PI-16): (lint, format, test). Empty strings
@@ -397,10 +419,17 @@ def main(argv: list[str] | None = None) -> int:
         language = args.language or "none"
         owner = args.owner
         license_choice = args.license
+        devcontainer = args.devcontainer
     else:
-        project_name, project_description, language, selected_mcps, owner, license_choice = (
-            _gather_inputs_interactive(default_name=target.name)
-        )
+        (
+            project_name,
+            project_description,
+            language,
+            selected_mcps,
+            owner,
+            license_choice,
+            devcontainer,
+        ) = _gather_inputs_interactive(default_name=target.name)
 
     is_lightrag = "lightrag" in preset.get("name", "")
     has_obsidian = "obsidian" in preset.get("layers", [])
@@ -432,6 +461,7 @@ def main(argv: list[str] | None = None) -> int:
         "node": "true" if language == "node" else "",
         "go": "true" if language == "go" else "",
         "justfile": "true" if language != "none" else "",
+        "devcontainer": "true" if devcontainer else "",
         "lightrag": "true" if is_lightrag else "",
         "obsidian": "true" if has_obsidian else "",
         "license_mit": "true" if license_choice == "mit" else "",

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -15,8 +15,11 @@ if not _TEMPLATES_DIR.exists():
 
 _DOT_PREFIX = "dot_"
 _VAR_RE = re.compile(r"\{\{(\w+)\}\}")
+# Matches an INNERMOST conditional block — the tempered dot forbids another
+# opener inside the body. _render loops to a fixpoint, so nested
+# {{#if outer}}...{{#if inner}}...{{/if}}...{{/if}} resolves inside-out.
 _BLOCK_RE = re.compile(
-    r"\{\{#if\s+(\w+)\}\}(.*?)\{\{/if(?:\s+\w+)?\}\}",
+    r"\{\{#if\s+(\w+)\}\}((?:(?!\{\{#if\s).)*?)\{\{/if(?:\s+\w+)?\}\}",
     re.DOTALL,
 )
 # Used by strict mode to detect unrendered handlebars-style markers.
@@ -55,13 +58,21 @@ def load_preset(name: str) -> dict:
 
 
 def _render(text: str, variables: dict[str, str]) -> str:
-    """Replace {{var}} placeholders and process {{#if var}}...{{/if var}} blocks."""
-    # Conditionals first.
+    """Replace {{var}} placeholders and process {{#if var}}...{{/if var}} blocks.
+
+    Conditional blocks may nest; each pass substitutes the innermost blocks,
+    looping until no block remains (unclosed markers survive for strict mode
+    to flag).
+    """
     def _replace_block(m: re.Match) -> str:
         key = m.group(1)
         return m.group(2) if variables.get(key) else ""
 
-    text = _BLOCK_RE.sub(_replace_block, text)
+    while True:
+        replaced = _BLOCK_RE.sub(_replace_block, text)
+        if replaced == text:
+            break
+        text = replaced
     # Then simple variable substitution.
     return _VAR_RE.sub(lambda m: variables.get(m.group(1), m.group(0)), text)
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -237,6 +237,8 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "lightrag": "true" if "lightrag" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "justfile": "true" if language != "none" else "",
+        # Devcontainer (PI-146) postdates pre-record configs: faithful as off.
+        "devcontainer": "",
         # Governance (PI-145) postdates pre-record configs: those projects
         # were scaffolded without a license or owner, so these are faithful.
         "project_owner": "",

--- a/templates/base/dot_claude/hooks/session_setup.sh
+++ b/templates/base/dot_claude/hooks/session_setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SessionStart bootstrap (PI-146): make a fresh/remote container immediately
+# usable — sync dependencies so tests and linters run instead of failing on
+# a missing venv. Fast on warm environments: a content stamp of the
+# dependency manifests short-circuits before any tool runs.
+set -uo pipefail # not -e: a failed bootstrap must never break the session
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$ROOT" || exit 0
+STAMP=".claude/.session_setup_stamp"
+LOG=".claude/logs/session_setup.log"
+mkdir -p .claude/logs
+
+fingerprint() {
+  cat pyproject.toml uv.lock package.json bun.lock bun.lockb go.mod go.sum 2>/dev/null \
+    | sha256sum | cut -d' ' -f1
+}
+
+# The stamp alone is not enough: an ephemeral container can restore the repo
+# (stamp included) without the synced environment, so check for it too.
+env_present() {
+  { [ ! -f pyproject.toml ] || [ -d .venv ]; } \
+    && { [ ! -f package.json ] || [ -d node_modules ]; }
+}
+
+CURRENT="$(fingerprint)"
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$CURRENT" ] && env_present; then
+  exit 0 # warm environment — nothing to do
+fi
+
+bootstrap() {
+  # Prefer the justfile setup recipe — the canonical bootstrap entry point.
+  if command -v just >/dev/null 2>&1 && [ -f justfile ] \
+    && just --show setup >/dev/null 2>&1; then
+    just setup
+  elif [ -f pyproject.toml ] && command -v uv >/dev/null 2>&1; then
+    uv sync --extra dev 2>/dev/null || uv sync
+  elif [ -f package.json ] && command -v bun >/dev/null 2>&1; then
+    bun install
+  elif [ -f go.mod ] && command -v go >/dev/null 2>&1; then
+    go mod download
+  else
+    return 0 # nothing recognized to set up — stay silent
+  fi
+}
+
+if bootstrap >"$LOG" 2>&1; then
+  echo "$CURRENT" >"$STAMP"
+  echo "session_setup: dependencies synced for fresh environment"
+else
+  echo "session_setup: bootstrap failed — see $LOG" >&2
+fi
+exit 0

--- a/templates/base/dot_claude/hooks/session_setup.sh
+++ b/templates/base/dot_claude/hooks/session_setup.sh
@@ -40,14 +40,23 @@ bootstrap() {
   elif [ -f go.mod ] && command -v go >/dev/null 2>&1; then
     go mod download
   else
-    return 0 # nothing recognized to set up — stay silent
+    return 2 # nothing recognized to set up
   fi
 }
 
-if bootstrap >"$LOG" 2>&1; then
+bootstrap >"$LOG" 2>&1
+case $? in
+0)
   echo "$CURRENT" >"$STAMP"
   echo "session_setup: dependencies synced for fresh environment"
-else
+  ;;
+2)
+  # No manifest/tool to bootstrap: stamp silently so later sessions skip
+  # the probe, but claim nothing — no sync happened.
+  echo "$CURRENT" >"$STAMP"
+  ;;
+*)
   echo "session_setup: bootstrap failed — see $LOG" >&2
-fi
+  ;;
+esac
 exit 0

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -16,6 +16,17 @@
     "pr-review-toolkit@claude-plugins-official": true
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_setup.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/templates/base/dot_devcontainer/devcontainer.json.tmpl
+++ b/templates/base/dot_devcontainer/devcontainer.json.tmpl
@@ -1,0 +1,17 @@
+{{#if devcontainer}}{
+  "name": "{{project_name}}",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+{{#if go}}  "features": {
+    "ghcr.io/devcontainers/features/go:1": {}
+  },
+{{/if go}}  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "remoteEnv": {
+    "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:HOME}/.bun/bin:${containerEnv:PATH}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["anthropic.claude-code"]
+    }
+  }
+}
+{{/if devcontainer}}

--- a/templates/base/dot_devcontainer/post-create.sh.tmpl
+++ b/templates/base/dot_devcontainer/post-create.sh.tmpl
@@ -1,0 +1,29 @@
+{{#if devcontainer}}#!/bin/bash
+# Devcontainer bootstrap (scaffolded by project-init): install the toolchain
+# the scaffolded workflow expects, then sync dependencies through the same
+# path the SessionStart hook uses. Idempotent — safe to re-run.
+set -euo pipefail
+
+mkdir -p "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
+
+# just — the canonical command surface (`just --list`)
+if ! command -v just >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+    | bash -s -- --to "$HOME/.local/bin"
+fi
+{{#if python}}
+# uv — Python toolchain and dependency manager
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+{{/if python}}{{#if node}}
+# bun — Node runtime and package manager
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
+fi
+{{/if node}}
+# Sync dependencies (stamps the environment so SessionStart stays fast).
+bash .claude/hooks/session_setup.sh
+{{/if devcontainer}}

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -1,6 +1,7 @@
 # project-init runtime artifacts
 .codex
 .claude/scheduled_tasks.lock
+.claude/.session_setup_stamp
 .claude/settings.local.json
 .claude/memory/.lightrag/
 .claude/memory/.cache/

--- a/templates/obsidian/dot_claude/settings.json.tmpl
+++ b/templates/obsidian/dot_claude/settings.json.tmpl
@@ -16,6 +16,17 @@
     "pr-review-toolkit@claude-plugins-official": true
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_setup.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/tests/contracts/test_session_bootstrap.py
+++ b/tests/contracts/test_session_bootstrap.py
@@ -1,0 +1,87 @@
+"""PI-146: SessionStart bootstrap hook and opt-in devcontainer overlay."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+class TestSessionStartHook:
+    def test_hook_scaffolded_executable_and_wired(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        hook = target / ".claude" / "hooks" / "session_setup.sh"
+        assert hook.exists()
+        assert os.access(hook, os.X_OK), "shell hooks must carry the executable bit"
+
+        settings = json.loads((target / ".claude" / "settings.json").read_text())
+        session_start = settings["hooks"]["SessionStart"]
+        commands = [h["command"] for entry in session_start for h in entry["hooks"]]
+        assert any("session_setup.sh" in c for c in commands)
+
+    def test_stamp_is_gitignored(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert ".claude/.session_setup_stamp" in (target / ".gitignore").read_text()
+
+    def test_hook_never_blocks_the_session(self, tmp_path: Path):
+        """No `set -e`, and the script's only exit paths are code 0."""
+        target = _scaffold(tmp_path / "p")
+        script = (target / ".claude" / "hooks" / "session_setup.sh").read_text()
+        assert "set -uo pipefail" in script
+        assert "set -euo" not in script
+
+
+class TestDevcontainerOverlay:
+    def test_absent_by_default(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert not (target / ".devcontainer").exists()
+
+    def test_rendered_when_opted_in(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", devcontainer="true")
+        config = json.loads((target / ".devcontainer" / "devcontainer.json").read_text())
+        assert config["name"] == "my-project"
+        assert "post-create.sh" in config["postCreateCommand"]
+        assert (target / ".devcontainer" / "post-create.sh").exists()
+
+    @pytest.mark.parametrize(
+        ("language", "marker", "absent"),
+        [
+            ("python", "astral.sh/uv", "bun.sh/install"),
+            ("node", "bun.sh/install", "astral.sh/uv"),
+        ],
+    )
+    def test_post_create_matches_language(
+        self, tmp_path: Path, language: str, marker: str, absent: str
+    ):
+        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go")}
+        target = _scaffold(
+            tmp_path / language, devcontainer="true", language=language, **flags
+        )
+        script = (target / ".devcontainer" / "post-create.sh").read_text()
+        assert marker in script
+        assert absent not in script
+        assert "just.systems/install.sh" in script, "just is always installed"
+        assert "session_setup.sh" in script, "must reuse the SessionStart bootstrap"
+
+    def test_go_uses_official_feature(self, tmp_path: Path):
+        target = _scaffold(
+            tmp_path / "go", devcontainer="true",
+            language="go", python="", go="true",
+        )
+        config = json.loads((target / ".devcontainer" / "devcontainer.json").read_text())
+        assert "ghcr.io/devcontainers/features/go:1" in config.get("features", {})
+
+    def test_non_go_has_no_features_block(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", devcontainer="true")
+        config = json.loads((target / ".devcontainer" / "devcontainer.json").read_text())
+        assert "features" not in config

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -50,6 +50,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "node": "",
         "go": "",
         "justfile": "true",
+        "devcontainer": "",
         "lightrag": "",
         "obsidian": "true",
         "llm_model": "claude-sonnet-4-6",

--- a/tests/integration/test_session_cold_start.py
+++ b/tests/integration/test_session_cold_start.py
@@ -1,0 +1,118 @@
+"""PI-146: cold-start / warm-start behavior of the SessionStart hook.
+
+The bootstrap tools are stubbed with PATH shims so the test is hermetic:
+a fake `just` records every invocation and creates `.venv` the way a real
+`just setup` (uv sync) would.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_STAMP = ".claude/.session_setup_stamp"
+
+
+def _scaffold_python(target: Path) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+    # A scaffolded *user* project has its own dependency manifest.
+    (target / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "0"\n'
+    )
+    return target
+
+
+def _make_shim_bin(tmp_path: Path, target: Path) -> Path:
+    """Fake `just`: append to a call log and create .venv like `uv sync`."""
+    bin_dir = tmp_path / "shim-bin"
+    bin_dir.mkdir()
+    just = bin_dir / "just"
+    just.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = "--show" ]; then exit 0; fi\n'
+        f'echo "$@" >> "{tmp_path}/just-calls.log"\n'
+        f'mkdir -p "{target}/.venv"\n'
+    )
+    just.chmod(just.stat().st_mode | stat.S_IXUSR)
+    return bin_dir
+
+
+def _run_hook(target: Path, bin_dir: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CLAUDE_PROJECT_DIR"] = str(target)
+    return subprocess.run(
+        ["bash", str(target / ".claude" / "hooks" / "session_setup.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=target,
+        timeout=60,
+    )
+
+
+class TestColdAndWarmStart:
+    def test_cold_start_bootstraps_and_stamps(self, tmp_path: Path):
+        target = _scaffold_python(tmp_path / "p")
+        bin_dir = _make_shim_bin(tmp_path, target)
+
+        result = _run_hook(target, bin_dir)
+        assert result.returncode == 0
+        assert "dependencies synced" in result.stdout
+        assert (tmp_path / "just-calls.log").read_text() == "setup\n"
+        assert (target / _STAMP).exists()
+        assert (target / ".venv").is_dir()
+
+    def test_warm_start_is_a_fast_no_op(self, tmp_path: Path):
+        target = _scaffold_python(tmp_path / "p")
+        bin_dir = _make_shim_bin(tmp_path, target)
+        assert _run_hook(target, bin_dir).returncode == 0
+
+        result = _run_hook(target, bin_dir)
+        assert result.returncode == 0
+        assert result.stdout == "", "warm start must stay silent"
+        calls = (tmp_path / "just-calls.log").read_text().splitlines()
+        assert calls == ["setup"], "warm start must not re-run the bootstrap"
+
+    def test_manifest_change_invalidates_stamp(self, tmp_path: Path):
+        target = _scaffold_python(tmp_path / "p")
+        bin_dir = _make_shim_bin(tmp_path, target)
+        assert _run_hook(target, bin_dir).returncode == 0
+
+        (target / "pyproject.toml").write_text(
+            '[project]\nname = "fixture"\nversion = "1"\n'
+        )
+        assert _run_hook(target, bin_dir).returncode == 0
+        calls = (tmp_path / "just-calls.log").read_text().splitlines()
+        assert calls == ["setup", "setup"], "changed manifest must re-bootstrap"
+
+    def test_restored_repo_without_env_re_bootstraps(self, tmp_path: Path):
+        """Stamp present but .venv missing (fresh container with restored
+        repo state) must re-run the bootstrap."""
+        target = _scaffold_python(tmp_path / "p")
+        bin_dir = _make_shim_bin(tmp_path, target)
+        assert _run_hook(target, bin_dir).returncode == 0
+
+        (target / ".venv").rmdir()
+        assert _run_hook(target, bin_dir).returncode == 0
+        calls = (tmp_path / "just-calls.log").read_text().splitlines()
+        assert calls == ["setup", "setup"]
+
+    def test_failed_bootstrap_does_not_break_session(self, tmp_path: Path):
+        target = _scaffold_python(tmp_path / "p")
+        bin_dir = _make_shim_bin(tmp_path, target)
+        (bin_dir / "just").write_text(
+            "#!/bin/bash\n"
+            'if [ "$1" = "--show" ]; then exit 0; fi\n'
+            "exit 1\n"
+        )
+
+        result = _run_hook(target, bin_dir)
+        assert result.returncode == 0, "SessionStart must never block the session"
+        assert "bootstrap failed" in result.stderr
+        assert not (target / _STAMP).exists(), "failure must not stamp as warm"

--- a/tests/integration/test_session_cold_start.py
+++ b/tests/integration/test_session_cold_start.py
@@ -103,6 +103,28 @@ class TestColdAndWarmStart:
         calls = (tmp_path / "just-calls.log").read_text().splitlines()
         assert calls == ["setup", "setup"]
 
+    def test_nothing_to_bootstrap_stays_silent(self, tmp_path: Path):
+        """No manifest and no tools: no misleading 'synced' message, but the
+        environment is stamped so later sessions skip the probe (PR #162
+        review)."""
+        target = tmp_path / "p"
+        scaffold(
+            target,
+            load_preset("obsidian-only"),
+            make_variables(
+                language="none", python="", justfile="",
+                lint_command="", format_command="", test_command="",
+            ),
+            strict=True,
+        )
+        empty_bin = tmp_path / "empty-bin"
+        empty_bin.mkdir()
+
+        result = _run_hook(target, empty_bin)
+        assert result.returncode == 0
+        assert result.stdout == "", "must not claim a sync that never ran"
+        assert (target / _STAMP).exists()
+
     def test_failed_bootstrap_does_not_break_session(self, tmp_path: Path):
         target = _scaffold_python(tmp_path / "p")
         bin_dir = _make_shim_bin(tmp_path, target)

--- a/tests/unit/test_render_nesting.py
+++ b/tests/unit/test_render_nesting.py
@@ -1,0 +1,35 @@
+"""PI-146: nested {{#if}} blocks resolve inside-out in the template engine."""
+
+from __future__ import annotations
+
+from project_init.scaffold import _render
+
+
+class TestNestedConditionals:
+    def test_outer_true_inner_true(self):
+        text = "{{#if a}}A{{#if b}}B{{/if b}}Z{{/if a}}"
+        assert _render(text, {"a": "true", "b": "true"}) == "ABZ"
+
+    def test_outer_true_inner_false(self):
+        text = "{{#if a}}A{{#if b}}B{{/if b}}Z{{/if a}}"
+        assert _render(text, {"a": "true", "b": ""}) == "AZ"
+
+    def test_outer_false_drops_inner_entirely(self):
+        text = "{{#if a}}A{{#if b}}B{{/if b}}Z{{/if a}}"
+        assert _render(text, {"a": "", "b": "true"}) == ""
+
+    def test_sequential_blocks_unchanged(self):
+        text = "{{#if a}}A{{/if a}}-{{#if b}}B{{/if b}}"
+        assert _render(text, {"a": "true", "b": ""}) == "A-"
+
+    def test_whole_file_wrapper_with_nested_language_blocks(self):
+        """The PI-146 devcontainer pattern: file-level flag wrapping
+        language-conditional sections."""
+        text = "{{#if devcontainer}}base\n{{#if python}}uv\n{{/if python}}end\n{{/if devcontainer}}"
+        assert _render(text, {"devcontainer": "true", "python": "true"}) == "base\nuv\nend\n"
+        assert _render(text, {"devcontainer": "true", "python": ""}) == "base\nend\n"
+        assert _render(text, {"devcontainer": "", "python": "true"}) == ""
+
+    def test_unclosed_block_survives_for_strict_mode(self):
+        text = "{{#if a}}no closer"
+        assert _render(text, {"a": "true"}) == "{{#if a}}no closer"


### PR DESCRIPTION
Closes #146

## Summary
- `.claude/hooks/session_setup.sh` wired to the SessionStart event (both settings.json variants): prefers `just setup`, falls back to `uv sync --extra dev` / `bun install` / `go mod download`. Warm environments short-circuit on a dependency-manifest content stamp + env presence check (restored repo without venv re-bootstraps). Failures warn to stderr and never block the session; stamp is gitignored.
- Opt-in `--devcontainer` flag + wizard prompt render `.devcontainer/devcontainer.json` + `post-create.sh` via `{{#if devcontainer}}` file-level conditionals — default scaffold unchanged. Go uses the official devcontainer feature; uv/bun install via their official scripts; post-create reuses the SessionStart bootstrap.
- Template engine upgrade: nested `{{#if}}` blocks resolve innermost-first to a fixpoint (previously the non-greedy regex mispaired outer openers with inner closers). Unclosed markers still surface in strict mode.
- Upgrade migration default (`devcontainer: off`) keeps pre-PI-146 re-renders faithful.

## Test plan
- `tests/integration/test_session_cold_start.py`: hermetic cold start (PATH-shimmed `just` records invocations), warm-start no-op, manifest-change invalidation, restored-repo-without-env re-bootstrap, failed-bootstrap-never-blocks
- `tests/contracts/test_session_bootstrap.py`: hook wiring/executability, gitignored stamp, devcontainer opt-in matrix per language
- `tests/unit/test_render_nesting.py`: nested conditional engine semantics
- Full suite: 441 passed