### PR TITLE
feat(PI-250): pull-and-recommend (version-span + recommendations)

### DIFF
--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -694,10 +694,13 @@ def _describe_version_span(prev: str | None, current: str | None) -> str:
     p, c = _parse_version(prev), _parse_version(current)
     if not p or not c or p == c:
         return ""
+    # Format from the parsed tuple so a recorded "v" prefix or a "-rc" suffix
+    # can't produce "vv1.2.3" or leak pre-release noise.
+    pv, cv = ".".join(map(str, p)), ".".join(map(str, c))
     if c < p:
-        return f"v{prev} → v{current} (downgrade)"
+        return f"v{pv} → v{cv} (downgrade)"
     level = "major" if c[0] > p[0] else "minor" if c[1] > p[1] else "patch"
-    return f"v{prev} → v{current} ({level} update)"
+    return f"v{pv} → v{cv} ({level} update)"
 
 
 def _print_addition_summary(groups: dict, gate: dict, span: str = "") -> None:

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -683,12 +683,39 @@ def _print_addition_gate(groups: dict, undecided: set) -> None:
     )
 
 
-def _print_addition_summary(groups: dict, gate: dict) -> None:
-    """Summarize addition groups and their accept/decline/undecided status."""
+def _parse_version(value: str | None) -> tuple[int, int, int] | None:
+    """Parse a leading ``X.Y.Z`` (optional ``v`` prefix) into a tuple."""
+    m = re.match(r"v?(\d+)\.(\d+)\.(\d+)", value or "")
+    return (int(m[1]), int(m[2]), int(m[3])) if m else None
+
+
+def _describe_version_span(prev: str | None, current: str | None) -> str:
+    """Human description of the version span an upgrade crosses (#250)."""
+    p, c = _parse_version(prev), _parse_version(current)
+    if not p or not c or p == c:
+        return ""
+    if c < p:
+        return f"v{prev} → v{current} (downgrade)"
+    level = "major" if c[0] > p[0] else "minor" if c[1] > p[1] else "patch"
+    return f"v{prev} → v{current} ({level} update)"
+
+
+def _print_addition_summary(groups: dict, gate: dict, span: str = "") -> None:
+    """Frame addition groups as opt-in recommendations (#249/#250).
+
+    Pull-and-recommend: new additions are surfaced with the version span they
+    arrived in and are *never* auto-applied — the owner adopts or skips each.
+    """
     from rich.console import Console
 
     console = Console()
-    console.print("\n[bold]addition groups[/bold] (#249):")
+    header = "recommended additions" if span else "addition groups"
+    suffix = f" — {span}" if span else ""
+    console.print(f"\n[bold]{header}{suffix}[/bold] (#250):")
+    console.print(
+        "[dim]Recommendations only — adopt with --accept-new, skip with "
+        "--decline-new; never auto-applied.[/dim]"
+    )
     for gid in sorted(groups):
         if gid in gate["declined_now"]:
             status = "declined"
@@ -779,7 +806,11 @@ def run_upgrade(
             _write_declined(target, gate["declined_map"])
         _print_report(report, applied=apply)
         if groups:
-            _print_addition_summary(groups, gate)
+            span = _describe_version_span(
+                variables.get("project_init_version_prev"),
+                variables.get("project_init_version"),
+            )
+            _print_addition_summary(groups, gate, span)
     finally:
         shutil.rmtree(staging_root, ignore_errors=True)
     return 0

--- a/tests/integration/test_consent.py
+++ b/tests/integration/test_consent.py
@@ -133,3 +133,14 @@ class TestConsentInternals:
         h_ab = _addition_groups([Path("docs/a.md"), Path("docs/b.md")], target)["docs"]["hash"]
         h_ac = _addition_groups([Path("docs/a.md"), Path("docs/c.md")], target)["docs"]["hash"]
         assert h_ab != h_ac
+
+
+class TestRecommendationFraming:
+    def test_report_frames_additions_as_recommendations(self, tmp_path: Path, capsys):
+        target, _ = _genuinely_new_docs(tmp_path)
+        run_upgrade(target, apply=False)
+        # Collapse whitespace — rich wraps lines at the console width.
+        out = " ".join(capsys.readouterr().out.lower().split())
+        assert "recommend" in out
+        assert "never auto-applied" in out
+        assert "update" in out  # the version span (#250) is surfaced

--- a/tests/unit/test_version_span.py
+++ b/tests/unit/test_version_span.py
@@ -1,0 +1,48 @@
+"""PI-250: pull-and-recommend — version-span detection (ADR-013)."""
+
+from __future__ import annotations
+
+import pytest
+
+from project_init.upgrade import _describe_version_span, _parse_version
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("0.4.0", (0, 4, 0)),
+            ("v1.2.3", (1, 2, 3)),
+            ("1.2.3-rc1", (1, 2, 3)),
+            ("", None),
+            (None, None),
+            ("nope", None),
+        ],
+    )
+    def test_parse(self, raw, expected):
+        assert _parse_version(raw) == expected
+
+
+class TestVersionSpan:
+    def test_minor(self):
+        assert "minor update" in _describe_version_span("0.3.0", "0.5.0")
+
+    def test_major(self):
+        assert "major update" in _describe_version_span("1.9.0", "2.0.0")
+
+    def test_patch(self):
+        assert "patch update" in _describe_version_span("0.4.0", "0.4.2")
+
+    def test_same_is_empty(self):
+        assert _describe_version_span("0.4.0", "0.4.0") == ""
+
+    def test_unknown_is_empty(self):
+        assert _describe_version_span(None, "0.4.0") == ""
+        assert _describe_version_span("0.4.0", "") == ""
+
+    def test_downgrade(self):
+        assert "downgrade" in _describe_version_span("0.5.0", "0.4.0")
+
+    def test_includes_both_versions(self):
+        span = _describe_version_span("0.3.0", "0.5.0")
+        assert "0.3.0" in span and "0.5.0" in span

--- a/tests/unit/test_version_span.py
+++ b/tests/unit/test_version_span.py
@@ -46,3 +46,14 @@ class TestVersionSpan:
     def test_includes_both_versions(self):
         span = _describe_version_span("0.3.0", "0.5.0")
         assert "0.3.0" in span and "0.5.0" in span
+
+    def test_v_prefixed_inputs_do_not_double_prefix(self):
+        span = _describe_version_span("v1.2.3", "v1.3.0")
+        assert "vv" not in span
+        assert "minor update" in span
+        assert "1.2.3" in span and "1.3.0" in span
+
+    def test_prerelease_suffix_is_normalized(self):
+        span = _describe_version_span("0.4.0", "0.5.0-rc1")
+        assert "rc" not in span
+        assert "v0.5.0" in span


### PR DESCRIPTION
Closes #250

Pull-and-recommend (ADR-013): surface upstream additions as opt-in recommendations with version-span context — never forced.

- **Version-span detection**: `_describe_version_span(prev, current)` reports the span an upgrade crosses (e.g. "v0.1.0 → v0.4.0 (minor update)"), using the `project_init_version_prev` → version fields from #248. Semver-aware (major/minor/patch/downgrade); empty for same/unknown versions.
- **Recommendation framing**: the addition groups from #249 are now presented as "recommended additions — <span>" with an explicit "Recommendations only — adopt with --accept-new, skip with --decline-new; never auto-applied" note. The consent gate already enforces opt-in; #250 frames it as version-span recommendations.
- Builds on #248 (version fields) + #249 (consent gate).
- Tests: `tests/unit/test_version_span.py` (parse + span) + a report-framing check. Full suite **681 green**.