### PR TITLE
fix(PI-199): gather interactive input before creating the target dir

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -590,12 +590,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     preset = _select_preset(args, parser, presets)
 
-    # Validate non-interactive args BEFORE creating the target directory
-    # (PI-20: a bad flag must not leave an empty dir behind).
+    # Validate non-interactive args / gather interactive input BEFORE creating
+    # the target directory (PI-20, PI-199: a bad flag OR a Ctrl-C at an
+    # interactive prompt must not leave an empty dir behind).
     inputs = _resolve_inputs(args, parser, target)
-    target.mkdir(parents=True, exist_ok=True)
     if inputs is None:
         inputs = _gather_inputs_interactive(default_name=target.name) + (args.no_plugin,)
+    target.mkdir(parents=True, exist_ok=True)
     (
         project_name,
         project_description,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -46,6 +46,22 @@ class TestCLI:
         assert rc == 0
         assert (tmp_target / ".claude" / "scripts" / "setup_graphify.sh").is_file()
 
+    def test_interactive_abort_at_prompt_leaves_no_dir(self, tmp_path: Path, monkeypatch):
+        """PI-199: a Ctrl-C (or error) at an interactive prompt must not leave
+        an empty target dir behind — input is gathered before the dir exists."""
+        from project_init import __main__
+
+        target = tmp_path / "aborted-proj"
+
+        def boom(**_kw):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(__main__, "_gather_inputs_interactive", boom)
+        with pytest.raises(KeyboardInterrupt):
+            # Interactive (no --non-interactive); --preset skips the preset prompt.
+            __main__.main([str(target), "--preset", "obsidian-only"])
+        assert not target.exists()
+
     def test_non_interactive_requires_flags(self):
         from project_init.__main__ import main
 


### PR DESCRIPTION
## Summary

Non-interactive runs validate args before `target.mkdir` (PI-20), but the **interactive** path gathered input *after* the `mkdir`:

```python
inputs = _resolve_inputs(...)       # None for interactive
target.mkdir(...)                   # dir created here
if inputs is None:
    inputs = _gather_inputs_interactive(...)   # prompts here
```

So `project-init /tmp/new` + Ctrl-C at the first prompt left an empty `/tmp/new` behind.

## Fix

Gather interactive input **before** `mkdir`, so no directory is created until the inputs are in hand. Non-interactive validation order is unchanged.

## Test

Adds `test_interactive_abort_at_prompt_leaves_no_dir` — monkeypatches the gather to raise `KeyboardInterrupt` and asserts the target dir was never created.

Closes #199
