### PR TITLE
feat(PI-309): retarget scaffolded CI/PR-validation to the base branch

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -643,7 +643,9 @@ def cmd_promote_env(target: str | None) -> int:
         if original and original != target:
             _git(["checkout", original])
         return 1
-    code, _ = _git(["push", "origin", target])
+    # --no-verify: a bare env-branch name fails the pre-push type-prefix rule;
+    # this promotion is sanctioned (server-side rulesets govern). See ADR-014.
+    code, _ = _git(["push", "--no-verify", "origin", target])
     if original and original != target:
         _git(["checkout", original])
     if code != 0:

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -643,7 +643,9 @@ def cmd_promote_env(target: str | None) -> int:
         if original and original != target:
             _git(["checkout", original])
         return 1
-    code, _ = _git(["push", "origin", target])
+    # --no-verify: a bare env-branch name fails the pre-push type-prefix rule;
+    # this promotion is sanctioned (server-side rulesets govern). See ADR-014.
+    code, _ = _git(["push", "--no-verify", "origin", target])
     if original and original != target:
         _git(["checkout", original])
     if code != 0:

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -643,7 +643,9 @@ def cmd_promote_env(target: str | None) -> int:
         if original and original != target:
             _git(["checkout", original])
         return 1
-    code, _ = _git(["push", "origin", target])
+    # --no-verify: a bare env-branch name fails the pre-push type-prefix rule;
+    # this promotion is sanctioned (server-side rulesets govern). See ADR-014.
+    code, _ = _git(["push", "--no-verify", "origin", target])
     if original and original != target:
         _git(["checkout", original])
     if code != 0:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [{{base_branch}}]
   pull_request:
-    branches: [main]
+    branches: [{{base_branch}}]
   # Optimization: Only run CI when relevant files change
   # Uncomment and adjust paths as needed for your project
 

--- a/templates/base/dot_github/workflows/validate-pr.yml.tmpl
+++ b/templates/base/dot_github/workflows/validate-pr.yml.tmpl
@@ -2,7 +2,7 @@ name: Validate PR
 
 on:
   pull_request:
-    branches: [main]
+    branches: [{{base_branch}}]
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -256,6 +256,22 @@ class TestPromoteEnvValidation:
         assert "merge" not in calls
         assert "push" not in calls
 
+    def test_push_uses_no_verify(self, monkeypatch):
+        # The promotion push must skip the local pre-push hook (bare env-branch
+        # names fail its type-prefix rule); server-side rulesets still govern.
+        dag = self._dag(monkeypatch, ["dev", "test", "main"])
+        monkeypatch.setattr(dag, "_current_branch", lambda: "dev")
+        pushes: list[list[str]] = []
+
+        def fake_git(args: list[str]) -> tuple[int, str]:
+            if args[0] == "push":
+                pushes.append(args)
+            return (0, "")
+
+        monkeypatch.setattr(dag, "_git", fake_git)
+        assert dag.cmd_promote_env("test") == 0
+        assert pushes and "--no-verify" in pushes[0]
+
 
 class TestPromoteEnvFastForward:
     def test_promotes_by_fast_forward(self, tmp_path: Path, monkeypatch):
@@ -364,3 +380,23 @@ class TestSetupEnvBranches:
         script = target / ".claude/scripts/setup_env_branches.sh"
         assert script.is_file()
         assert script.stat().st_mode & 0o111
+
+
+class TestCIRetargeting:
+    def _scaffold(self, tmp_path: Path, **overrides: str) -> Path:
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(**overrides), strict=True)
+        return target
+
+    def test_validate_pr_default_targets_main(self, tmp_path: Path):
+        vp = (self._scaffold(tmp_path) / ".github/workflows/validate-pr.yml").read_text()
+        assert "branches: [main]" in vp
+
+    def test_validate_pr_targets_base_for_env(self, tmp_path: Path):
+        vp = (self._scaffold(tmp_path, base_branch="dev") / ".github/workflows/validate-pr.yml").read_text()
+        assert "branches: [dev]" in vp
+
+    def test_ci_targets_base_for_env(self, tmp_path: Path):
+        ci = (self._scaffold(tmp_path, base_branch="dev") / ".github/workflows/ci.yml").read_text()
+        assert "branches: [dev]" in ci
+        assert "branches: [main]" not in ci


### PR DESCRIPTION
Implements ticket #309 (epic #298): scaffolded CI + PR validation follow the configured base branch.

- `validate-pr.yml` → `validate-pr.yml.tmpl` (renamed so the scaffolder renders it) with trigger `branches: [{{base_branch}}]`.
- `ci.yml.tmpl`: push + pull_request triggers → `[{{base_branch}}]`.
- Renders `[main]` for single-trunk (unchanged) and `[dev]` (etc.) for env projects.
- `cmd_promote_env`: push with `--no-verify` so the pre-push type-prefix rule doesn't block bare env-branch pushes (server-side rulesets from #307 govern). `pre-push` unchanged.
- Tests: rendered validate-pr.yml/ci.yml carry the base branch (default + env override); promote push uses `--no-verify`. Full suite green (760).

Closes #309