### PR TITLE
fix(PI-207): repair board automation on user-owned repos (resolver + repo pin)

### DIFF
--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -118,9 +118,15 @@ jobs:
                   }
                 }
               }
-            }' -f owner="$OWNER" -F number="$PROJECT_NUMBER")
+            }' -f owner="$OWNER" -F number="$PROJECT_NUMBER" 2>/dev/null || true)
 
-          PROJECT=$(echo "$PROJECT_DATA" | jq -c '.data.user.projectV2 // .data.organization.projectV2 // empty')
+          # A personal (user-owned) account errors on the organization(...) path
+          # (and an org errors on the user(...) path); gh exits non-zero whenever
+          # the response carries an `errors` array, even though valid data.user /
+          # data.organization is still on stdout. Tolerate that so the jq fallback
+          # below can select whichever path applies. Total failures leave
+          # PROJECT_DATA empty -> PROJECT_ID empty -> graceful skip. (PI-207)
+          PROJECT=$(echo "$PROJECT_DATA" | jq -c '.data.user.projectV2 // .data.organization.projectV2 // empty' 2>/dev/null || true)
           PROJECT_ID=$(echo "$PROJECT" | jq -r '.id // empty')
 
           if [ -z "$PROJECT_ID" ]; then

--- a/templates/base/dot_github/workflows/board-automation.yml
+++ b/templates/base/dot_github/workflows/board-automation.yml
@@ -24,6 +24,10 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      # No actions/checkout in this job (it only needs API access); pin the repo
+      # so every `gh` call (e.g. `gh issue view`) works checkout-free instead of
+      # failing on a missing git remote (PI-234).
+      GH_REPO: ${{ github.repository }}
       OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       PROJECT_NUMBER: 1

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -128,6 +128,12 @@ class TestScaffoldGitHubFiles:
     def test_board_automation_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "board-automation.yml").is_file()
 
+    def test_board_automation_tolerates_personal_accounts(self):
+        """PI-207: the user+organization project query errors on one path; the
+        lookup must tolerate that so the jq fallback selects whichever applies."""
+        content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
+        assert "2>/dev/null || true)" in content
+
     def test_review_status_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "review-status.yml").is_file()
 

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -129,10 +129,12 @@ class TestScaffoldGitHubFiles:
         assert (self.target / ".github" / "workflows" / "board-automation.yml").is_file()
 
     def test_board_automation_tolerates_personal_accounts(self):
-        """PI-207: the user+organization project query errors on one path; the
-        lookup must tolerate that so the jq fallback selects whichever applies."""
+        """PI-207/PI-234: the user+organization project query errors on one path
+        (tolerate it so the jq fallback selects whichever applies), and the
+        checkout-free job must pin the repo so gh calls work without a remote."""
         content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
         assert "2>/dev/null || true)" in content
+        assert "GH_REPO:" in content
 
     def test_review_status_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "review-status.yml").is_file()

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -133,7 +133,26 @@ class TestScaffoldGitHubFiles:
         (tolerate it so the jq fallback selects whichever applies), and the
         checkout-free job must pin the repo so gh calls work without a remote."""
         content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
-        assert "2>/dev/null || true)" in content
+        lines = content.splitlines()
+        # Target the specific PROJECT_DATA assignment instead of matching the
+        # error-suppression substring anywhere in the file (brittle to harmless
+        # whitespace/formatting changes): locate the multi-line `gh api graphql`
+        # command substitution and capture it through the line that closes it.
+        starts = [
+            i for i, line in enumerate(lines) if line.lstrip().startswith("PROJECT_DATA=")
+        ]
+        assert starts, "board-automation.yml must assign PROJECT_DATA from a gh query"
+        start = starts[0]
+        ends = [i for i, line in enumerate(lines[start:], start) if "|| true" in line]
+        assert ends, "the PROJECT_DATA assignment must close with an error-tolerant guard"
+        assignment = "\n".join(lines[start : ends[0] + 1])
+        # The query must hit the Projects API and tolerate the errors path a
+        # personal (user-owned) account produces on the organization(...) branch,
+        # so the jq fallback can still select whichever path applies. (PI-207)
+        assert "gh api graphql" in assignment
+        assert "projectV2" in assignment
+        assert "2>/dev/null" in assignment
+        assert "|| true" in assignment
         assert "GH_REPO:" in content
 
     def test_review_status_workflow_created(self):


### PR DESCRIPTION
## Summary

Repairs `board-automation.yml` so the project-board sync works on **user-owned** repos. Two bugs (both reported in #234; Bug 1 is the original #207):

### Bug 1 — project resolver aborts under `set -euo pipefail` (PI-207)
The lookup queries both `user(login:)` and `organization(login:)` in one GraphQL call. On a personal account the `organization` half returns HTTP 200 with `data` **plus** an `errors` array, so `gh api graphql` exits non-zero and the command-substitution assignment aborts the step before any board mutation runs. **Fix:** tolerate the partial-error (`2>/dev/null || true`) so the existing `jq '.data.user.projectV2 // .data.organization.projectV2 // empty'` fallback selects whichever owner type resolved.

### Bug 2 — gh needs repo context with no checkout (PI-234)
The board-sync job has no `actions/checkout` (by design). The `gh issue view` call has been pinned via `-R "$OWNER/$REPO_NAME"` since PI-111, so it already works — but per the reporter's suggestion this adds the cleaner **env-level** pin so *every* gh call in the job resolves the repo checkout-free:
```yaml
GH_REPO: ${{ github.repository }}
```

## Test
`test_board_automation_tolerates_personal_accounts` asserts both the partial-error tolerance and the repo pin.

Closes #207
Closes #234
