### PR TITLE
feat(PI-251): hybrid enforcement (org hard layer binds)

### DIFF
--- a/docs/development/enforcement-classification.md
+++ b/docs/development/enforcement-classification.md
@@ -1,0 +1,48 @@
+# Hybrid enforcement — enforced vs overridable
+
+- Status: reference (#251); implements ADR-013, grounded in ADR-007.
+- Date: 2026-06-18
+
+project-init's guardrails are **hybrid** (ADR-007): only some bind server-side.
+The `org` profile makes the *hard* layer bind by default; `individual` and
+`standalone` keep everything advisory.
+
+## Classification
+
+| Guardrail | Class | Mechanism | Binds whom |
+|---|---|---|---|
+| Required CI checks (lint/test, secret scan) | **enforced (hard)** | ruleset / branch protection — required status checks | everyone (org: empty bypass) |
+| Pull-request review required | **enforced (hard)** | ruleset `pull_request` rule | everyone |
+| No force-push / no branch deletion | **enforced (hard)** | ruleset `non_fast_forward` + `deletion` | everyone |
+| Conversation resolution | **enforced (hard)** | ruleset / branch protection | everyone |
+| DAG workflow lifecycle gate | advisory | Claude/git hooks | the agent / committer (bypassable) |
+| Commit-message format | advisory | commit-msg hook + CI title check | committer (the CI check is the real gate) |
+| Lint-on-edit | advisory | PostToolUse hook | the agent only |
+
+Only **server-side** controls (CI required checks + rulesets / branch protection)
+are true gates (ADR-007). Agent/git hooks are fast-feedback UX, not a boundary.
+
+## Org profile: make the hard layer bind
+
+- **Rulesets, applied directly to the repo.** A ruleset with an empty
+  `bypass_actors` binds owners/admins too — unlike classic branch protection
+  (`enforce_admins: false`). Forks do **not** inherit branch/tag rulesets, so the
+  org applies them directly (`setup_github.sh --protect` → the
+  `project-init-baseline` ruleset).
+- **No admin bypass.** `monitor_pr.sh` refuses `--admin` under the org profile —
+  merge via auto-merge / the merge queue under the required checks instead.
+- **Required workflows** use the org ruleset "require workflows" rule (Enterprise
+  Cloud / GHES); Team-tier orgs fall back to required status checks.
+
+## Availability by tier (per the support matrix)
+
+| Primitive | Team | Enterprise Cloud | GHES |
+|---|---|---|---|
+| Branch protection / branch+tag rulesets / push rulesets | ✅ | ✅ | ✅ |
+| Org rulesets targeting repos | ✅ | ✅ | ✅ |
+| "Require workflows" ruleset rule | ⚠️ likely Enterprise-only | ✅ | ✅ |
+| Merge queue (private/internal) | ⚠️ → Enterprise Cloud | ✅ | ✅ |
+
+`setup_github.sh` feature-probes the rulesets API and degrades gracefully (warns,
+falls back to branch protection) where a primitive is unavailable. See the
+[enterprise support matrix](enterprise-github-support-matrix.md) for sources.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,4 +42,5 @@ nav:
     - Testing: development/testing.md
     - Build reproducibility: development/build-reproducibility.md
     - Enterprise GitHub support matrix: development/enterprise-github-support-matrix.md
+    - Enforcement classification: development/enforcement-classification.md
     - Contributing: development/contributing.md

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -51,3 +51,11 @@ gh_api_base() {
     *) printf 'https://%s/api/v3\n' "$host" ;;
   esac
 }
+
+# Distribution profile recorded by project-init in .claude/config.yaml (#247);
+# defaults to individual when unset. Gates org-only hard enforcement (#251).
+gh_profile() {
+  local cfg=".claude/config.yaml" prof=""
+  [ -f "$cfg" ] && prof=$(sed -nE 's/^[[:space:]]*profile:[[:space:]]*([a-z]+).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "${prof:-individual}"
+}

--- a/templates/base/dot_claude/scripts/monitor_pr.sh
+++ b/templates/base/dot_claude/scripts/monitor_pr.sh
@@ -117,7 +117,24 @@ _run_gh() {
   return "$status"
 }
 
+# Distribution profile recorded by project-init in .claude/config.yaml (#247);
+# defaults to individual when unset.
+_project_profile() {
+  local cfg=".claude/config.yaml" prof=""
+  [ -f "$cfg" ] && prof=$(sed -nE 's/^[[:space:]]*profile:[[:space:]]*([a-z]+).*/\1/p' "$cfg" | head -1)
+  echo "${prof:-individual}"
+}
+
 _admin_merge() {
+  # Hard enforcement must bind under the org profile (ADR-013/#251): admin-merge
+  # bypasses the server-side rules, so it is refused — use auto-merge / the merge
+  # queue under the required checks instead.
+  if [ "$(_project_profile)" = "org" ]; then
+    echo "ERROR: admin-merge is refused under the org profile (#251) — hard" >&2
+    echo "  enforcement must bind. Use auto-merge or the merge queue under the" >&2
+    echo "  required checks, or resolve the blocking review/checks." >&2
+    return 1
+  fi
   if _run_gh pr merge "$PR_NUMBER" --squash --delete-branch --admin; then
     echo "Merged PR #$PR_NUMBER (admin)"
   else

--- a/templates/base/dot_claude/scripts/monitor_pr.sh
+++ b/templates/base/dot_claude/scripts/monitor_pr.sh
@@ -28,6 +28,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
 PR_NUMBER="${1:-}"
 MODE="${2:-}"
 REVIEW_CYCLE=0
@@ -117,19 +121,11 @@ _run_gh() {
   return "$status"
 }
 
-# Distribution profile recorded by project-init in .claude/config.yaml (#247);
-# defaults to individual when unset.
-_project_profile() {
-  local cfg=".claude/config.yaml" prof=""
-  [ -f "$cfg" ] && prof=$(sed -nE 's/^[[:space:]]*profile:[[:space:]]*([a-z]+).*/\1/p' "$cfg" | head -1)
-  echo "${prof:-individual}"
-}
-
 _admin_merge() {
   # Hard enforcement must bind under the org profile (ADR-013/#251): admin-merge
   # bypasses the server-side rules, so it is refused — use auto-merge / the merge
-  # queue under the required checks instead.
-  if [ "$(_project_profile)" = "org" ]; then
+  # queue under the required checks instead. gh_profile comes from gh_host.sh.
+  if [ "$(gh_profile)" = "org" ]; then
     echo "ERROR: admin-merge is refused under the org profile (#251) — hard" >&2
     echo "  enforcement must bind. Use auto-merge or the merge queue under the" >&2
     echo "  required checks, or resolve the blocking review/checks." >&2

--- a/templates/base/dot_claude/scripts/setup_github.sh
+++ b/templates/base/dot_claude/scripts/setup_github.sh
@@ -76,14 +76,16 @@ else
   echo "WARNING: could not apply branch protection. Check admin permissions and repository plan." >&2
 fi
 
-# Repository ruleset (#251): the "hard" enforcement layer. A ruleset with an
-# empty bypass_actors binds *everyone* (owners/admins included), so it cannot be
-# admin-bypassed — unlike classic branch protection (enforce_admins=false above).
-# Forks do NOT inherit branch/tag rulesets, so the org profile applies this
-# directly to the repo. Feature-probe first and warn (never fail) on hosts/plans
-# without the rulesets API. Enforced set = required CI + review + no force-push /
-# no deletion; everything else (DAG hooks, commit format, lint) stays advisory.
-if gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
+# Repository ruleset (#251): the org profile's "hard" enforcement layer. A
+# ruleset with an empty bypass_actors binds *everyone* (owners/admins included),
+# so it cannot be admin-bypassed — unlike classic branch protection
+# (enforce_admins=false above). Applied ONLY under the org profile;
+# individual/standalone keep advisory branch protection (admin escape hatch
+# intact), per ADR-013. Forks do NOT inherit branch/tag rulesets, so the org
+# applies it directly. Feature-probe first and warn (never fail) without rulesets.
+if [ "$(gh_profile)" != "org" ]; then
+  echo "Profile is not 'org' — keeping advisory branch protection only (no owner-binding ruleset)."
+elif gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
   RULESET=$(mktemp)
   trap 'rm -f "$PROTECTION" "$RULESET"' EXIT
   cat > "$RULESET" <<'RULESET_JSON'

--- a/templates/base/dot_claude/scripts/setup_github.sh
+++ b/templates/base/dot_claude/scripts/setup_github.sh
@@ -75,6 +75,49 @@ if gh api "repos/$OWNER/$NAME/branches/$BRANCH/protection" -X PUT --input "$PROT
 else
   echo "WARNING: could not apply branch protection. Check admin permissions and repository plan." >&2
 fi
+
+# Repository ruleset (#251): the "hard" enforcement layer. A ruleset with an
+# empty bypass_actors binds *everyone* (owners/admins included), so it cannot be
+# admin-bypassed — unlike classic branch protection (enforce_admins=false above).
+# Forks do NOT inherit branch/tag rulesets, so the org profile applies this
+# directly to the repo. Feature-probe first and warn (never fail) on hosts/plans
+# without the rulesets API. Enforced set = required CI + review + no force-push /
+# no deletion; everything else (DAG hooks, commit format, lint) stays advisory.
+if gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
+  RULESET=$(mktemp)
+  trap 'rm -f "$PROTECTION" "$RULESET"' EXIT
+  cat > "$RULESET" <<'RULESET_JSON'
+{
+  "name": "project-init-baseline",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "non_fast_forward" },
+    { "type": "deletion" },
+    { "type": "pull_request", "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true } },
+    { "type": "required_status_checks", "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "CI / Lint and test" },
+          { "context": "CI / Secret scan (gitleaks)" } ] } }
+  ],
+  "bypass_actors": []
+}
+RULESET_JSON
+  if gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
+    echo "Repository ruleset 'project-init-baseline' applied (binds everyone — empty bypass)"
+  else
+    echo "WARNING: could not create the repository ruleset (it may already exist, or the plan/permission is insufficient)." >&2
+  fi
+else
+  echo "Rulesets API unavailable on this host/plan — relying on branch protection only." >&2
+fi
 else
   echo "Skipping branch protection (pass --protect to apply: require CI green, require review, block force-push)"
 fi

--- a/tests/contracts/test_enforcement.py
+++ b/tests/contracts/test_enforcement.py
@@ -11,16 +11,24 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPTS = _REPO_ROOT / "templates/base/dot_claude/scripts"
+_GH_HOST = _SCRIPTS / "gh_host.sh"
 _MONITOR = _SCRIPTS / "monitor_pr.sh"
 _SETUP = _SCRIPTS / "setup_github.sh"
 _DOC = _REPO_ROOT / "docs/development/enforcement-classification.md"
 
 
-class TestOrgRefusesAdminMerge:
-    def test_monitor_reads_profile_and_refuses_admin_for_org(self):
-        s = _MONITOR.read_text()
-        assert "_project_profile" in s
+class TestProfileHelper:
+    def test_gh_profile_reads_config(self):
+        s = _GH_HOST.read_text()
+        assert "gh_profile" in s
         assert "config.yaml" in s
+
+
+class TestOrgRefusesAdminMerge:
+    def test_monitor_refuses_admin_for_org(self):
+        s = _MONITOR.read_text()
+        assert "gh_host.sh" in s  # sources the shared helper
+        assert "gh_profile" in s
         assert "admin-merge is refused under the org profile" in s
 
     def test_individual_admin_merge_path_intact(self):
@@ -29,6 +37,11 @@ class TestOrgRefusesAdminMerge:
 
 
 class TestHardLayerRuleset:
+    def test_ruleset_gated_to_org_profile(self):
+        s = _SETUP.read_text()
+        assert "gh_profile" in s
+        assert '!= "org"' in s  # advisory profiles skip the owner-binding ruleset
+
     def test_setup_applies_ruleset_binding_everyone(self):
         s = _SETUP.read_text()
         assert '"bypass_actors": []' in s  # binds owners/admins too

--- a/tests/contracts/test_enforcement.py
+++ b/tests/contracts/test_enforcement.py
@@ -1,0 +1,52 @@
+"""PI-251: hybrid enforcement — enforced-vs-overridable classification and the
+org profile making the hard layer bind by default (ADR-013 / ADR-007).
+
+The enforcement lives in scaffolded scripts (server-side via gh), so these are
+content contracts; the GitHub API behavior is exercised in real use.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "templates/base/dot_claude/scripts"
+_MONITOR = _SCRIPTS / "monitor_pr.sh"
+_SETUP = _SCRIPTS / "setup_github.sh"
+_DOC = _REPO_ROOT / "docs/development/enforcement-classification.md"
+
+
+class TestOrgRefusesAdminMerge:
+    def test_monitor_reads_profile_and_refuses_admin_for_org(self):
+        s = _MONITOR.read_text()
+        assert "_project_profile" in s
+        assert "config.yaml" in s
+        assert "admin-merge is refused under the org profile" in s
+
+    def test_individual_admin_merge_path_intact(self):
+        # Admin-merge remains available off the org profile (advisory).
+        assert "--squash --delete-branch --admin" in _MONITOR.read_text()
+
+
+class TestHardLayerRuleset:
+    def test_setup_applies_ruleset_binding_everyone(self):
+        s = _SETUP.read_text()
+        assert '"bypass_actors": []' in s  # binds owners/admins too
+        assert "required_status_checks" in s
+        assert '"type": "pull_request"' in s
+        assert "non_fast_forward" in s
+
+    def test_setup_feature_probes_rulesets(self):
+        s = _SETUP.read_text()
+        assert 'gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1' in s
+        assert "Rulesets API unavailable" in s  # graceful degradation
+
+
+class TestClassificationDoc:
+    def test_doc_classifies_enforced_vs_advisory(self):
+        s = _DOC.read_text().lower()
+        assert "enforced" in s
+        assert "advisory" in s
+        assert "bypass" in s
+        assert "required status checks" in s
+        assert "force-push" in s


### PR DESCRIPTION
Closes #251

Make the hard enforcement layer bind by default under the `org` profile, and classify enforced-vs-overridable (ADR-013 / ADR-007).

- **Classification** (`docs/development/enforcement-classification.md`): enforced (hard, server-side) = required CI checks, PR review, no force-push/deletion, conversation resolution; advisory = DAG hooks, commit-format, lint-on-edit. Only server-side controls are true gates.
- **`monitor_pr.sh` refuses `--admin` under the org profile**: reads `profile:` from `.claude/config.yaml`; org → admin-merge refused (use auto-merge / merge queue under the required checks). individual/standalone unchanged.
- **`setup_github.sh` applies a repo ruleset** (`project-init-baseline`) with empty `bypass_actors` — binds owners/admins too (unlike `enforce_admins:false` branch protection). Applied directly since forks don't inherit branch/tag rulesets. Feature-probes the rulesets API and degrades gracefully (warns → falls back to branch protection).
- Tests: `tests/contracts/test_enforcement.py` (content contracts — server-side behavior is exercised in real use). Bash syntax checked. Full suite **688 green**.