### PR TITLE
docs(PI-256): org fork lifecycle runbook skeleton

### DIFF
--- a/docs/guides/org-fork-lifecycle.md
+++ b/docs/guides/org-fork-lifecycle.md
@@ -6,8 +6,8 @@
 > plumbing). It exists early so those tickets validate against a real path instead of
 > baking unvalidated assumptions.
 
-For *why* the model is shaped this way, see **ADR-013** (distribution & governance) and
-the [Enterprise GitHub support matrix](../development/enterprise-github-support-matrix.md).
+For *why* the model is shaped this way, see [ADR-013](../adr/adr-013-distribution-governance-model.md)
+(distribution & governance) and the [Enterprise GitHub support matrix](../development/enterprise-github-support-matrix.md).
 This runbook covers the **`org`** profile only; `individual` and `standalone` users do
 not need a fork.
 
@@ -33,8 +33,8 @@ prerequisites (forking of private/internal repos defaults to *disallow*).
 ## Stage 2 — Customize
 
 - Select `--profile org` (recorded in `.claude/config.yaml`).
-- Choose delivery: marketplace with a **full git URL** on github.com/GHES; **copied-in
-  (`--no-plugin`)** on EMU/GHE.com.
+- Choose delivery: marketplace (`owner/repo` shorthand on github.com, **full git URL** on
+  GHES); **copied-in (`--no-plugin`)** on EMU/GHE.com.
 - Apply a company preset; for locked-down orgs, enable no-egress via
   `managed-settings.json`.
 

--- a/docs/guides/org-fork-lifecycle.md
+++ b/docs/guides/org-fork-lifecycle.md
@@ -1,0 +1,74 @@
+# Org fork lifecycle runbook
+
+> **Status: skeleton (#256).** This is the adoption path the `org` profile is designed
+> around. The mechanics in each stage are filled by #247 (profiles), #248 (fork/pin),
+> #251 (enforcement), #255 (host implementation), and #257 (end-to-end + release
+> plumbing). It exists early so those tickets validate against a real path instead of
+> baking unvalidated assumptions.
+
+For *why* the model is shaped this way, see **ADR-013** (distribution & governance) and
+the [Enterprise GitHub support matrix](../development/enterprise-github-support-matrix.md).
+This runbook covers the **`org`** profile only; `individual` and `standalone` users do
+not need a fork.
+
+## At a glance
+
+```
+1. Create the org copy   →  2. Customize  →  3. Publish a fork version  →  4. Onboard a teammate
+        (fork | import)         (preset)          (tag + pin)                  (install + enforce)
+                         ⟲  Update flow: pull upstream, recommend (never forced)
+```
+
+## Stage 1 — Create the org copy (fork or import)
+
+The mechanism is **host-adaptive** (per the spike):
+
+- **github.com / GHES** → **fork** project-init into the org.
+- **EMU / GHE.com** → **import or mirror** (EMU blocks external forks; import/mirror is
+  the supported path).
+
+_To be filled (#255):_ host-aware commands, `gh` host selection, org forking-policy
+prerequisites (forking of private/internal repos defaults to *disallow*).
+
+## Stage 2 — Customize
+
+- Select `--profile org` (recorded in `.claude/config.yaml`).
+- Choose delivery: marketplace with a **full git URL** on github.com/GHES; **copied-in
+  (`--no-plugin`)** on EMU/GHE.com.
+- Apply a company preset; for locked-down orgs, enable no-egress via
+  `managed-settings.json`.
+
+_To be filled:_ profile bundle + notify-of-options (#247), company-preset authoring
+(#252), no-egress mode (#258).
+
+## Stage 3 — Publish a fork version
+
+- Cut a release/tag on the fork so teammates install a pinned, reproducible version.
+- Record the plugin-version pin in config.
+
+_To be filled:_ version-record fields + re-pointable reference (#248), fork release
+plumbing (#257).
+
+## Stage 4 — Onboard a teammate
+
+- Install from the fork (the re-pointed reference); the recorded `org` profile drives
+  delivery and enforcement.
+- Server-side enforcement binds via **org rulesets applied directly to the repo**
+  (forks don't inherit branch/tag rulesets); admin-merge is refused.
+
+_To be filled:_ onboarding command + observability record (#259), hybrid enforcement
+(#251).
+
+## Update flow — pull-and-recommend
+
+The fork **pulls upstream** and surfaces **recommendations** to adopt new additions —
+never forced. New additions require **consent** before they land; nothing is silent.
+
+_To be filled:_ version-span detection + recommendations (#250), opt-in consent for new
+additions (#249).
+
+## Validation reference
+
+Each stage above is intentionally a placeholder anchored to the ticket that fills it.
+#247/#248/#251/#255 should check their design against this path; #257 turns it into a
+validated end-to-end walkthrough and owns the epic's "usable end-to-end" criterion.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Home: README.md
   - Guide:
     - Using project-init: guides/using-project-init.md
+    - Org fork lifecycle (runbook): guides/org-fork-lifecycle.md
   - Architecture Decisions:
     - Overview: adr/adr-001-scaffolder-design.md
     - dot_ prefix convention: adr/adr-002-dotglob-template-convention.md


### PR DESCRIPTION
Closes #256

Minimal org fork-lifecycle **runbook skeleton** (create/import → customize → publish a fork version → onboard a teammate), authored early so #247/#248/#251/#255 validate against a real adoption path. Full end-to-end validation is #257.

DoR satisfied: spike #254 answered fork-vs-import (host-adaptive — fork on github.com/GHES, import/mirror on EMU). Each stage is a placeholder anchored to the ticket that fills it.