### PR TITLE
feat(PI-303): config-driven base branch in the shared lifecycle

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -501,7 +501,9 @@ def _base_branch(config_path: Path | None = None) -> str | None:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
         return None
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
+    # prose shows unquoted forms like [main] / [dev, test, main]).
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
     return m.group(1) if m else None
 
 

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -489,6 +489,22 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
+    None when no chain is configured (single-trunk → the repo's default branch).
+
+    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
+    PRs against the base; a project with no chain is unaffected.
+    """
+    cfg = config_path or Path(".claude/config.yaml")
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
 def cmd_create_pr_nojira(
     type_: str, title: str, branch: str | None, base: str | None
 ) -> int:
@@ -546,6 +562,10 @@ def cmd_create_pr_nojira(
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
+    # Target the base of the promotion chain when one is configured (ADR-014);
+    # no chain → base stays None → gh uses the repo default branch.
+    if base is None:
+        base = _base_branch()
     args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -501,7 +501,9 @@ def _base_branch(config_path: Path | None = None) -> str | None:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
         return None
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
+    # prose shows unquoted forms like [main] / [dev, test, main]).
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
     return m.group(1) if m else None
 
 

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -489,6 +489,22 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
+    None when no chain is configured (single-trunk → the repo's default branch).
+
+    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
+    PRs against the base; a project with no chain is unaffected.
+    """
+    cfg = config_path or Path(".claude/config.yaml")
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
 def cmd_create_pr_nojira(
     type_: str, title: str, branch: str | None, base: str | None
 ) -> int:
@@ -546,6 +562,10 @@ def cmd_create_pr_nojira(
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
+    # Target the base of the promotion chain when one is configured (ADR-014);
+    # no chain → base stays None → gh uses the repo default branch.
+    if base is None:
+        base = _base_branch()
     args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -501,7 +501,9 @@ def _base_branch(config_path: Path | None = None) -> str | None:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
         return None
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
+    # prose shows unquoted forms like [main] / [dev, test, main]).
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
     return m.group(1) if m else None
 
 

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -489,6 +489,22 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
+    None when no chain is configured (single-trunk → the repo's default branch).
+
+    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
+    PRs against the base; a project with no chain is unaffected.
+    """
+    cfg = config_path or Path(".claude/config.yaml")
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r'^\s*promotion_chain:\s*\[\s*"([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
 def cmd_create_pr_nojira(
     type_: str, title: str, branch: str | None, base: str | None
 ) -> int:
@@ -546,6 +562,10 @@ def cmd_create_pr_nojira(
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
+    # Target the base of the promotion chain when one is configured (ADR-014);
+    # no chain → base stays None → gh uses the repo default branch.
+    if base is None:
+        base = _base_branch()
     args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -59,3 +59,13 @@ gh_profile() {
   [ -f "$cfg" ] && prof=$(sed -nE 's/^[[:space:]]*profile:[[:space:]]*([a-z]+).*/\1/p' "$cfg" | head -1)
   printf '%s\n' "${prof:-individual}"
 }
+
+# Base branch for feature PRs (ADR-014): the first branch in the promotion chain
+# recorded in .claude/config.yaml; falls back to the repo's default branch (then
+# main) when no chain is configured (single-trunk). Used by start_issue.sh.
+base_branch() {
+  local cfg=".claude/config.yaml" base=""
+  [ -f "$cfg" ] && base=$(sed -nE 's/^[[:space:]]*promotion_chain:[[:space:]]*\[[[:space:]]*"([^"]+)".*/\1/p' "$cfg" | head -1)
+  [ -z "$base" ] && base=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
+  printf '%s\n' "${base:-main}"
+}

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -65,7 +65,8 @@ gh_profile() {
 # main) when no chain is configured (single-trunk). Used by start_issue.sh.
 base_branch() {
   local cfg=".claude/config.yaml" base=""
-  [ -f "$cfg" ] && base=$(sed -nE 's/^[[:space:]]*promotion_chain:[[:space:]]*\[[[:space:]]*"([^"]+)".*/\1/p' "$cfg" | head -1)
+  # Tolerate quoted or unquoted entries (config.yaml is hand-editable).
+  [ -f "$cfg" ] && base=$(sed -nE 's/^[[:space:]]*promotion_chain:[[:space:]]*\[[[:space:]]*"?([^]",[:space:]]+).*/\1/p' "$cfg" | head -1)
   [ -z "$base" ] && base=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
   printf '%s\n' "${base:-main}"
 }

--- a/templates/base/dot_claude/scripts/start_issue.sh
+++ b/templates/base/dot_claude/scripts/start_issue.sh
@@ -11,6 +11,9 @@
 
 set -euo pipefail
 
+# Resolve the base branch (ADR-014) from the promotion chain via gh_host.sh.
+source "$(dirname "$0")/gh_host.sh"
+
 VALID_TYPES="feat fix chore docs test"
 
 usage() {
@@ -130,8 +133,10 @@ fi
 PR_TITLE="${TYPE}(${ISSUE_REF}): ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
+BASE_BRANCH=$(base_branch)
 PR_URL=$(gh pr create \
   --draft \
+  --base "$BASE_BRANCH" \
   --title "$PR_TITLE" \
   --body "$PR_BODY")
 

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -15,7 +15,7 @@ from project_init.__main__ import (
     resolve_branch_chain,
 )
 from project_init.scaffold import load_preset, scaffold
-from tests.helpers import make_variables
+from tests.helpers import fallback_preset, fallback_variables, make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DAG_HOOK = _REPO_ROOT / ".claude" / "hooks" / "dag_workflow.py"
@@ -169,16 +169,32 @@ class TestBaseBranchReader:
         cfg.write_text("project:\n  name: x\n")
         assert _load_dag()._base_branch(cfg) is None
 
+    def test_reads_unquoted_chain(self, tmp_path: Path):
+        # config.yaml is hand-editable; tolerate unquoted lists (ADR-014 prose).
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("    promotion_chain: [dev, test, main]\n")
+        assert _load_dag()._base_branch(cfg) == "dev"
+
 
 class TestBaseBranchWiring:
-    def test_gh_host_defines_base_branch(self):
-        assert "base_branch()" in (_SCRIPTS / "gh_host.sh").read_text()
+    """The base-branch wiring must survive scaffolding into a real project tree
+    (repo rule: templates/ changes need a scaffold-into-tempdir test)."""
 
-    def test_start_issue_targets_base(self):
-        s = (_SCRIPTS / "start_issue.sh").read_text()
+    def _scaffold(self, tmp_path: Path) -> Path:
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True)
+        return target
+
+    def test_scaffolded_gh_host_defines_base_branch(self, tmp_path: Path):
+        target = self._scaffold(tmp_path)
+        assert "base_branch()" in (target / ".claude/scripts/gh_host.sh").read_text()
+
+    def test_scaffolded_start_issue_targets_base(self, tmp_path: Path):
+        target = self._scaffold(tmp_path)
+        s = (target / ".claude/scripts/start_issue.sh").read_text()
         assert "gh_host.sh" in s
         assert "--base" in s
 
-    def test_dag_workflow_has_base_reader(self):
-        hook = _REPO_ROOT / "templates" / "base" / "dot_claude" / "hooks" / "dag_workflow.py"
-        assert "_base_branch" in hook.read_text()
+    def test_scaffolded_dag_workflow_has_base_reader(self, tmp_path: Path):
+        target = self._scaffold(tmp_path)
+        assert "_base_branch" in (target / ".claude/hooks/dag_workflow.py").read_text()

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -3,6 +3,7 @@ rendered config, and the upgrade backfill for pre-branch-model records."""
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,17 @@ from project_init.__main__ import (
 )
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DAG_HOOK = _REPO_ROOT / ".claude" / "hooks" / "dag_workflow.py"
+_SCRIPTS = _REPO_ROOT / "templates" / "base" / "dot_claude" / "scripts"
+
+
+def _load_dag():
+    spec = importlib.util.spec_from_file_location("dag_workflow_under_test", _DAG_HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def _inputs(branch_chain: list[str]) -> ScaffoldInputs:
@@ -136,3 +148,37 @@ class TestUpgradeBackfill:
         write_scaffold_record(target, "obsidian-only", legacy, created)
         # Strict re-render must succeed (branch vars are backfilled to single-trunk).
         assert run_upgrade(target, apply=False) == 0
+
+
+class TestBaseBranchReader:
+    def test_reads_first_chain_element(self, tmp_path: Path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('  branch_model:\n    promotion_chain: ["dev", "test", "main"]\n')
+        assert _load_dag()._base_branch(cfg) == "dev"
+
+    def test_single_trunk_returns_main(self, tmp_path: Path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('    promotion_chain: ["main"]\n')
+        assert _load_dag()._base_branch(cfg) == "main"
+
+    def test_missing_config_returns_none(self, tmp_path: Path):
+        assert _load_dag()._base_branch(tmp_path / "absent.yaml") is None
+
+    def test_no_chain_returns_none(self, tmp_path: Path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("project:\n  name: x\n")
+        assert _load_dag()._base_branch(cfg) is None
+
+
+class TestBaseBranchWiring:
+    def test_gh_host_defines_base_branch(self):
+        assert "base_branch()" in (_SCRIPTS / "gh_host.sh").read_text()
+
+    def test_start_issue_targets_base(self):
+        s = (_SCRIPTS / "start_issue.sh").read_text()
+        assert "gh_host.sh" in s
+        assert "--base" in s
+
+    def test_dag_workflow_has_base_reader(self):
+        hook = _REPO_ROOT / "templates" / "base" / "dot_claude" / "hooks" / "dag_workflow.py"
+        assert "_base_branch" in hook.read_text()


### PR DESCRIPTION
Implements ticket #303 (epic #298): feature PRs target the configured promotion-chain base branch.

- `_base_branch()` reader in `dag_workflow.py` (all 3 copies: repo + template + plugin, kept in sync) — first element of `branch_model.promotion_chain`, else None.
- `create-pr-nojira` defaults `--base` to it.
- `base_branch()` shell reader in `gh_host.sh`; `start_issue.sh` sources it and passes `--base`.
- No chain configured → resolves to the repo default branch; single-trunk and existing projects unaffected.
- Tests: `_base_branch()` unit tests + wiring contract assertions.

Closes #303