### PR TITLE
fix(PI-198): block gh-api merges regardless of flag position

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -244,7 +244,10 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        re.compile(r"\bgh\s+api\s+repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path) without
+        # crossing a command separator (PI-198).
+        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -244,10 +244,11 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
-        # needs `--method PUT`/`-X PUT`, often written before the path) without
-        # crossing a command separator (PI-198).
-        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path). `|` is NOT
+        # excluded: a pipe inside a quoted flag (e.g. `--jq '.a|.b'`) must not let a
+        # merge slip past the guard — only `;`/`&` end the command segment (PI-198).
+        re.compile(r"\bgh\s+api\b[^&;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -244,7 +244,10 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        re.compile(r"\bgh\s+api\s+repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path) without
+        # crossing a command separator (PI-198).
+        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -244,10 +244,11 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
-        # needs `--method PUT`/`-X PUT`, often written before the path) without
-        # crossing a command separator (PI-198).
-        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path). `|` is NOT
+        # excluded: a pipe inside a quoted flag (e.g. `--jq '.a|.b'`) must not let a
+        # merge slip past the guard — only `;`/`&` end the command segment (PI-198).
+        re.compile(r"\bgh\s+api\b[^&;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -244,7 +244,10 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        re.compile(r"\bgh\s+api\s+repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path) without
+        # crossing a command separator (PI-198).
+        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -244,10 +244,11 @@ COMMAND_RULES: list[tuple[re.Pattern[str], str | None, str]] = [
         "Direct pushes to main/master are blocked. Open a feature branch and PR.",
     ),
     (
-        # `[^&|;]*?` allows flags between `gh api` and the endpoint (a real merge
-        # needs `--method PUT`/`-X PUT`, often written before the path) without
-        # crossing a command separator (PI-198).
-        re.compile(r"\bgh\s+api\b[^&|;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
+        # `[^&;]*?` allows flags between `gh api` and the endpoint (a real merge
+        # needs `--method PUT`/`-X PUT`, often written before the path). `|` is NOT
+        # excluded: a pipe inside a quoted flag (e.g. `--jq '.a|.b'`) must not let a
+        # merge slip past the guard — only `;`/`&` end the command segment (PI-198).
+        re.compile(r"\bgh\s+api\b[^&;]*?repos/[^/\s]+/[^/\s]+/pulls/\d+/merge\b"),
         "pr.merged",
         "Use .claude/scripts/monitor_pr.sh <pr> --merge instead of `gh api .../merge` so CI and review gates are honored.",
     ),

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -246,6 +246,15 @@ class TestGitHubWorkflowHooks:
         )
         assert out is not None and out["decision"] == "block"
 
+    def test_github_command_guard_blocks_gh_api_merge_with_jq_pipe(self):
+        """PI-198 review: a pipe inside a quoted flag (e.g. `--jq '.a|.b'`) before
+        the endpoint must not let a `gh api .../merge` slip past the guard."""
+        out = self._run_hook(
+            "github_command_guard.sh",
+            "gh api --jq '.a|.b' --method PUT repos/o/r/pulls/42/merge",
+        )
+        assert out is not None and out["decision"] == "block"
+
     def test_github_command_guard_blocks_raw_pr_create(self):
         out = self._run_hook(
             "github_command_guard.sh",

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -237,6 +237,15 @@ class TestGitHubWorkflowHooks:
         out = self._run_hook("github_command_guard.sh", "gh pr merge 42 --auto")
         assert out is not None and out["decision"] == "block"
 
+    def test_github_command_guard_blocks_gh_api_merge_with_flags(self):
+        """PI-198: a `--method PUT` before the endpoint (the natural way to
+        merge via gh api) must not bypass the merge guard."""
+        out = self._run_hook(
+            "github_command_guard.sh",
+            "gh api --method PUT repos/o/r/pulls/42/merge",
+        )
+        assert out is not None and out["decision"] == "block"
+
     def test_github_command_guard_blocks_raw_pr_create(self):
         out = self._run_hook(
             "github_command_guard.sh",


### PR DESCRIPTION
## Summary

The PreToolUse guard rule that blocks PR merges via `gh api` required the endpoint *immediately* after `gh api`:
`\bgh\s+api\s+repos/.../pulls/\d+/merge\b`. But merging via gh api needs a `PUT`, and the flag is naturally written **before** the endpoint — `gh api --method PUT repos/o/r/pulls/42/merge` did **not** match and bypassed the `monitor_pr.sh --merge` redirect that honors CI/review gates.

## Fix

Allow flags between `gh api` and the endpoint with `[^&|;]*?` (non-greedy, and stops at a command separator so it can't false-match across `&&`/`;`). The endpoint-first form still matches.

Mirrored to all three copies (template, repo `.claude/`, and the plugin payload via `tools/sync_plugin.py`).

## Test

Adds `test_github_command_guard_blocks_gh_api_merge_with_flags` — runs the scaffolded guard hook on `gh api --method PUT …/merge` and asserts `block`.

Closes #198
