### PR TITLE
chore(PI-200): validate-pr verifies title key matches the Closes number

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -63,17 +63,31 @@ jobs:
             exit 1
           fi
 
+          # Extract the issue key from the title scope, e.g. fix(PI-7): ... -> PI-7.
+          TITLE_KEY=$(echo "$PR_TITLE" | sed -nE 's/.*\(([A-Z][A-Z0-9]*-[0-9]+)\).*/\1/p')
+          TITLE_KEY_NUM=$(echo "$TITLE_KEY" | grep -oE '[0-9]+$' || true)
+
+          # Defense in depth: when the branch is *also* issue-linked, its key must
+          # match the title scope key. Otherwise a PR on branch fix/PI-99-* with
+          # title fix(PI-1): ... + body "Closes #1" passes every other check while
+          # closing the wrong issue off the wrong branch (PI-200 review).
+          BRANCH_KEY_NUM=$(echo "$PR_BRANCH" | sed -nE 's#^(feat|fix|chore|docs|test)/[A-Z][A-Z0-9]*-([0-9]+)-.*#\2#p')
+          if [ -n "$TITLE_KEY_NUM" ] && [ -n "$BRANCH_KEY_NUM" ] && [ "$TITLE_KEY_NUM" != "$BRANCH_KEY_NUM" ]; then
+            echo "ERROR: branch issue key (#$BRANCH_KEY_NUM) and title scope key ($TITLE_KEY -> #$TITLE_KEY_NUM) reference different issues."
+            echo "Rename the branch or fix the title so both point at the same issue."
+            exit 1
+          fi
+
           # Verify the title scope key number is among the Closes numbers — a
-          # `type(PI-N): ...` PR must `Closes #N` (PI-N maps to issue #N), so it
+          # type(PI-N): ... PR must Closes #N (PI-N maps to issue #N), so it
           # can't auto-close an unrelated issue (PI-200).
-          TITLE_KEY_NUM=$(echo "$PR_TITLE" | sed -nE 's/.*\([A-Z][A-Z0-9]*-([0-9]+)\).*/\1/p')
           if [ -n "$TITLE_KEY_NUM" ]; then
             CLOSES_NUMS=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | grep -oE '[0-9]+' || true)
             if echo "$CLOSES_NUMS" | grep -qx "$TITLE_KEY_NUM"; then
-              echo "Closes #$TITLE_KEY_NUM matches the title scope key"
+              echo "Closes #$TITLE_KEY_NUM matches the title scope key $TITLE_KEY"
             else
-              echo "ERROR: title scope key (#$TITLE_KEY_NUM) is not among the Closes numbers: $(echo $CLOSES_NUMS | tr '\n' ' ')"
-              echo "A 'type(KEY-$TITLE_KEY_NUM): ...' PR must 'Closes #$TITLE_KEY_NUM' — PI-N maps to issue #N."
+              echo "ERROR: title scope key $TITLE_KEY (#$TITLE_KEY_NUM) is not among the Closes numbers: $(echo $CLOSES_NUMS | tr '\n' ' ')"
+              echo "A '$TITLE_KEY' PR must 'Closes #$TITLE_KEY_NUM' — PI-N maps to issue #N."
               exit 1
             fi
           fi

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -62,3 +62,18 @@ jobs:
             echo "ERROR: PR body must include 'Closes #<number>' to auto-close the linked issue"
             exit 1
           fi
+
+          # Verify the title scope key number is among the Closes numbers — a
+          # `type(PI-N): ...` PR must `Closes #N` (PI-N maps to issue #N), so it
+          # can't auto-close an unrelated issue (PI-200).
+          TITLE_KEY_NUM=$(echo "$PR_TITLE" | sed -nE 's/.*\([A-Z][A-Z0-9]*-([0-9]+)\).*/\1/p')
+          if [ -n "$TITLE_KEY_NUM" ]; then
+            CLOSES_NUMS=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+            if echo "$CLOSES_NUMS" | grep -qx "$TITLE_KEY_NUM"; then
+              echo "Closes #$TITLE_KEY_NUM matches the title scope key"
+            else
+              echo "ERROR: title scope key (#$TITLE_KEY_NUM) is not among the Closes numbers: $(echo $CLOSES_NUMS | tr '\n' ' ')"
+              echo "A 'type(KEY-$TITLE_KEY_NUM): ...' PR must 'Closes #$TITLE_KEY_NUM' — PI-N maps to issue #N."
+              exit 1
+            fi
+          fi

--- a/tests/contracts/test_repo_validate_pr.py
+++ b/tests/contracts/test_repo_validate_pr.py
@@ -1,0 +1,62 @@
+"""PI-200: the root validate-pr workflow must verify the PR title's scope key
+number is among the Closes numbers — a `type(PI-N): ...` PR must `Closes #N`
+(PI-N maps to issue #N), so it can't auto-close an unrelated issue.
+
+The workflow's added check is mirrored here so its bash logic can be exercised
+directly with sample inputs; a content test guards that the workflow keeps it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Mirror of the check in .github/workflows/validate-pr.yml (closes-keyword job).
+_CHECK = r"""
+set -eo pipefail
+TITLE_KEY_NUM=$(echo "$PR_TITLE" | sed -nE 's/.*\([A-Z][A-Z0-9]*-([0-9]+)\).*/\1/p')
+if [ -n "$TITLE_KEY_NUM" ]; then
+  CLOSES_NUMS=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | grep -oE '[0-9]+' || true)
+  if echo "$CLOSES_NUMS" | grep -qx "$TITLE_KEY_NUM"; then
+    echo "MATCH"
+  else
+    echo "MISMATCH"; exit 1
+  fi
+fi
+"""
+
+
+def _run(title: str, body: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PR_TITLE": title, "PR_BODY": body}
+    return subprocess.run(
+        ["bash", "-c", _CHECK], env=env, capture_output=True, text=True
+    )
+
+
+def test_workflow_keeps_the_key_match_check():
+    wf = (_REPO_ROOT / ".github" / "workflows" / "validate-pr.yml").read_text()
+    assert "TITLE_KEY_NUM" in wf
+    assert "is not among the Closes numbers" in wf
+
+
+def test_matching_key_and_closes_passes():
+    r = _run("fix(PI-99): bug", "Closes #99")
+    assert r.returncode == 0 and "MATCH" in r.stdout
+
+
+def test_mismatched_key_and_closes_fails():
+    r = _run("fix(PI-99): bug", "Closes #1")
+    assert r.returncode == 1 and "MISMATCH" in r.stdout
+
+
+def test_scopeless_title_is_not_checked():
+    r = _run("fix: typo", "")
+    assert r.returncode == 0
+
+
+def test_multiple_closes_with_key_among_them_passes():
+    r = _run("fix(PI-99): bug", "Closes #1\nCloses #99")
+    assert r.returncode == 0 and "MATCH" in r.stdout

--- a/tests/contracts/test_repo_validate_pr.py
+++ b/tests/contracts/test_repo_validate_pr.py
@@ -17,7 +17,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # Mirror of the check in .github/workflows/validate-pr.yml (closes-keyword job).
 _CHECK = r"""
 set -eo pipefail
-TITLE_KEY_NUM=$(echo "$PR_TITLE" | sed -nE 's/.*\([A-Z][A-Z0-9]*-([0-9]+)\).*/\1/p')
+TITLE_KEY=$(echo "$PR_TITLE" | sed -nE 's/.*\(([A-Z][A-Z0-9]*-[0-9]+)\).*/\1/p')
+TITLE_KEY_NUM=$(echo "$TITLE_KEY" | grep -oE '[0-9]+$' || true)
+BRANCH_KEY_NUM=$(echo "$PR_BRANCH" | sed -nE 's#^(feat|fix|chore|docs|test)/[A-Z][A-Z0-9]*-([0-9]+)-.*#\2#p')
+if [ -n "$TITLE_KEY_NUM" ] && [ -n "$BRANCH_KEY_NUM" ] && [ "$TITLE_KEY_NUM" != "$BRANCH_KEY_NUM" ]; then
+  echo "BRANCH_MISMATCH"; exit 1
+fi
 if [ -n "$TITLE_KEY_NUM" ]; then
   CLOSES_NUMS=$(echo "$PR_BODY" | grep -oiE 'closes\s+#[0-9]+' | grep -oE '[0-9]+' || true)
   if echo "$CLOSES_NUMS" | grep -qx "$TITLE_KEY_NUM"; then
@@ -29,8 +34,8 @@ fi
 """
 
 
-def _run(title: str, body: str) -> subprocess.CompletedProcess:
-    env = {**os.environ, "PR_TITLE": title, "PR_BODY": body}
+def _run(title: str, body: str, branch: str = "") -> subprocess.CompletedProcess:
+    env = {**os.environ, "PR_TITLE": title, "PR_BODY": body, "PR_BRANCH": branch}
     return subprocess.run(
         ["bash", "-c", _CHECK], env=env, capture_output=True, text=True
     )
@@ -40,6 +45,28 @@ def test_workflow_keeps_the_key_match_check():
     wf = (_REPO_ROOT / ".github" / "workflows" / "validate-pr.yml").read_text()
     assert "TITLE_KEY_NUM" in wf
     assert "is not among the Closes numbers" in wf
+    # The branch/title consistency guard must stay too (PI-200 review).
+    assert "BRANCH_KEY_NUM" in wf
+    assert "reference different issues" in wf
+
+
+def test_branch_and_title_key_must_agree():
+    # Copilot scenario: issue-linked branch PI-99, title scope PI-1, Closes #1.
+    # The title<->Closes check alone passes, but the wrong issue would close.
+    r = _run("fix(PI-1): bug", "Closes #1", branch="fix/PI-99-bug")
+    assert r.returncode == 1 and "BRANCH_MISMATCH" in r.stdout
+
+
+def test_matching_branch_and_title_key_passes():
+    r = _run("fix(PI-99): bug", "Closes #99", branch="fix/PI-99-bug")
+    assert r.returncode == 0 and "MATCH" in r.stdout
+
+
+def test_scopeless_title_with_issue_branch_is_not_key_checked():
+    # A scopeless title has no key to compare; the branch-link rule is enforced
+    # earlier in the workflow, not by this numeric consistency check.
+    r = _run("fix: typo", "", branch="fix/PI-99-bug")
+    assert r.returncode == 0
 
 
 def test_matching_key_and_closes_passes():


### PR DESCRIPTION
## Summary
The root `validate-pr.yml` required *a* `Closes #N` for issue PRs but never checked that N matched the title's scope key. Since PI-N maps to issue #N in this repo, a PR titled `fix(PI-99): …` with `Closes #1` passed validation and would auto-close the **wrong** issue.

## Fix
After confirming a `Closes` exists, extract the title scope key number and require it to be **among** the Closes numbers (so multi-issue PRs still work). Scopeless/no-issue and legacy-bracket titles are unaffected.

## Test
`tests/contracts/test_repo_validate_pr.py` exercises the extracted bash logic — matching key passes, mismatched fails, scopeless is skipped, multi-Closes-with-key passes — plus a content guard that the workflow keeps the check.

Closes #200