### PR TITLE
fix(PI-187): parse multi-line YAML safety.allow lists, not just inline JSON

### DIFF
--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -65,7 +65,11 @@ def _find_config(start: Path) -> Path | None:
 
 
 def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
-    """Read the safety.allow JSON list from .claude/config.yaml (fail-open).
+    """Read the safety.allow list from .claude/config.yaml (fail-open).
+
+    Accepts both an inline JSON list (``allow: ["a", "b"]``) and a multi-line
+    YAML list (``allow:`` on its own line followed by ``- "a"`` items). The
+    inline-only parser silently dropped the natural YAML form to ``[]`` (PI-187).
 
     *root* is the Bash tool's cwd, which may be a subdirectory after `cd` —
     the config is located by walking up the tree.
@@ -73,22 +77,34 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
     config = _find_config(root)
     if config is None:
         return []
+    patterns: list[str] = []
     try:
         in_safety = False
+        in_allow = False
         for line in config.read_text(encoding="utf-8").splitlines():
             if line.startswith("safety:"):
                 in_safety = True
                 continue
-            if in_safety:
-                if line.strip() and not line.startswith(" "):
-                    break
-                stripped = line.strip()
-                if stripped.startswith("allow:"):
-                    raw = stripped.split(":", 1)[1].strip()
-                    return [re.compile(p) for p in json.loads(raw)]
+            if not in_safety:
+                continue
+            if line.strip() and not line.startswith((" ", "\t")):
+                break  # a column-0 key ends the safety block
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if in_allow and stripped.startswith("- "):
+                patterns.append(stripped[2:].strip().strip("\"'"))
+                continue
+            in_allow = False
+            if stripped.startswith("allow:"):
+                raw = stripped.split(":", 1)[1].strip()
+                if raw:
+                    patterns.extend(json.loads(raw))  # inline JSON list
+                else:
+                    in_allow = True  # multi-line YAML list follows
+        return [re.compile(p) for p in patterns if p]
     except (OSError, json.JSONDecodeError, re.error):
-        pass
-    return []
+        return []
 
 
 def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -64,6 +64,15 @@ def _find_config(start: Path) -> Path | None:
     return None
 
 
+def _unquote(value: str) -> str:
+    """Strip one pair of matching surrounding quotes, leaving mismatched or
+    single quotes intact so ``'foo"`` is not silently corrupted (PI-187 review).
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
 def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
     """Read the safety.allow list from .claude/config.yaml (fail-open).
 
@@ -93,13 +102,19 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
             if not stripped or stripped.startswith("#"):
                 continue
             if in_allow and stripped.startswith("- "):
-                patterns.append(stripped[2:].strip().strip("\"'"))
+                patterns.append(_unquote(stripped[2:].strip()))
                 continue
             in_allow = False
             if stripped.startswith("allow:"):
                 raw = stripped.split(":", 1)[1].strip()
                 if raw:
-                    patterns.extend(json.loads(raw))  # inline JSON list
+                    parsed = json.loads(raw)  # inline JSON list
+                    # A non-list allow (JSON string/object/number) must not be
+                    # iterated character-by-character into an over-permissive
+                    # allowlist or crash the guard — ignore it and keep
+                    # guarding (PI-187 review).
+                    if isinstance(parsed, list):
+                        patterns.extend(p for p in parsed if isinstance(p, str))
                 else:
                     in_allow = True  # multi-line YAML list follows
         return [re.compile(p) for p in patterns if p]

--- a/templates/fallback/dot_claude/hooks/prod_guard.py
+++ b/templates/fallback/dot_claude/hooks/prod_guard.py
@@ -65,7 +65,11 @@ def _find_config(start: Path) -> Path | None:
 
 
 def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
-    """Read the safety.allow JSON list from .claude/config.yaml (fail-open).
+    """Read the safety.allow list from .claude/config.yaml (fail-open).
+
+    Accepts both an inline JSON list (``allow: ["a", "b"]``) and a multi-line
+    YAML list (``allow:`` on its own line followed by ``- "a"`` items). The
+    inline-only parser silently dropped the natural YAML form to ``[]`` (PI-187).
 
     *root* is the Bash tool's cwd, which may be a subdirectory after `cd` —
     the config is located by walking up the tree.
@@ -73,22 +77,34 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
     config = _find_config(root)
     if config is None:
         return []
+    patterns: list[str] = []
     try:
         in_safety = False
+        in_allow = False
         for line in config.read_text(encoding="utf-8").splitlines():
             if line.startswith("safety:"):
                 in_safety = True
                 continue
-            if in_safety:
-                if line.strip() and not line.startswith(" "):
-                    break
-                stripped = line.strip()
-                if stripped.startswith("allow:"):
-                    raw = stripped.split(":", 1)[1].strip()
-                    return [re.compile(p) for p in json.loads(raw)]
+            if not in_safety:
+                continue
+            if line.strip() and not line.startswith((" ", "\t")):
+                break  # a column-0 key ends the safety block
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if in_allow and stripped.startswith("- "):
+                patterns.append(stripped[2:].strip().strip("\"'"))
+                continue
+            in_allow = False
+            if stripped.startswith("allow:"):
+                raw = stripped.split(":", 1)[1].strip()
+                if raw:
+                    patterns.extend(json.loads(raw))  # inline JSON list
+                else:
+                    in_allow = True  # multi-line YAML list follows
+        return [re.compile(p) for p in patterns if p]
     except (OSError, json.JSONDecodeError, re.error):
-        pass
-    return []
+        return []
 
 
 def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:

--- a/templates/fallback/dot_claude/hooks/prod_guard.py
+++ b/templates/fallback/dot_claude/hooks/prod_guard.py
@@ -64,6 +64,15 @@ def _find_config(start: Path) -> Path | None:
     return None
 
 
+def _unquote(value: str) -> str:
+    """Strip one pair of matching surrounding quotes, leaving mismatched or
+    single quotes intact so ``'foo"`` is not silently corrupted (PI-187 review).
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
 def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
     """Read the safety.allow list from .claude/config.yaml (fail-open).
 
@@ -93,13 +102,19 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
             if not stripped or stripped.startswith("#"):
                 continue
             if in_allow and stripped.startswith("- "):
-                patterns.append(stripped[2:].strip().strip("\"'"))
+                patterns.append(_unquote(stripped[2:].strip()))
                 continue
             in_allow = False
             if stripped.startswith("allow:"):
                 raw = stripped.split(":", 1)[1].strip()
                 if raw:
-                    patterns.extend(json.loads(raw))  # inline JSON list
+                    parsed = json.loads(raw)  # inline JSON list
+                    # A non-list allow (JSON string/object/number) must not be
+                    # iterated character-by-character into an over-permissive
+                    # allowlist or crash the guard — ignore it and keep
+                    # guarding (PI-187 review).
+                    if isinstance(parsed, list):
+                        patterns.extend(p for p in parsed if isinstance(p, str))
                 else:
                     in_allow = True  # multi-line YAML list follows
         return [re.compile(p) for p in patterns if p]

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -145,6 +145,18 @@ class TestVerdicts:
         )
         assert verdict is not None, "broken allowlist must not disable the guard"
 
+    def test_scalar_inline_allow_does_not_overpermit(self, tmp_path: Path):
+        """A scalar `allow:` (valid JSON string/object, not a list) must not be
+        iterated character-by-character into an allowlist whose single-char
+        patterns silently suppress every command (PI-187 review)."""
+        config = tmp_path / ".claude" / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text('safety:\n  allow: "terraform destroy"\n')
+        verdict = _run_hook(
+            _payload("terraform destroy", "bypassPermissions", tmp_path), tmp_path
+        )
+        assert verdict is not None, "a scalar allow must not disable the guard"
+
 
 class TestWiring:
     def test_fallback_settings_wire_the_guard(self, tmp_path: Path):

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -110,6 +110,20 @@ class TestVerdicts:
         payload = _payload(command, "bypassPermissions", subdir)
         assert _run_hook(payload, subdir) is None
 
+    def test_allowlist_multiline_yaml_suppresses_flag(self, tmp_path: Path):
+        """PI-187: a multi-line YAML allow list must work, not just inline JSON
+        — the old parser silently dropped it to []."""
+        config = tmp_path / ".claude" / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text(
+            'safety:\n  allow:\n    - "kubectl delete .* --context kind-dev"\n'
+        )
+        command = "kubectl delete pod web --context kind-dev"
+        assert _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path) is None
+        # A verb not on the list is still blocked.
+        other = "kubectl delete pod web --context prod"
+        assert _run_hook(_payload(other, "bypassPermissions", tmp_path), tmp_path) is not None
+
     def test_garbage_stdin_fails_open(self, tmp_path: Path):
         result = subprocess.run(
             ["python3", str(_HOOK)],


### PR DESCRIPTION
## Summary

The documented `safety.allow` escape hatch in `prod_guard.py` only parsed an **inline JSON** list — `raw = allow:` remainder, then `json.loads(raw)`. A user writing the natural multi-line YAML form:

```yaml
safety:
  allow:
    - "kubectl delete .* --context kind-dev"
```

got `raw == ""` → `json.loads("")` raised → caught → `[]`. The allowlist silently did nothing, and the user's allowed commands kept getting blocked with no indication the config failed to parse.

## Fix

Parse **both** forms: inline JSON (`allow: ["a", "b"]`) and a multi-line YAML list (`allow:` followed by `- "a"` items). Fail-open behavior (a corrupt/unparseable allow → `[]`, guard still active) is unchanged. Mirrored to the plugin copy.

## Test

Adds `test_allowlist_multiline_yaml_suppresses_flag` (multi-line allow suppresses the flagged command; a non-listed command is still blocked). Existing inline + corrupt-fail-open tests still pass.

Closes #187
