### PR TITLE
feat(PI-169): publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,29 @@ jobs:
         with:
           files: dist/*
           body_path: RELEASE_NOTES.md
+
+  # PyPI via trusted publishing (ADR-011): OIDC, no tokens to custody.
+  # One-time setup: register the pending publisher on pypi.org
+  # (project: project-init, owner: VytCepas, workflow: release.yml,
+  # environment: pypi).
+  publish-pypi:
+    needs: release
+    runs-on: ubuntu-24.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/project-init
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/project-init
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -53,12 +53,16 @@ Two honest caveats:
 
 ## Install (one-time)
 
-Preferred — from PyPI (after the first published release):
+Two install paths — pick by how you'll invoke it:
+
+**CLI-only, from PyPI** (after the first published release; ADR-011). Gives
+you the `project-init` command — no `/project-init` slash command:
 
 ```bash
-uv tool install project-init   # or one-off: uvx project-init
+uv tool install project-init   # or one-off: uvx project-init .
 ```
 
+**Full setup, from git** — adds the Claude Code slash command:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
@@ -79,13 +83,13 @@ Direct tool install without the slash command (any pinned tag):
 uv tool install git+https://github.com/VytCepas/project-init@v0.2.0
 ```
 
-Distribution is git-only by design — see [ADR-008](docs/adr/adr-008-distribution-channel.md).
+Distribution rationale: [ADR-008](docs/adr/adr-008-distribution-channel.md) (git channel), [ADR-011](docs/adr/adr-011-pypi-trusted-publishing.md) (PyPI via trusted publishing).
 
 ## Use
 
 ### Option 1: Inside a Claude Code session (interactive)
 
-After installing, a `/project-init` slash command is available in any Claude Code session:
+After the **git install** (`install.sh`), a `/project-init` slash command is available in any Claude Code session:
 
 ```
 /project-init
@@ -94,6 +98,9 @@ After installing, a `/project-init` slash command is available in any Claude Cod
 This runs the interactive wizard in the current project directory. It asks for project name, language, memory stack, and MCPs — then scaffolds `.claude/` for you.
 
 ### Option 2: From a shell (non-interactive, for CI / scripts)
+
+With the PyPI install, plain `project-init . --non-interactive …` (or
+`uvx project-init . …`) works anywhere. With the git install:
 
 ```bash
 cd your-project

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Two honest caveats:
 
 ## Install (one-time)
 
+Preferred — from PyPI (after the first published release):
+
+```bash
+uv tool install project-init   # or one-off: uvx project-init
+```
+
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
 ```

--- a/docs/adr/adr-008-distribution-channel.md
+++ b/docs/adr/adr-008-distribution-channel.md
@@ -1,6 +1,6 @@
 # ADR-008: Distribution stays git-based with tagged releases; PyPI deferred
 
-- Status: Accepted
+- Status: Superseded in part by ADR-011 (PyPI publishing added; git channel unchanged)
 - Date: 2026-06-11
 - Implements: distribution decision required by #144
 

--- a/docs/adr/adr-011-pypi-trusted-publishing.md
+++ b/docs/adr/adr-011-pypi-trusted-publishing.md
@@ -30,7 +30,8 @@ Publish every tagged release to PyPI from the existing `release.yml` via a
 - Authenticates via OIDC (`id-token: write`) against the `pypi`
   environment — protection rules can be added on the environment later.
 - Uses `pypa/gh-action-pypi-publish` (the canonical action; `release/v1`
-  per its own guidance, digest-pinned by Renovate like every other action).
+  per its own guidance — Renovate's `pinGitHubActionDigests` preset will
+  pin it to a digest on its next run, like every other action here).
 
 Install paths after this lands, in recommendation order:
 

--- a/docs/adr/adr-011-pypi-trusted-publishing.md
+++ b/docs/adr/adr-011-pypi-trusted-publishing.md
@@ -1,0 +1,55 @@
+# ADR-011: Publish to PyPI via trusted publishing; supersedes ADR-008's deferral
+
+- Status: Accepted
+- Date: 2026-06-12
+- Supersedes: ADR-008 (in part — git distribution stays supported)
+- Implements: #169
+
+## Context
+
+ADR-008 chose git-only distribution and deferred PyPI over two costs:
+API-token custody and mandatory version discipline. Both have since been
+eliminated:
+
+- **Trusted publishing** authenticates the GitHub Actions workflow to PyPI
+  directly via OIDC — there is no token to create, store, rotate, or leak.
+- **Release discipline already exists**: PI-144 introduced tag-triggered
+  releases with a version-match gate and a Conventional-Commits changelog.
+
+Meanwhile the `project-init` name was confirmed free on PyPI (checked
+2026-06-12 against both the JSON API and the simple index). A naming review
+considered rebranding (pamatas, formwork, agent-scaffold); the owner chose
+to keep `project-init` — claiming the name also defends it.
+
+## Decision Outcome
+
+Publish every tagged release to PyPI from the existing `release.yml` via a
+`publish-pypi` job:
+
+- Runs only after the GitHub Release job succeeds (`needs: release`).
+- Authenticates via OIDC (`id-token: write`) against the `pypi`
+  environment — protection rules can be added on the environment later.
+- Uses `pypa/gh-action-pypi-publish` (the canonical action; `release/v1`
+  per its own guidance, digest-pinned by Renovate like every other action).
+
+Install paths after this lands, in recommendation order:
+
+1. `uv tool install project-init` / `uvx project-init` (PyPI)
+2. `curl … install.sh | bash` (git, release-pinned — unchanged)
+3. `uv tool install git+https://github.com/VytCepas/project-init@vX.Y.Z`
+
+## One-time manual step (owner)
+
+Before the first publish, register the *pending publisher* on pypi.org
+(Account → Publishing): project `project-init`, owner `VytCepas`,
+repository `project-init`, workflow `release.yml`, environment `pypi`.
+The first tagged release after that claims the name.
+
+## Consequences
+
+- Anyone can install without trusting a curl-pipe-bash script.
+- The wheel already bundles `templates/` (hatch force-include), so PyPI
+  installs are fully functional — verified by the existing wheel-smoke CI
+  job.
+- Version bumps remain manual in two places (pyproject + `__init__.py`);
+  the release workflow's version-match gate keeps tags honest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,17 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Vytautas Čepas", email = "vyt.cepas.ve@gmail.com" }]
 keywords = ["claude-code", "agents", "scaffolding", "obsidian", "lightrag"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Code Generators",
+    "Environment :: Console",
+]
 
 dependencies = [
     "rich>=13.7",

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -106,8 +106,16 @@ class TestPyPIPublishing:
 
     def test_publish_runs_only_after_release(self):
         content = self._workflow()
-        publish_section = content.split("publish-pypi:")[1]
+        assert "publish-pypi:" in content, "publish job missing from release.yml"
+        publish_section = content.split("publish-pypi:", 1)[1]
         assert "needs: release" in publish_section
+
+    def test_publish_job_can_check_out(self):
+        """Job-level permissions replace workflow-level ones — without
+        contents: read the checkout step loses repo access."""
+        content = self._workflow()
+        publish_section = content.split("publish-pypi:", 1)[1]
+        assert "contents: read" in publish_section
 
     def test_pyproject_has_pypi_metadata(self):
         config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -89,3 +89,29 @@ class TestVersionConsistency:
         content = (_REPO_ROOT / "README.md").read_text()
         assert "PROJECT_INIT_REF" in content
         assert "adr-008" in content
+
+
+class TestPyPIPublishing:
+    """ADR-011: trusted publishing from the release workflow."""
+
+    def _workflow(self) -> str:
+        return (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    def test_publish_job_uses_trusted_publishing(self):
+        content = self._workflow()
+        assert "publish-pypi:" in content
+        assert "id-token: write" in content, "OIDC — no tokens to custody"
+        assert "pypa/gh-action-pypi-publish" in content
+        assert "name: pypi" in content, "environment gates the publisher"
+
+    def test_publish_runs_only_after_release(self):
+        content = self._workflow()
+        publish_section = content.split("publish-pypi:")[1]
+        assert "needs: release" in publish_section
+
+    def test_pyproject_has_pypi_metadata(self):
+        config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+        project = config["project"]
+        assert project["name"] == "project-init"
+        assert any("MIT License" in c for c in project["classifiers"])
+        assert project["urls"]["Repository"]


### PR DESCRIPTION
Closes #169

## Summary
- `release.yml` gains a `publish-pypi` job that runs after the GitHub Release succeeds: builds with `uv build`, publishes via `pypa/gh-action-pypi-publish` using OIDC trusted publishing (`id-token: write`, environment `pypi`) — no API token exists anywhere.
- `pyproject.toml` gains PyPI classifiers; name/metadata/console-script/template bundling were already publish-ready (wheel-smoke CI verifies the bundled templates).
- **ADR-011** records the decision and why ADR-008's deferral no longer applies (trusted publishing kills token custody; PI-144 already provides release discipline). ADR-008 marked superseded in part — install.sh and git installs stay supported.
- README documents `uv tool install project-init` / `uvx project-init` as the preferred install.

## Manual step before the first publish (owner)
On pypi.org → Account → Publishing → add **pending publisher**: project `project-init`, owner `VytCepas`, repository `project-init`, workflow `release.yml`, environment `pypi`. The next tagged release then claims the name (verified free on 2026-06-12).

## Test plan
- `TestPyPIPublishing` contract tests: trusted-publishing wiring, needs-release ordering, metadata
- Full suite: 501 passed