### PR TITLE
docs(PI-193): note ADR-006 supersession in ADR-003 and ADR-005

### DIFF
--- a/docs/adr/adr-003-github-native-workflow.md
+++ b/docs/adr/adr-003-github-native-workflow.md
@@ -1,7 +1,7 @@
 # ADR-003: GitHub-native project management — GitHub Projects + Issues over Linear
 
 **Date:** 2026-04-27
-**Status:** Accepted
+**Status:** Accepted — superseded in part by [ADR-006](adr-006-conventional-commit-titles.md) (the PR/commit title format)
 
 ## Context
 

--- a/docs/adr/adr-005-github-pr-board-workflow.md
+++ b/docs/adr/adr-005-github-pr-board-workflow.md
@@ -1,7 +1,7 @@
 # ADR-005: GitHub PR and board lifecycle workflow
 
 **Date:** 2026-04-27
-**Status:** Accepted
+**Status:** Accepted — superseded in part by [ADR-006](adr-006-conventional-commit-titles.md) (the PR/commit title format)
 
 ## Context
 

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -132,5 +132,9 @@ def test_superseded_adrs_note_adr_006():
     Status line must say so rather than read a bare 'Accepted'."""
     for name in ("adr-003-github-native-workflow.md", "adr-005-github-pr-board-workflow.md"):
         adr = (_REPO_ROOT / "docs" / "adr" / name).read_text()
-        status = next(line for line in adr.splitlines() if line.startswith("**Status:**"))
+        status = next(
+            (line for line in adr.splitlines() if line.startswith("**Status:**")),
+            None,
+        )
+        assert status is not None, f"{name} has no **Status:** line"
         assert "ADR-006" in status, f"{name} status must note the ADR-006 supersession"

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -125,3 +125,12 @@ class TestBranchProtectionBootstrap:
         script = _SETUP_GITHUB.read_text()
         assert '"CI / Lint and test"' in script
         assert '"CI / Secret scan (gitleaks)"' in script
+
+
+def test_superseded_adrs_note_adr_006():
+    """PI-193: ADR-003/005's PR-title rule was superseded by ADR-006; their
+    Status line must say so rather than read a bare 'Accepted'."""
+    for name in ("adr-003-github-native-workflow.md", "adr-005-github-pr-board-workflow.md"):
+        adr = (_REPO_ROOT / "docs" / "adr" / name).read_text()
+        status = next(line for line in adr.splitlines() if line.startswith("**Status:**"))
+        assert "ADR-006" in status, f"{name} status must note the ADR-006 supersession"


### PR DESCRIPTION
## Summary
ADR-006 (conventional-commit titles) superseded the PR/commit-title format defined in ADR-003 and ADR-005, but both still read `Status: Accepted` with no note — reading either standalone yields a title rule that contradicts current practice. (ADR-008 was correctly annotated when ADR-011 superseded it; these two were missed.)

## Fix
Add `superseded in part by ADR-006 (the PR/commit title format)` to both Status lines, with a link. The rest of each ADR's decision stands.

## Test
`test_superseded_adrs_note_adr_006` asserts both Status lines reference ADR-006.

Closes #193