### PR TITLE
feat(PI-247): distribution profile (individual/standalone/org)

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -45,6 +45,7 @@ class ScaffoldInputs:
     vscode: bool
     agents: list[str]
     no_plugin: bool
+    profile: str
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -143,6 +144,16 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--profile",
+        choices=["individual", "standalone", "org"],
+        default=None,
+        help=(
+            "Distribution profile (ADR-013): individual (default — plugin-first, "
+            "track upstream, advisory), standalone (copied-in, owner-driven, "
+            "pinned), org (fork source-of-truth, hard enforcement)"
+        ),
+    )
+    p.add_argument(
         "--non-interactive",
         action="store_true",
         help="Skip all prompts (requires --preset, --name, --description)",
@@ -233,6 +244,23 @@ def _choose_browser_interactive() -> bool:
     return Confirm.ask("\nAdd Playwright (browser automation)?", default=False)
 
 
+def _choose_profile_interactive() -> str:
+    """Present the three distribution profiles and what each bundles (#247)."""
+    from rich.console import Console
+    from rich.prompt import IntPrompt
+
+    console = Console()
+    console.print("\n[bold]Distribution profile[/bold] (ADR-013):")
+    for i, name in enumerate(_PROFILES, 1):
+        console.print(f"  [cyan]{i}[/cyan]. {name} — {_PROFILE_SUMMARY[name]}")
+    console.print()
+    choice = IntPrompt.ask("Choose a profile", default=1)
+    if choice < 1 or choice > len(_PROFILES):
+        console.print("[red]Invalid choice. Using individual.[/red]")
+        choice = 1
+    return _PROFILES[choice - 1]
+
+
 def _resolve_mcps_non_interactive(
     mcps_arg: str,
     db_arg: str,
@@ -294,6 +322,26 @@ def _print_summary(target: Path, created: list[Path], preset_name: str) -> None:
     console.print()
     console.print(Panel(body.rstrip(), title="project-init", border_style="green"))
     console.print()
+
+
+def _print_profile_notice(profile: str, *, no_plugin: bool) -> None:
+    """Surface the resolved profile and its egress posture (#247).
+
+    Called on the non-interactive path so a default is never applied silently:
+    it states the profile, the delivery/egress state, and the enforcement mode.
+    """
+    from rich.console import Console
+
+    delivery = (
+        "copied-in, no external marketplace"
+        if no_plugin
+        else "plugin-first, external official marketplace enabled (network egress)"
+    )
+    Console().print(
+        f"[cyan]Profile:[/cyan] {profile} — {_PROFILE_SUMMARY[profile]}\n"
+        f"[cyan]Delivery:[/cyan] {delivery}; "
+        f"[cyan]enforcement:[/cyan] {_profile_enforcement(profile)}"
+    )
 
 
 def _print_conflicts(conflicts: list[tuple[Path, Path]]) -> None:
@@ -361,8 +409,12 @@ def _select_preset(
     return _choose_preset_interactive(presets)
 
 
-def _gather_inputs_interactive(default_name: str, *, no_plugin: bool) -> ScaffoldInputs:
-    """Prompt for project basics, MCPs, governance, and opt-in overlays."""
+def _gather_inputs_interactive(
+    default_name: str, *, no_plugin: bool, profile: str | None
+) -> ScaffoldInputs:
+    """Prompt for the profile, project basics, MCPs, governance, and overlays."""
+    resolved_profile = profile or _choose_profile_interactive()
+    no_plugin = _profile_delivery_no_plugin(resolved_profile, no_plugin)
     project_name = _prompt("Project name", default=default_name)
     project_description = _prompt("Description", default="")
     language = _prompt("Language (python/node/go/none)", default="none")
@@ -414,6 +466,7 @@ def _gather_inputs_interactive(default_name: str, *, no_plugin: bool) -> Scaffol
         vscode=vscode,
         agents=agents,
         no_plugin=no_plugin,
+        profile=resolved_profile,
     )
 
 
@@ -435,6 +488,41 @@ def resolve_agents(raw: str) -> list[str]:
 def agent_layers(agents: list[str]) -> list[str]:
     """Template layers contributed by the selected agents (no fallback)."""
     return overlay_layers(agents, no_plugin=False)
+
+
+_PROFILES = ("individual", "standalone", "org")
+
+# One-line summary of what each profile bundles — shown at selection time and in
+# the non-interactive notice so the choice is never silent (ADR-013, #247).
+_PROFILE_SUMMARY = {
+    "individual": (
+        "plugin-first (external official marketplace), track upstream, advisory "
+        "enforcement — today's default"
+    ),
+    "standalone": (
+        "copied-in (no external marketplace), owner-driven pinned updates, "
+        "advisory enforcement"
+    ),
+    "org": (
+        "fork as source-of-truth, host-adaptive delivery, hard (server-side) "
+        "enforcement"
+    ),
+}
+
+
+def _profile_delivery_no_plugin(profile: str, explicit_no_plugin: bool) -> bool:
+    """Resolve copied-in vs plugin delivery for a profile.
+
+    ``standalone`` is copied-in by definition; ``individual``/``org`` default to
+    plugin delivery (``org``'s copied-in-on-EMU is decided host-side, #248). An
+    explicit ``--no-plugin`` always forces copied-in.
+    """
+    return explicit_no_plugin or profile == "standalone"
+
+
+def _profile_enforcement(profile: str) -> str:
+    """Profile-derived enforcement default (the enforcing behavior lands in #251)."""
+    return "hard" if profile == "org" else "advisory"
 
 
 # Per-language tooling commands (PI-16): (lint, format, test). Empty strings
@@ -542,6 +630,10 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         "ollama": "true" if "ollama" in agents else "",
         "multi_agent": "true" if ("codex" in agents or "gemini" in agents) else "",
         "other_agents": "true" if len(agents) > 1 else "",
+        # Distribution profile (ADR-013, #247): recorded + drives the delivery
+        # and enforcement defaults. The enforcing behavior lands in #251.
+        "profile": inputs.profile,
+        "enforcement": _profile_enforcement(inputs.profile),
         # Plugin cutover (PI-165): inverse pair, same pattern as vscode_off.
         "plugin_mode": "" if no_plugin else "true",
         "no_plugin": "true" if no_plugin else "",
@@ -571,6 +663,9 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
         agents = resolve_agents(args.agents)
     except ValueError as e:
         parser.error(str(e))
+    profile = args.profile or "individual"
+    no_plugin = _profile_delivery_no_plugin(profile, args.no_plugin)
+    _print_profile_notice(profile, no_plugin=no_plugin)
     return ScaffoldInputs(
         project_name=args.name,
         project_description=args.description,
@@ -582,7 +677,8 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
         mise=args.mise,
         vscode=args.vscode,
         agents=agents,
-        no_plugin=args.no_plugin,
+        no_plugin=no_plugin,
+        profile=profile,
     )
 
 
@@ -612,7 +708,9 @@ def main(argv: list[str] | None = None) -> int:
     # interactive prompt must not leave an empty dir behind).
     inputs = _resolve_inputs(args, parser, target)
     if inputs is None:
-        inputs = _gather_inputs_interactive(default_name=target.name, no_plugin=args.no_plugin)
+        inputs = _gather_inputs_interactive(
+            default_name=target.name, no_plugin=args.no_plugin, profile=args.profile
+        )
     target.mkdir(parents=True, exist_ok=True)
 
     # Agent overlays append to the preset's layers (PI-137); --no-plugin

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -332,10 +332,14 @@ def _print_profile_notice(profile: str, *, no_plugin: bool) -> None:
     """
     from rich.console import Console
 
+    # Honest egress: --no-plugin only copies project-init's own payload locally;
+    # the external official marketplace stays enabled in every mode until the
+    # org no-egress mode (#258) disables it.
     delivery = (
-        "copied-in, no external marketplace"
+        "project-init copied in locally; external official marketplace still "
+        "enabled (network egress)"
         if no_plugin
-        else "plugin-first, external official marketplace enabled (network egress)"
+        else "plugin-first; external official marketplace enabled (network egress)"
     )
     Console().print(
         f"[cyan]Profile:[/cyan] {profile} — {_PROFILE_SUMMARY[profile]}\n"
@@ -496,12 +500,13 @@ _PROFILES = ("individual", "standalone", "org")
 # the non-interactive notice so the choice is never silent (ADR-013, #247).
 _PROFILE_SUMMARY = {
     "individual": (
-        "plugin-first (external official marketplace), track upstream, advisory "
-        "enforcement — today's default"
+        "plugin-first (project-init + external official plugins), track upstream, "
+        "advisory enforcement — today's default"
     ),
     "standalone": (
-        "copied-in (no external marketplace), owner-driven pinned updates, "
-        "advisory enforcement"
+        "project-init payload copied in locally, owner-driven pinned updates, "
+        "advisory enforcement (external official marketplace still enabled — "
+        "full no-egress is the org mode, #258)"
     ),
     "org": (
         "fork as source-of-truth, host-adaptive delivery, hard (server-side) "

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -99,6 +99,8 @@ def _overlay_off_defaults() -> dict[str, str]:
         "other_agents": "",
         "plugin_mode": "",
         "no_plugin": "true",
+        "profile": "individual",
+        "enforcement": "advisory",
         "project_owner": "",
         "license": "none",
         "license_mit": "",
@@ -529,6 +531,10 @@ def run_upgrade(target: Path, *, apply: bool, no_plugin: bool = False) -> int:
 
     variables = dict(variables)
     variables["project_init_version"] = __version__
+    # Backfill profile/enforcement for pre-#247 records so the strict re-render
+    # (config.yaml.tmpl references {{profile}}) never crashes on old projects.
+    variables.setdefault("profile", "individual")
+    variables.setdefault("enforcement", "advisory")
 
     staging_root = Path(tempfile.mkdtemp(prefix="project-init-upgrade-"))
     staging = staging_root / "render"

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -6,6 +6,7 @@ project:
   description: "{{project_description}}"
   created: {{created_date}}
   project_init_version: {{project_init_version}}
+  profile: {{profile}}     # individual | standalone | org — distribution profile (ADR-013)
   project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use feat(PI-42):
   github_project_number: 1 # numeric GitHub Project V2 board number (used by board-automation.yml and create_issue.sh)
 

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -59,7 +59,9 @@ class TestAgentSelection:
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 
-        result = cli._gather_inputs_interactive(default_name="proj", no_plugin=False)
+        result = cli._gather_inputs_interactive(
+            default_name="proj", no_plugin=False, profile="individual"
+        )
         assert result.agents == ["claude", "codex"], "valid retry must be honored"
         assert "unknown agent(s): cursor" in capsys.readouterr().out
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -57,6 +57,8 @@ def make_variables(**overrides: str) -> dict[str, str]:
         # the copied payload use fallback_variables()/fallback_preset().
         "plugin_mode": "true",
         "no_plugin": "",
+        "profile": "individual",
+        "enforcement": "advisory",
         "graphify": "",
         "obsidian": "true",
         "project_owner": "",

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -476,6 +476,7 @@ class TestInteractiveNoPlugin:
                 vscode=False,
                 agents=["claude"],
                 no_plugin=kw["no_plugin"],
+                profile=kw.get("profile") or "individual",
             )
 
         monkeypatch.setattr(cli, "_gather_inputs_interactive", _fake_gather)

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -1,0 +1,134 @@
+"""PI-247: distribution profile (individual/standalone/org) — flag, bundle
+mapping, recording, and the upgrade backfill for pre-profile records (ADR-013)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.__main__ import (
+    ScaffoldInputs,
+    _build_parser,
+    _build_variables,
+    _profile_delivery_no_plugin,
+    _profile_enforcement,
+)
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _inputs(profile: str, *, explicit_no_plugin: bool = False) -> ScaffoldInputs:
+    return ScaffoldInputs(
+        project_name="p",
+        project_description="d",
+        language="python",
+        selected_mcps=[],
+        owner="",
+        license_choice="none",
+        devcontainer=False,
+        mise=False,
+        vscode=False,
+        agents=["claude"],
+        no_plugin=_profile_delivery_no_plugin(profile, explicit_no_plugin),
+        profile=profile,
+    )
+
+
+def _vars(profile: str, **kw: bool) -> dict:
+    return _build_variables(load_preset("obsidian-only"), _inputs(profile, **kw))
+
+
+class TestProfileBundles:
+    def test_individual_is_plugin_first_advisory(self):
+        v = _vars("individual")
+        assert v["profile"] == "individual"
+        assert v["enforcement"] == "advisory"
+        assert v["plugin_mode"] == "true"
+        assert v["no_plugin"] == ""
+
+    def test_standalone_is_copied_in_advisory(self):
+        v = _vars("standalone")
+        assert v["profile"] == "standalone"
+        assert v["enforcement"] == "advisory"
+        assert v["plugin_mode"] == ""
+        assert v["no_plugin"] == "true"
+
+    def test_org_is_hard_enforcement_plugin_by_default(self):
+        v = _vars("org")
+        assert v["profile"] == "org"
+        assert v["enforcement"] == "hard"
+        assert v["no_plugin"] == ""  # plugin on github.com/GHES by default
+
+    def test_org_on_emu_forces_copied_in(self):
+        v = _vars("org", explicit_no_plugin=True)
+        assert v["enforcement"] == "hard"
+        assert v["no_plugin"] == "true"
+
+
+class TestProfileHelpers:
+    def test_delivery_mapping(self):
+        assert _profile_delivery_no_plugin("standalone", False) is True
+        assert _profile_delivery_no_plugin("individual", False) is False
+        assert _profile_delivery_no_plugin("org", False) is False
+        # An explicit --no-plugin always wins, even for individual.
+        assert _profile_delivery_no_plugin("individual", True) is True
+
+    def test_enforcement_mapping(self):
+        assert _profile_enforcement("org") == "hard"
+        assert _profile_enforcement("individual") == "advisory"
+        assert _profile_enforcement("standalone") == "advisory"
+
+
+class TestProfileFlag:
+    def test_default_is_none(self):
+        # None lets the resolver print "defaulting to individual" rather than
+        # applying it silently.
+        args = _build_parser().parse_args(["."])
+        assert args.profile is None
+
+    def test_accepts_three_profiles(self):
+        for name in ("individual", "standalone", "org"):
+            args = _build_parser().parse_args([".", "--profile", name])
+            assert args.profile == name
+
+
+class TestProfileRecorded:
+    def test_config_yaml_shows_profile(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(
+            target,
+            load_preset("obsidian-only"),
+            make_variables(profile="standalone"),
+            strict=True,
+        )
+        cfg = (target / ".claude" / "config.yaml").read_text()
+        assert "profile: standalone" in cfg
+
+    def test_record_variables_include_profile(self, tmp_path: Path):
+        from project_init.upgrade import read_scaffold_record, write_scaffold_record
+
+        target = tmp_path / "p"
+        variables = make_variables(profile="org", enforcement="hard")
+        created = scaffold(target, load_preset("obsidian-only"), variables, strict=True)
+        write_scaffold_record(target, "obsidian-only", variables, created)
+        _, recorded, _, _ = read_scaffold_record(target)
+        assert recorded["profile"] == "org"
+        assert recorded["enforcement"] == "hard"
+
+
+class TestUpgradeBackfill:
+    def test_pre_247_record_upgrades_without_crash(self, tmp_path: Path):
+        """A record whose variables predate ``profile`` must still re-render —
+        config.yaml.tmpl uses {{profile}} and upgrade renders strictly."""
+        from project_init.upgrade import run_upgrade, write_scaffold_record
+
+        target = tmp_path / "p"
+        variables = make_variables()
+        created = scaffold(target, load_preset("obsidian-only"), variables, strict=True)
+        # Simulate a pre-#247 record: drop profile/enforcement from stored vars.
+        legacy = {k: v for k, v in variables.items() if k not in ("profile", "enforcement")}
+        write_scaffold_record(target, "obsidian-only", legacy, created)
+        # The record stores variables as JSON; a legacy record has no "profile" key
+        # (the human section uses `profile:`, the record JSON would use `"profile":`).
+        assert '"profile":' not in (target / ".claude" / "config.yaml").read_text()
+        # Upgrade must not crash on the strict re-render (profile is backfilled).
+        assert run_upgrade(target, apply=False) == 0

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -58,7 +58,9 @@ class TestProfileBundles:
         assert v["enforcement"] == "hard"
         assert v["no_plugin"] == ""  # plugin on github.com/GHES by default
 
-    def test_org_on_emu_forces_copied_in(self):
+    def test_org_with_explicit_no_plugin_is_copied_in(self):
+        # No host detection here — just that an explicit --no-plugin wins for org
+        # (the EMU/GHE.com host-adaptive choice lands in #248).
         v = _vars("org", explicit_no_plugin=True)
         assert v["enforcement"] == "hard"
         assert v["no_plugin"] == "true"

--- a/tests/unit/test_scaffold_inputs.py
+++ b/tests/unit/test_scaffold_inputs.py
@@ -36,7 +36,8 @@ def test_resolve_inputs_none_when_interactive():
 
 def test_scaffold_inputs_is_frozen():
     si = ScaffoldInputs(
-        "n", "d", "python", [], "", "none", False, False, False, ["claude"], False
+        "n", "d", "python", [], "", "none", False, False, False, ["claude"], False,
+        "individual",
     )
     with pytest.raises(dataclasses.FrozenInstanceError):
         si.project_name = "x"  # type: ignore[misc]


### PR DESCRIPTION
Closes #247

Introduce `--profile {individual,standalone,org}` (ADR-013), recorded in `.claude/config.yaml` and honored on upgrade.

- **Three profiles** keyed on the relationship to upstream:
  - `individual` (default) — plugin-first, track upstream, advisory (today's behavior; backward-compatible).
  - `standalone` — copied-in (`--no-plugin`), owner-driven pinned, advisory.
  - `org` — fork source-of-truth, host-adaptive delivery (plugin on github.com/GHES; `--no-plugin` for EMU/GHE.com), hard enforcement.
- **Notify-of-options**: the wizard presents the three profiles + what each bundles; non-interactive prints the resolved profile + its plugin/external-marketplace (egress) state — never silent.
- Profile drives the `no_plugin` (delivery) and `enforcement` (advisory/hard) defaults; both recorded in the human config and the scaffold record.
- **Upgrade backfill**: `run_upgrade` defaults `profile`/`enforcement` so pre-#247 records don't crash the strict re-render (`config.yaml.tmpl` now references `{{profile}}`).
- Tests: new `tests/unit/test_profile.py` (bundles, helpers, flag, recording, upgrade backfill); `make_variables` carries the new vars. Full suite **634 green**.

Scope note: enforcement *behavior* (rulesets) is #251, no-egress mode is #258, version-pin fields are #248 — this ticket records the profile and wires the defaults.