### PR TITLE
feat(PI-129): plugin + same-repo marketplace, dual-shipped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "project-init",
+  "owner": {
+    "name": "Vytautas Čepas",
+    "url": "https://github.com/VytCepas"
+  },
+  "plugins": [
+    {
+      "name": "project-init-workflow",
+      "source": "./plugins/project-init-workflow",
+      "description": "GitHub lifecycle skills and deterministic guard hooks for projects scaffolded by project-init (dual-shipped with scaffolded copies during the transition; see ADR-010)."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -249,9 +249,14 @@ adopters know what this tool owns and where it defers:
   LightRAG overlay remains available as a legacy option.
 - **Distributing `.claude/` components**: the official
   [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins)
-  is the standard channel for hooks/skills/agents. Migrating the template
-  payloads to a plugin is planned (#129); the scaffolder will keep owning
-  project files.
+  is the standard channel for hooks/skills/agents. This repo doubles as a
+  marketplace (`.claude-plugin/marketplace.json`) shipping the
+  `project-init-workflow` plugin — the project-agnostic skills and guard
+  hooks, auto-update included. Scaffolded projects register the marketplace
+  in `settings.json`, so teammates get the plugin offered on first trust.
+  During the transition, scaffolds also keep file copies (the active
+  wiring) — see ADR-010 for the cutover plan; the scaffolder keeps owning
+  project files either way.
 - **`AGENTS.md` vs `CLAUDE.md`**: Claude Code still reads only `CLAUDE.md`
   ([anthropics/claude-code#34235](https://github.com/anthropics/claude-code/issues/34235)),
   while most other tools read the `AGENTS.md` standard — which is why this

--- a/docs/adr/adr-010-plugin-marketplace-dual-ship.md
+++ b/docs/adr/adr-010-plugin-marketplace-dual-ship.md
@@ -1,0 +1,55 @@
+# ADR-010: Same-repo plugin marketplace; dual-ship before template cutover
+
+- Status: Accepted
+- Date: 2026-06-12
+- Implements: distribution decision required by #129
+
+## Context
+
+The scaffolder copies ~30 `.claude/` files into every target project.
+Copies drift: a hook fix here never reaches already-scaffolded projects.
+The Claude Code plugin ecosystem solves exactly this — plugins update
+centrally, and a trusted marketplace offers them to every teammate.
+
+Two questions needed answers: where the marketplace lives, and whether the
+scaffolder stops copying files the moment the plugin exists.
+
+## Decision Outcome
+
+**Marketplace lives in this repo.** `.claude-plugin/marketplace.json` at
+the repo root lists `project-init-workflow` with a relative source
+(`./plugins/project-init-workflow`). No second repo to maintain; relative
+sources resolve for git-based marketplace adds, which is how scaffolded
+settings reference it. A dedicated company marketplace can supersede this
+later without changing the plugin.
+
+**Dual-ship first.** Scaffolded projects keep receiving file copies (the
+active wiring), and `settings.json` additionally registers the
+`project-init` marketplace via `extraKnownMarketplaces` — teammates who
+trust the project get the plugin *offered*, not force-enabled:
+
+- The plugin is deliberately **not** in `enabledPlugins`: its
+  `hooks/hooks.json` wires the same guard scripts the scaffolded
+  `settings.json` already wires, and enabling both would double-fire every
+  PreToolUse/SessionStart hook (twice the lint latency on every commit).
+- Cutover (templates shrink to project-specific files, plugin becomes the
+  single source of hooks/skills) is a follow-up once the plugin has
+  real-world mileage. At that point scaffolds enable the plugin and stop
+  copying the shared payload.
+
+**Plugin contents = the project-agnostic subset.** Every non-`.tmpl`
+SKILL.md tree and every hook script. Templated components (e.g.
+`plan/SKILL.md.tmpl`, settings, rules) are project-specific by definition
+and stay scaffold-only. `tools/sync_plugin.py` (`just sync-plugin`)
+regenerates the plugin payload from `templates/`; a contract test fails CI
+when the copies drift, so the duplication cannot rot silently.
+
+## Consequences
+
+- A hook/skill fix shipped in the plugin reaches every project that
+  enabled it without re-scaffolding; projects that didn't still get fixes
+  through `project-init upgrade` (PI-142).
+- Until cutover, template edits to shared skills/hooks require
+  `just sync-plugin` — enforced by CI, one command.
+- Plugin versioning starts at 0.1.0, independent of the scaffolder
+  version; bump it when the payload changes behavior.

--- a/justfile
+++ b/justfile
@@ -24,3 +24,7 @@ docs:
 
 # what CI runs
 ci: lint test
+
+# sync the plugin payload from templates (PI-129)
+sync-plugin:
+    uv run python tools/sync_plugin.py

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "project-init-workflow",
+  "displayName": "project-init Workflow",
+  "version": "0.1.0",
+  "description": "GitHub lifecycle skills and deterministic guard hooks from project-init: issue->branch->PR->review->merge workflow, commit gating, and session bootstrap.",
+  "author": {
+    "name": "Vytautas Čepas",
+    "url": "https://github.com/VytCepas"
+  },
+  "repository": "https://github.com/VytCepas/project-init",
+  "license": "MIT",
+  "keywords": ["workflow", "github", "hooks", "scaffolding"],
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""DAG-based workflow enforcement for the GitHub lifecycle.
+
+Subcommands:
+  check <node>          exit 0 if every prerequisite of <node> is satisfied,
+                        exit 2 otherwise (with reason on stdout).
+  guard                 read PreToolUse hook input JSON from stdin, map the
+                        Bash command to a target node, emit
+                        {decision: block, reason: ...} if disallowed.
+  nodes                 list every DAG node and its prerequisites.
+  push [<branch>] [N]   push current (or named) branch with retry + remote-SHA
+                        verification (handles transient GitHub 5xx).
+  promote [<pr>]        mark current (or numbered) draft PR ready for review.
+  finish [<pr>] [--review-cycle N]
+                        push, promote, then exec monitor_pr.sh --merge.
+  create-pr-nojira <type> <title> [--branch B] [--base B]
+                        create a no-issue feature branch + draft PR.
+
+The `check` and `guard` paths are pure read-only; they're used by hooks and
+lifecycle scripts. The other subcommands consolidate the bash lifecycle
+scripts (push_branch.sh, promote_review.sh, finish_pr.sh,
+create_nojira_pr.sh) so the tool is the single source of truth for the
+GitHub workflow. The .sh files become thin shims that exec into here.
+
+Issue-ref prefix detection:
+  By default, branches matching `[A-Z]{2,}-<n>` (e.g. PI-98, ACME-42) are
+  treated as issue-backed. Override with the DAG_ISSUE_PREFIX env var to pin
+  a specific prefix (e.g. DAG_ISSUE_PREFIX=PROJ matches only `PROJ-<n>`).
+  Branches with no recognized prefix fall through to the no-jira flow.
+
+stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CACHE_PATH = Path(".claude/.workflow-state.json")
+
+GRAPH: dict[str, list[str]] = {
+    "issue.created": [],
+    "branch.created": [],
+    "branch.pushed": ["branch.created"],
+    "pr.opened": ["branch.pushed", "issue.created"],
+    "ci.green": ["pr.opened"],
+    "review.approved": ["pr.opened"],
+    "pr.merged": ["ci.green", "review.approved"],
+}
+
+_CONFIGURED_PREFIX = os.environ.get("DAG_ISSUE_PREFIX", "").strip()
+if _CONFIGURED_PREFIX:
+    ISSUE_RE: re.Pattern[str] = re.compile(
+        rf"\b{re.escape(_CONFIGURED_PREFIX)}-(\d+)\b", re.IGNORECASE
+    )
+else:
+    ISSUE_RE = re.compile(r"\b[A-Z]{2,}-(\d+)\b")
+
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return 1, ""
+    return proc.returncode, proc.stdout
+
+
+def _gh(args: list[str]) -> tuple[int, str]:
+    return _run(["gh", *args])
+
+
+def _git(args: list[str]) -> tuple[int, str]:
+    return _run(["git", *args])
+
+
+def _current_branch() -> str | None:
+    code, out = _git(["branch", "--show-current"])
+    branch = out.strip()
+    return branch if code == 0 and branch else None
+
+
+def _issue_from_branch(branch: str) -> int | None:
+    m = ISSUE_RE.search(branch)
+    return int(m.group(1)) if m else None
+
+
+def check_issue_created() -> tuple[bool, str]:
+    branch = _current_branch()
+    if not branch:
+        return False, "no current branch"
+    n = _issue_from_branch(branch)
+    if n is None:
+        return True, f"branch '{branch}' has no issue ref (no-jira flow allowed)"
+    code, out = _gh(["issue", "view", str(n), "--json", "number,state"])
+    if code != 0:
+        return False, f"issue #{n} not found via gh"
+    try:
+        data = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return False, f"issue #{n}: malformed gh output"
+    if data.get("number") != n:
+        return False, f"issue #{n} not present"
+    return True, f"issue #{n} exists ({data.get('state', 'UNKNOWN')})"
+
+
+def check_branch_created() -> tuple[bool, str]:
+    branch = _current_branch()
+    if not branch:
+        return False, "not in a git repo / no current branch"
+    if branch in {"main", "master"}:
+        return False, "must be on a feature branch, not main/master"
+    return True, f"on branch '{branch}'"
+
+
+def check_branch_pushed() -> tuple[bool, str]:
+    branch = _current_branch()
+    if not branch:
+        return False, "no current branch"
+    code, _ = _git(["rev-parse", "--verify", f"origin/{branch}"])
+    if code != 0:
+        return False, f"origin/{branch} does not exist (push the branch first)"
+    code, out = _git(["rev-list", "--count", f"origin/{branch}..HEAD"])
+    if code == 0 and out.strip() and out.strip() != "0":
+        return False, f"branch has {out.strip()} unpushed commit(s)"
+    return True, f"branch '{branch}' is pushed and up to date with origin"
+
+
+def check_pr_opened() -> tuple[bool, str]:
+    code, out = _gh(["pr", "view", "--json", "number,state"])
+    if code != 0:
+        return False, "no PR exists for the current branch"
+    try:
+        data = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return False, "malformed gh pr view output"
+    if data.get("state") != "OPEN":
+        return False, f"PR is {data.get('state', 'unknown')}, not OPEN"
+    return True, f"PR #{data.get('number')} is open"
+
+
+def check_ci_green() -> tuple[bool, str]:
+    code, out = _gh(["pr", "view", "--json", "number,statusCheckRollup"])
+    if code != 0:
+        return False, "cannot read PR / CI status"
+    try:
+        data = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return False, "malformed gh statusCheckRollup output"
+    n = data.get("number", "?")
+    rollup = data.get("statusCheckRollup") or []
+    pending = failing = 0
+    for entry in rollup:
+        name = (entry.get("name") or entry.get("context") or "").lower()
+        if "review/decision" in name:
+            continue
+        status = (entry.get("status") or "").upper()
+        conclusion = (entry.get("conclusion") or "").upper()
+        if conclusion in {"FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED"}:
+            failing += 1
+        elif status in {"PENDING", "QUEUED", "IN_PROGRESS", "WAITING"} or (
+            not conclusion and not status
+        ):
+            pending += 1
+    if failing:
+        return False, f"PR #{n}: {failing} CI check(s) failing"
+    if pending:
+        return False, f"PR #{n}: {pending} CI check(s) still running"
+    return True, f"PR #{n}: CI green"
+
+
+def check_review_approved() -> tuple[bool, str]:
+    code, out = _gh(["pr", "view", "--json", "number,reviewDecision"])
+    if code != 0:
+        return False, "cannot read PR review decision"
+    try:
+        data = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return False, "malformed gh reviewDecision output"
+    n = data.get("number", "?")
+    decision = data.get("reviewDecision") or ""
+    if decision == "APPROVED":
+        return True, f"PR #{n}: review approved"
+    if decision == "CHANGES_REQUESTED":
+        return False, f"PR #{n}: review requested changes"
+    return False, f"PR #{n}: review pending (decision={decision or 'none'})"
+
+
+def check_pr_merged() -> tuple[bool, str]:
+    code, out = _gh(["pr", "view", "--json", "number,state"])
+    if code != 0:
+        return False, "no PR for current branch"
+    try:
+        data = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return False, "malformed gh output"
+    if data.get("state") == "MERGED":
+        return True, f"PR #{data.get('number')} is merged"
+    return False, f"PR #{data.get('number')} state is {data.get('state')}"
+
+
+CHECKS = {
+    "issue.created": check_issue_created,
+    "branch.created": check_branch_created,
+    "branch.pushed": check_branch_pushed,
+    "pr.opened": check_pr_opened,
+    "ci.green": check_ci_green,
+    "review.approved": check_review_approved,
+    "pr.merged": check_pr_merged,
+}
+
+
+def prereqs_satisfied(node: str, _seen: set[str] | None = None) -> tuple[bool, str]:
+    """Walk all ancestors of `node` and return (True, '') if every prereq passes,
+    else (False, '<first failing prereq>: <reason>').
+    """
+    if node not in GRAPH:
+        return False, f"unknown node: {node}"
+    seen = _seen if _seen is not None else set()
+    if node in seen:
+        return True, ""
+    seen.add(node)
+    for prereq in GRAPH[node]:
+        ok, reason = CHECKS[prereq]()
+        if not ok:
+            return False, f"{prereq}: {reason}"
+        ok, reason = prereqs_satisfied(prereq, seen)
+        if not ok:
+            return False, reason
+    return True, "all prerequisites satisfied"
+
+
+# Steering rules: command pattern -> (target_node | None, redirect_message)
+# The first matching rule wins. target_node=None means a hard block with no
+# DAG validation; otherwise, prereqs of target_node are appended to the reason.
+COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
+    (
+        re.compile(r"git\s+push\s+(?:\S+\s+)?(?:origin\s+)?(?:main|master)\b"),
+        None,
+        "Direct pushes to main/master are blocked. Open a feature branch and PR.",
+    ),
+    (
+        re.compile(r"\bgh\s+api\s+repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        "pr.merged",
+        "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
+    ),
+    (
+        re.compile(r"\bgh\s+pr\s+merge\b"),
+        "pr.merged",
+        "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh pr merge` so CI, review waits, and review cycles are handled.",
+    ),
+    (
+        re.compile(r"\bgh\s+pr\s+checks\b.*--watch"),
+        None,
+        "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh pr checks --watch`.",
+    ),
+    (
+        re.compile(r"\bgh\s+pr\s+ready\b"),
+        "pr.opened",
+        "Use .claude/scripts/promote_review.sh instead of `gh pr ready`.",
+    ),
+    (
+        re.compile(r"\bgh\s+pr\s+create\b"),
+        "pr.opened",
+        "Use .claude/scripts/start_issue.sh (issue-backed) or .claude/scripts/create_nojira_pr.sh (no issue) instead of `gh pr create`.",
+    ),
+    (
+        re.compile(r"\bgh\s+issue\s+create\b"),
+        None,
+        "Use .claude/scripts/create_issue.sh (or the start_task skill) so priority, references, and acceptance criteria are captured.",
+    ),
+    (
+        re.compile(r"\bgit\s+push\b"),
+        "branch.pushed",
+        "Use .claude/scripts/push_branch.sh instead of raw `git push` so transient GitHub failures are retried and the remote SHA is verified.",
+    ),
+]
+
+
+_HEREDOC_RE = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?[ \t]*\n.*?\n\1[ \t]*(?:\n|$)",
+    re.DOTALL,
+)
+
+
+def _strip_heredocs(cmd: str) -> str:
+    """Remove heredoc body text so pattern rules don't fire on body content."""
+    return _HEREDOC_RE.sub("", cmd)
+
+
+def _redirect_target_exists(reason: str) -> bool:
+    """Best-effort: scan the redirect message for a `.claude/scripts/<name>`
+    reference and check whether the file exists. If no reference is found,
+    treat the rule as always-applicable (e.g. main/master block).
+    """
+    m = re.search(r"\.claude/scripts/([\w.-]+)", reason)
+    if not m:
+        return True
+    return (Path(".claude/scripts") / m.group(1)).exists()
+
+
+def guard(payload: dict) -> dict | None:
+    cmd = ((payload.get("tool_input") or {}).get("command") or "").strip()
+    if not cmd:
+        return None
+
+    # Strip heredoc bodies so pattern rules don't fire on body content
+    # (e.g. `gh issue create --body "$(cat <<'EOF'\n...git push...\nEOF\n)"`)
+    cmd_scan = _strip_heredocs(cmd)
+
+    for pattern, target, message in COMMAND_RULES:
+        if not pattern.search(cmd_scan):
+            continue
+        # If the redirect points at a wrapper script that doesn't exist in
+        # this repo, skip (don't block — there's nothing to redirect to).
+        if not _redirect_target_exists(message):
+            continue
+
+        reason = message
+        if target is not None:
+            ok, why = prereqs_satisfied(target)
+            if not ok:
+                reason = f"{message}\n\nDAG prerequisite for {target} not met: {why}."
+        return {"decision": "block", "reason": reason}
+    return None
+
+
+def cmd_check(node: str) -> int:
+    if node not in GRAPH:
+        sys.stdout.write(f"unknown node: {node}\n")
+        return 2
+    ok, reason = prereqs_satisfied(node)
+    if ok:
+        # Also report the node's own check, for human consumption.
+        own_ok, own_reason = CHECKS[node]()
+        marker = "OK" if own_ok else "REACHABLE (state not yet satisfied)"
+        sys.stdout.write(f"{marker}: {node} — {own_reason}\n")
+        return 0 if own_ok else 0  # prereqs satisfied = transition allowed
+    sys.stdout.write(f"BLOCKED: cannot reach {node}: {reason}\n")
+    return 2
+
+
+def cmd_guard() -> int:
+    raw = sys.stdin.read()
+    if not raw:
+        return 0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+    result = guard(payload)
+    if result is not None:
+        sys.stdout.write(json.dumps(result))
+    return 0
+
+
+def _detect_pr_number() -> int | None:
+    code, out = _gh(["pr", "view", "--json", "number", "-q", ".number"])
+    if code != 0:
+        return None
+    try:
+        return int(out.strip())
+    except ValueError:
+        return None
+
+
+def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> int:
+    """Push the current (or named) branch with retry + remote-SHA verification.
+
+    Handles transient GitHub 5xx where `git push` exits non-zero but the
+    commit actually landed on the remote. *force* adds --force-with-lease
+    for the rebase-after-squash-merge case; main/master are refused.
+    """
+    if branch is None:
+        branch = _current_branch()
+    if not branch:
+        sys.stderr.write("push: no current branch\n")
+        return 1
+    if force and branch in ("main", "master"):
+        sys.stderr.write("push: refusing to force-push main/master\n")
+        return 1
+
+    code, sha_out = _git(["rev-parse", branch])
+    if code != 0:
+        sys.stderr.write(f"push: cannot resolve sha for {branch}\n")
+        return 1
+    expected_sha = sha_out.strip()
+
+    def remote_has_sha() -> bool:
+        code, out = _git(["ls-remote", "origin", f"refs/heads/{branch}"])
+        if code != 0:
+            return False
+        for line in out.splitlines():
+            parts = line.split()
+            if parts and parts[0] == expected_sha:
+                return True
+        return False
+
+    for attempt in range(max_retries + 1):
+        push_cmd = ["git", "push", "-u", "origin", branch]
+        if force:
+            push_cmd.append("--force-with-lease")
+        proc = subprocess.run(push_cmd)
+        if proc.returncode == 0:
+            sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
+            return 0
+        if remote_has_sha():
+            sys.stdout.write(
+                f"push: remote already has {expected_sha} on {branch} "
+                "(transient error, treating as success)\n"
+            )
+            _git(["branch", f"--set-upstream-to=origin/{branch}", branch])
+            return 0
+        if attempt < max_retries:
+            time.sleep(3)
+    sys.stderr.write(f"push: failed after {max_retries} retries\n")
+    return 1
+
+
+def cmd_promote(pr_number: int | None) -> int:
+    """Mark a draft PR ready for review."""
+    if pr_number is None:
+        pr_number = _detect_pr_number()
+    if pr_number is None:
+        sys.stderr.write(
+            "promote: no PR found for current branch. Pass a PR number.\n"
+        )
+        return 1
+    code, out = _gh(
+        ["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"]
+    )
+    if code != 0:
+        sys.stderr.write(f"promote: cannot read PR #{pr_number}\n")
+        return 1
+    if out.strip() == "false":
+        _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
+        sys.stdout.write(
+            f"PR #{pr_number} is already ready for review: {url.strip()}\n"
+        )
+        return 0
+    code, _ = _gh(["pr", "ready", str(pr_number)])
+    if code != 0:
+        sys.stderr.write(f"promote: gh pr ready failed for #{pr_number}\n")
+        return code
+    _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
+    sys.stdout.write(
+        f"PR #{pr_number} is now ready for review: {url.strip()}\n"
+    )
+    return 0
+
+
+def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
+    """Push, promote, then hand off to monitor_pr.sh for CI/review/merge."""
+    rc = cmd_push(None, 3)
+    if rc != 0:
+        return rc
+    if pr_number is None:
+        pr_number = _detect_pr_number()
+    if pr_number is None:
+        sys.stderr.write("finish: no PR found for current branch.\n")
+        return 1
+    rc = cmd_promote(pr_number)
+    if rc != 0:
+        return rc
+    monitor_args = [".claude/scripts/monitor_pr.sh", str(pr_number), "--merge"]
+    if review_cycle is not None:
+        monitor_args += ["--review-cycle", str(review_cycle)]
+    return subprocess.run(monitor_args).returncode
+
+
+_VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}
+_BRANCH_RE = re.compile(r"^(feat|fix|chore|docs|test)/[A-Za-z0-9._/-]+$")
+
+
+def _slugify(text: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", text.lower())
+    return s.strip("-")
+
+
+def cmd_create_pr_nojira(
+    type_: str, title: str, branch: str | None, base: str | None
+) -> int:
+    """Create a no-issue feature branch (if needed) and open a draft PR."""
+    if type_ not in _VALID_TYPES:
+        sys.stderr.write(
+            f"ERROR: invalid type '{type_}'. Valid: {' '.join(sorted(_VALID_TYPES))}\n"
+        )
+        return 1
+    if not title.strip():
+        sys.stderr.write("ERROR: title must not be empty\n")
+        return 1
+
+    current = _current_branch()
+    if not branch:
+        if current and current not in {"main", "master"}:
+            branch = current
+        else:
+            slug = _slugify(title)
+            if not slug:
+                sys.stderr.write(
+                    "ERROR: title must contain at least one letter or number\n"
+                )
+                return 1
+            prefix = "nojira-"
+            max_slug = max(12, 80 - len(type_) - 1 - len(prefix))
+            slug = slug[:max_slug].rstrip("-")
+            branch = f"{type_}/{prefix}{slug}"
+
+    if not _BRANCH_RE.match(branch):
+        sys.stderr.write(
+            f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n"
+        )
+        return 1
+
+    if current == branch:
+        sys.stdout.write(f"Already on branch {branch}\n")
+    else:
+        code, _ = _git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"])
+        if code == 0:
+            sys.stdout.write(f"Branch {branch} already exists - switching\n")
+            _git(["checkout", branch])
+        else:
+            _git(["checkout", "-b", branch])
+
+    rc = cmd_push(branch, 3)
+    if rc != 0:
+        return rc
+
+    code, url = _gh(["pr", "view", "--json", "url", "-q", ".url"])
+    if code == 0 and url.strip():
+        sys.stdout.write(f"Draft PR already exists: {url.strip()}\n")
+        return 0
+
+    # Conventional Commits, no scope = no linked issue (ADR-006)
+    pr_title = f"{type_}: {title}"
+    pr_body = "No linked issue (nojira)."
+    args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
+    if base:
+        args += ["--base", base]
+    code, out = _gh(args)
+    if code != 0:
+        sys.stderr.write("create-pr-nojira: gh pr create failed\n")
+        return code
+    sys.stdout.write(f"Draft PR: {out.strip()}\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="dag_workflow")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_check = sub.add_parser("check", help="check whether a node is reachable")
+    p_check.add_argument("node", help="DAG node name (e.g. pr.merged)")
+
+    sub.add_parser("guard", help="PreToolUse hook entrypoint (reads stdin)")
+    sub.add_parser("nodes", help="list all DAG nodes")
+
+    p_push = sub.add_parser("push", help="push current branch with retry + SHA verify")
+    p_push.add_argument("branch", nargs="?", default=None)
+    p_push.add_argument("max_retries", nargs="?", type=int, default=3)
+    p_push.add_argument(
+        "--force-with-lease",
+        action="store_true",
+        dest="force_with_lease",
+        help="force-push safely after a rebase (refused on main/master)",
+    )
+
+    p_promote = sub.add_parser("promote", help="mark a draft PR ready for review")
+    p_promote.add_argument("pr_number", nargs="?", type=int, default=None)
+
+    p_finish = sub.add_parser("finish", help="push, promote, monitor_pr --merge")
+    p_finish.add_argument("pr_number", nargs="?", type=int, default=None)
+    p_finish.add_argument("--review-cycle", type=int, default=None)
+
+    p_nojira = sub.add_parser(
+        "create-pr-nojira",
+        help="create a no-issue branch + draft PR",
+    )
+    p_nojira.add_argument("type", choices=sorted(_VALID_TYPES))
+    p_nojira.add_argument("title")
+    p_nojira.add_argument("--branch", default=None)
+    p_nojira.add_argument("--base", default=None)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "check":
+        return cmd_check(args.node)
+    if args.cmd == "guard":
+        return cmd_guard()
+    if args.cmd == "nodes":
+        for node, prereqs in GRAPH.items():
+            sys.stdout.write(f"{node}: requires={prereqs or '[]'}\n")
+        return 0
+    if args.cmd == "push":
+        return cmd_push(args.branch, args.max_retries, force=args.force_with_lease)
+    if args.cmd == "promote":
+        return cmd_promote(args.pr_number)
+    if args.cmd == "finish":
+        return cmd_finish(args.pr_number, args.review_cycle)
+    if args.cmd == "create-pr-nojira":
+        return cmd_create_pr_nojira(args.type, args.title, args.branch, args.base)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/project-init-workflow/hooks/github_command_guard.sh
+++ b/plugins/project-init-workflow/hooks/github_command_guard.sh
@@ -3,8 +3,8 @@
 # PreToolUse hook on Bash. Receives tool input JSON on stdin.
 #
 # All command-pattern matching, redirect rules, and DAG prerequisite checks
-# live in .claude/hooks/dag_workflow.py. Adding a new banned command means
-# editing COMMAND_RULES there, not this file.
+# live in dag_workflow.py next to this script. Adding a new banned command
+# means editing COMMAND_RULES there, not this file.
 
 set -euo pipefail
 

--- a/plugins/project-init-workflow/hooks/github_command_guard.sh
+++ b/plugins/project-init-workflow/hooks/github_command_guard.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# github_command_guard.sh — delegate to dag_workflow.py guard.
+# PreToolUse hook on Bash. Receives tool input JSON on stdin.
+#
+# All command-pattern matching, redirect rules, and DAG prerequisite checks
+# live in .claude/hooks/dag_workflow.py. Adding a new banned command means
+# editing COMMAND_RULES there, not this file.
+
+set -euo pipefail
+
+exec python3 "$(dirname "$0")/dag_workflow.py" guard

--- a/plugins/project-init-workflow/hooks/hooks.json
+++ b/plugins/project-init-workflow/hooks/hooks.json
@@ -1,0 +1,55 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/session_setup.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/pre_commit_gate.sh",
+            "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/github_command_guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/post_edit_lint.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/workflow_state_reminder.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# post_edit_lint.sh — runs linter on edited files after Edit/Write/MultiEdit.
+# Invoked by Claude Code's PostToolUse hook.
+# Outputs additionalContext JSON if unfixable lint errors remain so Claude
+# self-corrects in the same turn.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+INPUT=$(cat)
+
+FILE=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+ti = d.get('tool_input', {}) or {}
+print(ti.get('file_path') or ti.get('filePath') or '')
+" 2>/dev/null || true)
+
+[ -z "$FILE" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+ERRORS=""
+
+case "$FILE" in
+    *.py)
+        # Prefer 'uv run ruff' inside a uv-managed project so the hook uses
+        # the same ruff the project itself uses; fall back to a system ruff.
+        if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
+            uv run ruff check --fix --quiet "$FILE" 2>/dev/null || true
+            uv run ruff format --quiet "$FILE" 2>/dev/null || true
+            ERRORS=$(uv run ruff check --quiet "$FILE" 2>&1 || true)
+        elif command -v ruff &>/dev/null; then
+            ruff check --fix --quiet "$FILE" 2>/dev/null || true
+            ruff format --quiet "$FILE" 2>/dev/null || true
+            ERRORS=$(ruff check --quiet "$FILE" 2>&1 || true)
+        fi
+        ;;
+    *.js|*.ts|*.jsx|*.tsx)
+        # Use bunx (bun's package runner) — consistent with project convention (PI-15).
+        if command -v bunx &>/dev/null; then
+            bunx eslint --fix --quiet "$FILE" 2>/dev/null || true
+            ERRORS=$(bunx eslint --quiet "$FILE" 2>&1 || true)
+        fi
+        ;;
+esac
+
+if [ -n "$ERRORS" ]; then
+    python3 -c "
+import json, sys
+file, errors = sys.argv[1], sys.argv[2]
+print(json.dumps({'additionalContext': f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'}))
+" "$FILE" "$ERRORS"
+fi
+
+exit 0

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# pre_commit_gate.sh — blocks git commit if staged files fail linting.
+# PreToolUse hook on Bash. Receives tool input JSON on stdin.
+# Auto-fixes what it can and re-stages; blocks only if errors remain.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+CMD=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get('tool_input', {}) or {}).get('command', '') or '')
+" 2>/dev/null || true)
+
+# Only intercept git commit commands
+case "$CMD" in
+    *"git commit"*) ;;
+    *) exit 0 ;;
+esac
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ERRORS=""
+
+# Lint and auto-fix staged Python files. Prefer 'uv run ruff' inside a
+# uv-managed project so the hook uses the same ruff the project itself uses;
+# fall back to a system ruff binary.
+mapfile -t STAGED_PY < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
+if [ "${#STAGED_PY[@]}" -gt 0 ]; then
+    LINT_OUT=""
+    if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
+        uv run ruff check --fix --quiet "${STAGED_PY[@]}" 2>/dev/null || true
+        uv run ruff format --quiet "${STAGED_PY[@]}" 2>/dev/null || true
+        LINT_OUT=$(uv run ruff check --quiet "${STAGED_PY[@]}" 2>&1 || true)
+    elif command -v ruff &>/dev/null; then
+        ruff check --fix --quiet "${STAGED_PY[@]}" 2>/dev/null || true
+        ruff format --quiet "${STAGED_PY[@]}" 2>/dev/null || true
+        LINT_OUT=$(ruff check --quiet "${STAGED_PY[@]}" 2>&1 || true)
+    fi
+    if [ -n "$LINT_OUT" ]; then
+        ERRORS="${ERRORS}Python lint errors:\n${LINT_OUT}\n"
+    fi
+    # Re-stage auto-fixed files so the commit includes the fixes
+    git add "${STAGED_PY[@]}" 2>/dev/null || true
+fi
+
+# Lint and auto-fix staged JS/TS files
+# Use bunx (bun's package runner) — consistent with project convention (PI-15).
+mapfile -t STAGED_JS < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(js|ts|jsx|tsx)$' || true)
+if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
+    bunx eslint --fix --quiet "${STAGED_JS[@]}" 2>/dev/null || true
+    LINT_OUT=$(bunx eslint --quiet "${STAGED_JS[@]}" 2>&1 || true)
+    if [ -n "$LINT_OUT" ]; then
+        ERRORS="${ERRORS}JS/TS lint errors:\n${LINT_OUT}\n"
+    fi
+    git add "${STAGED_JS[@]}" 2>/dev/null || true
+fi
+
+# PI-139: when the project ships a justfile with a lint recipe and just is
+# installed, additionally gate on `just lint` — the same definition of "lint
+# passes" CI and every agent use. Per-file findings above are preserved: the
+# recipe is language-specific, so in a mixed repo it may not cover everything
+# the per-file checks caught (a passing recipe must not wash those out).
+if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ] \
+   && (cd "$ROOT" && just --show lint >/dev/null 2>&1); then
+    JUST_OUT=$(cd "$ROOT" && just lint 2>&1) || ERRORS="${ERRORS}Lint errors (just lint):\n${JUST_OUT}\n"
+fi
+
+if [ -n "$ERRORS" ]; then
+    python3 -c "
+import json, sys
+errors = sys.argv[1].replace('\\\\n', '\n')
+msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
+print(json.dumps({'decision': 'block', 'reason': msg}))
+" "$ERRORS"
+fi
+
+exit 0

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SessionStart bootstrap (PI-146): make a fresh/remote container immediately
+# usable — sync dependencies so tests and linters run instead of failing on
+# a missing venv. Fast on warm environments: a content stamp of the
+# dependency manifests short-circuits before any tool runs.
+set -uo pipefail # not -e: a failed bootstrap must never break the session
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$ROOT" || exit 0
+STAMP=".claude/.session_setup_stamp"
+LOG=".claude/logs/session_setup.log"
+mkdir -p .claude/logs
+
+fingerprint() {
+  cat pyproject.toml uv.lock package.json bun.lock bun.lockb go.mod go.sum 2>/dev/null \
+    | sha256sum | cut -d' ' -f1
+}
+
+# The stamp alone is not enough: an ephemeral container can restore the repo
+# (stamp included) without the synced environment, so check for it too.
+env_present() {
+  { [ ! -f pyproject.toml ] || [ -d .venv ]; } \
+    && { [ ! -f package.json ] || [ -d node_modules ]; }
+}
+
+CURRENT="$(fingerprint)"
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$CURRENT" ] && env_present; then
+  exit 0 # warm environment — nothing to do
+fi
+
+bootstrap() {
+  # Prefer the justfile setup recipe — the canonical bootstrap entry point.
+  if command -v just >/dev/null 2>&1 && [ -f justfile ] \
+    && just --show setup >/dev/null 2>&1; then
+    just setup
+  elif [ -f pyproject.toml ] && command -v uv >/dev/null 2>&1; then
+    uv sync --extra dev 2>/dev/null || uv sync
+  elif [ -f package.json ] && command -v bun >/dev/null 2>&1; then
+    bun install
+  elif [ -f go.mod ] && command -v go >/dev/null 2>&1; then
+    go mod download
+  else
+    return 2 # nothing recognized to set up
+  fi
+}
+
+bootstrap >"$LOG" 2>&1
+case $? in
+0)
+  echo "$CURRENT" >"$STAMP"
+  echo "session_setup: dependencies synced for fresh environment"
+  ;;
+2)
+  # No manifest/tool to bootstrap: stamp silently so later sessions skip
+  # the probe, but claim nothing — no sync happened.
+  echo "$CURRENT" >"$STAMP"
+  ;;
+*)
+  echo "session_setup: bootstrap failed — see $LOG" >&2
+  ;;
+esac
+exit 0

--- a/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
@@ -42,7 +42,7 @@ dag_state = os.environ.get("DAG_STATE", "").strip()
 state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
 context = (
-    "GitHub workflow rules (enforced by .claude/hooks/dag_workflow.py):\n"
+    "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
     "\n"
     "Lifecycle order (DAG):\n"
     "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"

--- a/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# workflow_state_reminder.sh — inject the full lifecycle rules when a prompt
+# mentions GitHub workflow actions, plus the current DAG state if available.
+# UserPromptSubmit hook. Receives prompt JSON on stdin.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Try to derive a current-state snapshot from dag_workflow.py.
+# Failures are non-fatal — the static rules are always injected.
+DAG_STATE=$(python3 "$(dirname "$0")/dag_workflow.py" nodes 2>/dev/null || true)
+
+printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" python3 -c '
+import json
+import os
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+prompt = (
+    data.get("prompt")
+    or data.get("user_prompt")
+    or data.get("message")
+    or ""
+)
+
+trigger = re.search(
+    r"\b(start work|implement|push|merge|finish|create issue|new issue|"
+    r"create pr|open pr|pull request|review|ticket|branch|ship)\b",
+    prompt,
+    re.I,
+)
+if not trigger:
+    sys.exit(0)
+
+dag_state = os.environ.get("DAG_STATE", "").strip()
+state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
+
+context = (
+    "GitHub workflow rules (enforced by .claude/hooks/dag_workflow.py):\n"
+    "\n"
+    "Lifecycle order (DAG):\n"
+    "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
+    "                                                  \\-> ci.green -+\n"
+    "                                                  \\-> review.approved -+-> pr.merged\n"
+    "\n"
+    "Use these scripts. Do NOT call the raw command — the DAG hook will block:\n"
+    "  - .claude/scripts/create_issue.sh    (not: gh issue create)\n"
+    "  - .claude/scripts/start_issue.sh     (not: gh pr create, for issue-backed)\n"
+    "  - .claude/scripts/create_nojira_pr.sh (not: gh pr create, for no-issue work)\n"
+    "  - .claude/scripts/push_branch.sh     (not: git push)\n"
+    "  - .claude/scripts/promote_review.sh  (not: gh pr ready)\n"
+    "  - .claude/scripts/monitor_pr.sh <pr> --merge   (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
+    "\n"
+    "Naming:\n"
+    "  branch:     <type>/PI-<n>-<kebab-slug>     e.g. feat/PI-98-dag-workflow\n"
+    "  PR title:   type(PI-N): description        e.g. feat(PI-98): Add DAG enforcement\n"
+    "              (no scope = no linked issue, e.g. fix: Correct typo) — ADR-006\n"
+    "  PR body:    must include `Closes #N`\n"
+    "\n"
+    "Iterating before push: edit, test, debug freely. The DAG only fires on\n"
+    "guarded commands (push, PR create/ready/merge). Push only when ready.\n"
+    f"{state_block}"
+)
+
+print(json.dumps({"additionalContext": context}))
+'

--- a/plugins/project-init-workflow/skills/add_adr/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_adr/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: add_adr
+description: Records an architectural decision as a new ADR in .claude/docs/adr/ using the MADR template. Use when a non-obvious design choice is made so future agents understand why.
+when_to_use: Use when the user says "record this decision", "write an ADR", or when you make an architectural choice (library, pattern, boundary, trade-off) that a future session would otherwise re-litigate. Do not use for trivial or easily reversed choices.
+user-invocable: true
+effort: low
+allowed-tools: Read Write Glob Bash(git *)
+---
+
+Record an architectural decision record (ADR).
+
+## When an ADR is warranted
+
+- The choice is hard to reverse, or expensive to re-derive
+- Multiple plausible options existed and one was deliberately picked
+- A future agent or developer would ask "why is it like this?"
+
+Not warranted: formatting choices, renames, anything fully explained by code.
+
+## Steps
+
+1. Find the next free number: list `.claude/docs/adr/adr-*.md` and take the
+   highest `NNN` + 1.
+2. Copy `.claude/docs/adr/adr-template.md` to
+   `.claude/docs/adr/adr-NNN-<kebab-slug>.md`.
+3. Fill every section. Keep it short — context (2-5 sentences), the options
+   actually considered, the decision with its justification, and honest
+   consequences (including the bad ones). Delete the template's comments.
+4. Set Status to `accepted` if the decision is already in effect, otherwise
+   `proposed`.
+5. If the ADR supersedes an older one, mark the old ADR
+   `superseded by ADR-NNN` — do not delete it.
+6. Mention the new ADR in the commit/PR that implements the decision.

--- a/plugins/project-init-workflow/skills/add_command/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_command/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: add_command
+description: Creates a new slash command (skill) that users can invoke with /name. Use when asked to add a command, automate a repeatable workflow step, or expose a task as a /name shortcut.
+when_to_use: Use when the user says "add a /command", "make a shortcut for X", or "I want to run this with a slash command".
+argument-hint: "<command-name> <what it does>"
+allowed-tools: Write
+---
+
+> **Claude Code specific**: this skill manages Claude Code configuration
+> (settings.json wiring). Other agents do not consume what it produces.
+
+
+## Create a skill
+
+Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
+
+## Step 1 — Create the file
+
+Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).
+
+## Step 2 — Write the frontmatter
+
+```yaml
+---
+name: <name>
+description: <What it does and when to use it. Third person. Include trigger keywords.>
+when_to_use: <Extra trigger context — action phrases the user might say.>
+argument-hint: "<expected arguments>"
+allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
+model: sonnet                    # optional model override
+effort: medium                   # low | medium | high | xhigh | max
+disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
+user-invocable: false            # false = Claude-only background knowledge
+context: fork                    # fork = runs in isolated subagent
+---
+```
+
+Not all fields are required — only include what changes the default behaviour.
+
+## Step 3 — Write the body
+
+```markdown
+Run this command to <what it does>.
+
+## Steps
+
+1. <step one — prefer shell commands over prose>
+2. <step two>
+
+## Rules
+
+- <constraint if any>
+```
+
+**`$ARGUMENTS`** expands to the full argument string. Use `$1`, `$2` for positional args.
+
+## Guidelines
+
+- **Name**: lowercase, hyphen-separated, max 64 chars
+- **Description quality is load-bearing**: if Claude doesn't trigger it automatically, the description is too vague — add keywords users would naturally say
+- **No file reads in the body**: embed what the agent needs inline; don't say "read X first"
+- **Side-effect commands**: set `disable-model-invocation: true` so only the user can invoke them
+- **Background conventions**: set `user-invocable: false` so Claude loads them automatically

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: add_hook
+description: Adds a deterministic hook that fires automatically on tool events. Use when asked to enforce a rule on every commit, block a dangerous pattern, validate output, or gate any tool call.
+when_to_use: Use when the user wants to automate a check or action that runs every time a specific event occurs — e.g. "block pushes to main", "run linter before every commit", "log every Bash command".
+argument-hint: "<hook-name> <event> <description>"
+allowed-tools: Read Write Bash
+---
+
+> **Claude Code specific**: this skill manages Claude Code configuration
+> (settings.json wiring). Other agents do not consume what it produces.
+
+
+## Step 1 — Choose an event
+
+Pick the event that matches when the hook should fire:
+
+**Tool execution** (most common):
+- `PreToolUse` — before a tool runs; output block JSON to block it
+- `PostToolUse` — after a tool runs; cannot block, can log or validate
+- `PostToolBatch` — after a batch of parallel tool calls completes
+- `PermissionRequest` — when Claude asks for permission; can auto-approve
+
+**Session lifecycle:**
+- `SessionStart` — when a session begins
+- `Stop` — when Claude stops generating (end of turn)
+- `StopFailure` — when a turn fails
+
+**User input:**
+- `UserPromptSubmit` — when the user submits a prompt
+- `UserPromptExpansion` — when slash commands expand
+
+**Agent/task events:**
+- `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task tracking events
+
+**File/config events:**
+- `FileChanged`, `CwdChanged`, `ConfigChange`
+
+## Step 2 — Write the hook script
+
+Create `.claude/hooks/<name>.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Hook receives JSON on stdin from Claude Code.
+INPUT=$(cat)
+
+# exit 0 = allow (or no-op for non-blocking events)
+# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# stdout JSON with {"additionalContext":"..."} = inject context
+# Always exit 0 — exit 1 means hook error, not a block
+
+# Example: block pushes to main
+CMD=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((data.get('tool_input', {}) or {}).get('command', '') or '')
+" 2>/dev/null || true)
+
+[ -z "$CMD" ] && exit 0
+
+if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
+  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+    "Direct push to main is not allowed. Use a branch and PR."
+  exit 0
+fi
+exit 0
+```
+
+Make it executable: `chmod +x .claude/hooks/<name>.sh`
+
+## Step 3 — Wire it in settings.json
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh", "timeout": 10}]
+      }
+    ]
+  }
+}
+```
+
+**Matchers:** tool name (`Bash`, `Write`, `Edit`), pipe-separated (`Write|Edit`), or `*` for all tools.
+
+## Alternative — Inline hook in a skill
+
+Hooks can also live in a skill's frontmatter and fire only while the skill is active:
+
+```yaml
+---
+name: my-skill
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./.claude/hooks/check.sh"
+---
+```
+
+## Step 4 — Test
+
+Trigger the wired tool and verify the hook fires. Check `$CLAUDE_PROJECT_DIR` is set correctly in the command path.

--- a/plugins/project-init-workflow/skills/audit/SKILL.md
+++ b/plugins/project-init-workflow/skills/audit/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: audit
+description: Full project health audit — scans hooks, skills, scripts, rules, CI config, docs, and GitHub workflow for inconsistencies, broken references, and common mistakes. Creates a GitHub issue with findings and optionally starts fixing them.
+when_to_use: Use when the user says "audit the project", "health check", "scan for issues", "hardening pass", or "review everything".
+argument-hint: "[--fix]"
+allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
+effort: high
+context: fork
+---
+
+Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.
+
+## Phase 1 — Inventory
+
+Read `.claude/config.yaml` for project metadata (language, memory stack, MCPs). This determines which checks apply.
+
+Scan these directories and build a file inventory:
+
+| Directory | What to check |
+|---|---|
+| `.claude/hooks/` | All hook scripts |
+| `.claude/skills/` | All SKILL.md files |
+| `.claude/scripts/` | All lifecycle scripts |
+| `.claude/rules/` | All rule .md files |
+| `.claude/docs/` | ADRs, conventions |
+| `.claude/memory/` | MEMORY.md index |
+| `.github/workflows/` | CI/CD configs |
+| `.github/hooks/` | Git hooks |
+
+## Phase 2 — Checks
+
+Run each check category. Track findings as `[PASS]`, `[WARN]`, or `[FAIL]`.
+
+### 2.1 Hook integrity
+
+For every file in `.claude/hooks/`:
+
+1. **Executable bit** — `stat -c '%a' <file>` must show execute permission
+2. **Hook protocol** — must output JSON to stdout and `exit 0` (never `exit 1` to block). Search for:
+   - `exit 1` that isn't inside a `trap` or error path before JSON parsing → `[FAIL]`
+   - `>&2` used for block output instead of stdout → `[FAIL]`
+   - Missing `exit 0` at end of file → `[WARN]`
+3. **JSON parsing** — must use python3 (not jq) for portability. `grep -l 'jq ' *.sh` → `[FAIL]`
+4. **Stdin reading** — must read `$CLAUDE_TOOL_USE_STDIN` or stdin JSON. Check the INPUT= line exists.
+5. **Referenced in settings.json** — every hook file should appear in `.claude/settings.json`. Orphaned hooks → `[WARN]`
+
+### 2.2 Script integrity
+
+For every file in `.claude/scripts/`:
+
+1. **Executable bit** — must be executable
+2. **Shebang** — first line must be `#!/usr/bin/env bash` or `#!/usr/bin/env python3`
+3. **set -euo pipefail** — bash scripts must have it
+4. **Referenced in docs** — check `.claude/scripts/README.md` and `.claude/project-init.md` mention the script. Undocumented scripts → `[WARN]`
+
+### 2.3 Git hooks
+
+For every file in `.github/hooks/`:
+
+1. **Executable bit** — must be executable
+2. **Shebang** — must have one
+
+### 2.4 Skill and command consistency
+
+For every SKILL.md in `.claude/skills/*/`:
+
+1. **Required frontmatter** — `name` and `description` must exist
+2. **Listed in INDEX.md** — `.claude/skills/INDEX.md` should reference every skill. Missing → `[WARN]`
+3. **Listed in project-init.md** — `.claude/project-init.md` Tools table should list it. Missing → `[WARN]`
+
+### 2.5 Settings.json coherence
+
+1. **Every hook file referenced** has a corresponding file in `.claude/hooks/`. Dead references → `[FAIL]`
+2. **Hook files referenced** in settings.json must exist on disk with the correct snake_case names
+
+### 2.6 Documentation cross-references
+
+1. **project-init.md** — every script, skill, command, hook, and agent listed in the Tools table must exist on disk
+2. **scripts/README.md** — every script in the directory should be documented
+3. **rules/hooks.md** (if present) — every hook listed must exist; every existing hook must be listed
+4. **Commit format** — verify that project-init.md, copilot-instructions.md, conventions.md, and config.yaml all agree on the commit/PR format (`type(KEY-N):`, ADR-006)
+
+### 2.7 CI workflow validation
+
+1. **Language match** — CI commands must match the project language from config.yaml:
+   - Python: `uv run ruff`, `uv run pytest`
+   - Node: `bun run lint`, `bun test`
+   - Go: `golangci-lint run`, `go test`
+   - None: no lint/test steps expected
+2. **PR validation workflow** — if `validate-pr.yml` exists, check its title regex matches the format in project-init.md
+
+### 2.8 Memory and vault
+
+1. **MEMORY.md exists** and is a valid index (links to files that exist)
+2. **Broken links** — any `[text](file.md)` in MEMORY.md where file.md doesn't exist → `[FAIL]`
+
+## Phase 3 — Report
+
+Compile findings into a structured report:
+
+```markdown
+## Project Audit Report
+
+**Project:** <name from config.yaml>
+**Date:** <today>
+**Language:** <language>
+
+### Summary
+- X checks passed
+- Y warnings
+- Z failures
+
+### Failures
+1. <file>: <what's wrong> — <how to fix>
+
+### Warnings
+1. <file>: <what's wrong>
+
+### All Checks
+<full checklist with [PASS]/[WARN]/[FAIL] markers>
+```
+
+## Phase 4 — Create issue
+
+Create a GitHub issue using the project's lifecycle script:
+
+```bash
+.claude/scripts/create_issue.sh chore "Project audit findings" \
+  --priority medium \
+  --area "tooling" \
+  --size M \
+  --acceptance "All [FAIL] items resolved, all [WARN] items reviewed"
+```
+
+Paste the full report as a comment on the issue.
+
+## Phase 5 — Fix (only if --fix)
+
+If `$ARGUMENTS` contains `--fix`:
+
+1. Start work on the issue: `.claude/scripts/start_issue.sh <n> fix`
+2. Fix all `[FAIL]` items. Review `[WARN]` items and fix where appropriate.
+3. Run lint and tests after fixes.
+4. Push and finish: `.claude/scripts/finish_pr.sh <n>`
+
+If `--fix` is not specified, stop after Phase 4 and report the issue number.

--- a/plugins/project-init-workflow/skills/create_issue/SKILL.md
+++ b/plugins/project-init-workflow/skills/create_issue/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: create_issue
+description: Creates a GitHub Issue with typed labels and structured planning metadata via create_issue.sh. Sub-skill invoked by start_task — do not call directly; use /start_task instead.
+when_to_use: Invoked by the start_task skill whenever a GitHub Issue must be created; never called directly by users.
+user-invocable: false
+allowed-tools: Bash(gh *) Bash(.claude/scripts/*) Read
+---
+
+Use this skill whenever creating a GitHub Issue.
+
+## Metadata to gather
+
+Before creating the issue, determine:
+
+- type: `feat`, `fix`, `chore`, `docs`, or `test`
+- title: short imperative description
+- priority: `high`, `medium`, or `low`
+- area: existing repo area label or plain body metadata
+- size: `XS`, `S`, `M`, `L`, or `XL`
+- references: related issues, PRs, ADRs, docs, designs, logs, or external links
+- dependencies: blocked-by, parent, or follow-up relationships
+- acceptance criteria: concrete checklist items
+
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+
+## Rules
+
+- Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
+- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Store relationships that GitHub does not support portably in markdown sections.
+- The script writes Definition of Ready/Done defaults so issues created from this skill satisfy the scaffolded issue-validation workflow.
+- Check for duplicate issues before creating a new one:
+  ```bash
+  gh issue list --state open --search "<keywords>"
+  ```
+
+## Create
+
+Run:
+
+```bash
+.claude/scripts/create_issue.sh <type> "<title>" \
+  --priority <high|medium|low> \
+  --area "<area>" \
+  --size <XS|S|M|L|XL> \
+  --reference "<reference>" \
+  --dependency "<dependency>" \
+  --acceptance "<criterion>"
+```
+
+Repeat `--reference`, `--dependency`, and `--acceptance` as needed.
+
+## Report
+
+After creation, report the issue number and URL:
+
+```bash
+gh issue view <number> --json url -q .url
+```

--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: github_workflow
+description: Guides the agent through the full GitHub PR lifecycle — branch naming, push, review responses, and merge. Loaded automatically before any push, PR creation, review response, or merge action.
+when_to_use: Load before any push, PR creation, PR review response, merge, or release action — including when lifecycle scripts fail and a git/gh fallback is needed.
+user-invocable: false
+effort: high
+allowed-tools: Bash(git *) Bash(gh *) Bash(.claude/scripts/*) Read
+---
+
+Load this skill before any push, PR creation, review response, or merge action.
+
+## Quick reference
+
+| Step | Pattern |
+|------|---------|
+| Branch | `<type>/<PROJECT-KEY>-<n>-<kebab-slug>` e.g. `feat/PI-42-add-oauth` |
+| PR title | `type(PROJECT-123): description` e.g. `feat(PI-42): Add OAuth login` |
+| No-issue PR | `type: description` (no scope) e.g. `fix: Fix typo` |
+| PR body | Must include `Closes #N` (skip for no-issue PRs) |
+
+Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123][type]` is accepted by validators during transition but must not be emitted.
+
+Types: `feat` `fix` `chore` `docs` `test`
+
+## Standard lifecycle
+
+1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates
+   the branch, pushes, and opens a draft PR.
+   For minor no-issue work, use `.claude/scripts/create_nojira_pr.sh <type> "description"`.
+
+2. **Push during development:**
+   ```bash
+   .claude/scripts/push_branch.sh
+   ```
+   Never use bare `git push` — `push_branch.sh` retries transient GitHub errors.
+
+3. **Finish — push, mark ready, and merge:**
+   ```bash
+   .claude/scripts/finish_pr.sh [pr-number]
+   ```
+   `finish_pr.sh` pushes, marks the draft ready, runs `monitor_pr.sh --merge`,
+   and handles review cycles automatically.
+
+   Or run steps individually:
+   ```bash
+   .claude/scripts/push_branch.sh
+   .claude/scripts/promote_review.sh [pr-number]
+   .claude/scripts/monitor_pr.sh <pr-number> --merge
+   ```
+
+## Review cycle protocol
+
+`monitor_pr.sh --merge` exits **1** for CI or merge failures and **2** when
+`review/decision` fails while review cycles remain. Treat any non-zero exit as
+unfinished work: inspect the printed failure, fix or retry, then rerun the
+workflow. Do not report a PR as merged unless the script exits 0 after printing
+the merged or auto-merge-enabled status.
+
+1. Post a response for each review comment:
+   ```
+   gh pr comment <pr-number> --body "**Review response:**
+   - [comment]: Fixing — <reason>
+   - [comment]: Not applying — <reason>"
+   ```
+2. Fix actionable code, then push: `.claude/scripts/push_branch.sh`
+3. Re-run with the next cycle number:
+   ```bash
+   .claude/scripts/monitor_pr.sh <pr-number> --merge --review-cycle <N>
+   ```
+4. After 1 review-fix cycle, the script auto force-merges with `--admin`.
+
+**Before applying any comment:** read the current file state. Check whether the
+comment is stale (already fixed), contradicts conventions, or is correct. Never
+blindly apply a suggestion — post reasoning even when rejecting.
+
+## Issue titles vs PR titles
+
+- **Issue titles**: plain description only — type is carried by the label.
+- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/plugins/project-init-workflow/skills/request_review/SKILL.md
+++ b/plugins/project-init-workflow/skills/request_review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: request_review
+description: Mark the current draft PR ready for review
+when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+argument-hint: "[pr-number]"
+allowed-tools: Bash Read
+---
+
+Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.
+
+## Steps
+
+1. **Promote to ready**:
+   ```bash
+   .claude/scripts/promote_review.sh $ARGUMENTS
+   ```
+   `board-automation.yml` moves the board card to **In Review** automatically.
+
+2. **Next steps**: Reviewers will be pinged. When they request changes, they'll post comments on the PR.

--- a/plugins/project-init-workflow/skills/review/SKILL.md
+++ b/plugins/project-init-workflow/skills/review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: review
+description: Review staged or recent changes for bugs, style issues, and missed edge cases
+when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
+argument-hint: "[commit-range or file]"
+allowed-tools: Bash Read Grep Glob
+---
+
+Review the code changes specified by: $ARGUMENTS
+
+If no argument given, review all staged changes (`git diff --cached`). If nothing is staged, review the last commit.
+
+Focus on:
+- **Bugs** — logic errors, off-by-ones, null/undefined risks
+- **Security** — injection, auth issues, secret exposure
+- **Style** — naming, dead code, overly complex logic
+- **Edge cases** — empty inputs, concurrency, error paths

--- a/plugins/project-init-workflow/skills/save_memory/SKILL.md
+++ b/plugins/project-init-workflow/skills/save_memory/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: save_memory
+description: Save a fact to project memory for future sessions
+when_to_use: Use when you learn something important that should persist across conversations — a decision, a constraint, a pattern, or an external reference.
+argument-hint: "<fact to remember>"
+allowed-tools: Read Write Glob
+---
+
+Save this to project memory: $ARGUMENTS
+
+Follow the memory convention in `.claude/memory/README.md`:
+
+1. Decide the memory type (user / feedback / project / reference)
+2. Choose a descriptive filename (e.g., `feedback_testing.md`, `project_deadline.md`)
+3. Check if an existing memory file already covers this — update it instead of duplicating
+4. Write the file with proper frontmatter (name, description, type)
+5. Add a one-line entry to `.claude/memory/MEMORY.md`

--- a/plugins/project-init-workflow/skills/session_summary/SKILL.md
+++ b/plugins/project-init-workflow/skills/session_summary/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: session_summary
+description: Summarizes the current session and saves it to the vault. Use at the end of a work session to record completed work, decisions made, and open items for the next session.
+when_to_use: Use when the user says "save the session", "wrap up", "summarize what we did", or at the end of a long work session.
+effort: medium
+allowed-tools: Bash(git *) Read Write Glob Grep
+---
+
+Summarize this session and save it to the vault:
+
+1. **Gather context**:
+   - Run `git log --since='2 hours ago' --oneline` for recent commits
+   - Run `git diff --stat` for uncommitted changes
+   - Review the conversation for key decisions and discoveries
+
+2. **Write the summary** to `.claude/vault/sessions/` with today's date:
+   ```
+   # Session YYYY-MM-DD (manual)
+
+   ## What was done
+   - (bullet list of completed work)
+
+   ## Decisions made
+   - (any architectural or approach decisions, with reasoning)
+
+   ## Open items
+   - (anything left unfinished or discovered but not addressed)
+
+   ## Notes
+   - (anything else worth remembering)
+   ```
+
+3. **Update memory** if any reusable facts emerged (write to the project memory directory)
+
+Keep the summary concise — a future agent should be able to skim it in 30 seconds.

--- a/plugins/project-init-workflow/skills/start_task/SKILL.md
+++ b/plugins/project-init-workflow/skills/start_task/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: start_task
+description: Creates a GitHub Issue, branch, and draft PR before implementation begins. Use before any non-trivial task to keep work traceable — one issue, one branch, one PR.
+when_to_use: Use when the user says "start work on X", "create a ticket for Y", or "begin a new task". Do not use for trivial one-off changes that don't need tracking.
+argument-hint: "[task title]"
+allowed-tools: Bash(gh *) Bash(git *) Read
+---
+
+Before starting any non-trivial task, create a GitHub Issue, a dedicated branch, and a draft PR. This keeps work traceable and every PR maps to exactly one issue.
+
+## Mandatory scripts
+
+| Action | Script | Never use |
+|--------|--------|-----------|
+| Start issue + branch + draft PR | `.claude/scripts/start_issue.sh <n> <type>` | bare `git checkout -b` + bare `gh pr create` |
+| Push branch | `.claude/scripts/push_branch.sh` | bare `git push` |
+| **Push + promote + merge (all-in-one)** | `.claude/scripts/finish_pr.sh <n>` | `gh pr ready`, bare `gh pr merge`, `gh pr checks --watch` |
+
+## Steps
+
+1. **Clarify scope** — if $ARGUMENTS is empty or vague, ask the user for:
+   - Task title (one line, imperative: "Add X", "Fix Y", "Refactor Z")
+   - Work type: `feat` / `fix` / `chore` / `docs` / `test`
+
+2. **Check for existing issue and PR** — run `gh issue list` and `gh pr list`. If an issue already exists, use its number. If a draft PR already exists for that issue, use it — do **not** create a second PR. Skip to step 5.
+
+3. **Create the issue** — load `.claude/skills/create_issue/SKILL.md` and follow it. It gathers priority, area, size, references, dependencies, and acceptance criteria before running:
+   ```bash
+   ISSUE_NUMBER=$(.claude/scripts/create_issue.sh <type> "<title>" --priority <priority> --area "<area>" --size <size> --acceptance "<criterion>")
+   echo "Created issue #$ISSUE_NUMBER"
+   ```
+
+4. **Start work** — create the branch, push, and open a draft PR:
+   ```bash
+   .claude/scripts/start_issue.sh <issue-number> <type>
+   ```
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+
+5. **Proceed** — only begin implementation after the scripts have run successfully.
+
+6. **When ready to merge** — load `.claude/skills/github_workflow/SKILL.md` for the
+   full push → promote → monitor/merge lifecycle and review-cycle protocol.
+
+## Rules
+
+- Every non-trivial task must have a GitHub Issue, a branch, and a draft PR — all before the first line of implementation code.
+- One issue → one branch → one PR.
+- `board-automation.yml` moves the board card to **In Progress** automatically when the PR is opened. No manual board move needed.

--- a/plugins/project-init-workflow/skills/status/SKILL.md
+++ b/plugins/project-init-workflow/skills/status/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: status
+description: Show project status — git state, recent commits, open tasks, and memory summary
+when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
+allowed-tools: Bash Read Grep Glob
+---
+
+Give me a concise project status report:
+
+1. **Git state** — current branch, uncommitted changes, commits ahead/behind remote
+2. **Recent work** — last 5 commits (one line each)
+3. **Memory** — read `.claude/memory/MEMORY.md` and list the key facts
+4. **Open items** — scan for TODO/FIXME/HACK in the codebase (top 10)
+
+Keep the report under 30 lines. Use markdown formatting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ max-complexity = 10
 # target the code a project ships. Scaffolded ruff.toml mirrors this.
 ".claude/**" = ["D", "C901", "PLR0912", "PLR0913", "PLR0915"]
 "templates/**" = ["D", "C901", "PLR0912", "PLR0913", "PLR0915"]
+# Synced byte-for-byte from templates/ by tools/sync_plugin.py (ADR-010).
+"plugins/**" = ["D", "C901", "PLR0912", "PLR0913", "PLR0915"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -470,6 +470,8 @@ def main(argv: list[str] | None = None) -> int:
         "created_date": date.today().isoformat(),
         "project_init_version": __version__,
         "project_init_url": __repo_url__,
+        # owner/name slug for the same-repo plugin marketplace (ADR-010)
+        "project_init_repo": __repo_url__.removeprefix("https://github.com/"),
         "language": language,
         "memory_stack": preset.get("vars", {}).get("memory_stack", "obsidian-only"),
         "installed_mcps": format_installed_mcps(selected_mcps),

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -48,6 +48,7 @@ _MIGRATION_DEFAULTS = {
     "llm_model": "claude-sonnet-4-6",
     "embedding_model": "text-embedding-3-small",
     "project_init_url": "https://github.com/VytCepas/project-init",
+    "project_init_repo": "VytCepas/project-init",
 }
 
 _LANGUAGE_FLAGS = ("python", "node", "go")

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -261,6 +261,47 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
     return preset_name, variables, {}
 
 
+def _backfill_variables(variables: dict) -> dict:
+    """Fill variables introduced after *variables* were recorded.
+
+    A record written by an older scaffolder version lacks any template
+    variable added since; strict re-rendering would then fail on the
+    surviving placeholder. Derive what we can from the recorded values and
+    default the rest to their "off" state — faithful, since the feature
+    did not exist when the project was scaffolded.
+    """
+    v = dict(variables)
+    language = v.get("language", "none")
+    stack = v.get("memory_stack", "obsidian-only")
+    url = v.get("project_init_url", _MIGRATION_DEFAULTS["project_init_url"])
+
+    derived: dict[str, str] = {
+        "project_init_repo": url.removeprefix("https://github.com/"),
+        "lightrag": "true" if "lightrag" in stack else "",
+        "graphify": "true" if "graphify" in stack else "",
+        "obsidian": "true" if "obsidian" in stack else "",
+        "justfile": "true" if language != "none" else "",
+        "license_holder": v.get("project_owner") or v.get("project_name", ""),
+        "created_year": v.get("created_date", "").split("-")[0],
+        "vscode_off": "" if v.get("vscode") else "true",
+        # Opt-in features default off — they postdate the record.
+        "devcontainer": "",
+        "mise": "",
+        "vscode": "",
+        "project_owner": "",
+        "license": "none",
+        "license_mit": "",
+        "license_apache": "",
+        "license_proprietary": "",
+        **_MIGRATION_DEFAULTS,
+    }
+    for flag in _LANGUAGE_FLAGS:
+        derived[flag] = "true" if language == flag else ""
+    for key, value in derived.items():
+        v.setdefault(key, value)
+    return v
+
+
 def read_scaffold_record(target: Path) -> tuple[str, dict, dict, bool]:
     """Return (preset_name, variables, manifest, migrated) for *target*."""
     config_path = target / _CONFIG_REL
@@ -274,9 +315,9 @@ def read_scaffold_record(target: Path) -> tuple[str, dict, dict, bool]:
     parsed = _parse_record_block(text)
     if parsed is not None:
         preset_name, variables, manifest = parsed
-        return preset_name, variables, manifest, False
+        return preset_name, _backfill_variables(variables), manifest, False
     preset_name, variables, manifest = _migrate_semantic_config(text.splitlines())
-    return preset_name, variables, manifest, True
+    return preset_name, _backfill_variables(variables), manifest, True
 
 
 def _unified_diff(rel: Path, old: bytes, new: bytes) -> str:

--- a/templates/base/dot_claude/hooks/github_command_guard.sh
+++ b/templates/base/dot_claude/hooks/github_command_guard.sh
@@ -3,8 +3,8 @@
 # PreToolUse hook on Bash. Receives tool input JSON on stdin.
 #
 # All command-pattern matching, redirect rules, and DAG prerequisite checks
-# live in .claude/hooks/dag_workflow.py. Adding a new banned command means
-# editing COMMAND_RULES there, not this file.
+# live in dag_workflow.py next to this script. Adding a new banned command
+# means editing COMMAND_RULES there, not this file.
 
 set -euo pipefail
 

--- a/templates/base/dot_claude/hooks/workflow_state_reminder.sh
+++ b/templates/base/dot_claude/hooks/workflow_state_reminder.sh
@@ -42,7 +42,7 @@ dag_state = os.environ.get("DAG_STATE", "").strip()
 state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
 context = (
-    "GitHub workflow rules (enforced by .claude/hooks/dag_workflow.py):\n"
+    "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
     "\n"
     "Lifecycle order (DAG):\n"
     "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -9,6 +9,12 @@
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
+    },
+    "project-init": {
+      "source": {
+        "source": "github",
+        "repo": "{{project_init_repo}}"
+      }
     }
   },
   "enabledPlugins": {

--- a/templates/obsidian/dot_claude/settings.json.tmpl
+++ b/templates/obsidian/dot_claude/settings.json.tmpl
@@ -9,6 +9,12 @@
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
+    },
+    "project-init": {
+      "source": {
+        "source": "github",
+        "repo": "{{project_init_repo}}"
+      }
     }
   },
   "enabledPlugins": {

--- a/tests/contracts/test_plugin_marketplace.py
+++ b/tests/contracts/test_plugin_marketplace.py
@@ -122,3 +122,27 @@ class TestScaffoldedSettingsWiring:
         assert not any(
             "project-init-workflow" in key for key in settings["enabledPlugins"]
         )
+
+
+class TestSyncTool:
+    def test_sync_removes_stale_hook_scripts(self, tmp_path: Path, monkeypatch):
+        """A renamed/deleted template hook must disappear from the plugin on
+        re-sync, while plugin-authored hooks.json survives (PR #166 review)."""
+        import shutil
+
+        import tools.sync_plugin as sync_plugin
+
+        fake_root = tmp_path / "repo"
+        fake_templates = fake_root / "templates" / "base" / "dot_claude"
+        shutil.copytree(_TEMPLATE_CLAUDE, fake_templates)
+        fake_plugin = fake_root / "plugins" / "project-init-workflow"
+        shutil.copytree(_PLUGIN_ROOT, fake_plugin)
+
+        monkeypatch.setattr(sync_plugin, "TEMPLATE_CLAUDE", fake_templates)
+        monkeypatch.setattr(sync_plugin, "PLUGIN_ROOT", fake_plugin)
+
+        (fake_templates / "hooks" / "pre_commit_gate.sh").unlink()
+        sync_plugin.sync()
+
+        assert not (fake_plugin / "hooks" / "pre_commit_gate.sh").exists()
+        assert (fake_plugin / "hooks" / "hooks.json").exists()

--- a/tests/contracts/test_plugin_marketplace.py
+++ b/tests/contracts/test_plugin_marketplace.py
@@ -1,0 +1,124 @@
+"""PI-129 / ADR-010: same-repo plugin marketplace, dual-shipped with copies."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MARKETPLACE = _REPO_ROOT / ".claude-plugin" / "marketplace.json"
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "project-init-workflow"
+_TEMPLATE_CLAUDE = _REPO_ROOT / "templates" / "base" / "dot_claude"
+
+
+class TestMarketplaceManifest:
+    def test_valid_and_lists_plugin_with_existing_source(self):
+        config = json.loads(_MARKETPLACE.read_text())
+        assert config["name"] == "project-init"
+        assert config["owner"]["name"]
+        (entry,) = config["plugins"]
+        assert entry["name"] == "project-init-workflow"
+        source = entry["source"]
+        assert source.startswith("./"), "same-repo plugins use relative sources"
+        assert (_REPO_ROOT / source).is_dir()
+
+
+class TestPluginManifest:
+    def test_plugin_json_valid(self):
+        manifest = json.loads(
+            (_PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text()
+        )
+        assert manifest["name"] == "project-init-workflow"
+        assert re.match(r"^\d+\.\d+\.\d+$", manifest["version"])
+        assert manifest["hooks"] == "./hooks/hooks.json"
+
+    def test_hooks_json_references_only_existing_scripts(self):
+        config = json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+        commands = [
+            h["command"]
+            for entries in config["hooks"].values()
+            for entry in entries
+            for h in entry["hooks"]
+        ]
+        assert commands, "plugin must wire at least one hook"
+        for command in commands:
+            assert "${CLAUDE_PLUGIN_ROOT}" in command
+            rel = command.split("${CLAUDE_PLUGIN_ROOT}")[1].strip('"').lstrip("/")
+            assert (_PLUGIN_ROOT / rel).is_file(), f"missing hook script: {rel}"
+
+    def test_hook_events_match_template_wiring(self):
+        """The plugin wires the same events the scaffolded settings wire, so
+        the documented cutover (ADR-010) is a drop-in swap."""
+        plugin_events = set(
+            json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
+        )
+        template_settings = (_TEMPLATE_CLAUDE / "settings.json.tmpl").read_text()
+        template_events = set(
+            re.findall(
+                r'"(SessionStart|PreToolUse|PostToolUse|UserPromptSubmit)"',
+                template_settings,
+            )
+        )
+        assert plugin_events == template_events
+
+    def test_no_templated_files_in_plugin(self):
+        """Plugins are static — anything needing render stays scaffold-only."""
+        assert not list(_PLUGIN_ROOT.rglob("*.tmpl"))
+
+
+class TestPluginPayloadInSync:
+    """tools/sync_plugin.py output must match templates byte-for-byte —
+    run `just sync-plugin` after editing shared template skills/hooks."""
+
+    def test_shared_skills_in_sync(self):
+        template_skills = {
+            p.parent.name: p
+            for p in (_TEMPLATE_CLAUDE / "skills").glob("*/SKILL.md")
+        }
+        plugin_skills = {
+            p.parent.name: p
+            for p in (_PLUGIN_ROOT / "skills").glob("*/SKILL.md")
+        }
+        assert set(template_skills) == set(plugin_skills)
+        for name, template_path in template_skills.items():
+            assert plugin_skills[name].read_bytes() == template_path.read_bytes(), (
+                f"plugin skill {name} drifted — run `just sync-plugin`"
+            )
+
+    def test_hook_scripts_in_sync(self):
+        template_hooks = {
+            p.name: p
+            for p in (_TEMPLATE_CLAUDE / "hooks").iterdir()
+            if p.suffix in {".sh", ".py"}
+        }
+        plugin_hooks = {
+            p.name: p
+            for p in (_PLUGIN_ROOT / "hooks").iterdir()
+            if p.suffix in {".sh", ".py"}
+        }
+        assert set(template_hooks) == set(plugin_hooks)
+        for name, template_path in template_hooks.items():
+            assert plugin_hooks[name].read_bytes() == template_path.read_bytes(), (
+                f"plugin hook {name} drifted — run `just sync-plugin`"
+            )
+
+
+class TestScaffoldedSettingsWiring:
+    def test_marketplace_offered_but_plugin_not_enabled(self, tmp_path: Path):
+        """ADR-010 dual-ship: marketplace registered (plugin offered on
+        trust); plugin NOT enabled — copies are the active wiring, and
+        enabling both would double-fire every hook."""
+        target = tmp_path / "p"
+        scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+        settings = json.loads((target / ".claude" / "settings.json").read_text())
+        assert (
+            settings["extraKnownMarketplaces"]["project-init"]["source"]["repo"]
+            == "example/project-init"
+        ), "slug comes from the project_init_repo variable, never hardcoded"
+        assert not any(
+            "project-init-workflow" in key for key in settings["enabledPlugins"]
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,6 +39,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "created_date": "2026-01-01",
         "project_init_version": "0.1.0",
         "project_init_url": "https://github.com/example/project-init",
+        "project_init_repo": "example/project-init",
         "language": "python",
         "memory_stack": "obsidian-only",
         "installed_mcps": "none",

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -277,6 +277,49 @@ class TestUpgradeApply:
         assert (target / "justfile.new").exists()
 
 
+class TestRecordBackfill:
+    def test_old_record_missing_new_variables_still_upgrades(self, tmp_path: Path):
+        """A record written before newer template variables existed must not
+        fail strict re-rendering (PR #166 review, P1). Simulated by stripping
+        post-PI-142 variables from the recorded JSON."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        config = target / _CONFIG_REL
+        text = config.read_text()
+        m = re.search(r"^(  variables: )(.*)$", text, re.MULTILINE)
+        assert m
+        variables = json.loads(m.group(2))
+        for newer in (
+            "project_init_repo", "project_owner", "license", "license_holder",
+            "license_mit", "license_apache", "license_proprietary",
+            "created_year", "justfile", "devcontainer", "mise", "vscode",
+            "vscode_off", "graphify",
+        ):
+            variables.pop(newer, None)
+        config.write_text(
+            text[: m.start()] + m.group(1) + json.dumps(variables, sort_keys=True) + text[m.end() :]
+        )
+
+        rc = main(["upgrade", str(target)])
+        assert rc == 0, "backfilled defaults must keep strict re-render working"
+
+    def test_backfill_derives_repo_slug_from_recorded_url(self, tmp_path: Path):
+        target = tmp_path / "p"
+        _scaffold(target)
+        config = target / _CONFIG_REL
+        text = config.read_text()
+        m = re.search(r"^(  variables: )(.*)$", text, re.MULTILINE)
+        variables = json.loads(m.group(2))
+        variables.pop("project_init_repo", None)
+        config.write_text(
+            text[: m.start()] + m.group(1) + json.dumps(variables, sort_keys=True) + text[m.end() :]
+        )
+
+        _, recovered, _, _ = read_scaffold_record(target)
+        url = recovered["project_init_url"]
+        assert recovered["project_init_repo"] == url.removeprefix("https://github.com/")
+
+
 class TestMigration:
     def test_pre_record_config_upgrades_with_conflicts(self, tmp_path: Path, capsys):
         """Configs from before the scaffold record existed still upgrade."""

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -52,6 +52,12 @@ def sync() -> list[str]:
 
     hooks_dest = PLUGIN_ROOT / "hooks"
     hooks_dest.mkdir(parents=True, exist_ok=True)
+    # Remove stale scripts (renamed/deleted upstream) but keep hooks.json —
+    # the wiring is plugin-authored, not synced from templates.
+    wanted = {script.name for script in hook_scripts()}
+    for existing in hooks_dest.iterdir():
+        if existing.suffix in {".sh", ".py"} and existing.name not in wanted:
+            existing.unlink()
     for script in hook_scripts():
         dest = hooks_dest / script.name
         shutil.copy2(script, dest)

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -1,0 +1,65 @@
+"""Sync the project-init-workflow plugin payload from templates (PI-129).
+
+The plugin under plugins/project-init-workflow/ ships the project-agnostic
+subset of the template `.claude/` payload: every non-.tmpl SKILL.md tree and
+every hook script. Templated files (e.g. plan/SKILL.md.tmpl) are
+project-specific and stay scaffold-only.
+
+Run: just sync-plugin   (or: uv run python tools/sync_plugin.py)
+The contract test tests/contracts/test_plugin_marketplace.py fails CI when
+the copies drift, so edits to template skills/hooks must re-run this.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_CLAUDE = REPO_ROOT / "templates" / "base" / "dot_claude"
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "project-init-workflow"
+
+
+def shared_skill_dirs() -> list[Path]:
+    """Template skill dirs whose SKILL.md is static (no .tmpl → shareable)."""
+    return sorted(
+        p.parent
+        for p in (TEMPLATE_CLAUDE / "skills").glob("*/SKILL.md")
+    )
+
+
+def hook_scripts() -> list[Path]:
+    """All hook scripts; README stays template-side."""
+    return sorted(
+        p
+        for p in (TEMPLATE_CLAUDE / "hooks").iterdir()
+        if p.is_file() and p.suffix in {".sh", ".py"}
+    )
+
+
+def sync() -> list[str]:
+    """Copy the shareable payload into the plugin; return synced rel paths."""
+    synced: list[str] = []
+
+    skills_dest = PLUGIN_ROOT / "skills"
+    if skills_dest.exists():
+        shutil.rmtree(skills_dest)
+    for skill_dir in shared_skill_dirs():
+        dest = skills_dest / skill_dir.name
+        shutil.copytree(skill_dir, dest)
+        synced.append(f"skills/{skill_dir.name}")
+
+    hooks_dest = PLUGIN_ROOT / "hooks"
+    hooks_dest.mkdir(parents=True, exist_ok=True)
+    for script in hook_scripts():
+        dest = hooks_dest / script.name
+        shutil.copy2(script, dest)
+        synced.append(f"hooks/{script.name}")
+
+    return synced
+
+
+if __name__ == "__main__":
+    for rel in sync():
+        sys.stdout.write(f"synced {rel}\n")


### PR DESCRIPTION
Closes #129

## Summary
- **Plugin**: `plugins/project-init-workflow/` packages the project-agnostic template payload — 12 shared skills (every non-.tmpl SKILL.md) and the 6 guard/bootstrap hook scripts, with `hooks/hooks.json` wired via `${CLAUDE_PLUGIN_ROOT}`. Templated components (plan skill, settings, rules) stay scaffold-only by definition.
- **Marketplace**: `.claude-plugin/marketplace.json` at the repo root lists the plugin with a relative source — this repo doubles as the marketplace (decision recorded in ADR-010; a dedicated company marketplace can supersede later without changing the plugin).
- **Scaffolder wiring**: both settings.json variants render `extraKnownMarketplaces` with the `{{project_init_repo}}` variable (the no-hardcoded-owner contract test caught the first attempt), so freshly scaffolded projects offer the plugin on first trust. The plugin is deliberately **not** in `enabledPlugins`: it wires the same scripts the scaffolded settings wire, and enabling both would double-fire every PreToolUse/SessionStart hook. Dual-ship semantics per your call; full cutover tracked in #165.
- **Sync**: `tools/sync_plugin.py` (`just sync-plugin`) regenerates the plugin payload from templates; a byte-level parity contract test fails CI when copies drift.

## Test plan
- `tests/contracts/test_plugin_marketplace.py` (8 tests): marketplace/plugin manifest validity, every hooks.json command resolves to an existing script, plugin events == template wiring events, no .tmpl in plugin, byte-level skills/hooks sync, scaffolded settings offered-not-enabled wiring
- Full suite: 476 passed