### PR TITLE
fix(PI-206): give start_issue a fallback slug for non-alphanumeric titles

### DIFF
--- a/templates/base/dot_claude/scripts/start_issue.sh
+++ b/templates/base/dot_claude/scripts/start_issue.sh
@@ -102,6 +102,11 @@ if [ "$MAX_SLUG" -lt 12 ]; then
 fi
 SLUG="${SLUG:0:$MAX_SLUG}"
 SLUG="${SLUG%-}"   # trim trailing dash if truncated mid-word
+# A title with no alphanumerics (e.g. "!!!") collapses to an empty slug, so the
+# branch would be `feat/PI-42-` — pushed and PR'd before validate-pr.yml rejects
+# it for a slug that doesn't start with [a-z0-9]. Fall back to a stable slug so
+# no malformed branch is created (PI-206).
+[ -z "$SLUG" ] && SLUG="issue"
 BRANCH="${TYPE}/${PREFIX}${SLUG}"
 
 echo "Branch: $BRANCH"

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -175,6 +175,15 @@ class TestScaffoldObsidianOnly:
         assert 'BRANCH="${TYPE}/${PREFIX}${SLUG}"' in content
         assert "<issue_type>/<project_abbr>-<issue_number>-<kebab-slug>" in content
 
+    def test_start_issue_sh_handles_empty_slug(self):
+        """PI-206: a non-alphanumeric title must not yield a slug-less branch
+        like `feat/PI-42-` that gets pushed before validation rejects it."""
+        content = (self.target / ".claude" / "scripts" / "start_issue.sh").read_text()
+        guard_idx = content.find('-z "$SLUG"')
+        branch_idx = content.find('BRANCH="${TYPE}/${PREFIX}${SLUG}"')
+        assert guard_idx != -1, "empty-slug fallback missing"
+        assert guard_idx < branch_idx, "empty-slug fallback must precede the branch name"
+
     def test_project_init_md_has_script_commands(self):
         content = (self.target / ".claude" / "project-init.md").read_text()
         assert "create_issue.sh" in content


### PR DESCRIPTION
## Summary

`start_issue.sh` slugified the issue title without checking the result was non-empty. A title with no alphanumerics (e.g. `!!!`) collapses to an **empty** slug, so `BRANCH` becomes `feat/PI-42-` (trailing dash, no slug). The script **pushes that branch and opens a draft PR** *before* any validation — and only then does `validate-pr.yml` reject it (slug must start with `[a-z0-9]`), leaving a junk remote branch and a failing draft PR behind.

## Fix

Fall back to a stable slug (`issue`) when the computed slug is empty, so a valid branch (`feat/PI-42-issue`) is created instead of a malformed one. Validated locally, before the push.

## Test

Adds `test_start_issue_sh_handles_empty_slug` — asserts the empty-slug fallback exists and precedes the branch-name assignment.

Closes #206
