### PR TITLE
fix(PI-204): install_hooks replaces a symlinked hook, not its referent

### DIFF
--- a/templates/base/dot_claude/scripts/install_hooks.sh
+++ b/templates/base/dot_claude/scripts/install_hooks.sh
@@ -32,7 +32,12 @@ for hook_file in "$GIT_HOOKS_SRC"/*; do
     echo "  Backed up existing $hook_name"
   fi
 
-  # Create symlink (or copy if symlinks not available)
+  # If the destination is a symlink (e.g. a hooks manager like husky), remove
+  # the link first so we replace it rather than writing through `cp` to its
+  # referent and clobbering a shared file outside .git/hooks (PI-204).
+  [ -L "$hook_dst" ] && rm -f "$hook_dst"
+
+  # Copy the project hook into place.
   if cp -P "$hook_file" "$hook_dst" 2>/dev/null; then
     chmod +x "$hook_dst"
   else

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -218,6 +218,31 @@ class TestInstallHooks:
             assert installed.is_file(), f"{name} not installed"
             assert installed.stat().st_mode & 0o111, f"{name} not executable"
 
+    def test_symlinked_destination_is_replaced_not_clobbered(self, tmp_target: Path):
+        """PI-204: when .git/hooks/<hook> is a symlink (e.g. a hooks manager),
+        install must replace the link, not write through to its referent."""
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        subprocess.run(
+            ["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True
+        )
+        referent = tmp_target / "shared-pre-commit"
+        referent.write_text("USER SHARED HOOK - DO NOT CLOBBER\n")
+        dst = tmp_target / ".git" / "hooks" / "pre-commit"
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.symlink_to(referent)
+
+        result = subprocess.run(
+            ["bash", str(tmp_target / ".claude" / "scripts" / "install_hooks.sh")],
+            cwd=tmp_target,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        # The user's shared file must be untouched ...
+        assert referent.read_text() == "USER SHARED HOOK - DO NOT CLOBBER\n"
+        # ... and the destination is now a real file (the project's hook).
+        assert dst.is_file() and not dst.is_symlink()
+
 
 class TestCiSecretScanMirror:
     """ADR-007: the gitleaks scan is mirrored as a hard gate in scaffolded CI."""


### PR DESCRIPTION
## Summary

`install_hooks.sh` only backed up a destination that exists and is **not** a symlink, then `cp -P`'d the hook into place. If `.git/hooks/<hook>` is an existing **symlink** (e.g. a shared hooks manager like husky/pre-commit), `cp -P` to a symlink destination follows the link and writes **through** to its referent (`-P` governs the *source*, not the dest) — silently overwriting a file outside `.git/hooks`, with no backup.

## Fix

Remove a symlink destination first (`[ -L "$hook_dst" ] && rm -f "$hook_dst"`) so the link is **replaced**, not dereferenced. Also corrects the stale "Create symlink" comment (the script copies) — folds in the #194 doc nit for this file.

## Test

Adds `test_symlinked_destination_is_replaced_not_clobbered` — a symlinked `pre-commit` dest leaves its referent untouched and becomes a real file.

Closes #204
