### PR TITLE
feat(PI-140): mise pinning, env/secret pattern, and .vscode overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ The wizard asks (interactive mode only):
 - Owner/team (`--owner`) — default CODEOWNERS owner, SECURITY contact, and LICENSE copyright holder (e.g. `@org/team`)
 - License (`--license mit|apache-2.0|proprietary|none`) — renders a LICENSE with the current year and the owner (or project name); `none` skips the file
 - Devcontainer (`--devcontainer`) — renders `.devcontainer/` for Codespaces, fresh clones, and remote agent containers (see below)
+- Toolchain pinning (`--mise`) — renders `mise.toml` pinning runtime/tool versions. Ownership rule: mise owns versions only; uv/bun own dependencies, just owns commands, `.env` owns environment
+- Editor config (`--vscode`) — renders `.vscode/extensions.json` + a minimal `settings.json` (format-on-save wired to the preset formatter); nothing personal, and the `.gitignore` shares only these two files
+
+Every preset also scaffolds the env/secret pattern: `.env.example`
+documents the variables and their loading order, `.env` is gitignored, and
+`.claude/docs/guides/secrets.md` covers when and how to escalate to an org
+secret manager (sops / 1Password CLI / Doppler) — none is installed, that
+choice is org-specific.
 
 Every preset also ships governance starters: `.github/CODEOWNERS`,
 `CONTRIBUTING.md` (setup, `just --list` command surface, branch/PR

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -490,6 +490,9 @@ def main(argv: list[str] | None = None) -> int:
         "devcontainer": "true" if devcontainer else "",
         "mise": "true" if mise else "",
         "vscode": "true" if vscode else "",
+        # Inverse flag: the template engine has no else-branch, and without
+        # --vscode the gitignore must keep personal .vscode/ fully ignored.
+        "vscode_off": "" if vscode else "true",
         "lightrag": "true" if is_lightrag else "",
         "obsidian": "true" if has_obsidian else "",
         "license_mit": "true" if license_choice == "mit" else "",

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -87,6 +87,22 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--mise",
+        action="store_true",
+        help=(
+            "Render mise.toml pinning toolchain versions (mise owns versions "
+            "only; uv/bun own deps, just owns commands, .env owns environment)"
+        ),
+    )
+    p.add_argument(
+        "--vscode",
+        action="store_true",
+        help=(
+            "Render .vscode/extensions.json + minimal settings.json "
+            "(format-on-save wired to the preset formatter; nothing personal)"
+        ),
+    )
+    p.add_argument(
         "--devcontainer",
         action="store_true",
         help=(
@@ -299,8 +315,8 @@ def _select_preset(
 
 def _gather_inputs_interactive(
     default_name: str,
-) -> tuple[str, str, str, list[dict], str, str, bool]:
-    """Prompt for name, description, language, MCPs, owner, license, devcontainer."""
+) -> tuple[str, str, str, list[dict], str, str, bool, bool, bool]:
+    """Prompt for project basics, MCPs, governance, and opt-in overlays."""
     project_name = _prompt("Project name", default=default_name)
     project_description = _prompt("Description", default="")
     language = _prompt("Language (python/node/go/none)", default="none")
@@ -326,6 +342,10 @@ def _gather_inputs_interactive(
     devcontainer = Confirm.ask(
         "Add a devcontainer (Codespaces / remote agent sessions)?", default=False
     )
+    mise = Confirm.ask("Pin toolchain versions with mise (mise.toml)?", default=False)
+    vscode = Confirm.ask(
+        "Add shared VS Code config (extensions + format-on-save)?", default=False
+    )
     return (
         project_name,
         project_description,
@@ -334,6 +354,8 @@ def _gather_inputs_interactive(
         owner,
         license_choice,
         devcontainer,
+        mise,
+        vscode,
     )
 
 
@@ -420,6 +442,8 @@ def main(argv: list[str] | None = None) -> int:
         owner = args.owner
         license_choice = args.license
         devcontainer = args.devcontainer
+        mise = args.mise
+        vscode = args.vscode
     else:
         (
             project_name,
@@ -429,6 +453,8 @@ def main(argv: list[str] | None = None) -> int:
             owner,
             license_choice,
             devcontainer,
+            mise,
+            vscode,
         ) = _gather_inputs_interactive(default_name=target.name)
 
     is_lightrag = "lightrag" in preset.get("name", "")
@@ -462,6 +488,8 @@ def main(argv: list[str] | None = None) -> int:
         "go": "true" if language == "go" else "",
         "justfile": "true" if language != "none" else "",
         "devcontainer": "true" if devcontainer else "",
+        "mise": "true" if mise else "",
+        "vscode": "true" if vscode else "",
         "lightrag": "true" if is_lightrag else "",
         "obsidian": "true" if has_obsidian else "",
         "license_mit": "true" if license_choice == "mit" else "",

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -242,6 +242,7 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "devcontainer": "",
         "mise": "",
         "vscode": "",
+        "vscode_off": "true",
         # Governance (PI-145) postdates pre-record configs: those projects
         # were scaffolded without a license or owner, so these are faithful.
         "project_owner": "",

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -237,8 +237,11 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "lightrag": "true" if "lightrag" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "justfile": "true" if language != "none" else "",
-        # Devcontainer (PI-146) postdates pre-record configs: faithful as off.
+        # Opt-in overlays (PI-146/PI-140) postdate pre-record configs:
+        # faithful as off.
         "devcontainer": "",
+        "mise": "",
+        "vscode": "",
         # Governance (PI-145) postdates pre-record configs: those projects
         # were scaffolded without a license or owner, so these are faithful.
         "project_owner": "",

--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -33,7 +33,8 @@ matches what you are about to do.
 {{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.
 - **Lint** — `just lint` must pass before closing a task. The linter config enforces docstrings and complexity caps on project code — fix the code, don't loosen the gate.
 {{/if}}- **Docs** — follow the Diátaxis layout in [`docs/`](docs/) (see `docs/index.md`). Record architectural decisions with the `add_adr` skill.
-- **No secrets in code** — never hardcode API keys, tokens, or personal data. Use `os.environ['KEY']` or a `.env` file (gitignored).
+- **Ownership boundaries** — each tool owns exactly one concern: {{#if mise}}`mise` owns toolchain versions, {{/if mise}}uv/bun own dependencies, `just` owns commands, `.env` owns environment variables. Don't blur them (no mise tasks/env, no version pins in scripts, no commands outside the justfile).
+- **No secrets in code** — never hardcode API keys, tokens, or personal data. Copy `.env.example` to `.env` (gitignored) and load it explicitly; see `.claude/docs/guides/secrets.md` for the escalation path to org secret managers.
 - **Enforcement is agent-agnostic** — secret scanning (gitleaks) and lifecycle gating run as git hooks plus CI checks (`validate-pr`, `secret-scan`), binding every agent and human alike. Run `.claude/scripts/install_hooks.sh` once per clone to activate them.
 
 ## Claude Code specifics

--- a/templates/base/dot_claude/docs/guides/secrets.md
+++ b/templates/base/dot_claude/docs/guides/secrets.md
@@ -1,0 +1,37 @@
+# Secrets handling
+
+How secrets flow through this project, and when to escalate beyond `.env`.
+
+## The local pattern (scaffolded)
+
+- `.env.example` documents every variable the project needs — committed,
+  values empty.
+- `.env` holds your real local values — gitignored, never committed.
+- Loading order: shell exports win over `.env`; tools load `.env`
+  explicitly (`uv run --env-file .env`, bun auto-load, or direnv).
+- Enforcement: the pre-commit hook runs a gitleaks scan and CI re-scans
+  the full history (ADR-007). A leaked value that reaches a commit must be
+  **rotated**, not just deleted — assume it is compromised.
+
+## When .env stops being enough
+
+`.env` files do not scale past a single developer: no audit trail, no
+rotation, manual sharing. Escalate to a secret manager when the team or
+the secret count grows. Common paths, in rough order of adoption effort:
+
+| Option | Shape | Fits when |
+|---|---|---|
+| [sops](https://github.com/getsops/sops) + age | encrypted files in the repo | small teams, GitOps workflows, no SaaS dependency |
+| [1Password CLI](https://developer.1password.com/docs/cli/) (`op run`) | secrets injected from a shared vault | team already uses 1Password |
+| [Doppler](https://docs.doppler.com/) | hosted secret manager with env sync | many environments/services, need audit + rotation |
+| Cloud-native (AWS/GCP/Azure secret managers) | IAM-scoped, per-service | production workloads already on that cloud |
+
+The scaffolder deliberately installs **none** of these — the choice is
+org-specific. Whichever you pick, keep the contract: `.env.example` stays
+the documentation of record for *what* variables exist; the manager owns
+*values*.
+
+## CI secrets
+
+Use the platform's mechanism (GitHub Actions secrets/environments), never
+files in the repo. Scope them per-environment and rotate on offboarding.

--- a/templates/base/dot_env.example.tmpl
+++ b/templates/base/dot_env.example.tmpl
@@ -1,0 +1,18 @@
+# .env.example — template for local environment (scaffolded by project-init).
+#
+# Copy to .env (gitignored) and fill in real values: cp .env.example .env
+#
+# Loading order (first match wins):
+#   1. variables already exported in your shell
+#   2. .env, loaded by the tool itself — `uv run --env-file .env`, bun
+#      auto-loads .env, or direnv if your team uses it
+# Nothing here is loaded implicitly by the scaffold; tools opt in.
+#
+# Never commit .env: the pre-commit gitleaks scan and CI both enforce this.
+# For team secrets, see .claude/docs/guides/secrets.md (escalation paths).
+{{#if lightrag}}
+# LightRAG memory stack
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+{{/if lightrag}}
+# EXAMPLE_API_KEY=

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -24,11 +24,12 @@ __pycache__/
 # OS / editor
 .DS_Store
 *.swp
-# Scaffolded editor config (--vscode) is shared; everything else is personal.
+{{#if vscode}}# Scaffolded editor config (--vscode) is shared; the rest stays personal.
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
-.idea/
+{{/if vscode}}{{#if vscode_off}}.vscode/
+{{/if vscode_off}}.idea/
 
 # Secrets
 .env

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -24,7 +24,10 @@ __pycache__/
 # OS / editor
 .DS_Store
 *.swp
-.vscode/
+# Scaffolded editor config (--vscode) is shared; everything else is personal.
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
 .idea/
 
 # Secrets

--- a/templates/base/dot_vscode/extensions.json.tmpl
+++ b/templates/base/dot_vscode/extensions.json.tmpl
@@ -1,0 +1,10 @@
+{{#if vscode}}{
+  "recommendations": [
+    "anthropic.claude-code"{{#if python}},
+    "charliermarsh.ruff"{{/if python}}{{#if node}},
+    "oven.bun-vscode"{{/if node}}{{#if go}},
+    "golang.go"{{/if go}}{{#if justfile}},
+    "nefrob.vscode-just-syntax"{{/if justfile}}
+  ]
+}
+{{/if vscode}}

--- a/templates/base/dot_vscode/settings.json.tmpl
+++ b/templates/base/dot_vscode/settings.json.tmpl
@@ -1,0 +1,8 @@
+{{#if vscode}}{
+  "editor.formatOnSave": true{{#if python}},
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }{{/if python}}{{#if go}},
+  "go.formatTool": "gofmt"{{/if go}}
+}
+{{/if vscode}}

--- a/templates/base/mise.toml.tmpl
+++ b/templates/base/mise.toml.tmpl
@@ -1,0 +1,20 @@
+{{#if mise}}# mise.toml — toolchain version pinning (scaffolded by project-init).
+#
+# Ownership boundaries (do not blur them):
+#   mise  owns toolchain VERSIONS only
+#   uv/bun own dependencies
+#   just  owns commands (`just --list`)
+#   .env  owns environment variables
+# mise tasks and mise env features are deliberately NOT used here.
+#
+# Pins below are deliberately loose majors so a fresh scaffold works today;
+# tighten to exact versions once the team standardizes.
+
+[tools]
+just = "1"
+{{#if python}}python = "3.12"
+uv = "latest"
+{{/if python}}{{#if node}}bun = "1"
+{{/if node}}{{#if go}}go = "1.24"
+golangci-lint = "2"
+{{/if go}}{{/if mise}}

--- a/tests/contracts/test_env_tooling.py
+++ b/tests/contracts/test_env_tooling.py
@@ -1,0 +1,113 @@
+"""PI-140: mise pinning, env/secret pattern, and .vscode overlays."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+class TestMiseOverlay:
+    def test_absent_by_default(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert not (target / "mise.toml").exists()
+
+    @pytest.mark.parametrize(
+        ("language", "tool", "absent"),
+        [
+            ("python", "python", "go"),
+            ("node", "bun", "python"),
+            ("go", "go", "bun"),
+        ],
+    )
+    def test_pins_per_language(self, tmp_path: Path, language: str, tool: str, absent: str):
+        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go")}
+        target = _scaffold(tmp_path / language, mise="true", language=language, **flags)
+        config = tomllib.loads((target / "mise.toml").read_text())
+        assert tool in config["tools"]
+        assert absent not in config["tools"]
+        assert "just" in config["tools"], "just is pinned for every language"
+
+    def test_ownership_rule_documented(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", mise="true")
+        mise = (target / "mise.toml").read_text()
+        assert "mise  owns toolchain VERSIONS only" in mise
+        agents = (target / "AGENTS.md").read_text()
+        assert "Ownership boundaries" in agents
+        assert "`mise` owns toolchain versions" in agents
+
+    def test_no_tasks_or_env_sections(self, tmp_path: Path):
+        """mise owns versions ONLY — tasks/env are deliberately unused."""
+        target = _scaffold(tmp_path / "p", mise="true")
+        config = tomllib.loads((target / "mise.toml").read_text())
+        assert set(config.keys()) == {"tools"}
+
+
+class TestEnvPattern:
+    @pytest.mark.parametrize("preset", ["obsidian-only", "obsidian-lightrag"])
+    def test_env_example_rendered_for_every_preset(self, tmp_path: Path, preset: str):
+        target = tmp_path / preset
+        flags = {"lightrag": "true" if "lightrag" in preset else ""}
+        scaffold(target, load_preset(preset), make_variables(**flags), strict=True)
+        example = (target / ".env.example").read_text()
+        assert "Loading order" in example
+        assert "Never commit .env" in example
+        if "lightrag" in preset:
+            assert "ANTHROPIC_API_KEY=" in example
+
+    def test_env_is_gitignored(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        lines = (target / ".gitignore").read_text().splitlines()
+        assert ".env" in lines
+
+    def test_secrets_guide_documents_escalation_without_deps(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        guide = (target / ".claude" / "docs" / "guides" / "secrets.md").read_text()
+        for manager in ("sops", "1Password CLI", "Doppler"):
+            assert manager in guide
+        assert "installs **none**" in guide, "manager choice stays org-specific"
+
+
+class TestVscodeOverlay:
+    def test_absent_by_default(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert not (target / ".vscode").exists()
+
+    def test_minimal_files_only(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", vscode="true")
+        files = sorted(p.name for p in (target / ".vscode").iterdir())
+        assert files == ["extensions.json", "settings.json"]
+
+    def test_python_wires_ruff_format_on_save(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", vscode="true")
+        settings = json.loads((target / ".vscode" / "settings.json").read_text())
+        assert settings["editor.formatOnSave"] is True
+        assert settings["[python]"]["editor.defaultFormatter"] == "charliermarsh.ruff"
+        extensions = json.loads((target / ".vscode" / "extensions.json").read_text())
+        assert "charliermarsh.ruff" in extensions["recommendations"]
+        assert "anthropic.claude-code" in extensions["recommendations"]
+
+    def test_go_recommends_go_extension(self, tmp_path: Path):
+        target = _scaffold(
+            tmp_path / "go", vscode="true", language="go", python="", go="true"
+        )
+        extensions = json.loads((target / ".vscode" / "extensions.json").read_text())
+        assert "golang.go" in extensions["recommendations"]
+        assert "charliermarsh.ruff" not in extensions["recommendations"]
+
+    def test_gitignore_shares_only_scaffolded_files(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", vscode="true")
+        gitignore = (target / ".gitignore").read_text()
+        assert ".vscode/*" in gitignore
+        assert "!.vscode/extensions.json" in gitignore
+        assert "!.vscode/settings.json" in gitignore

--- a/tests/contracts/test_env_tooling.py
+++ b/tests/contracts/test_env_tooling.py
@@ -78,18 +78,22 @@ class TestEnvPattern:
         assert "installs **none**" in guide, "manager choice stays org-specific"
 
 
+def _scaffold_vscode(target: Path, **overrides: str) -> Path:
+    return _scaffold(target, vscode="true", vscode_off="", **overrides)
+
+
 class TestVscodeOverlay:
     def test_absent_by_default(self, tmp_path: Path):
         target = _scaffold(tmp_path / "p")
         assert not (target / ".vscode").exists()
 
     def test_minimal_files_only(self, tmp_path: Path):
-        target = _scaffold(tmp_path / "p", vscode="true")
+        target = _scaffold_vscode(tmp_path / "p")
         files = sorted(p.name for p in (target / ".vscode").iterdir())
         assert files == ["extensions.json", "settings.json"]
 
     def test_python_wires_ruff_format_on_save(self, tmp_path: Path):
-        target = _scaffold(tmp_path / "p", vscode="true")
+        target = _scaffold_vscode(tmp_path / "p")
         settings = json.loads((target / ".vscode" / "settings.json").read_text())
         assert settings["editor.formatOnSave"] is True
         assert settings["[python]"]["editor.defaultFormatter"] == "charliermarsh.ruff"
@@ -98,16 +102,24 @@ class TestVscodeOverlay:
         assert "anthropic.claude-code" in extensions["recommendations"]
 
     def test_go_recommends_go_extension(self, tmp_path: Path):
-        target = _scaffold(
-            tmp_path / "go", vscode="true", language="go", python="", go="true"
+        target = _scaffold_vscode(
+            tmp_path / "go", language="go", python="", go="true"
         )
         extensions = json.loads((target / ".vscode" / "extensions.json").read_text())
         assert "golang.go" in extensions["recommendations"]
         assert "charliermarsh.ruff" not in extensions["recommendations"]
 
     def test_gitignore_shares_only_scaffolded_files(self, tmp_path: Path):
-        target = _scaffold(tmp_path / "p", vscode="true")
+        target = _scaffold_vscode(tmp_path / "p")
         gitignore = (target / ".gitignore").read_text()
         assert ".vscode/*" in gitignore
         assert "!.vscode/extensions.json" in gitignore
         assert "!.vscode/settings.json" in gitignore
+
+    def test_gitignore_keeps_personal_vscode_ignored_by_default(self, tmp_path: Path):
+        """Without --vscode, no unignore rules may leak personal editor
+        config into git (PR #163 review)."""
+        target = _scaffold(tmp_path / "p")
+        gitignore = (target / ".gitignore").read_text()
+        assert "\n.vscode/\n" in gitignore
+        assert "!.vscode" not in gitignore

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -53,6 +53,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "devcontainer": "",
         "mise": "",
         "vscode": "",
+        "vscode_off": "true",
         "lightrag": "",
         "obsidian": "true",
         "llm_model": "claude-sonnet-4-6",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,6 +51,8 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "go": "",
         "justfile": "true",
         "devcontainer": "",
+        "mise": "",
+        "vscode": "",
         "lightrag": "",
         "obsidian": "true",
         "llm_model": "claude-sonnet-4-6",

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -83,6 +83,38 @@ class TestCLIGovernanceFlags:
         assert "gov-cli. All rights reserved." in (target / "LICENSE").read_text()
 
 
+class TestCLIOverlayFlags:
+    """PI-140/PI-146: opt-in overlay flags render their files; defaults stay off."""
+
+    def _run(self, target: Path, *extra: str) -> int:
+        from project_init.__main__ import main
+
+        return main([
+            str(target),
+            "--non-interactive",
+            "--preset", "obsidian-only",
+            "--name", "overlay-cli",
+            "--description", "test",
+            "--language", "python",
+            *extra,
+        ])
+
+    def test_all_overlays_render(self, tmp_path: Path):
+        target = tmp_path / "p"
+        assert self._run(target, "--mise", "--vscode", "--devcontainer") == 0
+        assert (target / "mise.toml").exists()
+        assert (target / ".vscode" / "settings.json").exists()
+        assert (target / ".devcontainer" / "devcontainer.json").exists()
+
+    def test_default_scaffold_unchanged(self, tmp_path: Path):
+        target = tmp_path / "p"
+        assert self._run(target) == 0
+        assert not (target / "mise.toml").exists()
+        assert not (target / ".vscode").exists()
+        assert not (target / ".devcontainer").exists()
+        assert (target / ".env.example").exists(), "env pattern is always scaffolded"
+
+
 class TestCLINonInteractiveCommandVariables:
     """PI-16: CLI passes correct command variables based on --language."""
 


### PR DESCRIPTION
Closes #140

## Summary
- **mise overlay (opt-in, `--mise`)**: renders `mise.toml` pinning `just` plus the preset's toolchain (python/uv, bun, go/golangci-lint). Versions only — mise tasks/env deliberately unused. The ownership rule (mise=versions, uv/bun=deps, just=commands, .env=env) is documented in the scaffolded AGENTS.md and the mise.toml header.
- **Env/secret pattern (always scaffolded)**: `.env.example` with documented loading order (shell > .env, tools opt in explicitly), `.env` gitignored, and `.claude/docs/guides/secrets.md` documenting the escalation path (sops / 1Password CLI / Doppler / cloud-native) without installing any manager.
- **Editor overlay (opt-in, `--vscode`)**: `extensions.json` (claude-code + preset-matching extensions) and a minimal `settings.json` wiring format-on-save to the preset formatter (ruff / gofmt). Nothing personal. `.gitignore` uses the exception pattern so only those two files are shared.
- Wizard prompts for both new flags; upgrade migration defaults keep pre-PI-140 re-renders faithful (overlays off).

## Test plan
- `tests/contracts/test_env_tooling.py` (15 tests): per-language mise pins via tomllib, tools-only sections, ownership docs, env.example per preset, gitignored .env, secrets guide without deps, vscode matrix incl. default-off and gitignore sharing
- `tests/integration/test_cli.py`: all-overlays-on and default-off CLI paths
- Full suite: 459 passed