### PR TITLE
feat(PI-214): derive scaffolded CI Python matrix from requires-python

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -13,9 +13,79 @@ permissions:
   pull-requests: write
 
 jobs:
+{{#if python}}
+  # PI-214: derive the test matrix from requires-python at runtime, so the
+  # version floor can never drift from what the project itself declares (a
+  # hardcoded matrix would reintroduce the PI-208 drift). This job reads
+  # requires-python and emits every supported version that satisfies it;
+  # lint-and-test then fans out across them. KNOWN is the only maintained
+  # list — the *ceiling* set enumerated up to; bump it (or let Renovate) when
+  # a new CPython is released. The floor is always taken from requires-python.
+  python-matrix:
+    name: Resolve Python matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      versions: ${{ steps.resolve.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Resolve versions satisfying requires-python
+        id: resolve
+        run: |
+          uv run --no-project --with packaging python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          from packaging.specifiers import SpecifierSet
+
+          # Maintained ceiling set — every CPython this template is willing to
+          # test. The floor comes from requires-python (below), never from here.
+          KNOWN = ["3.11", "3.12", "3.13", "3.14"]
+
+          spec = ""
+          pyproject = pathlib.Path("pyproject.toml")
+          if pyproject.is_file():
+              try:
+                  data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+                  spec = data.get("project", {}).get("requires-python", "") or ""
+              except (tomllib.TOMLDecodeError, OSError):
+                  spec = ""
+
+          if spec:
+              allowed = SpecifierSet(spec)
+              versions = [v for v in KNOWN if allowed.contains(v + ".0")]
+          else:
+              # No declared floor yet (e.g. a fresh scaffold) — test the full set.
+              versions = list(KNOWN)
+          if not versions:
+              # requires-python excludes every KNOWN version — fall back to the
+              # newest so CI still runs instead of erroring on an empty matrix.
+              versions = [KNOWN[-1]]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write("versions=" + json.dumps(versions) + "\n")
+          print("requires-python:", spec or "(none) -> full KNOWN set")
+          print("matrix:", versions)
+          PY
+{{/if python}}
+
   lint-and-test:
     name: Lint and test
     runs-on: ubuntu-24.04
+{{#if python}}
+    needs: python-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(needs.python-matrix.outputs.versions) }}
+{{/if python}}
     steps:
       - uses: actions/checkout@v6
 
@@ -24,11 +94,13 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.7"
+          # Pin this job to the matrix version (PI-214). Not the PI-208 drift:
+          # every matrix entry is >= the requires-python floor by construction
+          # (see the python-matrix job), so the floor can't drift below what
+          # the project declares.
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-          # No python-version pin (PI-208): `uv sync` installs the version the
-          # project requires (.python-version / requires-python), so CI never
-          # drifts below the floor. Add a matrix here to test multiple versions.
 
       # CI invokes the same justfile recipes agents and humans use (PI-139),
       # so the command surface is defined exactly once.

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -43,7 +43,7 @@ jobs:
           import pathlib
           import tomllib
 
-          from packaging.specifiers import SpecifierSet
+          from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
           # Maintained ceiling set — every CPython this template is willing to
           # test. The floor comes from requires-python (below), never from here.
@@ -59,8 +59,13 @@ jobs:
                   spec = ""
 
           if spec:
-              allowed = SpecifierSet(spec)
-              versions = [v for v in KNOWN if allowed.contains(v + ".0")]
+              try:
+                  allowed = SpecifierSet(spec)
+                  versions = [v for v in KNOWN if allowed.contains(v + ".0")]
+              except InvalidSpecifier:
+                  # Present but malformed — fall back to the full set rather
+                  # than failing the job on a bad requires-python.
+                  versions = list(KNOWN)
           else:
               # No declared floor yet (e.g. a fresh scaffold) — test the full set.
               versions = list(KNOWN)

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -55,6 +57,13 @@ class TestNodeTemplate:
             content = (self.target / ".claude" / "hooks" / hook).read_text()
             assert "node_modules/.bin/eslint" not in content
             assert "bunx eslint" in content
+
+    def test_no_python_matrix_job_in_node_template(self):
+        # PI-214: the runtime version-matrix machinery is python-only; node
+        # scaffolds must not carry the python-matrix job or its consumers.
+        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "python-matrix:" not in ci
+        assert "fromJSON(needs.python-matrix" not in ci
 
 
 class TestTemplateIdentifiers:
@@ -212,6 +221,20 @@ class TestScaffoldGitHubFiles:
             "CI must not hard-pin python-version to a literal (PI-208)"
         )
 
+    def test_ci_resolves_python_matrix_from_requires_python(self):
+        """PI-214: a setup job derives the version matrix from requires-python
+        at runtime, and lint-and-test fans out over the result — so the floor
+        is read from the project's own declaration and cannot drift (unlike a
+        hardcoded matrix, which PI-208 warned against)."""
+        content = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        # The resolver job reads requires-python and filters with packaging.
+        assert "python-matrix:" in content
+        assert "requires-python" in content
+        assert "SpecifierSet" in content
+        # lint-and-test consumes the resolved versions as its matrix.
+        assert "fromJSON(needs.python-matrix.outputs.versions)" in content
+        assert "python-version: ${{ matrix.python-version }}" in content
+
     def test_pull_request_template_created(self):
         assert (self.target / ".github" / "pull_request_template.md").is_file()
 
@@ -356,3 +379,70 @@ def test_project_validate_pr_workflow_accepts_project_keys():
     assert "[A-Z]" in content  # generic project key pattern
     assert "nojira" in content
     assert "feat|fix|chore|docs|test" in content
+
+
+class TestPythonMatrixResolution:
+    """PI-214 (Definition of Done): the matrix must be derived from
+    requires-python and must never include a version below the declared floor.
+
+    Rather than re-implement the resolver, these tests extract the *actual*
+    inline script shipped in ci.yml and execute it — so the regression guard
+    tracks the real behavior, not a copy that could silently diverge.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _resolver(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        ci = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
+        self.resolver = self._extract_resolver(ci)
+
+    @staticmethod
+    def _extract_resolver(ci_yaml: str) -> str:
+        """Pull the heredoc'd Python between `<<'PY'` and its `PY` terminator."""
+        lines = ci_yaml.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.rstrip().endswith("<<'PY'"))
+        end = next(
+            i for i, ln in enumerate(lines[start + 1 :], start + 1) if ln.strip() == "PY"
+        )
+        return textwrap.dedent("\n".join(lines[start + 1 : end]))
+
+    def _resolve(self, requires_python, tmp_path, monkeypatch) -> list[str]:
+        """Run the shipped resolver against a synthetic pyproject.toml and return
+        the matrix it would emit. `requires_python=None` omits the key entirely."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        body = '[project]\nname = "x"\n'
+        if requires_python is not None:
+            body += f'requires-python = "{requires_python}"\n'
+        (proj / "pyproject.toml").write_text(body)
+        out = tmp_path / "gh_output"
+        out.write_text("")
+        monkeypatch.chdir(proj)
+        monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+        exec(compile(self.resolver, "<ci-resolver>", "exec"), {})  # noqa: S102
+        line = next(
+            ln for ln in out.read_text().splitlines() if ln.startswith("versions=")
+        )
+        return json.loads(line.split("=", 1)[1])
+
+    def test_floor_excludes_lower_versions(self, tmp_path, monkeypatch):
+        versions = self._resolve(">=3.13", tmp_path, monkeypatch)
+        assert versions == ["3.13", "3.14"]
+        assert "3.12" not in versions and "3.11" not in versions
+
+    def test_low_floor_includes_more(self, tmp_path, monkeypatch):
+        versions = self._resolve(">=3.11", tmp_path, monkeypatch)
+        assert versions[0] == "3.11"
+        assert "3.14" in versions
+
+    def test_upper_bound_respected(self, tmp_path, monkeypatch):
+        versions = self._resolve(">=3.11,<3.13", tmp_path, monkeypatch)
+        assert versions == ["3.11", "3.12"]
+
+    def test_missing_requires_python_falls_back_to_full_set(self, tmp_path, monkeypatch):
+        versions = self._resolve(None, tmp_path, monkeypatch)
+        assert versions == ["3.11", "3.12", "3.13", "3.14"]
+
+    def test_no_satisfying_version_falls_back_to_newest(self, tmp_path, monkeypatch):
+        versions = self._resolve(">=3.99", tmp_path, monkeypatch)
+        assert versions == ["3.14"]

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -443,6 +443,12 @@ class TestPythonMatrixResolution:
         versions = self._resolve(None, tmp_path, monkeypatch)
         assert versions == ["3.11", "3.12", "3.13", "3.14"]
 
+    def test_malformed_requires_python_falls_back_to_full_set(self, tmp_path, monkeypatch):
+        # Copilot review on #238: a present-but-invalid specifier must not crash
+        # the job (InvalidSpecifier) — it falls back to the full KNOWN set.
+        versions = self._resolve("not-a-version", tmp_path, monkeypatch)
+        assert versions == ["3.11", "3.12", "3.13", "3.14"]
+
     def test_no_satisfying_version_falls_back_to_newest(self, tmp_path, monkeypatch):
         versions = self._resolve(">=3.99", tmp_path, monkeypatch)
         assert versions == ["3.14"]


### PR DESCRIPTION
## Summary

Follow-up to #208/#209. The single-version CI fix landed; this adds the **multi-version matrix** half — and does it so the version floor can never drift from the project's own `requires-python` (the failure mode #208 warned a hardcoded matrix would reintroduce).

## Approach — runtime derivation (Option C)

A new **`python-matrix`** CI job reads `requires-python` from the project's `pyproject.toml` at workflow time and emits every supported CPython that satisfies it (filtered with `packaging.SpecifierSet`). `lint-and-test` then `needs:` that job and fans out via `strategy.matrix` over `fromJSON(needs.python-matrix.outputs.versions)`, pinning each leg with `python-version: ${{ matrix.python-version }}`.

- **Floor is always read from `requires-python`** → cannot drift. Only the *ceiling* enumeration (`KNOWN = 3.11–3.14`) is a maintained list; bump it (or let Renovate) when a new CPython ships.
- **No scaffold variable needed** — pure CI YAML, so the scaffolder stays untouched (the deliberately-noted fact that the scaffolder generates no `pyproject.toml` and never reads `requires-python` is *why* scaffold-time derivation was rejected).
- **Python-only** via `{{#if python}}`; node/go scaffolds are unchanged (verified: their `ci.yml` carries no `python-matrix` job).
- **Fresh-scaffold safe**: missing/unparseable `requires-python` → full `KNOWN` set; a `requires-python` that excludes every `KNOWN` → newest, so CI never errors on an empty matrix.

## Acceptance criteria / DoR / DoD

- ✅ Scaffolded `ci.yml` runs a Python matrix whose floor respects `requires-python` and cannot drift from it.
- ✅ DoR decision (how the version set is obtained): **derive at CI runtime from `requires-python`** — the only option that satisfies "cannot drift."
- ✅ Matrix renders correctly for `language=python` scaffolds; absent for node/go.
- ✅ Regression test asserts the matrix respects the `requires-python` floor — the test **extracts and executes the actual shipped resolver** from the rendered `ci.yml` against synthetic `requires-python` values (`>=3.13` → `["3.13","3.14"]`, `>=3.11,<3.13` → `["3.11","3.12"]`, missing → full set, `>=3.99` → newest).

## Test plan

- `uv run pytest` — 611 passed (5 new behavioral resolver tests + structural + node-negative).
- Rendered `ci.yml` for python/node/go all parse as valid YAML; job topology confirmed (`python-matrix` only for python).
- `ruff check` clean.
- Existing PI-208 guard (`test_ci_does_not_hardcode_python_version`) still passes — `${{ matrix.* }}` is not a literal pin.

Closes #214