### PR TITLE
fix(PI-205): require matching {{/if name}} in the render engine

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -18,8 +18,11 @@ _VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 # Matches an INNERMOST conditional block — the tempered dot forbids another
 # opener inside the body. _render loops to a fixpoint, so nested
 # {{#if outer}}...{{#if inner}}...{{/if}}...{{/if}} resolves inside-out.
+# A named closing tag must match the opener via the \1 backreference, so
+# {{#if x}}...{{/if y}} does NOT match — it's left unrendered (strict mode then
+# flags it) instead of silently gating on x and ignoring the typo'd y (PI-205).
 _BLOCK_RE = re.compile(
-    r"\{\{#if\s+(\w+)\}\}((?:(?!\{\{#if\s).)*?)\{\{/if(?:\s+\w+)?\}\}",
+    r"\{\{#if\s+(\w+)\}\}((?:(?!\{\{#if\s).)*?)\{\{/if(?:\s+\1)?\}\}",
     re.DOTALL,
 )
 # Used by strict mode to detect unrendered handlebars-style markers.

--- a/tests/unit/test_render_nesting.py
+++ b/tests/unit/test_render_nesting.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from project_init.scaffold import _render
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import TemplateRenderError, _render, scaffold
+from tests.helpers import make_variables
 
 
 class TestNestedConditionals:
@@ -43,3 +48,29 @@ class TestNestedConditionals:
         # A matching close (or no name) still renders normally.
         assert _render("{{#if python}}X{{/if python}}", {"python": "true"}) == "X"
         assert _render("{{#if python}}X{{/if}}", {"python": "true"}) == "X"
+
+    def test_mismatched_close_tag_raises_in_strict_scaffold(self, tmp_path: Path):
+        """PI-205 acceptance criterion (end-to-end): because a mismatched close
+        tag survives rendering (above), a real strict scaffold of a template
+        containing it raises TemplateRenderError instead of silently gating on
+        the opener and shipping the typo (PI-205 review)."""
+        import project_init.scaffold as sm
+
+        fake_dir = tmp_path / "mismatch-layer"
+        (fake_dir / "dot_claude").mkdir(parents=True)
+        (fake_dir / "dot_claude" / "typo.md.tmpl").write_text(
+            "{{#if python}}body{{/if node}}\n"
+        )
+        original = sm._TEMPLATES_DIR
+        sm._TEMPLATES_DIR = fake_dir.parent
+        try:
+            with pytest.raises(TemplateRenderError) as excinfo:
+                scaffold(
+                    tmp_path / "out",
+                    {"name": "fake", "layers": ["mismatch-layer"]},
+                    make_variables(python="true"),
+                    strict=True,
+                )
+            assert "typo.md" in str(excinfo.value)
+        finally:
+            sm._TEMPLATES_DIR = original

--- a/tests/unit/test_render_nesting.py
+++ b/tests/unit/test_render_nesting.py
@@ -33,3 +33,13 @@ class TestNestedConditionals:
     def test_unclosed_block_survives_for_strict_mode(self):
         text = "{{#if a}}no closer"
         assert _render(text, {"a": "true"}) == "{{#if a}}no closer"
+
+    def test_mismatched_close_tag_is_not_rendered(self):
+        """PI-205: a closing tag whose name differs from the opener must not be
+        treated as a valid block — the markers survive (strict mode then flags
+        them) rather than silently gating on the opener and ignoring the typo."""
+        text = "{{#if python}}X{{/if node}}"
+        assert _render(text, {"python": "true", "node": ""}) == text
+        # A matching close (or no name) still renders normally.
+        assert _render("{{#if python}}X{{/if python}}", {"python": "true"}) == "X"
+        assert _render("{{#if python}}X{{/if}}", {"python": "true"}) == "X"


### PR DESCRIPTION
## Summary

`_BLOCK_RE` captured the opening conditional's name but the closing tag's optional name was never required to match it (`{{/if(?:\s+\w+)?}}`). So `{{#if python}}…{{/if node}}` rendered based solely on `python`, silently ignoring the typo'd `node`, and passed strict-mode validation.

## Fix

Backreference the opener (`\1`) in the closing tag: `{{/if(?:\s+\1)?}}`. A mismatched `{{/if name}}` no longer matches, so the block is left unrendered and strict mode flags it (`TemplateRenderError`) rather than silently gating on the opener. Matching (`{{/if python}}`) and unnamed (`{{/if}}`) closes are unaffected.

Verified the full suite — including both presets rendered in strict mode — still passes, confirming no shipped template relied on mismatched tags.

## Test

Adds `test_mismatched_close_tag_is_not_rendered`.

Closes #205
