### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.3.0"
+version = "0.4.0"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,4 +1,4 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

Release prep: bump `0.3.0` → `0.4.0` (minor) — **26 commits** since v0.3.0, spanning new features and fixes.

Highlights since v0.3.0:
- **feat** PI-214: runtime-derived Python CI matrix from `requires-python`
- **feat** PI-190: `ScaffoldInputs` dataclass / single source for variable defaults
- **fix** PI-209/208: CI dev-deps via PEP 735 groups; drop hardcoded Python pin
- **fix** PI-186/203: bound the monitor_pr CI-wait loop; correct merge-success reporting
- **fix** PI-196/197/199: scaffold/upgrade data-loss and crash hardening
- **fix** PI-207: board-automation works on user-owned accounts
- plus PI-187/188/202/204/205/206/210 and docs (PI-192/193/194).

## What changed
- `pyproject.toml` and `src/project_init/__init__.py` → `0.4.0` (kept in sync by the release gate in `test_release_engineering.py`).

## Release
No changelog edit needed — `release.yml` generates it from Conventional Commits via git-cliff on tag push. After this merges, pushing the `v0.4.0` tag cuts the GitHub Release and publishes to PyPI.

## Test plan
- `uv run pytest tests/contracts/test_release_engineering.py tests/smoke/test_packaging.py` → 19 passed (version sync + wheel build/import).

(No issue — release chore.)