### PR TITLE
test(PI-195): cover the interactive wizard leaf parsers and install.sh

### DIFF
--- a/tests/integration/test_install_script.py
+++ b/tests/integration/test_install_script.py
@@ -28,10 +28,18 @@ def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
     bindir = tmp_path / "bin"
     bindir.mkdir()
     # Stub the external tools so the bootstrap runs without network or installs.
-    for tool in ("uv", "git"):
-        stub = bindir / tool
-        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
-        stub.chmod(0o755)
+    # uv is a pure no-op; git minimally emulates `clone <url> <dest>` by creating
+    # <dest>/.git, so install.sh runs against a real clone directory instead of an
+    # all-no-op stub that hides whether the clone path actually ran (PI-195 review).
+    (bindir / "uv").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (bindir / "uv").chmod(0o755)
+    git_stub = bindir / "git"
+    git_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = clone ]; then mkdir -p "${@: -1}/.git"; fi\n'
+        "exit 0\n"
+    )
+    git_stub.chmod(0o755)
 
     env = {
         "HOME": str(home),
@@ -43,6 +51,8 @@ def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
         ["bash", str(_INSTALL_SH)], capture_output=True, text=True, env=env
     )
     assert result.returncode == 0, result.stdout + result.stderr
+    # The clone branch must have run (not the "update existing clone" path).
+    assert (tmp_path / "install" / ".git").is_dir(), "install.sh must clone into INSTALL_DIR"
 
     cmd = home / ".claude" / "commands" / "project-init.md"
     assert cmd.is_file(), "install.sh must write the /project-init slash command"

--- a/tests/integration/test_install_script.py
+++ b/tests/integration/test_install_script.py
@@ -1,0 +1,49 @@
+"""PI-195: execution coverage for install.sh (the curl|bash bootstrap).
+
+It was previously only string-checked (read as text), never run. Here we run
+it for real with stubbed `uv`/`git` and `PROJECT_INIT_REF=main` so no network
+or actual installs happen, and assert it completes and writes the slash command.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "install.sh"
+
+
+def test_install_sh_syntax_is_valid():
+    result = subprocess.run(
+        ["bash", "-n", str(_INSTALL_SH)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    # Stub the external tools so the bootstrap runs without network or installs.
+    for tool in ("uv", "git"):
+        stub = bindir / tool
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+        stub.chmod(0o755)
+
+    env = {
+        "HOME": str(home),
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "PROJECT_INIT_REF": "main",  # short-circuits the network ref resolution
+        "PROJECT_INIT_HOME": str(tmp_path / "install"),
+    }
+    result = subprocess.run(
+        ["bash", str(_INSTALL_SH)], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    cmd = home / ".claude" / "commands" / "project-init.md"
+    assert cmd.is_file(), "install.sh must write the /project-init slash command"
+    assert "project-init" in cmd.read_text()

--- a/tests/unit/test_interactive_prompts.py
+++ b/tests/unit/test_interactive_prompts.py
@@ -1,0 +1,50 @@
+"""PI-195: execution coverage for the interactive wizard leaf parsers.
+
+These were previously reached only via stubs (every leaf was monkeypatched
+away in the integration tests), so their number-parsing / dedup / fallback
+branches never actually ran. Here we drive them directly with canned prompts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from project_init import __main__
+from project_init.mcps import MCP_CATALOG
+
+
+def test_choose_preset_interactive_out_of_range_falls_back(monkeypatch):
+    presets = [{"name": "a", "description": "x"}, {"name": "b", "description": "y"}]
+    monkeypatch.setattr("rich.prompt.IntPrompt.ask", lambda *a, **k: 99)
+    assert __main__._choose_preset_interactive(presets) is presets[0]
+
+
+def test_choose_preset_interactive_valid_choice(monkeypatch):
+    presets = [{"name": "a", "description": "x"}, {"name": "b", "description": "y"}]
+    monkeypatch.setattr("rich.prompt.IntPrompt.ask", lambda *a, **k: 2)
+    assert __main__._choose_preset_interactive(presets) is presets[1]
+
+
+def test_choose_mcps_interactive_parses_and_dedups(monkeypatch):
+    # Duplicates collapse; out-of-range and non-numeric tokens are ignored.
+    monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "1,1,99,abc")
+    selected = __main__._choose_mcps_interactive(MCP_CATALOG)
+    assert [m["id"] for m in selected] == [MCP_CATALOG[0]["id"]]
+
+
+def test_choose_mcps_interactive_empty_skips(monkeypatch):
+    monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "")
+    assert __main__._choose_mcps_interactive(MCP_CATALOG) == []
+
+
+@pytest.mark.parametrize(
+    ("choice", "expected"),
+    [(1, None), (2, "postgres"), (3, "sqlite")],
+)
+def test_choose_db_interactive_maps_choices(monkeypatch, choice, expected):
+    monkeypatch.setattr("rich.prompt.IntPrompt.ask", lambda *a, **k: choice)
+    result = __main__._choose_db_interactive()
+    if expected is None:
+        assert result is None
+    else:
+        assert result["id"] == expected


### PR DESCRIPTION
## Summary
Two areas had zero execution coverage:
- **Wizard leaf parsers** (`_choose_preset_interactive`, `_choose_mcps_interactive`, `_choose_db_interactive`) — the integration tests monkeypatched every leaf away, so their number-parse/dedup/out-of-range branches never ran.
- **install.sh** — the 125-line curl|bash bootstrap was only read as text, never run.

## Tests added
- `tests/unit/test_interactive_prompts.py` — drives each leaf parser directly with canned prompts (out-of-range fallback, comma-parse + dedup, empty-skip, db mapping).
- `tests/integration/test_install_script.py` — `bash -n` syntax gate + an end-to-end run with **stubbed uv/git** and `PROJECT_INIT_REF=main` (no network/installs), asserting the `/project-init` slash command is written.

Both are new files (no overlap with other open PRs).

Closes #195