### PR TITLE
fix(PI-208): stop pinning CI to Python 3.12; let uv resolve the version

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -26,7 +26,9 @@ jobs:
           version: "0.11.7"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-          python-version: "3.12"
+          # No python-version pin (PI-208): `uv sync` installs the version the
+          # project requires (.python-version / requires-python), so CI never
+          # drifts below the floor. Add a matrix here to test multiple versions.
 
       # CI invokes the same justfile recipes agents and humans use (PI-139),
       # so the command surface is defined exactly once.
@@ -141,9 +143,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
-      - name: Set up Python
-        run: uv python install 3.12
-
+      # uv sync installs the project's required Python (.python-version /
+      # requires-python) — no version to drift (PI-208).
       - name: Sync dev dependencies
         run: uv sync --extra dev
 

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -151,10 +151,24 @@ class TestScaffoldGitHubFiles:
 
     def test_ci_does_not_hardcode_python_version(self):
         """PI-208: a pinned Python version drifts below requires-python; let uv
-        resolve the project's interpreter from .python-version/requires-python."""
+        resolve the project's interpreter from .python-version/requires-python.
+
+        Version-agnostic (Copilot review): guards against *any* hardcoded pin,
+        not just 3.12, so reintroducing 3.13 or `uv python install <x>` also
+        fails. A version matrix (list or ${{ matrix.* }} reference) stays
+        allowed — neither matches a bare scalar literal.
+        """
+        import re
+
         content = (self.target / ".github" / "workflows" / "ci.yml").read_text()
-        assert 'python-version: "3.12"' not in content
-        assert "uv python install 3.12" not in content
+        # No `uv python install <version>` for any version.
+        assert not re.search(r"uv python install \d", content), (
+            "CI must not run `uv python install <version>` (PI-208)"
+        )
+        # No literal `python-version:` scalar pin for any version.
+        assert not re.search(r"""python-version:\s*["']?\d""", content), (
+            "CI must not hard-pin python-version to a literal (PI-208)"
+        )
 
     def test_pull_request_template_created(self):
         assert (self.target / ".github" / "pull_request_template.md").is_file()

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -149,6 +149,13 @@ class TestScaffoldGitHubFiles:
         assert "actions/checkout@v4" not in content
         assert "astral-sh/setup-uv@v3" not in content
 
+    def test_ci_does_not_hardcode_python_version(self):
+        """PI-208: a pinned Python version drifts below requires-python; let uv
+        resolve the project's interpreter from .python-version/requires-python."""
+        content = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert 'python-version: "3.12"' not in content
+        assert "uv python install 3.12" not in content
+
     def test_pull_request_template_created(self):
         assert (self.target / ".github" / "pull_request_template.md").is_file()
 


### PR DESCRIPTION
## Summary

`ci.yml` hardcoded the interpreter in two places — `astral-sh/setup-uv` `python-version: "3.12"` and `uv python install 3.12` — which is **below** a scaffold that sets `requires-python >= 3.13`. `uv sync` then refused to resolve and CI failed on a fresh scaffold.

## Fix

Drop both pins. `uv sync` installs the version the project requires (from `.python-version` / `requires-python`), so CI tracks the project and can never pin below the floor.

> The **multi-version matrix** enhancement requested in the issue is a follow-up (filed separately) — a real derived matrix needs a scaffold variable so the version set can't drift from `requires-python`. This PR fixes the breakage; the comment in the template marks where a matrix would slot in.

## Test

Adds `test_ci_does_not_hardcode_python_version` (scaffold-into-temp contract test).

Closes #208
