### PR TITLE
fix(PI-201): write planning metadata into the issue body (issue lifecycle)

### DIFF
--- a/templates/base/dot_claude/scripts/create_issue.sh
+++ b/templates/base/dot_claude/scripts/create_issue.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Create a GitHub issue with typed labels and planning metadata.
-# Priority, Size, Agent ready, and Confidence are set directly on the
-# GitHub Project v2 board — not written to the issue body.
+# Priority, Size, Agent ready, and Confidence are written into the issue body
+# (so the issue is self-contained) and mirrored to the GitHub Project v2 board.
 #
 # Usage:
 #   .claude/scripts/create_issue.sh <type> "Short description" [metadata flags]
@@ -27,10 +27,10 @@ Types:
   feat  fix  chore  docs  test
 
 Options:
-  --priority high|medium|low           Set Priority on the project board
-  --size XS|S|M|L|XL                   Set Size on the project board
-  --agent-ready Yes|No                 Set Agent ready on the project board
-  --confidence high|medium|low|unknown Set Confidence on the project board
+  --priority high|medium|low           Set Priority (issue body + project board)
+  --size XS|S|M|L|XL                   Set Size (issue body + project board)
+  --agent-ready Yes|No                 Set Agent ready (issue body + project board)
+  --confidence high|medium|low|unknown Set Confidence (issue body + project board)
   --area VALUE                         Record affected area in body metadata
   --scale epic|task                    Mark as epic (parent) or task (leaf); adds scale label
   --parent VALUE                       Link new issue as sub-issue of VALUE
@@ -50,9 +50,11 @@ Sub-issues:
 
 Metadata model:
   GitHub labels: type and scale when labels exist or can be created.
-  GitHub Project fields: priority, size, agent-ready, confidence (set directly via GraphQL).
-  Markdown body: area, scale, parent, references, dependencies, acceptance criteria,
+  Markdown body (self-contained source of truth): priority, size, agent-ready,
+  confidence, area, scale, parent, references, dependencies, acceptance criteria,
   Definition of Ready, and Definition of Done.
+  GitHub Project fields: priority, size, agent-ready, and confidence are also
+  mirrored to the board via GraphQL so they stay sortable/filterable for humans.
 
 Missing label fallback:
   If a label is missing and cannot be created, issue creation continues without

--- a/templates/base/dot_claude/scripts/create_issue.sh
+++ b/templates/base/dot_claude/scripts/create_issue.sh
@@ -296,6 +296,13 @@ write_bullets() {
   echo "## Metadata"
   echo
   echo "- Type: $TYPE"
+  # PI-201: planning fields live in the body (so issue-validation.yml and the
+  # issue forms agree, and an agent reading the issue needs no board query);
+  # they are ALSO mirrored to the project board below for human sorting/filter.
+  [ -n "$PRIORITY" ]    && echo "- Priority: $PRIORITY"
+  [ -n "$SIZE" ]        && echo "- Size: $SIZE"
+  [ -n "$AGENT_READY" ] && echo "- Agent ready: $AGENT_READY"
+  [ -n "$CONFIDENCE" ]  && echo "- Confidence: $CONFIDENCE"
   [ -n "$SCALE" ] && echo "- Scale: $SCALE"
   [ -n "$AREA" ] && echo "- Area: $AREA"
   if [ -n "$PARENT" ]; then
@@ -307,17 +314,23 @@ write_bullets() {
   if [ -n "$MILESTONE" ]; then
     echo "- Milestone: $MILESTONE"
   fi
+  # Always emit these sections (PI-201): issue-validation.yml requires them in
+  # the body; "None" satisfies the check when the agent passed nothing.
+  echo
+  echo "## References"
+  echo
   if [ "${#REFERENCES[@]}" -gt 0 ]; then
-    echo
-    echo "## References"
-    echo
     write_bullets "None" "${REFERENCES[@]}"
+  else
+    echo "- None"
   fi
+  echo
+  echo "## Dependencies"
+  echo
   if [ "${#DEPENDENCIES[@]}" -gt 0 ]; then
-    echo
-    echo "## Dependencies"
-    echo
     write_bullets "None" "${DEPENDENCIES[@]}"
+  else
+    echo "- None"
   fi
   echo
   echo "## Acceptance criteria"
@@ -381,9 +394,10 @@ ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" "${LABEL_ARGS[@]}")
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
 # ---------------------------------------------------------------------------
-# Set Priority / Size / Agent ready / Confidence directly on the GitHub
-# Project v2 board. These are not written to the issue body — the board is
-# the authoritative location for these fields.
+# Mirror Priority / Size / Agent ready / Confidence to the GitHub Project v2
+# board. They are also written into the issue body above (PI-201) so the issue
+# is self-contained and passes issue-validation.yml; the board copy makes them
+# sortable/filterable for humans.
 # PROJECT_NUMBER defaults to 1; override with the env var if needed.
 # ---------------------------------------------------------------------------
 sync_project_fields() {

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -149,11 +149,17 @@ class TestCreateIssueScript:
         content = self.script.read_text()
         assert "label missing" in content.lower() or "missing label" in content.lower()
 
-    def test_project_fields_not_written_to_body(self):
+    def test_project_fields_written_to_body_and_synced(self):
+        """PI-201: planning fields go in the body (so issue-validation.yml and
+        the issue forms agree, and the issue is self-contained for agents) AND
+        are mirrored to the project board."""
         content = self.script.read_text()
-        # Priority/Size/Agent ready/Confidence go to project board, not the body
-        assert "Priority:" not in content.split("## Metadata")[1].split("sync_project_fields")[0]
-        # Confirm the sync function exists instead
+        metadata_block = content.split("## Metadata")[1].split("sync_project_fields")[0]
+        assert "Priority: $PRIORITY" in metadata_block
+        assert "Size: $SIZE" in metadata_block
+        assert "Agent ready: $AGENT_READY" in metadata_block
+        assert "Confidence: $CONFIDENCE" in metadata_block
+        # ... and still mirrored to the board.
         assert "sync_project_fields" in content
         assert "updateProjectV2ItemFieldValue" in content
 


### PR DESCRIPTION
## Summary

`create_issue.sh` synced Priority/Size/Agent ready/Confidence to the project board but **never wrote them to the issue body**, while `issue-validation.yml` greps the **body** for exactly those fields. So every issue created by the blessed script was immediately stamped `status:needs-info`, and `validate-pr.yml` then blocked any linked PR (`linked issue #N is labeled status:needs-info`). The default `create_issue.sh` → `start_issue.sh` → PR lifecycle was broken out of the box for scaffolded projects.

## Fix (design: body self-contained)

The three issue-creation surfaces disagreed — the **issue forms** and the **validator** both expect these fields in the body; only `create_issue.sh` chose board-only. Aligned on **body self-contained** (owner-approved):
- Write Priority/Size/Agent ready/Confidence into the body Metadata section when provided (**still mirrored to the board** for human sorting/filtering).
- Always emit the `## References` and `## Dependencies` sections (with `- None`) so the validator's required body sections are present.

## Test

Replaces the test that asserted the board-only design with `test_project_fields_written_to_body_and_synced` (fields in body **and** still synced).

Closes #201
