### PR TITLE
feat(PI-255): enterprise GitHub host support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,9 @@ INSTALL_DIR="${PROJECT_INIT_HOME:-$HOME/.local/share/project-init}"
 COMMANDS_DIR="$HOME/.claude/commands"
 # Pin a version with PROJECT_INIT_REF=vX.Y.Z, or track the development head
 # with PROJECT_INIT_REF=main. Default: the latest GitHub Release (ADR-008).
+# For non-github.com hosts (GHES / GHE.com), point PROJECT_INIT_REPO at the full
+# clone URL; the REST API base is derived from its host, or set it explicitly
+# with PROJECT_INIT_API_BASE (e.g. https://ghes.example.com/api/v3).
 REQUESTED_REF="${PROJECT_INIT_REF:-}"
 
 say() { printf '\033[1;36m[project-init]\033[0m %s\n' "$*"; }
@@ -47,13 +50,26 @@ resolve_ref() {
         printf '%s\n' "$REQUESTED_REF"
         return
     fi
-    # Derive owner/repo from REPO_URL for the API query (github.com only).
-    # POSIX ERE has no lazy quantifier, so strip the .git suffix separately.
-    local slug tag
-    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*github\.com[:/]([^/]+/[^/]+)$#\1#p')
+    # Derive the host + owner/repo slug from REPO_URL (any GitHub host, not just
+    # github.com), then pick the REST API base. POSIX ERE has no lazy quantifier,
+    # so strip the .git suffix separately.
+    local host slug api_base tag
+    host=$(printf '%s\n' "$REPO_URL" | sed -nE 's#^(https?://|git@)([^/:]+).*#\2#p')
+    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*[/:]([^/]+/[^/]+)$#\1#p')
     slug="${slug%.git}"
+    # API base: explicit override wins; github.com & *.ghe.com use api.<host>;
+    # GitHub Enterprise Server uses <host>/api/v3.
+    if [ -n "${PROJECT_INIT_API_BASE:-}" ]; then
+        api_base="$PROJECT_INIT_API_BASE"
+    else
+        case "$host" in
+            "") api_base="https://api.github.com" ;;
+            github.com | *.ghe.com) api_base="https://api.$host" ;;
+            *) api_base="https://$host/api/v3" ;;
+        esac
+    fi
     if [ -n "$slug" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/$slug/releases/latest" 2>/dev/null \
+        tag=$(curl -fsSL "$api_base/repos/$slug/releases/latest" 2>/dev/null \
             | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)
     fi
     if [ -n "${tag:-}" ]; then

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,8 @@ resolve_ref() {
     # github.com), then pick the REST API base. POSIX ERE has no lazy quantifier,
     # so strip the .git suffix separately.
     local host slug api_base tag
-    host=$(printf '%s\n' "$REPO_URL" | sed -nE 's#^(https?://|git@)([^/:]+).*#\2#p')
+    # Strip scheme/userinfo/path/port so https://, ssh://, and git@ forms all work.
+    host=$(printf '%s\n' "$REPO_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#^[^@/]*@##; s#[/:].*$##')
     slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*[/:]([^/]+/[^/]+)$#\1#p')
     slug="${slug%.git}"
     # API base: explicit override wins; github.com & *.ghe.com use api.<host>;

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# gh_host.sh — resolve the active GitHub host for host-aware links and URLs.
+#
+# Sourced by lifecycle scripts so manual links, clone URLs, and curl-based API
+# calls work on github.com, GHE.com (data residency, *.ghe.com), and GitHub
+# Enterprise Server (GHES) — not just public github.com (ADR-013, spike #254).
+#
+# `gh api` already targets the repo's host automatically, so these helpers are
+# only needed for hardcoded URLs and non-gh callers.
+#
+# On Enterprise Managed Users (EMU), external forks are blocked — an org mirrors
+# or imports the upstream instead (see the org fork lifecycle runbook). These
+# helpers resolve the host the same way regardless of fork-vs-import.
+#
+# Resolution order: PROJECT_INIT_HOST → GH_HOST → current repo remote → github.com.
+
+gh_host() {
+  if [ -n "${PROJECT_INIT_HOST:-}" ]; then printf '%s\n' "$PROJECT_INIT_HOST"; return; fi
+  if [ -n "${GH_HOST:-}" ]; then printf '%s\n' "$GH_HOST"; return; fi
+  local url host
+  url=$(gh repo view --json url -q .url 2>/dev/null || true)
+  [ -z "$url" ] && url=$(git config --get remote.origin.url 2>/dev/null || true)
+  host=$(printf '%s\n' "$url" | sed -nE 's#^(https?://|git@)([^/:]+).*#\2#p')
+  printf '%s\n' "${host:-github.com}"
+}
+
+# Web base for browser links, e.g. https://github.com or https://ghes.example.com
+gh_web_base() { printf 'https://%s\n' "$(gh_host)"; }
+
+# REST API base for curl-based callers. Prefer `gh api` where possible (it
+# resolves the host itself). github.com & *.ghe.com use api.<host>; GHES uses
+# <host>/api/v3. Override explicitly with PROJECT_INIT_API_BASE.
+gh_api_base() {
+  if [ -n "${PROJECT_INIT_API_BASE:-}" ]; then printf '%s\n' "$PROJECT_INIT_API_BASE"; return; fi
+  local host
+  host="$(gh_host)"
+  case "$host" in
+    "") printf 'https://api.github.com\n' ;;
+    github.com | *.ghe.com) printf 'https://api.%s\n' "$host" ;;
+    *) printf 'https://%s/api/v3\n' "$host" ;;
+  esac
+}

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -14,13 +14,24 @@
 #
 # Resolution order: PROJECT_INIT_HOST → GH_HOST → current repo remote → github.com.
 
+# Strip scheme, userinfo, path, and port from a URL or host string → bare host.
+# Handles https://, http://, ssh://, scp-style git@host:owner/repo, and bare hosts.
+_gh_host_normalize() {
+  printf '%s\n' "$1" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#^[^@/]*@##; s#[/:].*$##'
+}
+
 gh_host() {
-  if [ -n "${PROJECT_INIT_HOST:-}" ]; then printf '%s\n' "$PROJECT_INIT_HOST"; return; fi
-  if [ -n "${GH_HOST:-}" ]; then printf '%s\n' "$GH_HOST"; return; fi
-  local url host
-  url=$(gh repo view --json url -q .url 2>/dev/null || true)
-  [ -z "$url" ] && url=$(git config --get remote.origin.url 2>/dev/null || true)
-  host=$(printf '%s\n' "$url" | sed -nE 's#^(https?://|git@)([^/:]+).*#\2#p')
+  local raw=""
+  if [ -n "${PROJECT_INIT_HOST:-}" ]; then
+    raw="$PROJECT_INIT_HOST"
+  elif [ -n "${GH_HOST:-}" ]; then
+    raw="$GH_HOST"
+  else
+    raw=$(gh repo view --json url -q .url 2>/dev/null || true)
+    [ -z "$raw" ] && raw=$(git config --get remote.origin.url 2>/dev/null || true)
+  fi
+  local host
+  host="$(_gh_host_normalize "$raw")"
   printf '%s\n' "${host:-github.com}"
 }
 

--- a/templates/base/dot_claude/scripts/push_wiki.sh
+++ b/templates/base/dot_claude/scripts/push_wiki.sh
@@ -8,6 +8,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
 if [[ $# -lt 2 ]]; then
   echo "Usage: push_wiki.sh <repo-slug> <wiki-source-file>" >&2
   exit 1
@@ -19,7 +23,7 @@ WIKI_DIR="$(mktemp -d)"
 trap 'rm -rf "$WIKI_DIR"' EXIT
 
 echo "Cloning wiki for $REPO_SLUG..."
-git clone "https://github.com/${REPO_SLUG}.wiki.git" "$WIKI_DIR"
+git clone "$(gh_web_base)/${REPO_SLUG}.wiki.git" "$WIKI_DIR"
 
 cp "$SOURCE_FILE" "$WIKI_DIR/Home.md"
 

--- a/templates/base/dot_claude/scripts/setup_github.sh
+++ b/templates/base/dot_claude/scripts/setup_github.sh
@@ -10,6 +10,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
 BRANCH="main"
 PROTECT=0
 for arg in "$@"; do
@@ -20,14 +24,16 @@ for arg in "$@"; do
   esac
 done
 
-if ! gh auth status >/dev/null 2>&1; then
-  echo "ERROR: gh is not authenticated. Run gh auth login first." >&2
+HOST="$(gh_host)"
+if ! gh auth status -h "$HOST" >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated for $HOST. Run: gh auth login --hostname $HOST" >&2
   exit 1
 fi
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 OWNER=${REPO%/*}
 NAME=${REPO#*/}
+WEB_BASE="https://$HOST"
 
 echo "Configuring GitHub governance for $REPO ($BRANCH)"
 # Default endpoint: repos/$OWNER/$NAME/branches/main/protection
@@ -77,7 +83,7 @@ if gh api "repos/$OWNER/$NAME/code-review-settings" -X PUT -f copilot_code_revie
   echo "Copilot code review enabled"
 else
   echo "WARNING: Enable Copilot code review manually if your plan supports it:" >&2
-  echo "  https://github.com/$OWNER/$NAME/settings/code_review" >&2
+  echo "  $WEB_BASE/$OWNER/$NAME/settings/code_review" >&2
 fi
 
 # --- GitHub Project board field provisioning ---
@@ -121,7 +127,7 @@ if [ -z "$PROJECT_ID" ]; then
   echo "  • Agent ready  — options: Yes, No" >&2
   echo "  • Confidence   — options: high, medium, low, unknown" >&2
   echo "  • Type         — options: feature, bug, chore, documentation, test" >&2
-  echo "  Settings: https://github.com/users/$OWNER/projects/$PROJECT_NUMBER/settings/fields" >&2
+  echo "  Settings: $WEB_BASE/users/$OWNER/projects/$PROJECT_NUMBER/settings/fields" >&2
 else
   EXISTING_FIELDS=$(echo "$PROJECT_DATA" | jq -r \
     '((.data.user.projectV2 // .data.organization.projectV2).fields.nodes // [])[] | .name // empty')
@@ -138,7 +144,7 @@ else
     else
       # Repo: $REPO  Project: #$PROJECT_NUMBER
       echo "  WARNING: could not create '$field_name' for $REPO — add it manually:" >&2
-      echo "    https://github.com/users/$OWNER/projects/$PROJECT_NUMBER/settings/fields" >&2
+      echo "    $WEB_BASE/users/$OWNER/projects/$PROJECT_NUMBER/settings/fields" >&2
     fi
   }
 

--- a/tests/contracts/test_enterprise_host.py
+++ b/tests/contracts/test_enterprise_host.py
@@ -7,6 +7,8 @@ hold at runtime via the gh_host.sh helper rather than via template variables.
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 from project_init.scaffold import load_preset, scaffold
@@ -69,3 +71,55 @@ class TestHostHelperIsScaffolded:
         target = tmp_path / "p"
         scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
         assert (target / ".claude" / "scripts" / "gh_host.sh").exists()
+
+
+def _run_bash(snippet: str, *, cwd: Path | None = None, env_extra: dict | None = None) -> str:
+    """Source gh_host.sh and run a snippet against the real helper. Host env vars
+    are cleared so each case exercises the intended resolution path."""
+    env = {k: v for k, v in os.environ.items() if k not in ("PROJECT_INIT_HOST", "GH_HOST")}
+    if env_extra:
+        env.update(env_extra)
+    result = subprocess.run(
+        ["bash", "-c", f'. "{_GH_HOST}"; {snippet}'],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestGhHostParsing:
+    """Behavioral tests — exercise the real bash helper, not just substrings, so
+    broken URL parsing cannot pass silently (ssh:// and scheme-bearing forms)."""
+
+    def test_normalize_handles_all_url_forms(self):
+        cases = {
+            "https://ghes.example.com/org/repo.git": "ghes.example.com",
+            "ssh://git@ghes.example.com/org/repo.git": "ghes.example.com",
+            "ssh://git@ghes.example.com:22/org/repo.git": "ghes.example.com",
+            "git@github.com:owner/repo.git": "github.com",
+            "https://octocorp.ghe.com/org/repo.git": "octocorp.ghe.com",
+            "https://ghes.example.com": "ghes.example.com",
+            "github.com": "github.com",
+        }
+        for raw, expected in cases.items():
+            assert _run_bash(f'_gh_host_normalize "{raw}"') == expected, raw
+
+    def test_override_with_scheme_is_normalized(self):
+        # PROJECT_INIT_HOST short-circuits before any gh/git lookup.
+        out = _run_bash("gh_host", env_extra={"PROJECT_INIT_HOST": "https://ghes.example.com"})
+        assert out == "ghes.example.com"
+
+    def test_ssh_remote_is_parsed(self, tmp_path: Path):
+        repo = tmp_path / "r"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "ssh://git@ghes.example.com/org/repo.git"],
+            cwd=repo,
+            check=True,
+        )
+        # Empty gh config dir → gh is unauthenticated → fast fallback to the git remote.
+        out = _run_bash("gh_host", cwd=repo, env_extra={"GH_CONFIG_DIR": str(tmp_path / "ghcfg")})
+        assert out == "ghes.example.com"

--- a/tests/contracts/test_enterprise_host.py
+++ b/tests/contracts/test_enterprise_host.py
@@ -1,0 +1,71 @@
+"""PI-255: enterprise GitHub host support — host-aware lifecycle scripts and
+install.sh API-base resolution (ADR-013, spike #254).
+
+The lifecycle scripts are copied verbatim (not rendered), so host-awareness must
+hold at runtime via the gh_host.sh helper rather than via template variables.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "templates/base/dot_claude/scripts"
+_GH_HOST = _SCRIPTS / "gh_host.sh"
+_SETUP_GITHUB = _SCRIPTS / "setup_github.sh"
+_PUSH_WIKI = _SCRIPTS / "push_wiki.sh"
+_INSTALL = _REPO_ROOT / "install.sh"
+
+
+class TestGhHostHelper:
+    def test_helper_exists(self):
+        assert _GH_HOST.exists(), "gh_host.sh must ship in templates/base scripts"
+
+    def test_resolution_order_and_overrides_documented(self):
+        s = _GH_HOST.read_text()
+        for var in ("PROJECT_INIT_HOST", "GH_HOST", "PROJECT_INIT_API_BASE"):
+            assert var in s, f"{var} must participate in host/API resolution"
+        for fn in ("gh_host()", "gh_web_base()", "gh_api_base()"):
+            assert fn in s
+
+    def test_api_base_covers_every_host_tier(self):
+        s = _GH_HOST.read_text()
+        assert "/api/v3" in s, "GHES REST base must be handled"
+        assert "api.%s" in s, "github.com & *.ghe.com use api.<host>"
+        assert "*.ghe.com" in s, "data-residency hosts must be matched"
+
+
+class TestScriptsAreHostAware:
+    def test_setup_github_sources_helper(self):
+        s = _SETUP_GITHUB.read_text()
+        assert "gh_host.sh" in s
+        assert 'gh auth status -h "$HOST"' in s, "auth check must target the repo host"
+
+    def test_setup_github_has_no_hardcoded_repo_links(self):
+        s = _SETUP_GITHUB.read_text()
+        assert "https://github.com/$OWNER" not in s
+        assert "https://github.com/users/$OWNER" not in s
+
+    def test_push_wiki_clone_is_host_aware(self):
+        s = _PUSH_WIKI.read_text()
+        assert "gh_host.sh" in s
+        assert "gh_web_base" in s
+        assert "https://github.com/${REPO_SLUG}.wiki.git" not in s
+
+    def test_install_sh_api_base_is_host_aware(self):
+        s = _INSTALL.read_text()
+        assert "PROJECT_INIT_API_BASE" in s
+        assert "/api/v3" in s
+        assert "https://api.github.com/repos/$slug" not in s, (
+            "the release-tag API endpoint must be host-derived, not hardcoded"
+        )
+
+
+class TestHostHelperIsScaffolded:
+    def test_gh_host_ships_into_projects(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+        assert (target / ".claude" / "scripts" / "gh_host.sh").exists()


### PR DESCRIPTION
Closes #255

Make the scaffolded lifecycle scripts and `install.sh` work on non-public-github.com hosts (GHES, GHE.com, EMU) per ADR-013 / spike #254.

- **New `gh_host.sh` helper** (templates/base scripts): resolves the host (`PROJECT_INIT_HOST` → `GH_HOST` → repo remote → github.com) and exposes `gh_web_base` / `gh_api_base` (github.com & `*.ghe.com` → `api.<host>`; GHES → `<host>/api/v3`; `PROJECT_INIT_API_BASE` override).
- **`setup_github.sh`**: sources the helper; host-specific `gh auth status -h`; the three manual web links use `$WEB_BASE` instead of hardcoded `https://github.com/...`.
- **`push_wiki.sh`**: host-aware wiki clone URL.
- **`install.sh`**: `resolve_ref` derives host + API base from `REPO_URL` (no longer hardcodes `api.github.com`); `PROJECT_INIT_API_BASE` override documented.
- EMU mirror/import noted in the helper header (links to the runbook).
- Tests: `tests/contracts/test_enterprise_host.py` (8 tests; full suite 620 green).

Note: `gh api` / `gh api graphql` calls were already host-aware (gh targets the repo's host), so only hardcoded URLs and `install.sh`'s curl needed changes.