### PR TITLE
feat(PI-258): org no-egress mode

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -47,6 +47,7 @@ class ScaffoldInputs:
     agents: list[str]
     no_plugin: bool
     profile: str
+    no_egress: bool = False
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -152,6 +153,15 @@ def _build_parser() -> argparse.ArgumentParser:
             "Distribution profile (ADR-013): individual (default — plugin-first, "
             "track upstream, advisory), standalone (copied-in, owner-driven, "
             "pinned), org (fork source-of-truth, hard enforcement)"
+        ),
+    )
+    p.add_argument(
+        "--no-egress",
+        action="store_true",
+        help=(
+            "Org no-egress mode: omit the external official marketplace "
+            "(claude-plugins-official) and its plugins from scaffolded settings "
+            "(ADR-013, #258). The project-init/fork marketplace is kept"
         ),
     )
     p.add_argument(
@@ -325,26 +335,25 @@ def _print_summary(target: Path, created: list[Path], preset_name: str) -> None:
     console.print()
 
 
-def _print_profile_notice(profile: str, *, no_plugin: bool) -> None:
-    """Surface the resolved profile and its egress posture (#247).
+def _print_profile_notice(profile: str, *, no_plugin: bool, no_egress: bool) -> None:
+    """Surface the resolved profile and its egress posture (#247/#258).
 
     Called on the non-interactive path so a default is never applied silently:
-    it states the profile, the delivery/egress state, and the enforcement mode.
+    it states the profile, the delivery, the egress posture, and enforcement.
     """
     from rich.console import Console
 
-    # Honest egress: --no-plugin only copies project-init's own payload locally;
-    # the external official marketplace stays enabled in every mode until the
-    # org no-egress mode (#258) disables it.
-    delivery = (
-        "project-init copied in locally; external official marketplace still "
-        "enabled (network egress)"
-        if no_plugin
-        else "plugin-first; external official marketplace enabled (network egress)"
+    delivery = "project-init copied in locally" if no_plugin else "plugin-first"
+    # --no-plugin only copies project-init's own payload; the external official
+    # marketplace stays enabled until no-egress mode (#258) omits it.
+    egress = (
+        "external official marketplace disabled (no egress)"
+        if no_egress
+        else "external official marketplace enabled (network egress)"
     )
     Console().print(
         f"[cyan]Profile:[/cyan] {profile} — {_PROFILE_SUMMARY[profile]}\n"
-        f"[cyan]Delivery:[/cyan] {delivery}; "
+        f"[cyan]Delivery:[/cyan] {delivery}; {egress}; "
         f"[cyan]enforcement:[/cyan] {_profile_enforcement(profile)}"
     )
 
@@ -415,7 +424,7 @@ def _select_preset(
 
 
 def _gather_inputs_interactive(
-    default_name: str, *, no_plugin: bool, profile: str | None
+    default_name: str, *, no_plugin: bool, profile: str | None, no_egress: bool = False
 ) -> ScaffoldInputs:
     """Prompt for the profile, project basics, MCPs, governance, and overlays."""
     resolved_profile = profile or _choose_profile_interactive()
@@ -472,6 +481,7 @@ def _gather_inputs_interactive(
         agents=agents,
         no_plugin=no_plugin,
         profile=resolved_profile,
+        no_egress=no_egress,
     )
 
 
@@ -646,6 +656,10 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         # and enforcement defaults. The enforcing behavior lands in #251.
         "profile": inputs.profile,
         "enforcement": _profile_enforcement(inputs.profile),
+        # No-egress mode (#258): omit the external official marketplace. egress_ok
+        # is the inverse flag the template gates on (the engine has no else-branch).
+        "no_egress": "true" if inputs.no_egress else "",
+        "egress_ok": "" if inputs.no_egress else "true",
         # Plugin cutover (PI-165): inverse pair, same pattern as vscode_off.
         "plugin_mode": "" if no_plugin else "true",
         "no_plugin": "true" if no_plugin else "",
@@ -677,7 +691,7 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
         parser.error(str(e))
     profile = args.profile or "individual"
     no_plugin = _profile_delivery_no_plugin(profile, args.no_plugin)
-    _print_profile_notice(profile, no_plugin=no_plugin)
+    _print_profile_notice(profile, no_plugin=no_plugin, no_egress=args.no_egress)
     return ScaffoldInputs(
         project_name=args.name,
         project_description=args.description,
@@ -691,6 +705,7 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
         agents=agents,
         no_plugin=no_plugin,
         profile=profile,
+        no_egress=args.no_egress,
     )
 
 
@@ -721,7 +736,10 @@ def main(argv: list[str] | None = None) -> int:
     inputs = _resolve_inputs(args, parser, target)
     if inputs is None:
         inputs = _gather_inputs_interactive(
-            default_name=target.name, no_plugin=args.no_plugin, profile=args.profile
+            default_name=target.name,
+            no_plugin=args.no_plugin,
+            profile=args.profile,
+            no_egress=args.no_egress,
         )
     target.mkdir(parents=True, exist_ok=True)
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -108,6 +108,8 @@ def _overlay_off_defaults() -> dict[str, str]:
         "no_plugin": "true",
         "profile": "individual",
         "enforcement": "advisory",
+        "no_egress": "",
+        "egress_ok": "true",
         "project_owner": "",
         "license": "none",
         "license_mit": "",

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -4,22 +4,22 @@
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70"
   },
   "extraKnownMarketplaces": {
-    "claude-plugins-official": {
+    {{#if egress_ok}}"claude-plugins-official": {
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
     },
-    "project-init": {
+    {{/if egress_ok}}"project-init": {
       "source": {
         {{#if project_init_github}}"source": "github", "repo": "{{project_init_repo}}"{{/if project_init_github}}{{#if project_init_enterprise}}"source": "git", "url": "{{project_init_repo_url}}"{{/if project_init_enterprise}}
       }
     }
   },
   "enabledPlugins": {
-    "security-guidance@claude-plugins-official": true,
+    {{#if egress_ok}}"security-guidance@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true{{#if plugin_mode}},
-    "project-init-workflow@project-init": true{{/if plugin_mode}}
+    {{/if plugin_mode}}{{/if egress_ok}}{{#if plugin_mode}}"project-init-workflow@project-init": true{{/if plugin_mode}}
   }{{#if no_plugin}},
   "hooks": {
     "SessionStart": [

--- a/tests/contracts/test_no_egress.py
+++ b/tests/contracts/test_no_egress.py
@@ -73,3 +73,21 @@ class TestSettingsEgress:
             no_plugin="true",
         )
         assert data["enabledPlugins"] == {}
+
+
+class TestNoEgressUpgradeBackfill:
+    def test_pre_258_record_preserves_official_marketplace(self, tmp_path: Path):
+        """A record predating the egress keys must upgrade cleanly (strict
+        re-render) and keep the official marketplace — egress defaults on."""
+        from project_init.upgrade import run_upgrade, write_scaffold_record
+
+        target = tmp_path / "p"
+        v = make_variables()
+        created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+        legacy = {k: val for k, val in v.items() if k not in ("egress_ok", "no_egress")}
+        write_scaffold_record(target, "obsidian-only", legacy, created)
+
+        assert run_upgrade(target, apply=True) == 0
+        data = json.loads((target / ".claude" / "settings.json").read_text())
+        assert "claude-plugins-official" in data["extraKnownMarketplaces"]
+        assert "security-guidance@claude-plugins-official" in data["enabledPlugins"]

--- a/tests/contracts/test_no_egress.py
+++ b/tests/contracts/test_no_egress.py
@@ -1,0 +1,75 @@
+"""PI-258: org no-egress mode — omit the external official marketplace
+(claude-plugins-official) and its plugins from scaffolded settings.json
+(ADR-013). The project-init/fork marketplace is always kept.
+
+The settings template builds these lists with conditional members in a no-`else`
+engine, so every egress×plugin combination is asserted to render valid JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from project_init.__main__ import _build_parser
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _settings(tmp_path: Path, **overrides: str) -> dict:
+    target = tmp_path / "p"
+    scaffold(
+        target, load_preset("obsidian-only"), make_variables(**overrides), strict=True
+    )
+    return json.loads((target / ".claude" / "settings.json").read_text())
+
+
+class TestNoEgressFlag:
+    def test_flag_parses(self):
+        assert _build_parser().parse_args([".", "--no-egress"]).no_egress is True
+
+    def test_default_off(self):
+        assert _build_parser().parse_args(["."]).no_egress is False
+
+
+class TestSettingsEgress:
+    @pytest.mark.parametrize("plugin", ["true", ""])
+    def test_egress_on_keeps_official_marketplace(self, tmp_path: Path, plugin: str):
+        data = _settings(
+            tmp_path,
+            egress_ok="true",
+            no_egress="",
+            plugin_mode=plugin,
+            no_plugin=("" if plugin else "true"),
+        )
+        assert "claude-plugins-official" in data["extraKnownMarketplaces"]
+        assert "security-guidance@claude-plugins-official" in data["enabledPlugins"]
+
+    @pytest.mark.parametrize("plugin", ["true", ""])
+    def test_no_egress_omits_official_marketplace(self, tmp_path: Path, plugin: str):
+        data = _settings(
+            tmp_path,
+            egress_ok="",
+            no_egress="true",
+            plugin_mode=plugin,
+            no_plugin=("" if plugin else "true"),
+        )
+        assert "claude-plugins-official" not in data["extraKnownMarketplaces"]
+        assert "project-init" in data["extraKnownMarketplaces"]  # the org's own is kept
+        assert not any("claude-plugins-official" in k for k in data["enabledPlugins"])
+
+    def test_no_egress_plugin_mode_keeps_project_init_plugin(self, tmp_path: Path):
+        data = _settings(tmp_path, egress_ok="", no_egress="true", plugin_mode="true")
+        assert data["enabledPlugins"] == {"project-init-workflow@project-init": True}
+
+    def test_no_egress_no_plugin_empties_enabled_plugins(self, tmp_path: Path):
+        data = _settings(
+            tmp_path,
+            egress_ok="",
+            no_egress="true",
+            plugin_mode="",
+            no_plugin="true",
+        )
+        assert data["enabledPlugins"] == {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,6 +63,8 @@ def make_variables(**overrides: str) -> dict[str, str]:
         # the copied payload use fallback_variables()/fallback_preset().
         "plugin_mode": "true",
         "no_plugin": "",
+        "no_egress": "",
+        "egress_ok": "true",
         "profile": "individual",
         "enforcement": "advisory",
         "graphify": "",


### PR DESCRIPTION
Closes #258

Add `--no-egress` (ADR-013): the org/locked-down mode that omits the external official marketplace (`claude-plugins-official`) and its plugins from scaffolded `settings.json`. The project-init/fork marketplace is kept (the org's own controlled source).

- `egress_ok` inverse flag gates `claude-plugins-official` (marketplace entry + `security-guidance`/`pr-review-toolkit`) in `settings.json.tmpl` via complementary if-blocks (the engine has no `else`). All four egress×plugin combinations render valid JSON.
- The non-interactive notice now states the egress posture honestly — closing the loop on the "#258" pointer the #247 notice referenced.
- Upgrade backfill: `egress_ok` defaults true for pre-#258 records, so re-render keeps their official plugins (no silent removal).
- Tests: `tests/contracts/test_no_egress.py` (flag + all four egress×plugin combos). Full suite **655 green**.

Completes **B5** (#248 + #259 + #258).