### PR TITLE
fix(PI-210): set GH_REPO so validate-pr can resolve the repo for gh

### DIFF
--- a/templates/base/dot_github/workflows/validate-pr.yml
+++ b/templates/base/dot_github/workflows/validate-pr.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Validate PR workflow metadata
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh needs the repo to resolve `gh issue view` without a checkout (PI-210).
+          GH_REPO: ${{ github.repository }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -128,7 +128,11 @@ class TestScaffoldGitHubFiles:
     def test_validate_pr_sets_gh_repo(self):
         """PI-210: `gh issue view` resolves the repo via GH_REPO, no checkout."""
         content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()
-        assert "GH_REPO:" in content
+        # Assert the value is wired to github.repository — not just the key present,
+        # and not commented out. A commented line keeps its leading "#" after strip(),
+        # so exact-line membership is a real regression guard for PI-210.
+        env_lines = {line.strip() for line in content.splitlines()}
+        assert "GH_REPO: ${{ github.repository }}" in env_lines
 
     def test_board_automation_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "board-automation.yml").is_file()

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -125,6 +125,11 @@ class TestScaffoldGitHubFiles:
     def test_validate_pr_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "validate-pr.yml").is_file()
 
+    def test_validate_pr_sets_gh_repo(self):
+        """PI-210: `gh issue view` resolves the repo via GH_REPO, no checkout."""
+        content = (self.target / ".github" / "workflows" / "validate-pr.yml").read_text()
+        assert "GH_REPO:" in content
+
     def test_board_automation_workflow_created(self):
         assert (self.target / ".github" / "workflows" / "board-automation.yml").is_file()
 


### PR DESCRIPTION
## Summary

The `validate-pr.yml` job's metadata step calls `gh issue view "$ISSUE_NUM" --json state,labels` to validate the linked issue, but the job has **no `actions/checkout` step** and sets **no `GH_REPO`**. With neither, `gh` falls back to resolving the repo from the local git remote — which isn't present — and fails with `fatal: not a git repository`.

## Fix

Add `GH_REPO: ${{ github.repository }}` to the step env so `gh` resolves the target repo without a checkout (lighter than adding `actions/checkout`, since the step only needs `gh`).

## Test

Adds `test_validate_pr_sets_gh_repo` (scaffold-into-temp contract test).

Closes #210
