### PR TITLE
fix(PI-188): reject path traversal in load_preset

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -48,9 +48,13 @@ def list_presets() -> list[dict]:
 
 def load_preset(name: str) -> dict:
     """Load a single preset by name (e.g. 'obsidian-only')."""
-    path = _TEMPLATES_DIR / "presets" / f"{name}.toml"
-    if not path.exists():
-        available = [p.stem for p in (_TEMPLATES_DIR / "presets").glob("*.toml")]
+    presets_dir = _TEMPLATES_DIR / "presets"
+    path = presets_dir / f"{name}.toml"
+    # A preset name is a bare stem, never a path — reject traversal so a value
+    # like `--preset ../../x` can't read a .toml outside presets/ (PI-188).
+    safe_name = bool(name) and not ({"/", "\\"} & set(name)) and ".." not in name
+    if not safe_name or path.resolve().parent != presets_dir.resolve() or not path.exists():
+        available = [p.stem for p in sorted(presets_dir.glob("*.toml"))]
         msg = f"Unknown preset {name!r}. Available: {', '.join(available)}"
         raise ValueError(msg)
     with path.open("rb") as f:

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -31,7 +31,17 @@ class TestLoadPreset:
 
     @pytest.mark.parametrize(
         "evil",
-        ["../../etc/passwd", "..", "a/b", "foo/../bar", "/etc/passwd", ""],
+        [
+            "../../etc/passwd",
+            "..",
+            "a/b",
+            "foo/../bar",
+            "/etc/passwd",
+            "",
+            # Windows-style separators: the guard rejects backslash too (PI-188).
+            "..\\..\\etc\\passwd",
+            "a\\b",
+        ],
     )
     def test_load_preset_rejects_path_traversal(self, evil):
         """PI-188: --preset must be a bare stem; a path must not read a .toml

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -28,3 +28,13 @@ class TestLoadPreset:
     def test_load_unknown_preset_raises(self):
         with pytest.raises(ValueError, match="Unknown preset"):
             load_preset("nonexistent")
+
+    @pytest.mark.parametrize(
+        "evil",
+        ["../../etc/passwd", "..", "a/b", "foo/../bar", "/etc/passwd", ""],
+    )
+    def test_load_preset_rejects_path_traversal(self, evil):
+        """PI-188: --preset must be a bare stem; a path must not read a .toml
+        outside presets/."""
+        with pytest.raises(ValueError, match="Unknown preset"):
+            load_preset(evil)


### PR DESCRIPTION
## Summary

`load_preset()` built `presets/<name>.toml` directly from the `--preset` value with no validation. In interactive mode the value comes from a fixed menu, but `--non-interactive --preset <value>` passes it straight through — `--preset ../../../tmp/evil` resolved outside `presets/` and would read an arbitrary `.toml`. Low severity (local CLI, user's own input), but free hardening.

## Fix

Reject names that aren't a bare stem (path separators, `..`, empty) **and** verify the resolved path's parent is still `presets/`; otherwise raise the existing `Unknown preset` error. Valid names and the existing not-found behavior are unchanged.

## Test

Adds a parametrized `test_load_preset_rejects_path_traversal` over `../../etc/passwd`, `..`, `a/b`, `foo/../bar`, `/etc/passwd`, `""`.

Closes #188
