### PR TITLE
feat(PI-305): promote-env fast-forward promotion command

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -625,7 +625,15 @@ def cmd_promote_env(target: str | None) -> int:
     if code != 0:
         sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
         return 1
-    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, _ = _git(["checkout", "-B", target, f"origin/{target}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: could not check out {target} (uncommitted changes or "
+            "conflicting local state?). Aborting; nothing merged or pushed.\n"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
     code, out = _git(["merge", "--ff-only", f"origin/{source}"])
     if code != 0:
         sys.stderr.write(

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -15,6 +15,8 @@ Subcommands:
                         push, promote, then exec monitor_pr.sh --merge.
   create-pr-nojira <type> <title> [--branch B] [--base B]
                         create a no-issue feature branch + draft PR.
+  promote-env [<target>]
+                        fast-forward promote one step along the chain (ADR-014).
 
 The `check` and `guard` paths are pure read-only; they're used by hooks and
 lifecycle scripts. The other subcommands consolidate the bash lifecycle
@@ -489,22 +491,30 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def _base_branch(config_path: Path | None = None) -> str | None:
-    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
-    None when no chain is configured (single-trunk → the repo's default branch).
+def _promotion_chain(config_path: Path | None = None) -> list[str]:
+    """The full promotion chain from .claude/config.yaml (ADR-014), base→production.
 
-    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
-    PRs against the base; a project with no chain is unaffected.
+    Empty list when no chain is configured. Tolerates quoted or unquoted entries
+    (config.yaml is hand-editable; ADR-014 prose shows forms like [main] and
+    [dev, test, main]).
     """
     cfg = config_path or Path(".claude/config.yaml")
     try:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
-        return None
-    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
-    # prose shows unquoted forms like [main] / [dev, test, main]).
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
-    return m.group(1) if m else None
+        return []
+    m = re.search(r"^\s*promotion_chain:\s*\[([^\]]*)\]", text, re.MULTILINE)
+    if not m:
+        return []
+    return re.findall(r'[^"\s,]+', m.group(1))
+
+
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain (ADR-014), or None when no chain is
+    configured (single-trunk → the repo's default branch). Feature PRs target it.
+    """
+    chain = _promotion_chain(config_path)
+    return chain[0] if chain else None
 
 
 def cmd_create_pr_nojira(
@@ -579,6 +589,62 @@ def cmd_create_pr_nojira(
     return 0
 
 
+def cmd_promote_env(target: str | None) -> int:
+    """Fast-forward promote one step along the configured chain (ADR-014).
+
+    Promotes the predecessor of *target* into *target* with `git merge --ff-only`,
+    then pushes. The push is an internal subprocess (not via cmd_push), so it can
+    update a protected env branch the same way cmd_push's subprocess bypasses the
+    PreToolUse hook; server-side rulesets govern what is actually allowed.
+    """
+    chain = _promotion_chain()
+    if len(chain) < 2:
+        sys.stderr.write(
+            "promote-env: no promotion chain configured (single-trunk). "
+            "Set branch_model.promotion_chain in .claude/config.yaml.\n"
+        )
+        return 1
+    if target is None:
+        sys.stderr.write(
+            f"promote-env: specify the target env. Chain: {' -> '.join(chain)}\n"
+        )
+        return 1
+    if target not in chain:
+        sys.stderr.write(f"promote-env: '{target}' is not in the chain {chain}\n")
+        return 1
+    idx = chain.index(target)
+    if idx == 0:
+        sys.stderr.write(
+            f"promote-env: '{target}' is the base branch — nothing promotes into it\n"
+        )
+        return 1
+    source = chain[idx - 1]
+    original = _current_branch()
+
+    code, _ = _git(["fetch", "origin", source, target])
+    if code != 0:
+        sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
+        return 1
+    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, out = _git(["merge", "--ff-only", f"origin/{source}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: {source} -> {target} is not a fast-forward "
+            f"({target} has diverged); resolve manually.\n{out}"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
+    code, _ = _git(["push", "origin", target])
+    if original and original != target:
+        _git(["checkout", original])
+    if code != 0:
+        sys.stderr.write(f"promote-env: push of {target} failed\n")
+        return 1
+    sys.stdout.write(f"promote-env: {source} -> {target} (fast-forward) pushed\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="dag_workflow")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -615,6 +681,12 @@ def main(argv: list[str] | None = None) -> int:
     p_nojira.add_argument("--branch", default=None)
     p_nojira.add_argument("--base", default=None)
 
+    p_promote_env = sub.add_parser(
+        "promote-env",
+        help="fast-forward promote one step along the configured chain (ADR-014)",
+    )
+    p_promote_env.add_argument("target", nargs="?", default=None)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "check":
@@ -633,6 +705,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_finish(args.pr_number, args.review_cycle)
     if args.cmd == "create-pr-nojira":
         return cmd_create_pr_nojira(args.type, args.title, args.branch, args.base)
+    if args.cmd == "promote-env":
+        return cmd_promote_env(args.target)
     return 1
 
 

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -625,7 +625,15 @@ def cmd_promote_env(target: str | None) -> int:
     if code != 0:
         sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
         return 1
-    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, _ = _git(["checkout", "-B", target, f"origin/{target}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: could not check out {target} (uncommitted changes or "
+            "conflicting local state?). Aborting; nothing merged or pushed.\n"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
     code, out = _git(["merge", "--ff-only", f"origin/{source}"])
     if code != 0:
         sys.stderr.write(

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -15,6 +15,8 @@ Subcommands:
                         push, promote, then exec monitor_pr.sh --merge.
   create-pr-nojira <type> <title> [--branch B] [--base B]
                         create a no-issue feature branch + draft PR.
+  promote-env [<target>]
+                        fast-forward promote one step along the chain (ADR-014).
 
 The `check` and `guard` paths are pure read-only; they're used by hooks and
 lifecycle scripts. The other subcommands consolidate the bash lifecycle
@@ -489,22 +491,30 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def _base_branch(config_path: Path | None = None) -> str | None:
-    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
-    None when no chain is configured (single-trunk → the repo's default branch).
+def _promotion_chain(config_path: Path | None = None) -> list[str]:
+    """The full promotion chain from .claude/config.yaml (ADR-014), base→production.
 
-    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
-    PRs against the base; a project with no chain is unaffected.
+    Empty list when no chain is configured. Tolerates quoted or unquoted entries
+    (config.yaml is hand-editable; ADR-014 prose shows forms like [main] and
+    [dev, test, main]).
     """
     cfg = config_path or Path(".claude/config.yaml")
     try:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
-        return None
-    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
-    # prose shows unquoted forms like [main] / [dev, test, main]).
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
-    return m.group(1) if m else None
+        return []
+    m = re.search(r"^\s*promotion_chain:\s*\[([^\]]*)\]", text, re.MULTILINE)
+    if not m:
+        return []
+    return re.findall(r'[^"\s,]+', m.group(1))
+
+
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain (ADR-014), or None when no chain is
+    configured (single-trunk → the repo's default branch). Feature PRs target it.
+    """
+    chain = _promotion_chain(config_path)
+    return chain[0] if chain else None
 
 
 def cmd_create_pr_nojira(
@@ -579,6 +589,62 @@ def cmd_create_pr_nojira(
     return 0
 
 
+def cmd_promote_env(target: str | None) -> int:
+    """Fast-forward promote one step along the configured chain (ADR-014).
+
+    Promotes the predecessor of *target* into *target* with `git merge --ff-only`,
+    then pushes. The push is an internal subprocess (not via cmd_push), so it can
+    update a protected env branch the same way cmd_push's subprocess bypasses the
+    PreToolUse hook; server-side rulesets govern what is actually allowed.
+    """
+    chain = _promotion_chain()
+    if len(chain) < 2:
+        sys.stderr.write(
+            "promote-env: no promotion chain configured (single-trunk). "
+            "Set branch_model.promotion_chain in .claude/config.yaml.\n"
+        )
+        return 1
+    if target is None:
+        sys.stderr.write(
+            f"promote-env: specify the target env. Chain: {' -> '.join(chain)}\n"
+        )
+        return 1
+    if target not in chain:
+        sys.stderr.write(f"promote-env: '{target}' is not in the chain {chain}\n")
+        return 1
+    idx = chain.index(target)
+    if idx == 0:
+        sys.stderr.write(
+            f"promote-env: '{target}' is the base branch — nothing promotes into it\n"
+        )
+        return 1
+    source = chain[idx - 1]
+    original = _current_branch()
+
+    code, _ = _git(["fetch", "origin", source, target])
+    if code != 0:
+        sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
+        return 1
+    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, out = _git(["merge", "--ff-only", f"origin/{source}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: {source} -> {target} is not a fast-forward "
+            f"({target} has diverged); resolve manually.\n{out}"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
+    code, _ = _git(["push", "origin", target])
+    if original and original != target:
+        _git(["checkout", original])
+    if code != 0:
+        sys.stderr.write(f"promote-env: push of {target} failed\n")
+        return 1
+    sys.stdout.write(f"promote-env: {source} -> {target} (fast-forward) pushed\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="dag_workflow")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -615,6 +681,12 @@ def main(argv: list[str] | None = None) -> int:
     p_nojira.add_argument("--branch", default=None)
     p_nojira.add_argument("--base", default=None)
 
+    p_promote_env = sub.add_parser(
+        "promote-env",
+        help="fast-forward promote one step along the configured chain (ADR-014)",
+    )
+    p_promote_env.add_argument("target", nargs="?", default=None)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "check":
@@ -633,6 +705,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_finish(args.pr_number, args.review_cycle)
     if args.cmd == "create-pr-nojira":
         return cmd_create_pr_nojira(args.type, args.title, args.branch, args.base)
+    if args.cmd == "promote-env":
+        return cmd_promote_env(args.target)
     return 1
 
 

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -625,7 +625,15 @@ def cmd_promote_env(target: str | None) -> int:
     if code != 0:
         sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
         return 1
-    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, _ = _git(["checkout", "-B", target, f"origin/{target}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: could not check out {target} (uncommitted changes or "
+            "conflicting local state?). Aborting; nothing merged or pushed.\n"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
     code, out = _git(["merge", "--ff-only", f"origin/{source}"])
     if code != 0:
         sys.stderr.write(

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -15,6 +15,8 @@ Subcommands:
                         push, promote, then exec monitor_pr.sh --merge.
   create-pr-nojira <type> <title> [--branch B] [--base B]
                         create a no-issue feature branch + draft PR.
+  promote-env [<target>]
+                        fast-forward promote one step along the chain (ADR-014).
 
 The `check` and `guard` paths are pure read-only; they're used by hooks and
 lifecycle scripts. The other subcommands consolidate the bash lifecycle
@@ -489,22 +491,30 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def _base_branch(config_path: Path | None = None) -> str | None:
-    """First branch of the promotion chain in .claude/config.yaml (ADR-014), or
-    None when no chain is configured (single-trunk → the repo's default branch).
+def _promotion_chain(config_path: Path | None = None) -> list[str]:
+    """The full promotion chain from .claude/config.yaml (ADR-014), base→production.
 
-    Feature PRs target this so an env-branch project (e.g. dev→test→main) opens
-    PRs against the base; a project with no chain is unaffected.
+    Empty list when no chain is configured. Tolerates quoted or unquoted entries
+    (config.yaml is hand-editable; ADR-014 prose shows forms like [main] and
+    [dev, test, main]).
     """
     cfg = config_path or Path(".claude/config.yaml")
     try:
         text = cfg.read_text(encoding="utf-8")
     except OSError:
-        return None
-    # Tolerate quoted or unquoted entries (config.yaml is hand-editable; ADR-014
-    # prose shows unquoted forms like [main] / [dev, test, main]).
-    m = re.search(r'^\s*promotion_chain:\s*\[\s*"?([^"\s,\]]+)', text, re.MULTILINE)
-    return m.group(1) if m else None
+        return []
+    m = re.search(r"^\s*promotion_chain:\s*\[([^\]]*)\]", text, re.MULTILINE)
+    if not m:
+        return []
+    return re.findall(r'[^"\s,]+', m.group(1))
+
+
+def _base_branch(config_path: Path | None = None) -> str | None:
+    """First branch of the promotion chain (ADR-014), or None when no chain is
+    configured (single-trunk → the repo's default branch). Feature PRs target it.
+    """
+    chain = _promotion_chain(config_path)
+    return chain[0] if chain else None
 
 
 def cmd_create_pr_nojira(
@@ -579,6 +589,62 @@ def cmd_create_pr_nojira(
     return 0
 
 
+def cmd_promote_env(target: str | None) -> int:
+    """Fast-forward promote one step along the configured chain (ADR-014).
+
+    Promotes the predecessor of *target* into *target* with `git merge --ff-only`,
+    then pushes. The push is an internal subprocess (not via cmd_push), so it can
+    update a protected env branch the same way cmd_push's subprocess bypasses the
+    PreToolUse hook; server-side rulesets govern what is actually allowed.
+    """
+    chain = _promotion_chain()
+    if len(chain) < 2:
+        sys.stderr.write(
+            "promote-env: no promotion chain configured (single-trunk). "
+            "Set branch_model.promotion_chain in .claude/config.yaml.\n"
+        )
+        return 1
+    if target is None:
+        sys.stderr.write(
+            f"promote-env: specify the target env. Chain: {' -> '.join(chain)}\n"
+        )
+        return 1
+    if target not in chain:
+        sys.stderr.write(f"promote-env: '{target}' is not in the chain {chain}\n")
+        return 1
+    idx = chain.index(target)
+    if idx == 0:
+        sys.stderr.write(
+            f"promote-env: '{target}' is the base branch — nothing promotes into it\n"
+        )
+        return 1
+    source = chain[idx - 1]
+    original = _current_branch()
+
+    code, _ = _git(["fetch", "origin", source, target])
+    if code != 0:
+        sys.stderr.write(f"promote-env: git fetch failed for {source}/{target}\n")
+        return 1
+    _git(["checkout", "-B", target, f"origin/{target}"])
+    code, out = _git(["merge", "--ff-only", f"origin/{source}"])
+    if code != 0:
+        sys.stderr.write(
+            f"promote-env: {source} -> {target} is not a fast-forward "
+            f"({target} has diverged); resolve manually.\n{out}"
+        )
+        if original and original != target:
+            _git(["checkout", original])
+        return 1
+    code, _ = _git(["push", "origin", target])
+    if original and original != target:
+        _git(["checkout", original])
+    if code != 0:
+        sys.stderr.write(f"promote-env: push of {target} failed\n")
+        return 1
+    sys.stdout.write(f"promote-env: {source} -> {target} (fast-forward) pushed\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="dag_workflow")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -615,6 +681,12 @@ def main(argv: list[str] | None = None) -> int:
     p_nojira.add_argument("--branch", default=None)
     p_nojira.add_argument("--base", default=None)
 
+    p_promote_env = sub.add_parser(
+        "promote-env",
+        help="fast-forward promote one step along the configured chain (ADR-014)",
+    )
+    p_promote_env.add_argument("target", nargs="?", default=None)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "check":
@@ -633,6 +705,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_finish(args.pr_number, args.review_cycle)
     if args.cmd == "create-pr-nojira":
         return cmd_create_pr_nojira(args.type, args.title, args.branch, args.base)
+    if args.cmd == "promote-env":
+        return cmd_promote_env(args.target)
     return 1
 
 

--- a/templates/base/dot_claude/scripts/promote_env.sh
+++ b/templates/base/dot_claude/scripts/promote_env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Thin shim — actual logic lives in .claude/hooks/dag_workflow.py.
+# Fast-forward promote one step along the branch_model chain (ADR-014):
+#   .claude/scripts/promote_env.sh <target-env>
+exec python3 "$(dirname "$0")/../hooks/dag_workflow.py" promote-env "$@"

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -4,6 +4,7 @@ rendered config, and the upgrade backfill for pre-branch-model records."""
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -19,7 +20,6 @@ from tests.helpers import fallback_preset, fallback_variables, make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DAG_HOOK = _REPO_ROOT / ".claude" / "hooks" / "dag_workflow.py"
-_SCRIPTS = _REPO_ROOT / "templates" / "base" / "dot_claude" / "scripts"
 
 
 def _load_dag():
@@ -198,3 +198,95 @@ class TestBaseBranchWiring:
     def test_scaffolded_dag_workflow_has_base_reader(self, tmp_path: Path):
         target = self._scaffold(tmp_path)
         assert "_base_branch" in (target / ".claude/hooks/dag_workflow.py").read_text()
+
+
+class TestPromotionChain:
+    def test_quoted(self, tmp_path: Path):
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text('    promotion_chain: ["dev", "test", "main"]\n')
+        assert _load_dag()._promotion_chain(cfg) == ["dev", "test", "main"]
+
+    def test_unquoted(self, tmp_path: Path):
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text("    promotion_chain: [dev, test, main]\n")
+        assert _load_dag()._promotion_chain(cfg) == ["dev", "test", "main"]
+
+    def test_single(self, tmp_path: Path):
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text('    promotion_chain: ["main"]\n')
+        assert _load_dag()._promotion_chain(cfg) == ["main"]
+
+    def test_missing(self, tmp_path: Path):
+        assert _load_dag()._promotion_chain(tmp_path / "absent.yaml") == []
+
+
+class TestPromoteEnvValidation:
+    def _dag(self, monkeypatch, chain: list[str]):
+        dag = _load_dag()
+        monkeypatch.setattr(dag, "_promotion_chain", lambda *a, **k: chain)
+        return dag
+
+    def test_single_trunk_refused(self, monkeypatch):
+        assert self._dag(monkeypatch, ["main"]).cmd_promote_env("main") == 1
+
+    def test_no_target_refused(self, monkeypatch):
+        assert self._dag(monkeypatch, ["dev", "test", "main"]).cmd_promote_env(None) == 1
+
+    def test_unknown_target_refused(self, monkeypatch):
+        assert self._dag(monkeypatch, ["dev", "test", "main"]).cmd_promote_env("nope") == 1
+
+    def test_base_target_refused(self, monkeypatch):
+        assert self._dag(monkeypatch, ["dev", "test", "main"]).cmd_promote_env("dev") == 1
+
+
+class TestPromoteEnvFastForward:
+    def test_promotes_by_fast_forward(self, tmp_path: Path, monkeypatch):
+        remote = tmp_path / "remote.git"
+        work = tmp_path / "work"
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", str(remote)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "clone", str(remote), str(work)], check=True, capture_output=True
+        )
+
+        def g(*args: str) -> None:
+            subprocess.run(["git", "-C", str(work), *args], check=True, capture_output=True)
+
+        g("config", "user.email", "t@t")
+        g("config", "user.name", "t")
+        (work / "a.txt").write_text("1")
+        g("add", "-A")
+        g("commit", "-m", "init")
+        g("branch", "dev")
+        g("branch", "test")
+        g("push", "origin", "main", "dev", "test")
+        g("checkout", "dev")
+        (work / "b.txt").write_text("2")
+        g("add", "-A")
+        g("commit", "-m", "feat")
+        g("push", "origin", "dev")
+        (work / ".claude").mkdir()
+        (work / ".claude" / "config.yaml").write_text(
+            '    promotion_chain: ["dev", "test", "main"]\n'
+        )
+        monkeypatch.chdir(work)
+        assert _load_dag().cmd_promote_env("test") == 0
+
+        def sha(ref: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(work), "rev-parse", ref],
+                capture_output=True, text=True,
+            ).stdout.strip()
+
+        assert sha("origin/test") == sha("origin/dev")
+
+
+class TestPromoteEnvShim:
+    def test_shim_scaffolded(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True)
+        shim = (target / ".claude/scripts/promote_env.sh").read_text()
+        assert "dag_workflow.py" in shim
+        assert "promote-env" in shim

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -238,6 +238,24 @@ class TestPromoteEnvValidation:
     def test_base_target_refused(self, monkeypatch):
         assert self._dag(monkeypatch, ["dev", "test", "main"]).cmd_promote_env("dev") == 1
 
+    def test_aborts_on_checkout_failure(self, monkeypatch):
+        # A failed checkout must abort before merge/push (Codex P1): otherwise the
+        # ff-merge runs on the wrong branch and a stale ref gets pushed as success.
+        dag = self._dag(monkeypatch, ["dev", "test", "main"])
+        monkeypatch.setattr(dag, "_current_branch", lambda: "dev")
+        calls: list[str] = []
+
+        def fake_git(args: list[str]) -> tuple[int, str]:
+            calls.append(args[0])
+            if args[0] == "checkout" and "-B" in args:
+                return (1, "error: local changes would be overwritten")
+            return (0, "")
+
+        monkeypatch.setattr(dag, "_git", fake_git)
+        assert dag.cmd_promote_env("test") == 1
+        assert "merge" not in calls
+        assert "push" not in calls
+
 
 class TestPromoteEnvFastForward:
     def test_promotes_by_fast_forward(self, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Implements ticket #305 (epic #298): the `promote-env` fast-forward promotion verb (distinct from `promote` = mark PR ready).

- `_promotion_chain()` reader (full chain, quoted/unquoted); `_base_branch()` refactored to use it.
- `cmd_promote_env(target)`: ff-only merge of the predecessor into the target env, then push; refuses non-fast-forward (diverged); validates single-trunk / base / unknown targets.
- `promote-env` argparse subcommand + `promote_env.sh` shim (executable); dag_workflow.py synced across all 3 copies (repo + template + plugin).
- No guard change: the promotion push is an internal subprocess (invisible to the PreToolUse hook, like cmd_push); server-side rulesets (#5) enforce env-branch protection.
- Tests: chain parsing, validation paths, a real fast-forward integration test (bare remote), and the scaffolded shim contract.

Closes #305