### PR TITLE
fix(PI-186): bound the monitor_pr CI-wait loop so it can't hang forever

### DIFF
--- a/templates/base/dot_claude/scripts/monitor_pr.sh
+++ b/templates/base/dot_claude/scripts/monitor_pr.sh
@@ -147,13 +147,28 @@ _has_review_activity() {
 # Guard: if checks haven't registered yet (empty list), keep polling.
 # An empty list is indistinguishable from "all done" without this guard,
 # which caused premature merges before CI even started.
+# Bounded wait (PI-186): a required check that never leaves PENDING/EXPECTED
+# (e.g. a workflow that never triggers on this branch) must not hang the
+# script — and any autonomous caller — forever. Fail closed on timeout.
+CI_TIMEOUT=900
+CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
   CHECK_COUNT=$(echo "$CHECKS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
-  [ "$CHECK_COUNT" -eq 0 ] && { sleep 10; continue; }
-  PENDING=$(_count_pending "$CHECKS")
-  [ "$PENDING" -eq 0 ] && break
+  if [ "$CHECK_COUNT" -gt 0 ] && [ "$(_count_pending "$CHECKS")" -eq 0 ]; then
+    break
+  fi
+  if [ "$CI_ELAPSED" -ge "$CI_TIMEOUT" ]; then
+    echo "PR #$PR_NUMBER: CI did not settle within ${CI_TIMEOUT}s. Still pending:"
+    echo "$CHECKS" | python3 -c "import json,sys
+for c in json.load(sys.stdin):
+    if c.get('name') != 'review/decision' and c.get('state') in ('PENDING','IN_PROGRESS','EXPECTED'):
+        print('  -', c.get('name'))" 2>/dev/null || true
+    echo "Re-run once the check registers, or investigate why it never started."
+    exit 1
+  fi
   sleep 10
+  CI_ELAPSED=$((CI_ELAPSED + 10))
 done
 
 FAIL_CODE=0

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -187,8 +187,12 @@ class TestScaffoldGitHubFiles:
         """PI-186: the CI-wait loop must time out and fail closed, not hang
         forever on a required check that never registers."""
         content = (self.target / ".claude" / "scripts" / "monitor_pr.sh").read_text()
-        assert "CI_TIMEOUT" in content
-        assert "CI_ELAPSED" in content
+        assert "CI_TIMEOUT=" in content, "CI_TIMEOUT must be assigned a value"
+        # Assert the real bounding logic, not just the variable names — the loop
+        # must compare elapsed vs timeout and increment elapsed, so the test fails
+        # if the guard is dropped while the declarations linger (PI-186 review).
+        assert '[ "$CI_ELAPSED" -ge "$CI_TIMEOUT" ]' in content, "missing timeout guard"
+        assert "CI_ELAPSED=$((CI_ELAPSED +" in content, "missing elapsed increment"
         assert "--delete-branch" in content
         assert "reviewDecision" in content
         assert "Waiting for reviewer" in content

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -182,6 +182,13 @@ class TestScaffoldGitHubFiles:
         assert "gh pr merge" in content
         assert "gh pr checks" in content
         assert "--json" in content  # uses json polling, not --watch, to suppress noise
+
+    def test_monitor_pr_ci_wait_is_bounded(self):
+        """PI-186: the CI-wait loop must time out and fail closed, not hang
+        forever on a required check that never registers."""
+        content = (self.target / ".claude" / "scripts" / "monitor_pr.sh").read_text()
+        assert "CI_TIMEOUT" in content
+        assert "CI_ELAPSED" in content
         assert "--delete-branch" in content
         assert "reviewDecision" in content
         assert "Waiting for reviewer" in content


### PR DESCRIPTION
## Summary

`monitor_pr.sh` caps the **review**-wait loop at `REVIEW_TIMEOUT` (360s), but the **CI**-wait loop was `while true` with no cap. A required check that never leaves `PENDING`/`EXPECTED`/`IN_PROGRESS` — a workflow that never triggers on the branch, or a branch-protection check that never registers — made the script (and any autonomous agent driving `--merge`) spin forever with no diagnostic.

## Fix

Add `CI_TIMEOUT` (900s) with elapsed tracking, mirroring the review loop. On timeout, print the still-pending check names and `exit 1` (fail closed) rather than hang. The "checks not registered yet" guard is preserved (now bounded).

## Test

Adds `test_monitor_pr_ci_wait_is_bounded` (scaffold-into-temp contract test).

Closes #186
