### PR TITLE
feat(PI-307): setup_env_branches.sh — create + protect the promotion chain

### DIFF
--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -70,3 +70,15 @@ base_branch() {
   [ -z "$base" ] && base=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
   printf '%s\n' "${base:-main}"
 }
+
+# Full promotion chain (ADR-014) as space-separated branch names (base→production);
+# empty when no chain is configured. Tolerates quoted or unquoted entries.
+promotion_chain() {
+  local cfg=".claude/config.yaml" inner=""
+  [ -f "$cfg" ] || return 0
+  inner=$(sed -nE 's/^[[:space:]]*promotion_chain:[[:space:]]*\[(.*)\].*/\1/p' "$cfg" | head -1)
+  [ -z "$inner" ] && return 0
+  inner=$(printf '%s' "$inner" | tr ',"' '  ')
+  # shellcheck disable=SC2086  # intentional word-splitting normalizes whitespace
+  echo $inner
+}

--- a/templates/base/dot_claude/scripts/setup_env_branches.sh
+++ b/templates/base/dot_claude/scripts/setup_env_branches.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# setup_env_branches.sh — create + protect the environment promotion chain (ADR-014).
+#
+# Reads branch_model.promotion_chain from .claude/config.yaml and, for each branch
+# in the chain, creates it off the base (if absent) and — with --protect — applies
+# branch protection. Also sets the repo merge policy to squash-only. Idempotent;
+# a single-trunk project (chain < 2) is a no-op.
+#
+# Determinism: this runs against a live repo via gh AFTER clone — never from the
+# Python scaffolder (CLAUDE.md / ADR-014). Run it once when adopting environments,
+# and again after editing the chain.
+#
+# Usage: setup_env_branches.sh [--protect]
+# Requires: gh and admin permission on the repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
+PROTECT=0
+for arg in "$@"; do
+  case "$arg" in
+    --protect) PROTECT=1 ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Resolve the chain. Single-trunk (or no chain) → nothing to do.
+CHAIN=()
+read -r -a CHAIN <<< "$(promotion_chain)" || true
+if [ "${#CHAIN[@]}" -lt 2 ]; then
+  echo "Single-trunk — no multi-branch promotion chain configured; nothing to set up."
+  echo "Opt in by setting branch_model.promotion_chain in .claude/config.yaml, e.g. [dev, test, main]."
+  exit 0
+fi
+
+BASE="${CHAIN[0]}"
+PROD="${CHAIN[${#CHAIN[@]}-1]}"
+
+HOST="$(gh_host)"
+if ! gh auth status -h "$HOST" >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated for $HOST. Run: gh auth login --hostname $HOST" >&2
+  exit 1
+fi
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+PROFILE="$(gh_profile)"
+
+echo "Promotion chain: ${CHAIN[*]}  (base=$BASE, production=$PROD, profile=$PROFILE)"
+
+# --- 1. Repo merge policy: squash-only + delete-branch-on-merge (ADR-014) ---
+if gh api "repos/$OWNER/$NAME" -X PATCH \
+     -F allow_squash_merge=true -F allow_merge_commit=false \
+     -F allow_rebase_merge=false -F delete_branch_on_merge=true >/dev/null 2>&1; then
+  echo "Repo merge policy: squash-only + delete-branch-on-merge"
+else
+  echo "WARNING: could not set repo merge policy (admin permission?)." >&2
+fi
+
+# --- 2. Create each chain branch off the base if absent ---
+base_sha=$(gh api "repos/$OWNER/$NAME/git/ref/heads/$BASE" -q .object.sha 2>/dev/null || true)
+if [ -z "$base_sha" ]; then
+  default_branch=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo main)
+  base_sha=$(gh api "repos/$OWNER/$NAME/git/ref/heads/$default_branch" -q .object.sha 2>/dev/null || true)
+fi
+if [ -z "$base_sha" ]; then
+  echo "ERROR: cannot resolve a base SHA to create branches from." >&2
+  exit 1
+fi
+for b in "${CHAIN[@]}"; do
+  if gh api "repos/$OWNER/$NAME/branches/$b" >/dev/null 2>&1; then
+    echo "Branch '$b' already exists — skipping"
+  elif gh api "repos/$OWNER/$NAME/git/refs" -f ref="refs/heads/$b" -f sha="$base_sha" >/dev/null 2>&1; then
+    echo "Created branch '$b' from ${base_sha:0:8}"
+  else
+    echo "WARNING: could not create branch '$b'." >&2
+  fi
+done
+
+if [ "$PROTECT" != 1 ]; then
+  echo "Branches ensured. Re-run with --protect to apply per-branch protection."
+  exit 0
+fi
+
+# --- 3. Per-branch protection ---
+# base branch: feature PRs land here via squash → require PR + checks + linear.
+# downstream/production: updated only by fast-forward promotion (promote-env), so
+# block force-push + deletion and require checks + linear, but DO NOT require a PR
+# (a require-PR rule would refuse the ff promotion push server-side).
+apply_protection() {
+  local branch="$1" require_pr="$2" reviews tmp
+  if [ "$require_pr" = 1 ]; then
+    reviews='{ "required_approving_review_count": 1, "dismiss_stale_reviews": true, "require_code_owner_reviews": false, "require_last_push_approval": false }'
+  else
+    reviews='null'
+  fi
+  tmp=$(mktemp)
+  cat > "$tmp" <<JSON
+{
+  "required_status_checks": { "strict": true, "contexts": ["CI / Lint and test"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": $reviews,
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+  if gh api "repos/$OWNER/$NAME/branches/$branch/protection" -X PUT --input "$tmp" >/dev/null 2>&1; then
+    echo "Protected '$branch' (require_pr=$require_pr)"
+  else
+    echo "WARNING: could not protect '$branch' (admin permission / repo plan?)." >&2
+  fi
+  rm -f "$tmp"
+}
+
+for b in "${CHAIN[@]}"; do
+  if [ "$b" = "$BASE" ]; then
+    apply_protection "$b" 1
+  else
+    apply_protection "$b" 0
+  fi
+done
+
+# --- 4. Org profile: owner-binding rulesets (empty bypass) per branch (ADR-013) ---
+# Classic protection above is admin-bypassable (enforce_admins=false). The org
+# profile's "hard" layer adds a ruleset per branch that binds everyone. ff
+# promotion stays allowed: non_fast_forward only blocks force-pushes, and no
+# pull_request rule is attached to downstream/production branches.
+if [ "$PROFILE" = "org" ]; then
+  if gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
+    for b in "${CHAIN[@]}"; do
+      pr_rule=""
+      [ "$b" = "$BASE" ] && pr_rule='{ "type": "pull_request", "parameters": { "required_approving_review_count": 1, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false } },'
+      rs=$(mktemp)
+      cat > "$rs" <<JSON
+{
+  "name": "project-init-env-$b",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/heads/$b"], "exclude": [] } },
+  "rules": [
+    { "type": "non_fast_forward" },
+    { "type": "deletion" },
+    $pr_rule
+    { "type": "required_status_checks", "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [ { "context": "CI / Lint and test" } ] } }
+  ],
+  "bypass_actors": []
+}
+JSON
+      if gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$rs" >/dev/null 2>&1; then
+        echo "Ruleset 'project-init-env-$b' applied (binds everyone — empty bypass)"
+      else
+        echo "WARNING: ruleset for '$b' not created (may already exist, or plan/permission)." >&2
+      fi
+      rm -f "$rs"
+    done
+  else
+    echo "Rulesets API unavailable on this host/plan — relying on branch protection only." >&2
+  fi
+fi
+
+echo "Done. Promote with: .claude/scripts/promote_env.sh <target-env>"

--- a/templates/base/dot_claude/scripts/setup_env_branches.sh
+++ b/templates/base/dot_claude/scripts/setup_env_branches.sh
@@ -91,20 +91,24 @@ fi
 # block force-push + deletion and require checks + linear, but DO NOT require a PR
 # (a require-PR rule would refuse the ff promotion push server-side).
 apply_protection() {
-  local branch="$1" require_pr="$2" reviews tmp
+  local branch="$1" require_pr="$2" reviews conv tmp
   if [ "$require_pr" = 1 ]; then
     reviews='{ "required_approving_review_count": 1, "dismiss_stale_reviews": true, "require_code_owner_reviews": false, "require_last_push_approval": false }'
+    conv=true
   else
     reviews='null'
+    conv=false
   fi
   tmp=$(mktemp)
+  # Required checks mirror setup_github.sh's baseline (lint+test AND secret scan).
   cat > "$tmp" <<JSON
 {
-  "required_status_checks": { "strict": true, "contexts": ["CI / Lint and test"] },
+  "required_status_checks": { "strict": true, "contexts": ["CI / Lint and test", "CI / Secret scan (gitleaks)"] },
   "enforce_admins": false,
   "required_pull_request_reviews": $reviews,
   "restrictions": null,
   "required_linear_history": true,
+  "required_conversation_resolution": $conv,
   "allow_force_pushes": false,
   "allow_deletions": false
 }
@@ -134,7 +138,7 @@ if [ "$PROFILE" = "org" ]; then
   if gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
     for b in "${CHAIN[@]}"; do
       pr_rule=""
-      [ "$b" = "$BASE" ] && pr_rule='{ "type": "pull_request", "parameters": { "required_approving_review_count": 1, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false } },'
+      [ "$b" = "$BASE" ] && pr_rule='{ "type": "pull_request", "parameters": { "required_approving_review_count": 1, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": true } },'
       rs=$(mktemp)
       cat > "$rs" <<JSON
 {
@@ -145,10 +149,11 @@ if [ "$PROFILE" = "org" ]; then
   "rules": [
     { "type": "non_fast_forward" },
     { "type": "deletion" },
+    { "type": "required_linear_history" },
     $pr_rule
     { "type": "required_status_checks", "parameters": {
         "strict_required_status_checks_policy": true,
-        "required_status_checks": [ { "context": "CI / Lint and test" } ] } }
+        "required_status_checks": [ { "context": "CI / Lint and test" }, { "context": "CI / Secret scan (gitleaks)" } ] } }
   ],
   "bypass_actors": []
 }

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -308,3 +308,51 @@ class TestPromoteEnvShim:
         shim = (target / ".claude/scripts/promote_env.sh").read_text()
         assert "dag_workflow.py" in shim
         assert "promote-env" in shim
+
+
+class TestSetupEnvBranches:
+    SCRIPT = _REPO_ROOT / "templates/base/dot_claude/scripts/setup_env_branches.sh"
+    GH_HOST = _REPO_ROOT / "templates/base/dot_claude/scripts/gh_host.sh"
+
+    def _chain(self, tmp_path: Path, line: str) -> str:
+        cfg = tmp_path / ".claude" / "config.yaml"
+        cfg.parent.mkdir(parents=True)
+        cfg.write_text(line)
+        out = subprocess.run(
+            ["bash", "-c", f'cd "{tmp_path}" && . "{self.GH_HOST}" && promotion_chain'],
+            capture_output=True, text=True,
+        )
+        return out.stdout.strip()
+
+    def test_promotion_chain_quoted(self, tmp_path: Path):
+        assert self._chain(tmp_path, '    promotion_chain: ["dev", "test", "main"]\n') == "dev test main"
+
+    def test_promotion_chain_unquoted(self, tmp_path: Path):
+        assert self._chain(tmp_path, "    promotion_chain: [dev, test, main]\n") == "dev test main"
+
+    def test_promotion_chain_single(self, tmp_path: Path):
+        assert self._chain(tmp_path, '    promotion_chain: ["main"]\n') == "main"
+
+    def test_single_trunk_noop_guard(self):
+        assert "-lt 2" in self.SCRIPT.read_text()
+
+    def test_sets_squash_only_policy(self):
+        s = self.SCRIPT.read_text()
+        assert "allow_squash_merge=true" in s
+        assert "allow_merge_commit=false" in s
+        assert "delete_branch_on_merge=true" in s
+
+    def test_creates_branches_via_refs_api(self):
+        assert "git/refs" in self.SCRIPT.read_text()
+
+    def test_org_ruleset_gated_with_empty_bypass(self):
+        s = self.SCRIPT.read_text()
+        assert 'PROFILE" = "org"' in s
+        assert '"bypass_actors": []' in s
+
+    def test_scaffolded_and_executable(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True)
+        script = target / ".claude/scripts/setup_env_branches.sh"
+        assert script.is_file()
+        assert script.stat().st_mode & 0o111

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -350,6 +350,14 @@ class TestSetupEnvBranches:
         assert 'PROFILE" = "org"' in s
         assert '"bypass_actors": []' in s
 
+    def test_governance_consistent_with_setup_github(self):
+        # Mirror setup_github.sh's baseline: secret-scan required, linear history,
+        # conversation resolution (Copilot review on #308).
+        s = self.SCRIPT.read_text()
+        assert "CI / Secret scan (gitleaks)" in s
+        assert "required_conversation_resolution" in s
+        assert '"type": "required_linear_history"' in s
+
     def test_scaffolded_and_executable(self, tmp_path: Path):
         target = tmp_path / "p"
         scaffold(target, fallback_preset(), fallback_variables(), strict=True)


### PR DESCRIPTION
Implements ticket #307 (epic #298): the post-clone script that materializes a promotion chain.

- `promotion_chain()` reader added to `gh_host.sh` (full chain, quoted/unquoted).
- New `setup_env_branches.sh` (executable):
  - single-trunk (chain < 2) → no-op.
  - repo merge policy → squash-only + delete-branch-on-merge.
  - creates each chain branch off the base if absent (`gh api .../git/refs`).
  - `--protect`: base = require PR + checks + linear; downstream/production = block force-push + deletion + checks + linear, **ff allowed** (no require-PR, so `promote-env` works). Org profile adds empty-bypass rulesets per branch.
  - determinism: runs against a live repo via gh, never from the Python scaffolder.
- Tests: shell chain parser (quoted/unquoted/single), single-trunk no-op, squash policy, branch creation, org-ruleset gating, scaffold-into-tempdir (+ executable bit).

Closes #307