### PR TITLE
feat(PI-259): local observability record

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -109,6 +109,7 @@ def marketplace_source_vars(repo_url: str) -> dict[str, str]:
     return {
         "project_init_repo": slug,  # owner/repo — github source + display
         "project_init_repo_url": url,  # full clone URL — git source (non-github hosts)
+        "project_init_host": host or "github.com",  # observability record (#259)
         "project_init_github": "true" if is_github else "",
         "project_init_enterprise": "" if is_github else "true",
     }

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -54,6 +54,7 @@ _MIGRATION_DEFAULTS = {
     "project_init_repo_url": "https://github.com/VytCepas/project-init.git",
     "project_init_github": "true",
     "project_init_enterprise": "",
+    "project_init_host": "github.com",
     "project_init_plugin_version": "0.1.0",
     "project_init_version_prev": "",
 }
@@ -432,6 +433,36 @@ def _copy_rendered(src: Path, dest: Path) -> None:
     shutil.copy2(src, dest)
 
 
+# Visible observability fields injected into the human `project:` block on upgrade
+# when a pre-#247/#248/#259 config lacks them (config.yaml is not re-rendered on
+# upgrade, so otherwise they live only in the hidden record). (key, comment) —
+# the value comes from the recorded/backfilled variables (#259).
+_PROJECT_OBSERVABILITY = (
+    ("project_init_plugin_version", "plugin payload version (ADR-010)"),
+    ("profile", "individual | standalone | org — distribution profile (ADR-013)"),
+    ("enforcement", "advisory | hard — see ADR-013 / #251"),
+    ("project_init_host", "upstream GitHub host — #255/#259"),
+)
+
+
+def _ensure_observability_fields(text: str, variables: dict) -> str:
+    """Insert missing observability fields into the human ``project:`` block.
+
+    Idempotent — fields already present are kept. Inserts after the
+    ``project_init_version`` line so upgraded pre-#259 configs surface them.
+    """
+    for key, comment in _PROJECT_OBSERVABILITY:
+        if re.search(rf"(?m)^\s+{re.escape(key)}:", text):
+            continue
+        value = variables.get(key, "")
+        text = _VERSION_LINE_RE.sub(
+            lambda m, k=key, v=value, c=comment: f"{m.group(0)}\n  {k}: {v}  # {c}",
+            text,
+            count=1,
+        )
+    return text
+
+
 def apply_drift(
     target: Path,
     staging: Path,
@@ -453,6 +484,7 @@ def apply_drift(
         text = _VERSION_LINE_RE.sub(
             rf"\g<1>{variables['project_init_version']}", text, count=1
         )
+        text = _ensure_observability_fields(text, variables)
         config_path.write_text(text, encoding="utf-8")
 
     # Only files whose on-disk content now equals the render are recorded —

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -445,22 +445,35 @@ _PROJECT_OBSERVABILITY = (
 )
 
 
-def _ensure_observability_fields(text: str, variables: dict) -> str:
-    """Insert missing observability fields into the human ``project:`` block.
+_UPDATES_BLOCK = (
+    "\n\nupdates:\n"
+    "  # Addition-group consent state (#249): declined IDs, suppressed on future\n"
+    "  # `upgrade --apply` unless the upstream addition changes materially.\n"
+    "  declined_additions: []\n"
+)
 
-    Idempotent — fields already present are kept. Inserts after the
-    ``project_init_version`` line so upgraded pre-#259 configs surface them.
+
+def _ensure_observability_fields(text: str, variables: dict) -> str:
+    """Surface the observability record in the hand-editable config (#259).
+
+    Idempotent. Operates on the human section only (above the scaffold-record
+    marker) so injected lines survive ``write_scaffold_record``'s strip-and-
+    re-append. Missing ``project:`` fields are inserted together, in declaration
+    order, in a single substitution after the ``project_init_version`` line; the
+    ``updates`` consent placeholder is appended if the config predates it.
     """
-    for key, comment in _PROJECT_OBSERVABILITY:
-        if re.search(rf"(?m)^\s+{re.escape(key)}:", text):
-            continue
-        value = variables.get(key, "")
-        text = _VERSION_LINE_RE.sub(
-            lambda m, k=key, v=value, c=comment: f"{m.group(0)}\n  {k}: {v}  # {c}",
-            text,
-            count=1,
-        )
-    return text
+    head, sep, tail = text.partition(_RECORD_MARKER)
+    missing = [
+        f"  {key}: {variables.get(key, '')}  # {comment}"
+        for key, comment in _PROJECT_OBSERVABILITY
+        if not re.search(rf"(?m)^\s+{re.escape(key)}:", head)
+    ]
+    if missing:
+        block = "\n".join(missing)
+        head = _VERSION_LINE_RE.sub(lambda m: f"{m.group(0)}\n{block}", head, count=1)
+    if "declined_additions:" not in head:
+        head = head.rstrip("\n") + _UPDATES_BLOCK
+    return head + sep + tail
 
 
 def apply_drift(

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -8,6 +8,8 @@ project:
   project_init_version: {{project_init_version}}
   project_init_plugin_version: {{project_init_plugin_version}}  # plugin payload version (ADR-010)
   profile: {{profile}}     # individual | standalone | org — distribution profile (ADR-013)
+  enforcement: {{enforcement}}      # advisory | hard — see ADR-013 / #251
+  project_init_host: {{project_init_host}}  # upstream GitHub host (github.com | *.ghe.com | GHES) — #255/#259
   project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use feat(PI-42):
   github_project_number: 1 # numeric GitHub Project V2 board number (used by board-automation.yml and create_issue.sh)
 
@@ -31,3 +33,9 @@ tooling:
   lint_command: "{{lint_command}}"
   format_command: "{{format_command}}"
   test_command: "{{test_command}}"
+
+updates:
+  # Addition-group consent state (#249): IDs the owner has declined are stored
+  # here and suppressed on future `upgrade --apply` unless the upstream addition
+  # changes materially. Populated by `--decline-new`; empty by default.
+  declined_additions: []

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,6 +33,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "project_init_url": "https://github.com/example/project-init",
         "project_init_repo": "example/project-init",
         "project_init_repo_url": "https://github.com/example/project-init.git",
+        "project_init_host": "github.com",
         "project_init_github": "true",
         "project_init_enterprise": "",
         "project_init_plugin_version": "0.1.0",

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -79,3 +79,20 @@ class TestUpgradeInjectsObservability:
         # Fields are present exactly once (no duplicate injection on a current config).
         assert human.count("\n  profile:") == 1
         assert human.count("\n  enforcement:") == 1
+
+    def test_pre_259_config_gains_updates_placeholder(self, tmp_path: Path):
+        target = tmp_path / "p"
+        v = make_variables()
+        created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+        write_scaffold_record(target, "obsidian-only", v, created)
+        cfg = target / ".claude" / "config.yaml"
+        # Simulate a config predating the updates section (strip the whole block).
+        text = re.sub(
+            r"\nupdates:\n(?:  #.*\n)*  declined_additions: \[\]\n",
+            "\n",
+            cfg.read_text(),
+        )
+        cfg.write_text(text)
+        assert "declined_additions:" not in cfg.read_text()  # genuinely gone
+        assert run_upgrade(target, apply=True) == 0
+        assert "declined_additions: []" in cfg.read_text()

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -1,0 +1,81 @@
+"""PI-259: local observability record — profile/source/host/plugin-version/
+enforcement surfaced in .claude/config.yaml, including injection into existing
+configs on upgrade (ADR-013). Closes the two deferred P2s from #247/#248.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from project_init.scaffold import load_preset, marketplace_source_vars, scaffold
+from project_init.upgrade import run_upgrade, write_scaffold_record
+from tests.helpers import make_variables
+
+_MARKER = "# --- scaffold record"
+
+
+def _human_section(config_text: str) -> str:
+    """The hand-editable part of config.yaml, above the generated record block."""
+    return config_text.split(_MARKER)[0]
+
+
+class TestMarketplaceVarsIncludeHost:
+    def test_host_is_derived(self):
+        assert marketplace_source_vars("https://github.com/o/r")["project_init_host"] == "github.com"
+        assert (
+            marketplace_source_vars("https://ghes.example.com/o/r")["project_init_host"]
+            == "ghes.example.com"
+        )
+
+
+class TestFreshScaffoldRecordsObservability:
+    def test_visible_fields_present(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+        config_text = (target / ".claude" / "config.yaml").read_text()
+        human = _human_section(config_text)
+        assert "profile:" in human
+        assert "enforcement:" in human
+        assert "project_init_host:" in human
+        assert "project_init_plugin_version:" in human
+        assert "declined_additions: []" in config_text
+
+
+class TestUpgradeInjectsObservability:
+    def test_pre_259_config_gets_fields_on_apply(self, tmp_path: Path):
+        target = tmp_path / "p"
+        v = make_variables()
+        created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+        write_scaffold_record(target, "obsidian-only", v, created)
+        cfg = target / ".claude" / "config.yaml"
+
+        # Simulate a pre-#259 human config: drop the visible enforcement/host lines.
+        text = cfg.read_text()
+        text = (
+            "\n".join(
+                ln
+                for ln in text.splitlines()
+                if not re.match(r"\s+(enforcement|project_init_host):", ln)
+            )
+            + "\n"
+        )
+        cfg.write_text(text)
+        assert "enforcement:" not in _human_section(cfg.read_text())  # genuinely gone
+
+        assert run_upgrade(target, apply=True) == 0
+
+        human = _human_section(cfg.read_text())
+        assert "enforcement:" in human, "upgrade must inject the visible enforcement field"
+        assert "project_init_host:" in human, "upgrade must inject the visible host field"
+
+    def test_injection_is_idempotent(self, tmp_path: Path):
+        target = tmp_path / "p"
+        v = make_variables()
+        created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+        write_scaffold_record(target, "obsidian-only", v, created)
+        assert run_upgrade(target, apply=True) == 0
+        human = _human_section((target / ".claude" / "config.yaml").read_text())
+        # Fields are present exactly once (no duplicate injection on a current config).
+        assert human.count("\n  profile:") == 1
+        assert human.count("\n  enforcement:") == 1


### PR DESCRIPTION
Closes #259

Surface the governance state in `.claude/config.yaml` and inject it into existing configs on upgrade — closing the two P2s deferred from #247/#248.

- **Visible observability fields** in the human `project:` block: `profile`, `enforcement`, `project_init_host`, `project_init_plugin_version` (the source repo is already recorded via #248). Plus an `updates.declined_additions: []` placeholder for #249's consent state.
- **`project_init_host`** is derived by `marketplace_source_vars` (the upstream GitHub host).
- **Upgrade-time injection**: `_ensure_observability_fields` inserts any missing fields into the human `project:` block on `upgrade --apply` (config.yaml is otherwise not re-rendered) — idempotent. Pre-#247/#248/#259 projects now show the fields, not just the hidden record.
- Local only — no external telemetry (ADR-013).
- Tests: `tests/integration/test_observability.py` (host derivation, fresh-scaffold fields, upgrade injection, idempotency). Full suite **646 green**.