### PR TITLE
docs(PI-194): fix README phantom examples/ and justfile test-cov comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ project-init/
 │   ├── obsidian/             # Obsidian vault overlay (both presets)
 │   ├── graphify/             # Graphify memory overlay
 │   └── presets/              # toml preset definitions
-├── examples/                 # sample scaffolded outputs
 └── tests/                    # focused pytest modules by behavior area
 ```
 

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -18,7 +18,7 @@ format:
 test:
     uv run --with pytest-xdist pytest -n auto --tb=short -q
 
-# tests with the coverage gate (what CI runs)
+# tests with the coverage gate (CI runs this when pytest-cov is installed)
 test-cov:
     uv run --with pytest-xdist --with pytest-cov pytest -n auto --tb=short -q --cov --cov-fail-under=70
 

--- a/tests/integration/test_readme_examples.py
+++ b/tests/integration/test_readme_examples.py
@@ -64,3 +64,12 @@ class TestREADMEExampleCommand:
         assert (target / ".claude" / "hooks" / "dag_workflow.py").is_file()
         assert not (target / ".claude" / "hooks" / "post_edit_lint.sh").exists()
         assert (target / ".github" / "hooks" / "pre-commit").is_file()
+
+
+def test_readme_layout_has_no_phantom_examples_dir():
+    """PI-194: the README repo-layout listed examples/ which doesn't exist
+    (it was removed per #24); the docs and tree must stay in sync."""
+    repo = Path(__file__).resolve().parents[2]
+    readme = (repo / "README.md").read_text()
+    if "examples/" in readme:
+        assert (repo / "examples").is_dir(), "README references examples/ but it doesn't exist"

--- a/tests/integration/test_readme_examples.py
+++ b/tests/integration/test_readme_examples.py
@@ -67,9 +67,14 @@ class TestREADMEExampleCommand:
 
 
 def test_readme_layout_has_no_phantom_examples_dir():
-    """PI-194: the README repo-layout listed examples/ which doesn't exist
-    (it was removed per #24); the docs and tree must stay in sync."""
+    """PI-194: guard against a phantom examples/ reference anywhere in README.md.
+
+    The README previously mentioned an examples/ directory (removed per #24) that
+    never existed on disk. This test scans the entire README — not just the
+    repo-layout section — and fails if any "examples/" reference appears without a
+    matching examples/ directory, keeping the docs and tree in sync.
+    """
     repo = Path(__file__).resolve().parents[2]
-    readme = (repo / "README.md").read_text()
+    readme = (repo / "README.md").read_text(encoding="utf-8")
     if "examples/" in readme:
         assert (repo / "examples").is_dir(), "README references examples/ but it doesn't exist"


### PR DESCRIPTION
## Summary
Two genuine doc-accuracy nits from #194:
- **README** repo-layout listed `examples/`, which doesn't exist (removed per #24 in favor of a README-command test). Dropped, plus a drift test that only permits the README to mention `examples/` if the directory exists.
- **justfile.tmpl** `test-cov` was commented `(what CI runs)` while the `ci:` recipe runs plain `test`. Reworded to `(CI runs this when pytest-cov is installed)` to match `ci.yml`.

## Not changed
- The **install_hooks** "symlink" comment (also listed in #194) was already corrected in #223 (PI-204).
- The **add_hook** event list was **verified against the current Claude Code hook docs** (code.claude.com/docs/en/hooks.md) — every event it lists is valid and `PreToolUse`/`PostToolUse` are present. That part of #194 was a false positive; `add_hook` is left unchanged.

Closes #194