### PR TITLE
chore(PI-190): ScaffoldInputs dataclass + one source for variable defaults

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
@@ -22,6 +23,28 @@ from project_init.scaffold import (
     overlay_layers,
     scaffold,
 )
+
+
+@dataclass(frozen=True)
+class ScaffoldInputs:
+    """The resolved wizard inputs as one named record (PI-190).
+
+    Replaces an 11-element positional tuple that was built and unpacked by hand
+    across the interactive, non-interactive, and main paths — where a field
+    reorder silently mis-mapped values with no error.
+    """
+
+    project_name: str
+    project_description: str
+    language: str
+    selected_mcps: list[dict]
+    owner: str
+    license_choice: str
+    devcontainer: bool
+    mise: bool
+    vscode: bool
+    agents: list[str]
+    no_plugin: bool
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -338,9 +361,7 @@ def _select_preset(
     return _choose_preset_interactive(presets)
 
 
-def _gather_inputs_interactive(
-    default_name: str,
-) -> tuple[str, str, str, list[dict], str, str, bool, bool, bool, list[str]]:
+def _gather_inputs_interactive(default_name: str, *, no_plugin: bool) -> ScaffoldInputs:
     """Prompt for project basics, MCPs, governance, and opt-in overlays."""
     project_name = _prompt("Project name", default=default_name)
     project_description = _prompt("Description", default="")
@@ -381,17 +402,18 @@ def _gather_inputs_interactive(
             from rich.console import Console
 
             Console().print(f"[red]{e}[/red]")
-    return (
-        project_name,
-        project_description,
-        language,
-        selected_mcps,
-        owner,
-        license_choice,
-        devcontainer,
-        mise,
-        vscode,
-        agents,
+    return ScaffoldInputs(
+        project_name=project_name,
+        project_description=project_description,
+        language=language,
+        selected_mcps=selected_mcps,
+        owner=owner,
+        license_choice=license_choice,
+        devcontainer=devcontainer,
+        mise=mise,
+        vscode=vscode,
+        agents=agents,
+        no_plugin=no_plugin,
     )
 
 
@@ -466,22 +488,19 @@ def _upgrade_main(argv: list[str]) -> int:
     return run_upgrade(Path(args.target).resolve(), apply=args.apply, no_plugin=args.no_plugin)
 
 
-def _build_variables(  # noqa: PLR0913 — one variable per wizard input
-    preset: dict,
-    *,
-    project_name: str,
-    project_description: str,
-    language: str,
-    selected_mcps: list[dict],
-    owner: str,
-    license_choice: str,
-    devcontainer: bool,
-    mise: bool,
-    vscode: bool,
-    agents: list[str],
-    no_plugin: bool,
-) -> dict[str, str]:
+def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
     """Assemble the template render context from the resolved inputs."""
+    project_name = inputs.project_name
+    project_description = inputs.project_description
+    language = inputs.language
+    selected_mcps = inputs.selected_mcps
+    owner = inputs.owner
+    license_choice = inputs.license_choice
+    devcontainer = inputs.devcontainer
+    mise = inputs.mise
+    vscode = inputs.vscode
+    agents = inputs.agents
+    no_plugin = inputs.no_plugin
     is_graphify = "graphify" in preset.get("name", "")
     has_obsidian = "obsidian" in preset.get("layers", [])
     lint_command, format_command, test_command = _LANGUAGE_COMMANDS.get(language, ("", "", ""))
@@ -539,7 +558,7 @@ def _build_variables(  # noqa: PLR0913 — one variable per wizard input
     }
 
 
-def _resolve_inputs(args, parser, target: Path) -> tuple | None:
+def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
     """Resolve all scaffold inputs from flags; None means prompt instead.
 
     Validation errors call ``parser.error`` (exits) BEFORE the target dir is
@@ -552,18 +571,18 @@ def _resolve_inputs(args, parser, target: Path) -> tuple | None:
         agents = resolve_agents(args.agents)
     except ValueError as e:
         parser.error(str(e))
-    return (
-        args.name,
-        args.description,
-        args.language or "none",
-        selected_mcps,
-        args.owner,
-        args.license,
-        args.devcontainer,
-        args.mise,
-        args.vscode,
-        agents,
-        args.no_plugin,
+    return ScaffoldInputs(
+        project_name=args.name,
+        project_description=args.description,
+        language=args.language or "none",
+        selected_mcps=selected_mcps,
+        owner=args.owner,
+        license_choice=args.license,
+        devcontainer=args.devcontainer,
+        mise=args.mise,
+        vscode=args.vscode,
+        agents=agents,
+        no_plugin=args.no_plugin,
     )
 
 
@@ -593,43 +612,17 @@ def main(argv: list[str] | None = None) -> int:
     inputs = _resolve_inputs(args, parser, target)
     target.mkdir(parents=True, exist_ok=True)
     if inputs is None:
-        inputs = _gather_inputs_interactive(default_name=target.name) + (args.no_plugin,)
-    (
-        project_name,
-        project_description,
-        language,
-        selected_mcps,
-        owner,
-        license_choice,
-        devcontainer,
-        mise,
-        vscode,
-        agents,
-        no_plugin,
-    ) = inputs
+        inputs = _gather_inputs_interactive(default_name=target.name, no_plugin=args.no_plugin)
 
     # Agent overlays append to the preset's layers (PI-137); --no-plugin
     # restores the shared hooks/skills copies via the fallback layer
     # (PI-165, ADR-010 cutover). The preset dict is copied so the loaded
     # definition stays pristine.
-    extra_layers = overlay_layers(agents, no_plugin=no_plugin)
+    extra_layers = overlay_layers(inputs.agents, no_plugin=inputs.no_plugin)
     if extra_layers:
         preset = {**preset, "layers": list(preset["layers"]) + extra_layers}
 
-    variables = _build_variables(
-        preset,
-        project_name=project_name,
-        project_description=project_description,
-        language=language,
-        selected_mcps=selected_mcps,
-        owner=owner,
-        license_choice=license_choice,
-        devcontainer=devcontainer,
-        mise=mise,
-        vscode=vscode,
-        agents=agents,
-        no_plugin=no_plugin,
-    )
+    variables = _build_variables(preset, inputs)
 
     # Overwrite protection (PI-179): scaffold() decides per file whether it is
     # user-owned (first scaffold, or an unresolved `.new` sibling still pending)
@@ -650,7 +643,7 @@ def main(argv: list[str] | None = None) -> int:
     _print_summary(target, created, preset["name"])
     if conflicts:
         _print_conflicts(conflicts)
-    _print_mcp_commands(selected_mcps)
+    _print_mcp_commands(inputs.selected_mcps)
     return 0
 
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -83,6 +83,33 @@ def _migrate_removed_preset(preset_name: str, variables: dict) -> tuple[str, dic
 _LANGUAGE_FLAGS = ("python", "node", "go")
 
 
+def _overlay_off_defaults() -> dict[str, str]:
+    """Opt-in overlay + governance variables in their "off" state (PI-190).
+
+    Records predating these features (PI-137/PI-145/PI-146, ADR-010 cutover)
+    re-render faithfully with them off. One source so migration and backfill
+    can't disagree on the ~16 keys they otherwise hand-built identically.
+    """
+    return {
+        "devcontainer": "",
+        "mise": "",
+        "vscode": "",
+        "agents": "claude",
+        "codex": "",
+        "gemini": "",
+        "ollama": "",
+        "multi_agent": "",
+        "other_agents": "",
+        "plugin_mode": "",
+        "no_plugin": "true",
+        "project_owner": "",
+        "license": "none",
+        "license_mit": "",
+        "license_apache": "",
+        "license_proprietary": "",
+    }
+
+
 class UpgradeError(Exception):
     """Raised when the project cannot be upgraded (missing/invalid config)."""
 
@@ -267,30 +294,12 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "justfile": "true" if language != "none" else "",
-        # Opt-in overlays (PI-146/PI-140) postdate pre-record configs:
-        # faithful as off.
-        "devcontainer": "",
-        "mise": "",
-        "vscode": "",
+        # Opt-in overlays + governance postdate pre-record configs — faithful as
+        # off; shared with backfill (PI-190). A pre-record config also predates
+        # vscode, so vscode_off is simply on.
+        **_overlay_off_defaults(),
         "vscode_off": "true",
-        "agents": "claude",
-        "codex": "",
-        "gemini": "",
-        "ollama": "",
-        "multi_agent": "",
-        "other_agents": "",
-        # Pre-cutover scaffolds shipped the file copies (ADR-010), so the
-        # faithful backfill is the fallback mode, not plugin mode.
-        "plugin_mode": "",
-        "no_plugin": "true",
-        # Governance (PI-145) postdates pre-record configs: those projects
-        # were scaffolded without a license or owner, so these are faithful.
-        "project_owner": "",
-        "license": "none",
         "license_holder": fields.get("project.name", ""),
-        "license_mit": "",
-        "license_apache": "",
-        "license_proprietary": "",
         "created_year": fields.get("project.created", "").split("-")[0],
         **_MIGRATION_DEFAULTS,
     }
@@ -321,24 +330,9 @@ def _backfill_variables(variables: dict) -> dict:
         "license_holder": v.get("project_owner") or v.get("project_name", ""),
         "created_year": v.get("created_date", "").split("-")[0],
         "vscode_off": "" if v.get("vscode") else "true",
-        # Opt-in features default off — they postdate the record.
-        "devcontainer": "",
-        "mise": "",
-        "vscode": "",
-        "agents": "claude",
-        "codex": "",
-        "gemini": "",
-        "ollama": "",
-        "multi_agent": "",
-        "other_agents": "",
-        # Records written before the cutover (ADR-010) shipped file copies.
-        "plugin_mode": "",
-        "no_plugin": "true",
-        "project_owner": "",
-        "license": "none",
-        "license_mit": "",
-        "license_apache": "",
-        "license_proprietary": "",
+        # Opt-in overlays + governance default off — they postdate the record;
+        # shared with migration (PI-190).
+        **_overlay_off_defaults(),
         **_MIGRATION_DEFAULTS,
     }
     for flag in _LANGUAGE_FLAGS:

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -59,8 +59,8 @@ class TestAgentSelection:
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 
-        result = cli._gather_inputs_interactive(default_name="proj")
-        assert result[-1] == ["claude", "codex"], "valid retry must be honored"
+        result = cli._gather_inputs_interactive(default_name="proj", no_plugin=False)
+        assert result.agents == ["claude", "codex"], "valid retry must be honored"
         assert "unknown agent(s): cursor" in capsys.readouterr().out
 
     def test_only_codex_and_gemini_contribute_layers(self):

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -445,11 +445,26 @@ class TestInteractiveNoPlugin:
         """--no-plugin without --non-interactive must not be silently
         dropped (PR #175 review)."""
         import project_init.__main__ as cli
+        from project_init.__main__ import ScaffoldInputs
 
-        canned = (
-            "proj", "desc", "python", [], "", "none", False, False, False, ["claude"],
-        )
-        monkeypatch.setattr(cli, "_gather_inputs_interactive", lambda **kw: canned)
+        def _fake_gather(**kw):
+            # Respect the no_plugin main forwards, so this still tests that the
+            # --no-plugin flag reaches the scaffold via the interactive path.
+            return ScaffoldInputs(
+                project_name="proj",
+                project_description="desc",
+                language="python",
+                selected_mcps=[],
+                owner="",
+                license_choice="none",
+                devcontainer=False,
+                mise=False,
+                vscode=False,
+                agents=["claude"],
+                no_plugin=kw["no_plugin"],
+            )
+
+        monkeypatch.setattr(cli, "_gather_inputs_interactive", _fake_gather)
         target = tmp_path / "p"
         assert cli.main([str(target), "--no-plugin", "--preset", "obsidian-only"]) == 0
         assert (target / ".claude" / "hooks" / "pre_commit_gate.sh").is_file()

--- a/tests/unit/test_scaffold_inputs.py
+++ b/tests/unit/test_scaffold_inputs.py
@@ -1,0 +1,53 @@
+"""PI-190: ScaffoldInputs (named record replacing the positional input tuple)
+and the single source for the migrate/backfill "off" variable defaults."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from project_init.__main__ import ScaffoldInputs, _build_parser, _resolve_inputs
+
+
+def test_resolve_inputs_returns_named_record():
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "x", "--non-interactive", "--preset", "obsidian-only",
+            "--name", "demo", "--description", "d", "--language", "python", "--no-plugin",
+        ]
+    )
+    inputs = _resolve_inputs(args, parser, Path("x"))
+    assert isinstance(inputs, ScaffoldInputs)
+    assert inputs.project_name == "demo"
+    assert inputs.language == "python"
+    assert inputs.agents == ["claude"]
+    assert inputs.no_plugin is True
+    assert inputs.selected_mcps == []
+
+
+def test_resolve_inputs_none_when_interactive():
+    parser = _build_parser()
+    args = parser.parse_args(["x", "--preset", "obsidian-only"])
+    assert _resolve_inputs(args, parser, Path("x")) is None
+
+
+def test_scaffold_inputs_is_frozen():
+    si = ScaffoldInputs(
+        "n", "d", "python", [], "", "none", False, False, False, ["claude"], False
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        si.project_name = "x"  # type: ignore[misc]
+
+
+def test_migrate_and_backfill_share_off_defaults():
+    """PI-190: the ~16 'off' overlay/governance defaults come from one source."""
+    from project_init.upgrade import _overlay_off_defaults
+
+    d = _overlay_off_defaults()
+    assert d["agents"] == "claude"
+    assert d["no_plugin"] == "true"
+    assert d["license"] == "none"
+    assert all(d[k] == "" for k in ("devcontainer", "mise", "vscode", "codex", "gemini"))


### PR DESCRIPTION
## Summary

The two sources-of-truth problems #190 flags:

1. **Positional input tuple.** The resolved wizard inputs were an 11-element tuple, **built and unpacked by hand in three places** — a field reorder silently mis-mapped values with no error. Replaced with a frozen `ScaffoldInputs` dataclass: `_gather_inputs_interactive`/`_resolve_inputs` return it; `main` and `_build_variables` take it. No more positional unpacking.
2. **Duplicated variable defaults.** `_migrate_semantic_config` and `_backfill_variables` each hand-built the same ~16 "off" overlay/governance variable defaults. Extracted `_overlay_off_defaults()` as the single source both spread (`**`).

Adds dataclass + shared-defaults unit tests; updated two tests that used the tuple. **Full suite green (555), ruff clean.** The migration tests (`test_migrated_inputs_re_render_faithfully`, `test_pre_record_config_upgrades`) confirm the extracted defaults render identically.

> ⚠️ **Stacked on #235 (PI-189)** — this PR's base is the `chore/PI-189` branch, so the diff shows only #190's changes. **Merge #235 first** (GitHub will retarget this to `main`). Both refactors also overlap the engine-fix PRs (#218/PI-196, #217/PI-197, #227/PI-199) — trivial import-line/adjacent rebases. Suggested order: engine-fix PRs → #235 → #236.

Closes #190
