### PR TITLE
feat(PI-249): opt-in consent for new additions during upgrade

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -588,8 +588,31 @@ def _upgrade_main(argv: list[str]) -> int:
         action="store_true",
         help="Accepted for CLI symmetry — upgrade never prompts",
     )
+    p.add_argument(
+        "--accept-new",
+        action="append",
+        default=[],
+        metavar="ID",
+        help="Accept an addition group on --apply (repeatable; 'all' accepts every new group, #249)",
+    )
+    p.add_argument(
+        "--decline-new",
+        action="append",
+        default=[],
+        metavar="ID",
+        help=(
+            "Decline an addition group; recorded and suppressed on future "
+            "--apply unless it changes materially ('all' declines every new group)"
+        ),
+    )
     args = p.parse_args(argv)
-    return run_upgrade(Path(args.target).resolve(), apply=args.apply, no_plugin=args.no_plugin)
+    return run_upgrade(
+        Path(args.target).resolve(),
+        apply=args.apply,
+        no_plugin=args.no_plugin,
+        accept_new=args.accept_new,
+        decline_new=args.decline_new,
+    )
 
 
 def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -595,7 +595,11 @@ def _addition_groups(new_paths: list[Path], staging: Path) -> dict[str, dict]:
     for group in groups.values():
         digest = hashlib.sha256()
         for rel in group["paths"]:
-            digest.update((staging / rel).read_bytes())
+            # Length-delimit path + content so different per-file splits can't
+            # collide (e.g. "ab"+"c" vs "a"+"bc" would otherwise match).
+            content = (staging / rel).read_bytes()
+            digest.update(f"{rel.as_posix()}\0{len(content)}\0".encode())
+            digest.update(content)
         group["hash"] = digest.hexdigest()[:12]
     return groups
 
@@ -611,8 +615,13 @@ def _read_declined(target: Path) -> dict[str, str]:
     match = _DECLINED_RE.search(config_path.read_text(encoding="utf-8"))
     if not match:
         return {}
+    # config.yaml is hand-editable: extract just the {...} object so a trailing
+    # inline YAML comment doesn't break JSON parsing (and silently drop declines).
+    obj = re.search(r"\{.*\}", match.group(2))
+    if not obj:
+        return {}
     try:
-        value = json.loads(match.group(2).strip() or "{}")
+        value = json.loads(obj.group(0))
     except json.JSONDecodeError:
         return {}
     return value if isinstance(value, dict) else {}

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -451,7 +451,7 @@ _UPDATES_BLOCK = (
     "\n\nupdates:\n"
     "  # Addition-group consent state (#249): declined IDs, suppressed on future\n"
     "  # `upgrade --apply` unless the upstream addition changes materially.\n"
-    "  declined_additions: []\n"
+    "  declined_additions: {}\n"
 )
 
 
@@ -556,7 +556,152 @@ def _print_report(report: DriftReport, applied: bool) -> None:
         console.print("\nRun [bold]project-init upgrade --apply[/bold] to apply.")
 
 
-def run_upgrade(target: Path, *, apply: bool, no_plugin: bool = False) -> int:
+# --- Opt-in consent for new additions (#249) -------------------------------
+
+# Ordered (path-prefix, group-id, rationale); first match wins, else "misc".
+# Groups bundle new files by feature/overlay so the owner accepts or declines a
+# meaningful unit instead of individual paths (ADR-013).
+_ADDITION_GROUP_RULES: tuple[tuple[tuple[str, ...], str, str], ...] = (
+    ((".devcontainer",), "devcontainer", "Dev container (Codespaces / remote agents)"),
+    ((".vscode",), "vscode", "Shared VS Code config"),
+    ((".github", "workflows"), "github-workflows", "CI / CD workflows"),
+    ((".github",), "github", "GitHub repo config (templates, CODEOWNERS, …)"),
+    ((".claude", "skills"), "claude-skills", "Claude Code skills"),
+    ((".claude", "hooks"), "claude-hooks", "Claude Code hooks"),
+    ((".claude", "agents"), "claude-agents", "Claude Code agent specs"),
+    ((".claude", "docs"), "claude-docs", "In-repo docs (.claude/docs)"),
+    ((".claude",), "claude-core", "Claude Code core config"),
+    ((".codex",), "codex-agent", "Codex agent wiring"),
+    ((".gemini",), "gemini-agent", "Gemini agent wiring"),
+    (("docs",), "docs", "Project documentation site"),
+)
+
+
+def _classify_addition(rel: Path) -> tuple[str, str]:
+    """Map a new file to its addition group ``(id, rationale)``."""
+    parts = rel.parts
+    for prefix, gid, rationale in _ADDITION_GROUP_RULES:
+        if parts[: len(prefix)] == prefix:
+            return gid, rationale
+    return "misc", "Miscellaneous new files"
+
+
+def _addition_groups(new_paths: list[Path], staging: Path) -> dict[str, dict]:
+    """Bucket new files into addition groups, each with a content hash."""
+    groups: dict[str, dict] = {}
+    for rel in sorted(new_paths):
+        gid, rationale = _classify_addition(rel)
+        groups.setdefault(gid, {"paths": [], "rationale": rationale})["paths"].append(rel)
+    for group in groups.values():
+        digest = hashlib.sha256()
+        for rel in group["paths"]:
+            digest.update((staging / rel).read_bytes())
+        group["hash"] = digest.hexdigest()[:12]
+    return groups
+
+
+_DECLINED_RE = re.compile(r"^(\s*declined_additions:\s*)(.*)$", re.MULTILINE)
+
+
+def _read_declined(target: Path) -> dict[str, str]:
+    """Read the recorded ``{group-id: hash}`` of declined additions."""
+    config_path = target / _CONFIG_REL
+    if not config_path.exists():
+        return {}
+    match = _DECLINED_RE.search(config_path.read_text(encoding="utf-8"))
+    if not match:
+        return {}
+    try:
+        value = json.loads(match.group(2).strip() or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_declined(target: Path, declined: dict[str, str]) -> None:
+    """Persist the ``{group-id: hash}`` of declined additions into config.yaml."""
+    config_path = target / _CONFIG_REL
+    if not config_path.exists():
+        return
+    text = config_path.read_text(encoding="utf-8")
+    payload = json.dumps(declined, sort_keys=True)
+    if _DECLINED_RE.search(text):
+        text = _DECLINED_RE.sub(lambda m: f"{m.group(1)}{payload}", text, count=1)
+    else:
+        text = text.rstrip("\n") + f"\n\nupdates:\n  declined_additions: {payload}\n"
+    config_path.write_text(text, encoding="utf-8")
+
+
+def _resolve_addition_consent(
+    target: Path, groups: dict, accept_new: list[str], decline_new: list[str]
+) -> dict:
+    """Classify each addition group as accepted / declined / undecided.
+
+    A previously-declined group stays declined only while its content hash is
+    unchanged; a materially changed group resurfaces as undecided (ADR-013).
+    """
+    recorded = _read_declined(target)
+    accepted = set(groups) if "all" in accept_new else {g for g in accept_new if g in groups}
+    declined_flag = set(groups) if "all" in decline_new else {g for g in decline_new if g in groups}
+    still_declined = {gid for gid in groups if recorded.get(gid) == groups[gid]["hash"]}
+    declined_now = (declined_flag | still_declined) - accepted
+    undecided = set(groups) - accepted - declined_now
+    return {
+        "accepted": accepted,
+        "declined_now": declined_now,
+        "undecided": undecided,
+        "declined_map": {gid: groups[gid]["hash"] for gid in declined_now},
+    }
+
+
+def _print_addition_gate(groups: dict, undecided: set) -> None:
+    """Print the consent gate that blocks --apply until new groups are decided."""
+    from rich.console import Console
+
+    console = Console()
+    console.print(
+        "\n[bold yellow]New additions need a decision before --apply[/bold yellow] (#249):"
+    )
+    for gid in sorted(undecided):
+        group = groups[gid]
+        console.print(f"  [cyan]{gid}[/cyan] — {group['rationale']} ({len(group['paths'])} files)")
+        for rel in group["paths"]:
+            console.print(f"      {rel}")
+    console.print(
+        "\nDecide per group, then re-run with --apply:\n"
+        "  --accept-new <id>    (or --accept-new all)\n"
+        "  --decline-new <id>   (or --decline-new all)"
+    )
+
+
+def _print_addition_summary(groups: dict, gate: dict) -> None:
+    """Summarize addition groups and their accept/decline/undecided status."""
+    from rich.console import Console
+
+    console = Console()
+    console.print("\n[bold]addition groups[/bold] (#249):")
+    for gid in sorted(groups):
+        if gid in gate["declined_now"]:
+            status = "declined"
+        elif gid in gate["accepted"]:
+            status = "accepted"
+        else:
+            status = "undecided"
+        group = groups[gid]
+        console.print(
+            f"  [cyan]{gid}[/cyan] [{status}] — {group['rationale']} "
+            f"({len(group['paths'])} files)"
+        )
+
+
+def run_upgrade(
+    target: Path,
+    *,
+    apply: bool,
+    no_plugin: bool = False,
+    accept_new: list[str] | None = None,
+    decline_new: list[str] | None = None,
+) -> int:
     """Entry point for the upgrade subcommand; returns a process exit code.
 
     *no_plugin* switches the project to the fallback mode on this run:
@@ -606,12 +751,26 @@ def run_upgrade(target: Path, *, apply: bool, no_plugin: bool = False) -> int:
 
         report = compute_drift(target, staging, rendered, manifest)
         report.migrated = migrated
-        # Run apply even with zero file drift: the config version line and
-        # the scaffold record must still be refreshed to the current tool
-        # version when the user explicitly applied the upgrade.
+        # Opt-in consent for new additions (#249): bucket genuinely-new files
+        # into groups and require an accept/decline decision before --apply
+        # touches them. A file in the recorded manifest that is merely missing is
+        # a restoration the user already consented to — not gated.
+        genuinely_new = [rel for rel in report.new if rel.as_posix() not in manifest]
+        groups = _addition_groups(genuinely_new, staging)
+        gate = _resolve_addition_consent(target, groups, accept_new or [], decline_new or [])
+        if apply and gate["undecided"]:
+            _print_addition_gate(groups, gate["undecided"])
+            return 2
+        # Run apply even with zero file drift: the config version line and the
+        # scaffold record must still refresh to the current tool version.
         if apply:
+            suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
+            report.new = [rel for rel in report.new if rel not in suppressed]
             apply_drift(target, staging, report, preset_name, variables)
+            _write_declined(target, gate["declined_map"])
         _print_report(report, applied=apply)
+        if groups:
+            _print_addition_summary(groups, gate)
     finally:
         shutil.rmtree(staging_root, ignore_errors=True)
     return 0

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -38,4 +38,4 @@ updates:
   # Addition-group consent state (#249): IDs the owner has declined are stored
   # here and suppressed on future `upgrade --apply` unless the upstream addition
   # changes materially. Populated by `--decline-new`; empty by default.
-  declined_additions: []
+  declined_additions: {}

--- a/tests/integration/test_consent.py
+++ b/tests/integration/test_consent.py
@@ -106,3 +106,30 @@ class TestConsentGate:
         doc.unlink()
         assert run_upgrade(target, apply=True) == 0
         assert doc.exists()
+
+
+class TestConsentInternals:
+    def test_read_declined_tolerates_inline_comment(self, tmp_path: Path):
+        from project_init.upgrade import _read_declined
+
+        target = _scaffolded(tmp_path)
+        cfg = target / ".claude/config.yaml"
+        cfg.write_text(
+            re.sub(
+                r"declined_additions:\s*\{.*\}",
+                'declined_additions: {"docs": "abc123"}  # hand-edited note',
+                cfg.read_text(),
+            )
+        )
+        assert _read_declined(target) == {"docs": "abc123"}
+
+    def test_group_hash_is_path_sensitive(self, tmp_path: Path):
+        # Same bytes under different filenames must hash differently — guards
+        # against per-file concatenation collisions.
+        target = tmp_path / "p"
+        (target / "docs").mkdir(parents=True)
+        for name in ("a.md", "b.md", "c.md"):
+            (target / "docs" / name).write_text("same")
+        h_ab = _addition_groups([Path("docs/a.md"), Path("docs/b.md")], target)["docs"]["hash"]
+        h_ac = _addition_groups([Path("docs/a.md"), Path("docs/c.md")], target)["docs"]["hash"]
+        assert h_ab != h_ac

--- a/tests/integration/test_consent.py
+++ b/tests/integration/test_consent.py
@@ -1,0 +1,108 @@
+"""PI-249: opt-in consent for new additions during upgrade (ADR-013).
+
+Genuinely-new files surfaced by an upgrade (absent from the recorded manifest)
+are bucketed into addition groups; `--apply` refuses to proceed until each group
+is accepted or declined. Declined groups are recorded and suppressed on future
+applies unless their content changes. Restoring a *manifested* file the user
+deleted is not gated (already consented to when first scaffolded).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from project_init.upgrade import (
+    _addition_groups,
+    _classify_addition,
+    run_upgrade,
+    write_scaffold_record,
+)
+from tests.helpers import make_variables
+
+
+def _declined(target: Path) -> dict:
+    m = re.search(
+        r"declined_additions:\s*(\{.*\})", (target / ".claude/config.yaml").read_text()
+    )
+    return json.loads(m.group(1)) if m else {}
+
+
+def _scaffolded(tmp_path: Path) -> Path:
+    target = tmp_path / "p"
+    v = make_variables()
+    created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+    write_scaffold_record(target, "obsidian-only", v, created)
+    return target
+
+
+def _genuinely_new_docs(tmp_path: Path) -> tuple[Path, Path]:
+    """Make one docs file look like a genuinely-new addition: exclude it from the
+    recorded manifest and delete it from the project, so the next upgrade sees it
+    as new (not a restoration of a manifested file)."""
+    target = tmp_path / "p"
+    v = make_variables()
+    created = scaffold(target, load_preset("obsidian-only"), v, strict=True)
+    rel = sorted(p.relative_to(target) for p in (target / "docs").rglob("*.md"))[0]
+    write_scaffold_record(target, "obsidian-only", v, [c for c in created if c != rel])
+    (target / rel).unlink()
+    return target, target / rel
+
+
+class TestClassify:
+    def test_known_areas(self):
+        assert _classify_addition(Path(".devcontainer/devcontainer.json"))[0] == "devcontainer"
+        assert _classify_addition(Path(".github/workflows/ci.yml"))[0] == "github-workflows"
+        assert _classify_addition(Path(".claude/skills/x/SKILL.md"))[0] == "claude-skills"
+        assert _classify_addition(Path("docs/guides/x.md"))[0] == "docs"
+
+    def test_unknown_is_misc(self):
+        assert _classify_addition(Path("random.txt"))[0] == "misc"
+
+    def test_groups_carry_paths_and_hash(self, tmp_path: Path):
+        target = _scaffolded(tmp_path)
+        real = [p.relative_to(target) for p in sorted((target / "docs").rglob("*.md"))[:1]]
+        groups = _addition_groups(real, target)
+        assert "docs" in groups
+        assert len(groups["docs"]["hash"]) == 12
+
+
+class TestConsentGate:
+    def test_apply_blocked_until_decided(self, tmp_path: Path):
+        target, new_file = _genuinely_new_docs(tmp_path)
+        assert run_upgrade(target, apply=True) == 2  # refused
+        assert not new_file.exists()  # nothing applied
+
+    def test_accept_new_applies(self, tmp_path: Path):
+        target, new_file = _genuinely_new_docs(tmp_path)
+        assert run_upgrade(target, apply=True, accept_new=["docs"]) == 0
+        assert new_file.exists()
+
+    def test_accept_all_applies(self, tmp_path: Path):
+        target, new_file = _genuinely_new_docs(tmp_path)
+        assert run_upgrade(target, apply=True, accept_new=["all"]) == 0
+        assert new_file.exists()
+
+    def test_decline_records_and_suppresses(self, tmp_path: Path):
+        target, new_file = _genuinely_new_docs(tmp_path)
+        assert run_upgrade(target, apply=True, decline_new=["docs"]) == 0
+        assert not new_file.exists()  # suppressed, not applied
+        assert "docs" in _declined(target)
+        # A later --apply is not blocked — the declined group is suppressed.
+        assert run_upgrade(target, apply=True) == 0
+        assert not new_file.exists()
+
+    def test_report_mode_never_blocks(self, tmp_path: Path):
+        target, _ = _genuinely_new_docs(tmp_path)
+        assert run_upgrade(target, apply=False) == 0
+
+    def test_deleted_manifested_file_is_restored_without_consent(self, tmp_path: Path):
+        # A file in the manifest that the user deleted is a restoration, not a
+        # new addition — applied without a decision.
+        target = _scaffolded(tmp_path)
+        doc = sorted((target / "docs").rglob("*.md"))[0]
+        doc.unlink()
+        assert run_upgrade(target, apply=True) == 0
+        assert doc.exists()

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -39,7 +39,7 @@ class TestFreshScaffoldRecordsObservability:
         assert "enforcement:" in human
         assert "project_init_host:" in human
         assert "project_init_plugin_version:" in human
-        assert "declined_additions: []" in config_text
+        assert "declined_additions: {}" in config_text
 
 
 class TestUpgradeInjectsObservability:
@@ -88,11 +88,11 @@ class TestUpgradeInjectsObservability:
         cfg = target / ".claude" / "config.yaml"
         # Simulate a config predating the updates section (strip the whole block).
         text = re.sub(
-            r"\nupdates:\n(?:  #.*\n)*  declined_additions: \[\]\n",
+            r"\nupdates:\n(?:  #.*\n)*  declined_additions: \{\}\n",
             "\n",
             cfg.read_text(),
         )
         cfg.write_text(text)
         assert "declined_additions:" not in cfg.read_text()  # genuinely gone
         assert run_upgrade(target, apply=True) == 0
-        assert "declined_additions: []" in cfg.read_text()
+        assert "declined_additions: {}" in cfg.read_text()

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -345,7 +345,7 @@ class TestMigration:
         config.write_text(text.split(_RECORD_MARKER)[0])
         (target / "justfile").write_bytes(b"# edited under old version\n")
 
-        rc = main(["upgrade", str(target), "--apply"])
+        rc = main(["upgrade", str(target), "--apply", "--accept-new", "all"])
         out = capsys.readouterr().out
         assert rc == 0
         assert "No scaffold record" in out
@@ -396,7 +396,7 @@ class TestRemovedPresets:
         config.write_text(
             config.read_text().replace("  preset: obsidian-only", "  preset: obsidian-lightrag")
         )
-        rc = main(["upgrade", str(target), "--apply"])
+        rc = main(["upgrade", str(target), "--apply", "--accept-new", "all"])
         assert rc == 0
         assert "re-rendering as obsidian-graphify" in capsys.readouterr().err
         # Successor preset's overlay landed and the record was rewritten.
@@ -443,7 +443,7 @@ class TestNoPluginSwitch:
         _scaffold(target)  # default: plugin mode, no copies
         assert not (target / ".claude" / "hooks" / "pre_commit_gate.sh").exists()
 
-        rc = main(["upgrade", str(target), "--no-plugin", "--apply"])
+        rc = main(["upgrade", str(target), "--no-plugin", "--apply", "--accept-new", "all"])
         assert rc == 0
         assert "switching to the no-plugin fallback" in capsys.readouterr().err
         assert (target / ".claude" / "hooks" / "pre_commit_gate.sh").is_file()


### PR DESCRIPTION
Closes #249

Add opt-in consent for new additions during `upgrade` (ADR-013).

- **Addition groups**: genuinely-new files (absent from the recorded manifest) are bucketed by feature/overlay (`devcontainer`, `claude-skills`, `docs`, … + `misc`) with a stable ID, rationale, and content hash.
- **Consent gate**: `upgrade --apply` refuses (exit 2) until every new group is accepted or declined, listing the groups + how to decide.
- **Flags**: `--accept-new <id|all>` applies a group; `--decline-new <id|all>` records it (in `updates.declined_additions` as `{id: hash}`) and suppresses it.
- **Suppression + material change**: declined groups are skipped on future applies; a declined group whose content hash changes resurfaces as undecided.
- **Restorations aren't gated**: a manifested file the user deleted is a restoration (already consented to) and is applied without a decision — only genuinely-new files need consent.
- Tests: `tests/integration/test_consent.py` (classify, gate, accept/decline, suppression, restoration). 3 existing upgrade tests opt past the gate with `--accept-new all` where they intentionally bulk-apply new files. Full suite **665 green**.

Unblocks #250 (pull-and-recommend), which builds on this consent gate.