### PR TITLE
fix(PI-202): push wrapper refuses main/master for any push, not just force

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -380,8 +380,12 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
     if not branch:
         sys.stderr.write("push: no current branch\n")
         return 1
-    if force and branch in ("main", "master"):
-        sys.stderr.write("push: refusing to force-push main/master\n")
+    if branch in ("main", "master"):
+        # Refuse main/master for ANY push, not only force-pushes — otherwise
+        # running push_branch.sh while on main bypasses the direct-push guard,
+        # since the internal `git push` subprocess is invisible to the
+        # PreToolUse hook (PI-202).
+        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
         return 1
 
     code, sha_out = _git(["rev-parse", branch])

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -380,8 +380,12 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
     if not branch:
         sys.stderr.write("push: no current branch\n")
         return 1
-    if force and branch in ("main", "master"):
-        sys.stderr.write("push: refusing to force-push main/master\n")
+    if branch in ("main", "master"):
+        # Refuse main/master for ANY push, not only force-pushes — otherwise
+        # running push_branch.sh while on main bypasses the direct-push guard,
+        # since the internal `git push` subprocess is invisible to the
+        # PreToolUse hook (PI-202).
+        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
         return 1
 
     code, sha_out = _git(["rev-parse", branch])

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -380,8 +380,12 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
     if not branch:
         sys.stderr.write("push: no current branch\n")
         return 1
-    if force and branch in ("main", "master"):
-        sys.stderr.write("push: refusing to force-push main/master\n")
+    if branch in ("main", "master"):
+        # Refuse main/master for ANY push, not only force-pushes — otherwise
+        # running push_branch.sh while on main bypasses the direct-push guard,
+        # since the internal `git push` subprocess is invisible to the
+        # PreToolUse hook (PI-202).
+        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
         return 1
 
     code, sha_out = _git(["rev-parse", branch])

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -407,6 +407,13 @@ class TestPushForceWithLease:
         assert dag.cmd_push("main", 0, force=True) == 1
         assert dag.cmd_push("master", 0, force=True) == 1
 
+    def test_refuses_nonforce_push_to_main(self, dag, capsys):
+        """PI-202: refuse main/master for ANY push, not only force-pushes —
+        otherwise push_branch.sh run on main bypasses the direct-push guard."""
+        assert dag.cmd_push("main", 0) == 1
+        assert dag.cmd_push("master", 0) == 1
+        assert "refusing to push" in capsys.readouterr().err
+
     def test_force_with_lease_pushes_rebased_branch(self, tmp_path: Path):
         remote = tmp_path / "origin.git"
         subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)


### PR DESCRIPTION
## Summary

`cmd_push` refused `main`/`master` only when `force=True`. The PreToolUse guard blocks raw `git push origin main`, but `push_branch.sh` execs `dag_workflow.py push`, and that internal `git push` subprocess is invisible to the hook — so running the **blessed** wrapper while checked out on `main` pushed straight to `main`/`master`, defeating the guard's whole purpose.

## Fix

Refuse `main`/`master` for **any** push (drop the `force and` condition). `force` still governs `--force-with-lease` for feature branches. Mirrored to all three copies (template, repo `.claude/`, plugin payload).

## Test

Adds `test_refuses_nonforce_push_to_main` — `cmd_push("main", 0)` (non-force) returns 1 with a "refusing to push" message, before any git op.

Closes #202
