### PR TITLE
feat(PI-313): epic-sizing guidance — keep child tickets small

### DIFF
--- a/plugins/project-init-workflow/skills/create_issue/SKILL.md
+++ b/plugins/project-init-workflow/skills/create_issue/SKILL.md
@@ -17,6 +17,7 @@ Before creating the issue, determine:
 - priority: `high`, `medium`, or `low`
 - area: existing repo area label or plain body metadata
 - size: `XS`, `S`, `M`, `L`, or `XL`
+- scale: `task` (default — one focused PR) or `epic` (a large initiative tracked as the parent of small child tasks)
 - references: related issues, PRs, ADRs, docs, designs, logs, or external links
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
@@ -25,6 +26,7 @@ If type, title, priority, area, size, or acceptance criteria are not clear from 
 
 ## Rules
 
+- **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
 - Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
@@ -43,6 +45,7 @@ Run:
   --priority <high|medium|low> \
   --area "<area>" \
   --size <XS|S|M|L|XL> \
+  --scale <task|epic> \
   --reference "<reference>" \
   --dependency "<dependency>" \
   --acceptance "<criterion>"

--- a/plugins/project-init-workflow/skills/create_issue/SKILL.md
+++ b/plugins/project-init-workflow/skills/create_issue/SKILL.md
@@ -22,13 +22,13 @@ Before creating the issue, determine:
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
 
-If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding (scale defaults to `task` — only set `epic` for a large parent initiative).
 
 ## Rules
 
 - **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
-- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Do not invent labels. The script may create priority, size, and scale labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
 - The script writes Definition of Ready/Done defaults so issues created from this skill satisfy the scaffolded issue-validation workflow.
 - Check for duplicate issues before creating a new one:

--- a/templates/base/dot_claude/docs/guides/issue-metadata.md
+++ b/templates/base/dot_claude/docs/guides/issue-metadata.md
@@ -9,6 +9,7 @@ Use labels for values that workflows and project boards can read.
 - Type labels: `feature`, `bug`, `chore`, `documentation`, `test`
 - Priority labels: `priority:high`, `priority:medium`, `priority:low`
 - Size labels: `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+- Scale labels: `scale:epic` (a large parent initiative) or `scale:task` (a focused leaf — the default). Keep an epic's child tickets `scale:task` and sized `S`/`M`, so PRs and agent context stay small.
 - Area labels are repository-specific. Use existing labels only; do not invent new area labels from agent context.
 
 `create_issue.sh` creates missing priority and size labels when the token has permission. If label creation fails, the issue is still created and the value remains in the markdown body.

--- a/templates/base/dot_claude/docs/guides/issue-metadata.md
+++ b/templates/base/dot_claude/docs/guides/issue-metadata.md
@@ -12,7 +12,7 @@ Use labels for values that workflows and project boards can read.
 - Scale labels: `scale:epic` (a large parent initiative) or `scale:task` (a focused leaf — the default). Keep an epic's child tickets `scale:task` and sized `S`/`M`, so PRs and agent context stay small.
 - Area labels are repository-specific. Use existing labels only; do not invent new area labels from agent context.
 
-`create_issue.sh` creates missing priority and size labels when the token has permission. If label creation fails, the issue is still created and the value remains in the markdown body.
+`create_issue.sh` creates missing priority, size, and scale labels when the token has permission. If label creation fails, the issue is still created and the value remains in the markdown body.
 
 ## Markdown body
 

--- a/templates/base/dot_claude/scripts/create_issue.sh
+++ b/templates/base/dot_claude/scripts/create_issue.sh
@@ -47,6 +47,8 @@ Sub-issues:
   --parent links the new issue as a native GitHub sub-issue of the given parent.
   Cross-repo parents use owner/repo#42 or the full issue URL.
   --scale epic marks this issue as a parent work item (adds scale:epic label).
+  Keep an epic's child tickets --scale task and sized S/M (avoid L/XL) so each is
+  one small PR — small tickets keep AI-assisted work and context bounded.
 
 Metadata model:
   GitHub labels: type and scale when labels exist or can be created.

--- a/templates/codex/dot_agents/skills/create_issue/SKILL.md
+++ b/templates/codex/dot_agents/skills/create_issue/SKILL.md
@@ -17,6 +17,7 @@ Before creating the issue, determine:
 - priority: `high`, `medium`, or `low`
 - area: existing repo area label or plain body metadata
 - size: `XS`, `S`, `M`, `L`, or `XL`
+- scale: `task` (default — one focused PR) or `epic` (a large initiative tracked as the parent of small child tasks)
 - references: related issues, PRs, ADRs, docs, designs, logs, or external links
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
@@ -25,6 +26,7 @@ If type, title, priority, area, size, or acceptance criteria are not clear from 
 
 ## Rules
 
+- **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
 - Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
@@ -43,6 +45,7 @@ Run:
   --priority <high|medium|low> \
   --area "<area>" \
   --size <XS|S|M|L|XL> \
+  --scale <task|epic> \
   --reference "<reference>" \
   --dependency "<dependency>" \
   --acceptance "<criterion>"

--- a/templates/codex/dot_agents/skills/create_issue/SKILL.md
+++ b/templates/codex/dot_agents/skills/create_issue/SKILL.md
@@ -22,13 +22,13 @@ Before creating the issue, determine:
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
 
-If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding (scale defaults to `task` — only set `epic` for a large parent initiative).
 
 ## Rules
 
 - **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
-- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Do not invent labels. The script may create priority, size, and scale labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
 - The script writes Definition of Ready/Done defaults so issues created from this skill satisfy the scaffolded issue-validation workflow.
 - Check for duplicate issues before creating a new one:

--- a/templates/fallback/dot_claude/skills/create_issue/SKILL.md
+++ b/templates/fallback/dot_claude/skills/create_issue/SKILL.md
@@ -17,6 +17,7 @@ Before creating the issue, determine:
 - priority: `high`, `medium`, or `low`
 - area: existing repo area label or plain body metadata
 - size: `XS`, `S`, `M`, `L`, or `XL`
+- scale: `task` (default — one focused PR) or `epic` (a large initiative tracked as the parent of small child tasks)
 - references: related issues, PRs, ADRs, docs, designs, logs, or external links
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
@@ -25,6 +26,7 @@ If type, title, priority, area, size, or acceptance criteria are not clear from 
 
 ## Rules
 
+- **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
 - Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
@@ -43,6 +45,7 @@ Run:
   --priority <high|medium|low> \
   --area "<area>" \
   --size <XS|S|M|L|XL> \
+  --scale <task|epic> \
   --reference "<reference>" \
   --dependency "<dependency>" \
   --acceptance "<criterion>"

--- a/templates/fallback/dot_claude/skills/create_issue/SKILL.md
+++ b/templates/fallback/dot_claude/skills/create_issue/SKILL.md
@@ -22,13 +22,13 @@ Before creating the issue, determine:
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
 
-If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding (scale defaults to `task` — only set `epic` for a large parent initiative).
 
 ## Rules
 
 - **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
-- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Do not invent labels. The script may create priority, size, and scale labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
 - The script writes Definition of Ready/Done defaults so issues created from this skill satisfy the scaffolded issue-validation workflow.
 - Check for duplicate issues before creating a new one:

--- a/templates/gemini/dot_agents/skills/create_issue/SKILL.md
+++ b/templates/gemini/dot_agents/skills/create_issue/SKILL.md
@@ -17,6 +17,7 @@ Before creating the issue, determine:
 - priority: `high`, `medium`, or `low`
 - area: existing repo area label or plain body metadata
 - size: `XS`, `S`, `M`, `L`, or `XL`
+- scale: `task` (default — one focused PR) or `epic` (a large initiative tracked as the parent of small child tasks)
 - references: related issues, PRs, ADRs, docs, designs, logs, or external links
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
@@ -25,6 +26,7 @@ If type, title, priority, area, size, or acceptance criteria are not clear from 
 
 ## Rules
 
+- **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
 - Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
@@ -43,6 +45,7 @@ Run:
   --priority <high|medium|low> \
   --area "<area>" \
   --size <XS|S|M|L|XL> \
+  --scale <task|epic> \
   --reference "<reference>" \
   --dependency "<dependency>" \
   --acceptance "<criterion>"

--- a/templates/gemini/dot_agents/skills/create_issue/SKILL.md
+++ b/templates/gemini/dot_agents/skills/create_issue/SKILL.md
@@ -22,13 +22,13 @@ Before creating the issue, determine:
 - dependencies: blocked-by, parent, or follow-up relationships
 - acceptance criteria: concrete checklist items
 
-If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding.
+If type, title, priority, area, size, or acceptance criteria are not clear from context, ask the user before proceeding (scale defaults to `task` — only set `epic` for a large parent initiative).
 
 ## Rules
 
 - **Keep tickets small.** An `epic` may be large, but every child ticket must be `--scale task` and sized `S`/`M` (split anything that would be `L`/`XL`). Small tickets mean small PRs and bounded context — where AI-assisted implementation works best.
 - Use `.claude/scripts/create_issue.sh`; do not call `gh issue create` directly unless the script cannot satisfy the case.
-- Do not invent labels. The script may create priority and size labels, but area labels are repository-specific.
+- Do not invent labels. The script may create priority, size, and scale labels, but area labels are repository-specific.
 - Store relationships that GitHub does not support portably in markdown sections.
 - The script writes Definition of Ready/Done defaults so issues created from this skill satisfy the scaffolded issue-validation workflow.
 - Check for duplicate issues before creating a new one:

--- a/tests/unit/test_branch_model.py
+++ b/tests/unit/test_branch_model.py
@@ -420,3 +420,26 @@ class TestBranchModelDocs:
         assert "base branch" in skill
         assert "promote_env.sh" in skill
         assert "project.branch_model.promotion_chain" in skill
+
+
+class TestEpicSizingGuidance:
+    """PI-313: the create_issue surface teaches epic→small-task discipline."""
+
+    def _scaffold(self, tmp_path: Path) -> Path:
+        target = tmp_path / "p"
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True)
+        return target
+
+    def test_create_issue_skill_has_sizing_rule(self, tmp_path: Path):
+        skill = (self._scaffold(tmp_path) / ".claude/skills/create_issue/SKILL.md").read_text()
+        assert "Keep tickets small" in skill
+        assert "--scale task" in skill
+
+    def test_issue_metadata_guide_documents_scale(self, tmp_path: Path):
+        guide = (self._scaffold(tmp_path) / ".claude/docs/guides/issue-metadata.md").read_text()
+        assert "scale:epic" in guide
+        assert "scale:task" in guide
+
+    def test_create_issue_sh_help_mentions_small_tickets(self, tmp_path: Path):
+        sh = (self._scaffold(tmp_path) / ".claude/scripts/create_issue.sh").read_text()
+        assert "Keep an epic's child tickets" in sh


### PR DESCRIPTION
Standalone ticket #313 (the "keep tickets small" request): teach the issue-creation surface that epics are large but their child tickets stay small, so AI-assisted PRs and context stay bounded.

- `create_issue` skill (×4 copies via fallback source + sync): surfaces `scale` in "Metadata to gather", adds a **Keep tickets small** rule (epic may be large; child tickets `--scale task`, sized S/M, split L/XL), and adds `--scale` to the Create example.
- `issue-metadata.md`: documents `scale:epic`/`scale:task` labels + the sizing note.
- `create_issue.sh`: `--scale` help now states child tickets stay small (one PR each).
- Tests: scaffolded create_issue skill / metadata guide / script carry the guidance.

Closes #313