### PR TITLE
fix(PI-183): upload only build artifacts; harden the pypi environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          # Only the build artifacts — a bare `dist/*` also globs the tracked
-          # dist/.gitignore and uploads it as a stray `default.gitignore` asset
-          # (PI-183).
+          # Only the build artifacts — an unscoped glob also picks up the
+          # tracked dist/.gitignore and uploads it as a stray
+          # `default.gitignore` asset (PI-183).
           files: |
             dist/*.whl
             dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*
+          # Only the build artifacts — a bare `dist/*` also globs the tracked
+          # dist/.gitignore and uploads it as a stray `default.gitignore` asset
+          # (PI-183).
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
           body_path: RELEASE_NOTES.md
 
   # PyPI via trusted publishing (ADR-011): OIDC, no tokens to custody.

--- a/docs/adr/adr-011-pypi-trusted-publishing.md
+++ b/docs/adr/adr-011-pypi-trusted-publishing.md
@@ -28,7 +28,9 @@ Publish every tagged release to PyPI from the existing `release.yml` via a
 
 - Runs only after the GitHub Release job succeeds (`needs: release`).
 - Authenticates via OIDC (`id-token: write`) against the `pypi`
-  environment — protection rules can be added on the environment later.
+  environment, which is restricted to `v*` tags so only a tagged release
+  can deploy to it (PI-184); a required reviewer can be added later if a
+  manual approval gate before each publish is wanted.
 - Uses `pypa/gh-action-pypi-publish` (the canonical action; `release/v1`
   per its own guidance — Renovate's `pinGitHubActionDigests` preset will
   pin it to a digest on its next run, like every other action here).
@@ -45,6 +47,9 @@ Before the first publish, register the *pending publisher* on pypi.org
 (Account → Publishing): project `project-init`, owner `VytCepas`,
 repository `project-init`, workflow `release.yml`, environment `pypi`.
 The first tagged release after that claims the name.
+
+Done for v0.3.0 (#171): the publisher is registered, the `pypi`
+environment exists and is tag-restricted, and v0.3.0 is live on PyPI.
 
 ## Consequences
 

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -25,7 +25,11 @@ class TestReleaseWorkflow:
         content = self._workflow()
         assert "uv build" in content
         assert "softprops/action-gh-release@v3" in content
-        assert "files: dist/*" in content
+        # Upload only the build artifacts. A bare `files: dist/*` also globs the
+        # tracked dist/.gitignore and attaches it as a stray asset (PI-183).
+        assert "dist/*.whl" in content
+        assert "dist/*.tar.gz" in content
+        assert "files: dist/*\n" not in content, "bare dist/* uploads dist/.gitignore"
 
     def test_changelog_generated_from_latest_tag(self):
         content = self._workflow()

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -6,6 +6,7 @@ ref resolution, and version consistency across the package.
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -25,11 +26,14 @@ class TestReleaseWorkflow:
         content = self._workflow()
         assert "uv build" in content
         assert "softprops/action-gh-release@v3" in content
-        # Upload only the build artifacts. A bare `files: dist/*` also globs the
-        # tracked dist/.gitignore and attaches it as a stray asset (PI-183).
+        # Upload only the build artifacts. A bare `dist/*` also globs the tracked
+        # dist/.gitignore and attaches it as a stray asset (PI-183). Guard against
+        # any `dist/*` that is not a specific artifact, regardless of trailing
+        # whitespace/comment/EOF.
         assert "dist/*.whl" in content
         assert "dist/*.tar.gz" in content
-        assert "files: dist/*\n" not in content, "bare dist/* uploads dist/.gitignore"
+        bare = re.findall(r"dist/\*(?!\.(?:whl|tar\.gz))", content)
+        assert not bare, f"release must not bare-glob dist/* (PI-183): {bare}"
 
     def test_changelog_generated_from_latest_tag(self):
         content = self._workflow()


### PR DESCRIPTION
Two release-infra follow-ups from the v0.3.0 publish.

## PI-183 — stray release asset
The `release` job used `files: dist/*`, which also globbed the tracked `dist/.gitignore` and attached it as a `default.gitignore` asset (visible on the v0.3.0 release). Narrowed to `dist/*.whl` + `dist/*.tar.gz`. Contract test updated to assert the artifacts and forbid the bare glob.

## PI-184 — harden the `pypi` deployment environment
The `pypi` environment was created bare to unblock the v0.3.0 publish. It is now restricted to `v*` tags (applied via the API), so only a tagged release can deploy to it — defense in depth on top of the PyPI-side OIDC trusted-publisher identity match. ADR-011 updated to record the protection and the completed one-time publisher setup. A required-reviewer approval gate can be added later if wanted (noted in the ADR).

550 tests pass, ruff clean, `release.yml` validated as YAML.

Closes #183
Closes #184