### PR TITLE
docs(PI-311): operator branch-model note + skill/copilot cross-refs

### DIFF
--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -22,7 +22,7 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
-**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `project.branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
 
 ## Standard lifecycle
 

--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -22,6 +22,8 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -99,6 +99,31 @@ Run the scaffolded setup helper after creating the repository:
 
 It attempts to configure branch protection, required checks, conversation resolution, and Copilot code review. If GitHub does not expose a setting through the API or your token lacks permission, it prints the manual setup step.
 
+### Branch model (ADR-014) — opinionated default, reworkable
+
+By default this project is **single-trunk**: feature PRs target `main` and merge by squash. That's a sensible default for most projects — **rework it freely** if yours needs environments.
+
+To use an environment **promotion chain** (e.g. `dev → test → main`, or `dev → uat → preprod → main`), set it in `.claude/config.yaml` and create the branches once:
+
+```yaml
+project:
+  branch_model:
+    promotion_chain: ["dev", "test", "main"]   # base first → production last
+```
+
+```bash
+.claude/scripts/setup_env_branches.sh --protect   # create + protect the chain
+```
+
+Feature PRs then target the **base** (first) branch and squash-merge there; advance downstream by **fast-forward** promotion (never a PR):
+
+```bash
+.claude/scripts/promote_env.sh test   # ff-promote dev → test
+.claude/scripts/promote_env.sh main   # ff-promote test → main
+```
+
+Single-trunk projects ignore all of this — the chain defaults to `["main"]`.
+
 ### Commit and PR format
 
 | What | Format | Example |

--- a/templates/base/dot_claude/project-init.md.tmpl
+++ b/templates/base/dot_claude/project-init.md.tmpl
@@ -122,6 +122,8 @@ Feature PRs then target the **base** (first) branch and squash-merge there; adva
 .claude/scripts/promote_env.sh main   # ff-promote test → main
 ```
 
+> **Enabling a chain at scaffold time is cleanest:** pass `--branch-model dev-test-main` (or a custom chain) to `project-init` so the CI / `validate-pr` workflows are generated for the base branch. If you enable a chain **later**, also point the `branches:` filters in `.github/workflows/ci.yml` and `.github/workflows/validate-pr.yml` at your base branch — they were rendered for `main` at scaffold time, so PRs to the base branch won't run the required checks until you do.
+
 Single-trunk projects ignore all of this — the chain defaults to `["main"]`.
 
 ### Commit and PR format

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -15,7 +15,7 @@ Canonical agent rules: [AGENTS.md](../AGENTS.md) | Workflow: [.claude/project-in
 - Draft PRs are opened immediately when work starts, not when done
 - When asked to push/finish a PR, load the `github_workflow` skill for the full lifecycle and review-cycle protocol.
 - No direct commits to `main`
-- Branch model (ADR-014): single-trunk by default; opt into env chains via `branch_model.promotion_chain` in `.claude/config.yaml` + `setup_env_branches.sh`, then `promote_env.sh <env>` to fast-forward downstream
+- Branch model (ADR-014): single-trunk by default; opt into env chains via `project.branch_model.promotion_chain` in `.claude/config.yaml` + `.claude/scripts/setup_env_branches.sh`, then `.claude/scripts/promote_env.sh <env>` to fast-forward downstream
 
 ## Key rules
 

--- a/templates/base/dot_github/copilot-instructions.md.tmpl
+++ b/templates/base/dot_github/copilot-instructions.md.tmpl
@@ -15,6 +15,7 @@ Canonical agent rules: [AGENTS.md](../AGENTS.md) | Workflow: [.claude/project-in
 - Draft PRs are opened immediately when work starts, not when done
 - When asked to push/finish a PR, load the `github_workflow` skill for the full lifecycle and review-cycle protocol.
 - No direct commits to `main`
+- Branch model (ADR-014): single-trunk by default; opt into env chains via `branch_model.promotion_chain` in `.claude/config.yaml` + `setup_env_branches.sh`, then `promote_env.sh <env>` to fast-forward downstream
 
 ## Key rules
 

--- a/templates/codex/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/codex/dot_agents/skills/github_workflow/SKILL.md
@@ -22,7 +22,7 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
-**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `project.branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
 
 ## Standard lifecycle
 

--- a/templates/codex/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/codex/dot_agents/skills/github_workflow/SKILL.md
@@ -22,6 +22,8 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
@@ -22,7 +22,7 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
-**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `project.branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
 
 ## Standard lifecycle
 

--- a/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
@@ -22,6 +22,8 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
@@ -22,7 +22,7 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
-**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `project.branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
 
 ## Standard lifecycle
 

--- a/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
@@ -22,6 +22,8 @@ Commit messages use the same format (Conventional Commits). Legacy `[PROJECT-123
 
 Types: `feat` `fix` `chore` `docs` `test`
 
+**Branch model (ADR-014):** feature PRs target the **base branch** — the first entry of `branch_model.promotion_chain` in `.claude/config.yaml` (`main` by default). In multi-environment projects, advance downstream branches by fast-forward with `.claude/scripts/promote_env.sh <env>` — never via a PR.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -400,3 +400,20 @@ class TestCIRetargeting:
         ci = (self._scaffold(tmp_path, base_branch="dev") / ".github/workflows/ci.yml").read_text()
         assert "branches: [dev]" in ci
         assert "branches: [main]" not in ci
+
+
+class TestBranchModelDocs:
+    def test_project_init_md_documents_branch_model(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True)
+        doc = (target / ".claude/project-init.md").read_text()
+        assert "Branch model (ADR-014)" in doc
+        assert "promote_env.sh" in doc
+        assert "setup_env_branches.sh" in doc
+
+    def test_github_workflow_skill_mentions_base_branch(self):
+        skill = (
+            _REPO_ROOT
+            / "templates/fallback/dot_claude/skills/github_workflow/SKILL.md"
+        )
+        assert "Branch model (ADR-014)" in skill.read_text()

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -415,5 +415,8 @@ class TestBranchModelDocs:
         skill = (
             _REPO_ROOT
             / "templates/fallback/dot_claude/skills/github_workflow/SKILL.md"
-        )
-        assert "Branch model (ADR-014)" in skill.read_text()
+        ).read_text()
+        assert "Branch model (ADR-014)" in skill
+        assert "base branch" in skill
+        assert "promote_env.sh" in skill
+        assert "project.branch_model.promotion_chain" in skill


### PR DESCRIPTION
Implements ticket #311 (epic #298): operator-facing documentation for the branch model.

- `project-init.md.tmpl`: "Branch model (ADR-014) — opinionated default, reworkable" subsection (single-trunk default, how to opt into a chain via config + `setup_env_branches.sh`, and `promote_env.sh` promotion).
- `copilot-instructions.md.tmpl`: one-line cross-reference.
- `github_workflow` skill: quick-ref note that feature PRs target the base branch and downstream is ff-promoted — edited the fallback source + `sync_plugin.py` to all 4 copies (plugin/fallback/codex/gemini, verified identical).
- Tests: scaffolded project-init.md carries the note; skill mentions the base branch.

Closes #311