### PR TITLE
feat(PI-130): Graphify memory preset; LightRAG demoted to legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The wizard asks (interactive mode only):
 
 - Project name / description
 - Language (Python/Node/Go/none) — drives `lint_command`, `format_command`, `test_command`
-- Memory stack — Obsidian-only or Obsidian + LightRAG
+- Memory stack — Obsidian-only, Obsidian + Graphify (recommended for code-heavy projects), or Obsidian + LightRAG (legacy)
 - Core MCPs (Context7)
 - Database MCP — none / Postgres / SQLite
 - Browser automation — Playwright (yes/no)
@@ -231,7 +231,7 @@ The hooks need `python3` on `PATH` (replaces the previous `jq` dependency). They
 Edit and commit from inside WSL (`wsl` then `cd ~/projects/...`). Editing WSL files from Git Bash on Windows mangles executable bits and line endings.
 
 **`Unknown preset 'foo'`**
-Run `project-init --help` and pick from `obsidian-only` or `obsidian-lightrag`. Custom presets go in `templates/presets/<name>.toml`.
+Run `project-init --help` and pick from `obsidian-only`, `obsidian-graphify`, or `obsidian-lightrag` (legacy; ADR-009). Custom presets go in `templates/presets/<name>.toml`.
 
 ## Positioning in the ecosystem
 
@@ -245,8 +245,8 @@ adopters know what this tool owns and where it defers:
   community plugin or scaffolder covers these.
 - **Knowledge-graph memory**: the community has consolidated around
   [Graphify](https://github.com/safishamsi/graphify) for codebase knowledge
-  graphs. The LightRAG overlay here remains supported; a Graphify-based preset
-  is planned (#130).
+  graphs. The `obsidian-graphify` preset wires it in (ADR-009); the
+  LightRAG overlay remains available as a legacy option.
 - **Distributing `.claude/` components**: the official
   [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins)
   is the standard channel for hooks/skills/agents. Migrating the template

--- a/docs/adr/adr-009-graphify-memory-preset.md
+++ b/docs/adr/adr-009-graphify-memory-preset.md
@@ -1,0 +1,59 @@
+# ADR-009: Graphify becomes the recommended KG memory preset; LightRAG demoted to legacy
+
+- Status: Accepted
+- Date: 2026-06-12
+- Implements: evaluation required by #130
+
+## Context
+
+The `obsidian-lightrag` preset ships hand-rolled ingestion/query scripts
+(`ingest_sessions.py`, `query_memory.py`) against `lightrag-hku`. As a
+solo-maintained integration it is the part of this repo most likely to rot:
+it pins a fast-moving Python dependency, requires both Anthropic and OpenAI
+API keys for entity extraction and embeddings, and every LightRAG API change
+lands on us.
+
+Meanwhile the community consolidated around
+[Graphify](https://github.com/safishamsi/graphify) (~65k stars, weekly
+releases — v0.8.38 shipped 2026-06-11) for knowledge-graph memory across
+Claude Code, Codex, Gemini CLI, and other agents.
+
+## Evaluation: Graphify vs LightRAG for scaffolded-project memory
+
+| Dimension | LightRAG overlay (current) | Graphify |
+|---|---|---|
+| Maintenance | ours — custom scripts against `lightrag-hku` | upstream — weekly releases, 711+ commits on the active branch |
+| Install | `lightrag-hku>=1.0` as a project core dependency | `uv tool install graphifyy` + `graphify install` — tool-level, no project dependency |
+| API keys | Anthropic + OpenAI required (extraction + embeddings) | none for IDE use (AST mode is 0 LLM tokens; headless extraction optionally uses any provider incl. Ollama) |
+| Claude Code integration | custom rules file + manual script invocation | self-registers as a project-scoped skill (`/graphify`) + PreToolUse hook nudging graph queries over grepping |
+| Obsidian path | custom ingestion into the vault | native `--obsidian` vault export |
+| Freshness | manual re-ingestion | `graphify hook install` rebuilds changed files post-commit (SHA256 cache) |
+| Multi-agent | Claude-specific scripts | works across the agents #137 targets |
+
+The community pattern we adopt (see
+[claude-code-memory-setup](https://github.com/lucasrosati/claude-code-memory-setup))
+layers Graphify's structural code graph alongside the Obsidian vault:
+graph for "how does the code fit together", vault for human decisions and
+session memory.
+
+## Decision Outcome
+
+Add an `obsidian-graphify` preset and recommend it for new projects;
+mark `obsidian-lightrag` legacy (still functional, no new features).
+
+Scaffolder boundaries (unchanged by this ADR):
+
+- The scaffolder never runs Graphify — it renders docs, a setup script the
+  *user* runs once (`.claude/scripts/setup_graphify.sh`), and agent rules.
+  Deterministic file ops only.
+- Graphify's own artifacts (`graphify-out/`) are gitignored except the
+  markdown report; the graph is a derived cache, not source.
+
+## Consequences
+
+- New projects get maintained KG memory with zero API-key setup.
+- The LightRAG overlay stays for existing projects; its preset description
+  and README mark it legacy. Removal is a future decision once
+  `obsidian-graphify` has real-world mileage.
+- `memory.stack` gains the value `obsidian-graphify`; `project-init
+  upgrade` maps memory stacks to preset names 1:1, so upgrades keep working.

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -458,6 +458,7 @@ def main(argv: list[str] | None = None) -> int:
         ) = _gather_inputs_interactive(default_name=target.name)
 
     is_lightrag = "lightrag" in preset.get("name", "")
+    is_graphify = "graphify" in preset.get("name", "")
     has_obsidian = "obsidian" in preset.get("layers", [])
     lint_command, format_command, test_command = _LANGUAGE_COMMANDS.get(
         language, ("", "", "")
@@ -494,6 +495,7 @@ def main(argv: list[str] | None = None) -> int:
         # --vscode the gitignore must keep personal .vscode/ fully ignored.
         "vscode_off": "" if vscode else "true",
         "lightrag": "true" if is_lightrag else "",
+        "graphify": "true" if is_graphify else "",
         "obsidian": "true" if has_obsidian else "",
         "license_mit": "true" if license_choice == "mit" else "",
         "license_apache": "true" if license_choice == "apache-2.0" else "",

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -235,6 +235,7 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "format_command": fields.get("tooling.format_command", ""),
         "test_command": fields.get("tooling.test_command", ""),
         "lightrag": "true" if "lightrag" in stack else "",
+        "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "justfile": "true" if language != "none" else "",
         # Opt-in overlays (PI-146/PI-140) postdate pre-record configs:

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -12,7 +12,7 @@ project:
 language: {{language}}            # python | node | go | none
 
 memory:
-  stack: {{memory_stack}}         # obsidian-only | obsidian-lightrag
+  stack: {{memory_stack}}         # obsidian-only | obsidian-graphify | obsidian-lightrag (legacy)
   vault_path: .claude/vault
   memory_path: .claude/memory
 

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -16,7 +16,11 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 
-# Obsidian (vault workspace state only; keep notes tracked)
+{{#if graphify}}# Graphify (derived graph artifacts; keep GRAPH_REPORT.md tracked)
+graphify-out/*
+!graphify-out/GRAPH_REPORT.md
+
+{{/if graphify}}# Obsidian (vault workspace state only; keep notes tracked)
 .claude/vault/.obsidian/workspace*
 .claude/vault/.obsidian/cache
 .claude/vault/.trash/

--- a/templates/graphify/dot_claude/docs/guides/using-graphify.md
+++ b/templates/graphify/dot_claude/docs/guides/using-graphify.md
@@ -1,0 +1,43 @@
+# Using Graphify memory
+
+This project uses the `obsidian-graphify` memory stack (ADR-009 in the
+project-init repo): the Obsidian vault holds human decisions and session
+notes; [Graphify](https://github.com/safishamsi/graphify) holds a queryable
+knowledge graph of the codebase. Graph for "how does the code fit
+together", vault for "why did we do it this way".
+
+## One-time setup
+
+```bash
+.claude/scripts/setup_graphify.sh
+```
+
+This installs the `graphify` CLI (`uv tool install graphifyy`), registers
+the project-scoped `/graphify` skill plus a PreToolUse hook that nudges
+agents toward querying the graph instead of grepping, and adds a
+post-commit hook that incrementally rebuilds the graph (SHA256-cached, only
+changed files). No API keys are needed — IDE usage runs through your
+existing agent session, and AST extraction costs zero LLM tokens.
+
+## Daily flow
+
+1. Build/refresh: the post-commit hook keeps the graph current; after large
+   uncommitted changes run `/graphify .` (or `graphify update .`).
+2. Query: agents read `graphify-out/graph.json` first (see
+   `.claude/rules/graphify.md`); the HTML visualization at
+   `graphify-out/graph.html` is for humans.
+3. Vault export (optional): `graphify . --obsidian` writes graph notes into
+   the vault so wikilinks can connect code structure to decisions.
+
+## What is committed
+
+`graphify-out/` is a derived artifact: the markdown report
+(`GRAPH_REPORT.md`) is worth committing for reviewers; the JSON/HTML/cache
+are gitignored. Never hand-edit graph output — fix the code or the vault
+note instead.
+
+## Relation to the legacy LightRAG stack
+
+`obsidian-lightrag` remains available for existing projects but is legacy:
+it needs Anthropic + OpenAI keys and hand-rolled ingestion scripts.
+New projects should prefer this stack.

--- a/templates/graphify/dot_claude/rules/graphify.md
+++ b/templates/graphify/dot_claude/rules/graphify.md
@@ -1,0 +1,18 @@
+---
+description: Graphify memory — query the code knowledge graph before grepping
+globs: ["graphify-out/**", ".claude/scripts/setup_graphify.sh"]
+alwaysApply: false
+---
+
+## Graphify memory
+
+- Context lookup order: `graphify-out/graph.json` → vault notes → raw code.
+  Query the graph before grepping the codebase; it is rebuilt per commit.
+- Rebuild manually after large uncommitted changes: `/graphify .` (skill)
+  or `graphify update .` (CLI).
+- Export to the vault: `graphify . --obsidian` writes graph notes
+  alongside human notes.
+- Not installed yet? Run `.claude/scripts/setup_graphify.sh` once.
+
+The graph is a derived artifact — never hand-edit `graphify-out/`, and keep
+decisions in the vault (`.claude/vault/decisions/`), not in graph notes.

--- a/templates/graphify/dot_claude/scripts/setup_graphify.sh
+++ b/templates/graphify/dot_claude/scripts/setup_graphify.sh
@@ -23,7 +23,9 @@ else
 fi
 
 echo "Registering project-scoped skill + hook..."
-graphify install
+# --project writes under the repo (.claude/skills/graphify/) so the skill is
+# committable and teammates get it on clone; default scope is user-global.
+graphify install --project
 
 echo "Installing post-commit graph rebuild hook..."
 graphify hook install

--- a/templates/graphify/dot_claude/scripts/setup_graphify.sh
+++ b/templates/graphify/dot_claude/scripts/setup_graphify.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# One-time Graphify setup (scaffolded by project-init; ADR-009).
+# Run this yourself — the scaffolder never installs tools.
+# Idempotent: safe to re-run after Graphify updates.
+#
+# What it does:
+#   1. installs the graphify CLI as a uv tool (PyPI package: graphifyy)
+#   2. registers the project-scoped /graphify skill + PreToolUse hook
+#   3. installs the post-commit hook that incrementally rebuilds the graph
+
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv is required (https://docs.astral.sh/uv/). Install it first." >&2
+  exit 1
+fi
+
+if ! command -v graphify >/dev/null 2>&1; then
+  echo "Installing graphify CLI (uv tool install graphifyy)..."
+  uv tool install graphifyy
+else
+  echo "graphify CLI already installed — skipping"
+fi
+
+echo "Registering project-scoped skill + hook..."
+graphify install
+
+echo "Installing post-commit graph rebuild hook..."
+graphify hook install
+
+cat <<'EOM'
+
+Done. Next steps:
+  /graphify .                  # build the initial knowledge graph (in your agent)
+  graphify . --obsidian        # optional: export graph notes into the vault
+
+Agents read graphify-out/graph.json before grepping (see .claude/rules/graphify.md).
+EOM

--- a/templates/presets/obsidian-graphify.toml
+++ b/templates/presets/obsidian-graphify.toml
@@ -1,0 +1,16 @@
+# Preset: Obsidian + Graphify memory stack (recommended for code-heavy projects)
+# Obsidian vault for humans; Graphify knowledge graph for agents (ADR-009).
+# Graphify is installed by the user via .claude/scripts/setup_graphify.sh —
+# the scaffolder only renders files.
+
+name = "obsidian-graphify"
+description = "Obsidian vault for humans, Graphify code knowledge graph for agents."
+
+layers = ["base", "obsidian", "graphify"]
+
+[vars]
+memory_stack = "obsidian-graphify"
+
+[scaffolded_project_dependencies.python]
+core = []
+dev = ["ruff"]

--- a/templates/presets/obsidian-lightrag.toml
+++ b/templates/presets/obsidian-lightrag.toml
@@ -1,8 +1,9 @@
-# Preset: Obsidian + LightRAG memory stack
-# For larger projects. Obsidian vault for humans, LightRAG KG for agents.
+# Preset: Obsidian + LightRAG memory stack (LEGACY — ADR-009)
+# Kept functional for existing projects; new projects should prefer
+# obsidian-graphify (maintained upstream, no API keys for IDE use).
 
 name = "obsidian-lightrag"
-description = "Obsidian vault for humans, LightRAG graph/vector index for agents."
+description = "LEGACY: Obsidian vault + LightRAG graph/vector index (prefer obsidian-graphify)."
 
 layers = ["base", "obsidian", "lightrag"]
 

--- a/tests/contracts/test_scaffold_graphify.py
+++ b/tests/contracts/test_scaffold_graphify.py
@@ -28,7 +28,9 @@ class TestScaffoldGraphify:
         assert os.access(script, os.X_OK)
         content = script.read_text()
         assert "uv tool install graphifyy" in content
-        assert "graphify install" in content
+        assert "graphify install --project" in content, (
+            "default scope is user-global; --project makes the skill committable"
+        )
         assert "graphify hook install" in content
 
     def test_rule_file_directs_graph_first_lookup(self):

--- a/tests/contracts/test_scaffold_graphify.py
+++ b/tests/contracts/test_scaffold_graphify.py
@@ -1,0 +1,76 @@
+"""PI-130 / ADR-009: obsidian-graphify preset renders a working Graphify setup."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+class TestScaffoldGraphify:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_path: Path):
+        self.target = tmp_path / "p"
+        preset = load_preset("obsidian-graphify")
+        variables = make_variables(
+            memory_stack="obsidian-graphify",
+            graphify="true",
+        )
+        self.created = scaffold(self.target, preset, variables, strict=True)
+
+    def test_setup_script_present_and_executable(self):
+        script = self.target / ".claude" / "scripts" / "setup_graphify.sh"
+        assert script.is_file()
+        assert os.access(script, os.X_OK)
+        content = script.read_text()
+        assert "uv tool install graphifyy" in content
+        assert "graphify install" in content
+        assert "graphify hook install" in content
+
+    def test_rule_file_directs_graph_first_lookup(self):
+        rule = (self.target / ".claude" / "rules" / "graphify.md").read_text()
+        assert "graphify-out/graph.json" in rule
+        assert "setup_graphify.sh" in rule
+
+    def test_guide_documents_workflow(self):
+        guide = (
+            self.target / ".claude" / "docs" / "guides" / "using-graphify.md"
+        ).read_text()
+        assert "--obsidian" in guide
+        assert "setup_graphify.sh" in guide
+        assert "legacy" in guide.lower()  # LightRAG relation stated
+
+    def test_gitignore_keeps_report_tracked(self):
+        gitignore = (self.target / ".gitignore").read_text()
+        assert "graphify-out/*" in gitignore
+        assert "!graphify-out/GRAPH_REPORT.md" in gitignore
+
+    def test_scaffolder_never_invokes_graphify(self):
+        """ADR-009 boundary: rendered files only — no install/run at scaffold
+        time. The only executable mention lives in the user-run setup script
+        and docs."""
+        assert not (self.target / "graphify-out").exists()
+
+    def test_obsidian_layer_included(self):
+        assert (self.target / ".claude" / "vault").is_dir()
+
+    def test_no_lightrag_files(self):
+        assert not (self.target / ".claude" / "scripts" / "ingest_sessions.py").exists()
+        assert not (self.target / ".claude" / "memory" / "lightrag.yaml").exists()
+
+
+class TestLightragLegacy:
+    def test_preset_marked_legacy_but_functional(self, tmp_path: Path):
+        preset = load_preset("obsidian-lightrag")
+        assert "LEGACY" in preset["description"]
+        created = scaffold(
+            tmp_path / "p",
+            preset,
+            make_variables(memory_stack="obsidian-lightrag", lightrag="true"),
+        )
+        assert created, "legacy preset must still scaffold"
+        assert (tmp_path / "p" / ".claude" / "scripts" / "ingest_sessions.py").is_file()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -55,6 +55,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "vscode": "",
         "vscode_off": "true",
         "lightrag": "",
+        "graphify": "",
         "obsidian": "true",
         "llm_model": "claude-sonnet-4-6",
         "embedding_model": "text-embedding-3-small",


### PR DESCRIPTION
Closes #130

## Summary
- **ADR-009** records the required evaluation (Graphify vs LightRAG): upstream-maintained (65.8k stars, v0.8.38 released 2026-06-11) vs solo-maintained scripts; zero API keys for IDE use (LightRAG needs Anthropic+OpenAI); native `--obsidian` vault export; post-commit SHA256-cached incremental rebuilds; works across the agents #137 targets.
- **New `obsidian-graphify` preset** (layers: base+obsidian+graphify). The overlay renders: `.claude/scripts/setup_graphify.sh` (idempotent user-run installer — the scaffolder itself never invokes Graphify, per repo rules), `.claude/rules/graphify.md` (graph-first context lookup), and `.claude/docs/guides/using-graphify.md`. `.gitignore` ignores `graphify-out/*` but keeps `GRAPH_REPORT.md` tracked.
- **`obsidian-lightrag` demoted to legacy** — preset description, config.yaml comment, and README all marked; the overlay stays fully functional and contract-tested.
- `graphify` template flag wired through CLI and upgrade migration (memory stacks map 1:1 onto preset names, so `project-init upgrade` keeps working).

## Test plan
- `tests/contracts/test_scaffold_graphify.py` (8 tests): strict-mode render, executable setup script with the documented install commands, rules/guide content, gitignore report exception, no LightRAG bleed-through, legacy preset still scaffolds
- Full suite: 468 passed