### PR TITLE
fix(PI-197): reject wrong-typed record fields with a clean UpgradeError

### DIFF
--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -202,12 +202,13 @@ def _parse_record_block(text: str) -> tuple[str, dict, dict] | None:
         )
         raise UpgradeError(msg) from e
 
-    if preset and variables is not None and manifest is not None:
+    if preset and isinstance(variables, dict) and isinstance(manifest, dict):
         return preset, variables, manifest
     msg = (
-        "scaffold record in .claude/config.yaml is incomplete (needs preset, "
-        "variables, and manifest). Fix the block or delete everything from "
-        f"the '{_RECORD_MARKER}' line down to fall back to migration."
+        "scaffold record in .claude/config.yaml is incomplete or malformed "
+        "(needs preset, plus variables and manifest as JSON objects). Fix the "
+        f"block or delete everything from the '{_RECORD_MARKER}' line down to "
+        "fall back to migration."
     )
     raise UpgradeError(msg)
 

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -95,6 +95,20 @@ class TestScaffoldRecord:
         assert rc == 1
         assert "corrupted" in capsys.readouterr().err
 
+    def test_wrong_typed_record_is_a_clean_error(self, tmp_path: Path, capsys):
+        """PI-197: a record field that is valid JSON but the wrong type (e.g.
+        ``manifest: []``) must raise a clean UpgradeError, not an
+        AttributeError from a later ``manifest.get(...)``."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        config = target / _CONFIG_REL
+        config.write_text(_MANIFEST_LINE_RE.sub(r"\1[]", config.read_text(), count=1))
+        rc = main(["upgrade", str(target)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "malformed" in err
+        assert "Traceback" not in err
+
     def test_unrelated_scaffold_section_is_not_the_record(self, tmp_path: Path):
         """Only the block after the marker is parsed (PR #160 review)."""
         target = tmp_path / "p"


### PR DESCRIPTION
## Summary

`_record_fields` `json.loads()` the `variables`/`manifest` record values without checking their type, and `_parse_record_block` only checked `is not None`. A record with `manifest: []` (valid JSON, wrong type) was accepted, then `compute_drift`'s `manifest.get(...)` raised `AttributeError` **outside** the `UpgradeError` path — violating the parser's documented "malformed content raises UpgradeError instead of leaking a JSON traceback" guarantee (the same applies to a wrong-typed `variables`).

## Fix

Require `variables` and `manifest` to be `dict`; otherwise raise `UpgradeError` with the existing recovery message ("…or delete everything from the record marker down to fall back to migration").

## Test

Adds `test_wrong_typed_record_is_a_clean_error` (rewrites the record to `manifest: []`, asserts `rc == 1` and no `Traceback`).

Closes #197
