### PR TITLE
docs(PI-192): add ADRs 005-012 and the usage guide to the docs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,11 +20,21 @@ theme:
 
 nav:
   - Home: README.md
+  - Guide:
+    - Using project-init: guides/using-project-init.md
   - Architecture Decisions:
     - Overview: adr/adr-001-scaffolder-design.md
     - dot_ prefix convention: adr/adr-002-dotglob-template-convention.md
     - GitHub-native workflow: adr/adr-003-github-native-workflow.md
     - Obsidian + docs integration: adr/adr-004-obsidian-docs-integration.md
+    - PR & board lifecycle: adr/adr-005-github-pr-board-workflow.md
+    - Conventional commit titles: adr/adr-006-conventional-commit-titles.md
+    - Security enforcement layers: adr/adr-007-security-enforcement-layers.md
+    - Distribution channel: adr/adr-008-distribution-channel.md
+    - Graphify memory preset: adr/adr-009-graphify-memory-preset.md
+    - Plugin marketplace dual-ship: adr/adr-010-plugin-marketplace-dual-ship.md
+    - PyPI trusted publishing: adr/adr-011-pypi-trusted-publishing.md
+    - Prod-safety guard: adr/adr-012-prod-safety-guard.md
   - Development:
     - Template system: development/template-system.md
     - Testing: development/testing.md

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -99,6 +99,20 @@ class TestVersionConsistency:
         assert "adr-008" in content
 
 
+class TestDocsNavCompleteness:
+    """PI-192: every ADR and the usage guide must be reachable from the docs
+    nav — they kept silently falling off as new ADRs were added."""
+
+    def test_all_adrs_in_mkdocs_nav(self):
+        nav = (_REPO_ROOT / "mkdocs.yml").read_text()
+        for adr in sorted((_REPO_ROOT / "docs" / "adr").glob("adr-0*.md")):
+            assert adr.name in nav, f"{adr.name} missing from mkdocs.yml nav"
+
+    def test_usage_guide_in_mkdocs_nav(self):
+        nav = (_REPO_ROOT / "mkdocs.yml").read_text()
+        assert "guides/using-project-init.md" in nav
+
+
 class TestPyPIPublishing:
     """ADR-011: trusted publishing from the release workflow."""
 

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -105,8 +105,12 @@ class TestDocsNavCompleteness:
 
     def test_all_adrs_in_mkdocs_nav(self):
         nav = (_REPO_ROOT / "mkdocs.yml").read_text()
-        for adr in sorted((_REPO_ROOT / "docs" / "adr").glob("adr-0*.md")):
-            assert adr.name in nav, f"{adr.name} missing from mkdocs.yml nav"
+        # Glob adr-*.md (not adr-0*) so coverage survives past adr-100, and assert
+        # the exact nav path so an unrelated mention can't satisfy it (PI-192 review).
+        adrs = sorted((_REPO_ROOT / "docs" / "adr").glob("adr-*.md"))
+        assert adrs, "no ADRs found — check the glob/path"
+        for adr in adrs:
+            assert f"adr/{adr.name}" in nav, f"{adr.name} missing from mkdocs.yml nav"
 
     def test_usage_guide_in_mkdocs_nav(self):
         nav = (_REPO_ROOT / "mkdocs.yml").read_text()


### PR DESCRIPTION
## Summary
`mkdocs.yml` listed only ADRs 001–004; ADRs 005–012 and `docs/guides/using-project-init.md` existed but were **unreachable** on the published site.

## Fix
Add all eight missing ADRs (with descriptive labels) and a **Guide** section to the nav.

## Test
`TestDocsNavCompleteness` asserts every `docs/adr/adr-*.md` and the guide are referenced in `mkdocs.yml` — a new ADR can't silently fall off again.

Closes #192