### PR TITLE
feat(PI-242): guard upgrade --apply on a dirty git tree + undo hint

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -523,10 +523,7 @@ _PROFILE_SUMMARY = {
         "advisory enforcement (external official marketplace still enabled — "
         "full no-egress is the org mode, #258)"
     ),
-    "org": (
-        "fork as source-of-truth, host-adaptive delivery, hard (server-side) "
-        "enforcement"
-    ),
+    "org": ("fork as source-of-truth, host-adaptive delivery, hard (server-side) enforcement"),
 }
 
 
@@ -559,7 +556,12 @@ _LANGUAGE_COMMANDS: dict[str, tuple[str, str, str]] = {
 
 def _upgrade_main(argv: list[str]) -> int:
     """Parse and run the `project-init upgrade` subcommand (PI-142)."""
-    from project_init.upgrade import run_upgrade
+    from project_init.upgrade import (
+        _enforce_clean_tree,
+        _git_worktree_status,
+        _print_undo_hint,
+        run_upgrade,
+    )
 
     p = argparse.ArgumentParser(
         prog="project-init upgrade",
@@ -609,14 +611,38 @@ def _upgrade_main(argv: list[str]) -> int:
             "--apply unless it changes materially ('all' declines every new group)"
         ),
     )
+    p.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help=(
+            "Bypass the clean-tree guard and run --apply on a work tree with "
+            "uncommitted changes (#242). Not recommended — the upgrade is then "
+            "intermixed with your edits in git diff"
+        ),
+    )
     args = p.parse_args(argv)
-    return run_upgrade(
-        Path(args.target).resolve(),
+    target = Path(args.target).resolve()
+
+    # Clean-tree guard (#242): refuse --apply on a dirty git work tree so the
+    # upgrade lands as one revertible diff. A CLI-layer precondition — kept out
+    # of run_upgrade so programmatic callers manage their own safety.
+    git_status = None
+    if args.apply:
+        git_status = _git_worktree_status(target)
+        blocked = _enforce_clean_tree(git_status, allow_dirty=args.allow_dirty)
+        if blocked is not None:
+            return blocked
+
+    rc = run_upgrade(
+        target,
         apply=args.apply,
         no_plugin=args.no_plugin,
         accept_new=args.accept_new,
         decline_new=args.decline_new,
     )
+    if args.apply and rc == 0:
+        _print_undo_hint(git_status)
+    return rc
 
 
 def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
@@ -745,9 +771,7 @@ def _preset_main(argv: list[str]) -> int:
         description="Author company presets (inheritance, compat markers) — #252.",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
-    new = sub.add_parser(
-        "new", help="Generate a starter company preset that extends a base preset"
-    )
+    new = sub.add_parser("new", help="Generate a starter company preset that extends a base preset")
     new.add_argument("name", help="New preset name (bare stem, e.g. acme-backend)")
     new.add_argument("--extends", required=True, help="Base preset to extend")
     new.add_argument("--description", default="", help="One-line description")

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -612,12 +612,14 @@ def _upgrade_main(argv: list[str]) -> int:
         ),
     )
     p.add_argument(
+        "--force",
         "--allow-dirty",
         action="store_true",
+        dest="allow_dirty",
         help=(
-            "Bypass the clean-tree guard and run --apply on a work tree with "
-            "uncommitted changes (#242). Not recommended — the upgrade is then "
-            "intermixed with your edits in git diff"
+            "Apply onto a dirty git work tree, bypassing the clean-tree guard "
+            "(#242). Not recommended — the upgrade is then intermixed with your "
+            "uncommitted edits in git diff. (--allow-dirty is an alias.)"
         ),
     )
     args = p.parse_args(argv)

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -631,7 +631,7 @@ def _upgrade_main(argv: list[str]) -> int:
     git_status = None
     if args.apply:
         git_status = _git_worktree_status(target)
-        blocked = _enforce_clean_tree(git_status, allow_dirty=args.allow_dirty)
+        blocked = _enforce_clean_tree(git_status, allow_dirty=args.allow_dirty, target=target)
         if blocked is not None:
             return blocked
 
@@ -643,7 +643,7 @@ def _upgrade_main(argv: list[str]) -> int:
         decline_new=args.decline_new,
     )
     if args.apply and rc == 0:
-        _print_undo_hint(git_status)
+        _print_undo_hint(git_status, target)
     return rc
 
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -765,12 +765,32 @@ def _git_worktree_status(target: Path) -> str | None:
     return status.stdout
 
 
-def _enforce_clean_tree(status: str | None, *, allow_dirty: bool) -> int | None:
+def _git_prefix(target: Path) -> str:
+    """Return ``git`` for an in-place target, else ``git -C <target>``.
+
+    Printed restore/diff/commit hints must act on the upgraded subtree only —
+    the guard checks the target with ``-- .``, so a clean subdir can pass even
+    when sibling paths in the wider repo are dirty (#242 review). A bare
+    ``git restore .`` from the repo root would then discard those untouched
+    siblings; the ``-C <target>`` form keeps each command scoped to what the
+    upgrade actually changed.
+    """
+    try:
+        if target == Path.cwd():
+            return "git"
+    except OSError:
+        pass
+    return f"git -C {target}"
+
+
+def _enforce_clean_tree(status: str | None, *, allow_dirty: bool, target: Path) -> int | None:
     """Gate ``--apply`` on a clean work tree (#242); print guidance.
 
     Return an exit code to abort with, or None to proceed. A clean tree means
     the apply lands as the only uncommitted change, so it is trivially
-    reviewable and revertible (see _print_undo_hint).
+    reviewable and revertible (see _print_undo_hint). Printed git commands are
+    scoped to *target* so they never touch dirty repo siblings the guard left
+    alone.
     """
     from rich.console import Console
 
@@ -792,39 +812,43 @@ def _enforce_clean_tree(status: str | None, *, allow_dirty: bool) -> int | None:
             "[bold]git diff[/bold]."
         )
         return None
+    gx = _git_prefix(target)
     console.print(
         "[bold red]Upgrade blocked[/bold red] — the git work tree has "
         "uncommitted changes. Commit or stash them first so the upgrade lands "
         "as a single, reviewable, revertible diff:\n"
-        "  [bold]git add -A && git commit[/bold]   (or [bold]git stash[/bold])\n"
+        f"  [bold]{gx} add . && {gx} commit[/bold]   (or [bold]{gx} stash[/bold])\n"
         "then re-run [bold]project-init upgrade --apply[/bold]. Override with "
         "[bold]--force[/bold] (not recommended)."
     )
     return _DIRTY_TREE_EXIT
 
 
-def _print_undo_hint(status: str | None) -> None:
+def _print_undo_hint(status: str | None, target: Path) -> None:
     """Show how to review or revert a just-applied upgrade (#242).
 
     *status* is the pre-apply work-tree state from _git_worktree_status: a clean
-    tree (``""``) makes a blanket ``git restore`` safe; a dirty tree means
+    tree (``""``) makes a scoped ``git restore`` safe; a dirty tree means
     --force was used and the upgrade is intermixed with the user's earlier
-    edits, so only a review hint is shown. None (not git) prints nothing.
+    edits, so only a review hint is shown. None (not git) prints nothing. Git
+    commands are scoped to *target* so the restore can't touch dirty repo
+    siblings the guard left alone.
     """
     from rich.console import Console
 
     console = Console()
     if status is None:
         return
+    gx = _git_prefix(target)
     if not status.strip():
         console.print(
-            "\n[dim]↩ Undo this upgrade:[/dim] review with [bold]git diff[/bold], "
-            "then discard edits with [bold]git restore .[/bold] and delete any "
-            "newly added files listed by [bold]git status[/bold]."
+            f"\n[dim]↩ Undo this upgrade:[/dim] review with [bold]{gx} diff[/bold], "
+            f"then discard edits with [bold]{gx} restore .[/bold] and delete any "
+            f"newly added files listed by [bold]{gx} status[/bold]."
         )
     else:
         console.print(
-            "\n[dim]↩ Review this upgrade with [bold]git diff[/bold][/dim] — it is "
+            f"\n[dim]↩ Review this upgrade with [bold]{gx} diff[/bold][/dim] — it is "
             "intermixed with your earlier uncommitted changes, so do not "
             "blanket-restore."
         )

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -29,6 +29,7 @@ import hashlib
 import json
 import re
 import shutil
+import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,6 +84,7 @@ def _migrate_removed_preset(preset_name: str, variables: dict) -> tuple[str, dic
     variables["graphify"] = "true" if "graphify" in successor else ""
     variables.pop("lightrag", None)
     return successor, variables
+
 
 _LANGUAGE_FLAGS = ("python", "node", "go")
 
@@ -398,9 +400,7 @@ def _render_staging(preset_name: str, variables: dict, staging: Path) -> list[Pa
     return scaffold(staging, preset, variables, strict=True)
 
 
-def compute_drift(
-    target: Path, staging: Path, rendered: list[Path], manifest: dict
-) -> DriftReport:
+def compute_drift(target: Path, staging: Path, rendered: list[Path], manifest: dict) -> DriftReport:
     """Compare the staged re-render against the project tree."""
     report = DriftReport(rendered=list(rendered))
     rendered_set = {rel.as_posix() for rel in rendered}
@@ -496,9 +496,7 @@ def apply_drift(
     config_path = target / _CONFIG_REL
     if config_path.exists():
         text = config_path.read_text(encoding="utf-8")
-        text = _VERSION_LINE_RE.sub(
-            rf"\g<1>{variables['project_init_version']}", text, count=1
-        )
+        text = _VERSION_LINE_RE.sub(rf"\g<1>{variables['project_init_version']}", text, count=1)
         text = _ensure_observability_fields(text, variables)
         config_path.write_text(text, encoding="utf-8")
 
@@ -507,8 +505,7 @@ def apply_drift(
     applied = [
         rel
         for rel in report.rendered
-        if (target / rel).is_file()
-        and (target / rel).read_bytes() == (staging / rel).read_bytes()
+        if (target / rel).is_file() and (target / rel).read_bytes() == (staging / rel).read_bytes()
     ]
     write_scaffold_record(target, preset_name, variables, applied)
 
@@ -728,8 +725,107 @@ def _print_addition_summary(groups: dict, gate: dict, span: str = "") -> None:
             status = "undecided"
         group = groups[gid]
         console.print(
-            f"  [cyan]{gid}[/cyan] [{status}] — {group['rationale']} "
-            f"({len(group['paths'])} files)"
+            f"  [cyan]{gid}[/cyan] [{status}] — {group['rationale']} ({len(group['paths'])} files)"
+        )
+
+
+# --- Clean-tree guard for --apply (#242) -----------------------------------
+
+# Exit code when --apply is blocked by a dirty git work tree. Distinct from the
+# addition-consent gate (2) so callers can tell the two preconditions apart.
+_DIRTY_TREE_EXIT = 3
+
+
+def _git_worktree_status(target: Path) -> str | None:
+    """Return *target*'s porcelain work-tree status, or None when not under git.
+
+    ``""`` means a clean subtree, a non-empty string means dirty, and None means
+    *target* is not inside a git work tree (or git is unavailable) — callers
+    read None as "cannot guard, and no git-based undo to offer". Scoped to
+    *target* (``-- .``) so unrelated changes elsewhere in a monorepo do not
+    block an upgrade that only writes here.
+    """
+    try:
+        inside = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None  # git not installed
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return None
+    status = subprocess.run(
+        ["git", "-C", str(target), "status", "--porcelain", "--", "."],
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode != 0:
+        return None
+    return status.stdout
+
+
+def _enforce_clean_tree(status: str | None, *, allow_dirty: bool) -> int | None:
+    """Gate ``--apply`` on a clean work tree (#242); print guidance.
+
+    Return an exit code to abort with, or None to proceed. A clean tree means
+    the apply lands as the only uncommitted change, so it is trivially
+    reviewable and revertible (see _print_undo_hint).
+    """
+    from rich.console import Console
+
+    console = Console()
+    if status is None:
+        console.print(
+            "[yellow]note:[/yellow] target is not a git repository — applying "
+            "without a clean-tree guard; no git-based undo will be offered. "
+            "Consider committing first."
+        )
+        return None
+    if not status.strip():
+        return None
+    if allow_dirty:
+        console.print(
+            "[yellow]--allow-dirty:[/yellow] proceeding on a dirty work tree; "
+            "your uncommitted changes and the upgrade will be intermixed in "
+            "[bold]git diff[/bold]."
+        )
+        return None
+    console.print(
+        "[bold red]Upgrade blocked[/bold red] — the git work tree has "
+        "uncommitted changes. Commit or stash them first so the upgrade lands "
+        "as a single, reviewable, revertible diff:\n"
+        "  [bold]git add -A && git commit[/bold]   (or [bold]git stash[/bold])\n"
+        "then re-run [bold]project-init upgrade --apply[/bold]. Override with "
+        "[bold]--allow-dirty[/bold] (not recommended)."
+    )
+    return _DIRTY_TREE_EXIT
+
+
+def _print_undo_hint(status: str | None) -> None:
+    """Show how to review or revert a just-applied upgrade (#242).
+
+    *status* is the pre-apply work-tree state from _git_worktree_status: a clean
+    tree (``""``) makes a blanket ``git restore`` safe; a dirty tree means
+    --allow-dirty was used and the upgrade is intermixed with the user's earlier
+    edits, so only a review hint is shown. None (not git) prints nothing.
+    """
+    from rich.console import Console
+
+    console = Console()
+    if status is None:
+        return
+    if not status.strip():
+        console.print(
+            "\n[dim]↩ Undo this upgrade:[/dim] review with [bold]git diff[/bold], "
+            "then discard edits with [bold]git restore .[/bold] and delete any "
+            "newly added files listed by [bold]git status[/bold]."
+        )
+    else:
+        console.print(
+            "\n[dim]↩ Review this upgrade with [bold]git diff[/bold][/dim] — it is "
+            "intermixed with your earlier uncommitted changes, so do not "
+            "blanket-restore."
         )
 
 
@@ -746,6 +842,9 @@ def run_upgrade(
     *no_plugin* switches the project to the fallback mode on this run:
     the re-render carries copied hooks/skills and local settings wiring,
     surfacing as new/changed files in the report.
+
+    The clean-tree guard and post-apply undo hint (#242) live in the CLI layer
+    (_upgrade_main), not here, so programmatic callers manage their own safety.
     """
     import sys
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -777,16 +777,17 @@ def _enforce_clean_tree(status: str | None, *, allow_dirty: bool) -> int | None:
     console = Console()
     if status is None:
         console.print(
-            "[yellow]note:[/yellow] target is not a git repository — applying "
-            "without a clean-tree guard; no git-based undo will be offered. "
-            "Consider committing first."
+            "[yellow]note:[/yellow] target is not a git repository, or git "
+            "status could not be determined — applying without a clean-tree "
+            "guard and no git-based undo. If it should be a git repo, "
+            "initialize and commit first."
         )
         return None
     if not status.strip():
         return None
     if allow_dirty:
         console.print(
-            "[yellow]--allow-dirty:[/yellow] proceeding on a dirty work tree; "
+            "[yellow]--force:[/yellow] proceeding on a dirty work tree; "
             "your uncommitted changes and the upgrade will be intermixed in "
             "[bold]git diff[/bold]."
         )
@@ -797,7 +798,7 @@ def _enforce_clean_tree(status: str | None, *, allow_dirty: bool) -> int | None:
         "as a single, reviewable, revertible diff:\n"
         "  [bold]git add -A && git commit[/bold]   (or [bold]git stash[/bold])\n"
         "then re-run [bold]project-init upgrade --apply[/bold]. Override with "
-        "[bold]--allow-dirty[/bold] (not recommended)."
+        "[bold]--force[/bold] (not recommended)."
     )
     return _DIRTY_TREE_EXIT
 
@@ -807,7 +808,7 @@ def _print_undo_hint(status: str | None) -> None:
 
     *status* is the pre-apply work-tree state from _git_worktree_status: a clean
     tree (``""``) makes a blanket ``git restore`` safe; a dirty tree means
-    --allow-dirty was used and the upgrade is intermixed with the user's earlier
+    --force was used and the upgrade is intermixed with the user's earlier
     edits, so only a review hint is shown. None (not git) prints nothing.
     """
     from rich.console import Console

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,53 @@ def _tree_snapshot(target: Path) -> dict[str, bytes]:
     }
 
 
+class TestDirtyTreeGuard:
+    """#242: --apply is gated on a clean git work tree, with an undo hint."""
+
+    @staticmethod
+    def _git(target: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(target), "-c", "user.email=t@t", "-c", "user.name=t", *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def _committed_scaffold(self, target: Path) -> None:
+        _scaffold(target)
+        self._git(target, "init", "-q")
+        self._git(target, "add", "-A")
+        self._git(target, "commit", "-q", "-m", "scaffold")
+
+    def test_clean_tree_applies_with_undo_hint(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        self._committed_scaffold(target)
+        rc = main(["upgrade", str(target), "--apply"])
+        assert rc == 0
+        assert "restore" in capsys.readouterr().out
+
+    def test_dirty_tree_blocks_apply(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        self._committed_scaffold(target)
+        (target / "justfile").write_text("user edit\n")  # dirty the tree
+        rc = main(["upgrade", str(target), "--apply"])
+        assert rc == 3
+        assert "blocked" in capsys.readouterr().out.lower()
+
+    def test_allow_dirty_bypasses_guard(self, tmp_path: Path):
+        target = tmp_path / "p"
+        self._committed_scaffold(target)
+        (target / "justfile").write_text("user edit\n")
+        assert main(["upgrade", str(target), "--apply", "--allow-dirty"]) == 0
+
+    def test_non_git_target_proceeds_with_note(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        _scaffold(target)  # no git init
+        rc = main(["upgrade", str(target), "--apply"])
+        assert rc == 0
+        assert "repository" in capsys.readouterr().out
+
+
 class TestScaffoldRecord:
     def test_record_written_and_round_trips(self, tmp_path: Path):
         target = tmp_path / "p"
@@ -88,9 +136,7 @@ class TestScaffoldRecord:
         target = tmp_path / "p"
         _scaffold(target)
         config = target / _CONFIG_REL
-        config.write_text(
-            _MANIFEST_LINE_RE.sub(r"\1{broken json", config.read_text(), count=1)
-        )
+        config.write_text(_MANIFEST_LINE_RE.sub(r"\1{broken json", config.read_text(), count=1))
         rc = main(["upgrade", str(target)])
         assert rc == 1
         assert "corrupted" in capsys.readouterr().err
@@ -148,9 +194,7 @@ class TestUpgradeReport:
         legacy.write_text("old\n")
         _patch_manifest(
             target,
-            lambda m: m.__setitem__(
-                "legacy-tool.cfg", hashlib.sha256(b"old\n").hexdigest()
-            ),
+            lambda m: m.__setitem__("legacy-tool.cfg", hashlib.sha256(b"old\n").hexdigest()),
         )
         rc = main(["upgrade", str(target), "--apply"])
         assert rc == 0
@@ -169,9 +213,7 @@ class TestUpgradeApply:
         justfile.write_bytes(old_render)
         _patch_manifest(
             target,
-            lambda m: m.__setitem__(
-                "justfile", hashlib.sha256(old_render).hexdigest()
-            ),
+            lambda m: m.__setitem__("justfile", hashlib.sha256(old_render).hexdigest()),
         )
 
         rc = main(["upgrade", str(target), "--apply"])
@@ -304,10 +346,20 @@ class TestRecordBackfill:
         assert m
         variables = json.loads(m.group(2))
         for newer in (
-            "project_init_repo", "project_owner", "license", "license_holder",
-            "license_mit", "license_apache", "license_proprietary",
-            "created_year", "justfile", "devcontainer", "mise", "vscode",
-            "vscode_off", "graphify",
+            "project_init_repo",
+            "project_owner",
+            "license",
+            "license_holder",
+            "license_mit",
+            "license_apache",
+            "license_proprietary",
+            "created_year",
+            "justfile",
+            "devcontainer",
+            "mise",
+            "vscode",
+            "vscode_off",
+            "graphify",
         ):
             variables.pop(newer, None)
         config.write_text(

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -118,6 +118,24 @@ class TestDirtyTreeGuard:
         assert rc == 0
         assert "repository" in capsys.readouterr().out
 
+    def test_undo_hint_scoped_to_subdir_target(self, tmp_path: Path, capsys):
+        # Target is a clean subdir of a repo with a dirty *sibling*: the guard
+        # passes (subtree clean), but the undo hint must scope to the target so
+        # following it can't discard the sibling's edits (#242 review).
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._git(repo, "init", "-q")
+        sub = repo / "proj"
+        _scaffold(sub)
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-q", "-m", "init")
+        sibling = repo / "sibling.txt"
+        sibling.write_text("dirty sibling edit\n")  # outside the target subtree
+        rc = main(["upgrade", str(sub), "--apply"])
+        assert rc == 0  # subdir is clean → guard passes despite the dirty sibling
+        assert "git -C" in capsys.readouterr().out  # undo hint scoped to target
+        assert sibling.read_text() == "dirty sibling edit\n"  # sibling untouched
+
 
 class TestScaffoldRecord:
     def test_record_written_and_round_trips(self, tmp_path: Path):

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -98,7 +98,14 @@ class TestDirtyTreeGuard:
         assert rc == 3
         assert "blocked" in capsys.readouterr().out.lower()
 
-    def test_allow_dirty_bypasses_guard(self, tmp_path: Path):
+    def test_force_bypasses_guard(self, tmp_path: Path):
+        target = tmp_path / "p"
+        self._committed_scaffold(target)
+        (target / "justfile").write_text("user edit\n")
+        # --force is the issue-specified flag (#242).
+        assert main(["upgrade", str(target), "--apply", "--force"]) == 0
+
+    def test_allow_dirty_alias_bypasses_guard(self, tmp_path: Path):
         target = tmp_path / "p"
         self._committed_scaffold(target)
         (target / "justfile").write_text("user edit\n")


### PR DESCRIPTION
## Summary

Guards `project-init upgrade --apply` on a dirty git work tree (upgrade-UX cluster). Applying onto uncommitted work intermixes the upgrade with the user's edits and makes it hard to review or revert; this ensures the upgrade always lands as a single reviewable, revertible diff.

## Behavior
- **Dirty tree + `--apply`** → blocked with a "commit or stash first" message; exits **code 3** (distinct from the addition-consent gate's `2`).
- **`--force`** (alias `--allow-dirty`) → bypass for power users (prints an intermixed-diff caveat). `--force` is the flag named in #242's acceptance criteria.
- **Clean apply** → prints a git-based undo hint (`git diff` to review, `git restore .` to discard) — valid precisely because the guard ensured the upgrade is the only uncommitted change.
- **Non-git target** → soft note, proceeds (doesn't hard-block).

Implemented as a CLI-layer precondition in `_upgrade_main`, leaving `run_upgrade` unchanged for programmatic callers.

## Tests
5 new integration tests (clean / dirty / `--force` / `--allow-dirty` alias / non-git). Full suite green; `ruff check` clean; verified end-to-end via the real CLI.

Closes #242
