### PR TITLE
docs(PI-317): ADR-015 env/deploy model + operator decision guide

### DIFF
--- a/docs/adr/adr-015-env-deploy-model.md
+++ b/docs/adr/adr-015-env-deploy-model.md
@@ -1,0 +1,112 @@
+# ADR-015: Agnostic local↔cloud environment & deploy model (single-trunk; deploy/IaC opt-in)
+
+- Status: Accepted
+- Date: 2026-06-19
+- Implements: epic #316
+- Supersedes: ADR-014 (branch-per-env promotion chains)
+- Relates to: ADR-005 (PR & board lifecycle — single-trunk base), ADR-007 (enforcement layers), ADR-013 (distribution & governance — profile tiers)
+
+## Context
+
+ADR-014 introduced opt-in **branch-per-environment promotion chains** for
+scaffolded projects. Research across five tracks (human best practice, AI-agent
+best practice, the PaaS landscape, self-managed/GitOps, and local↔cloud parity;
+summarized in `PLAN.md` / `PLAN-REVIEW-LOG.md`, hardened over three Codex rounds)
+found branch-per-env to be a deprecated pattern for **both** humans and AI agents:
+environments differ by **config and deploy target**, not by **branch**. Conflating
+them causes merge/config drift and — for an AI agent — forces it to reconstruct an
+implicit branch→env model every session and hands it the deploy capability *as* a
+destructive git capability.
+
+The scaffolder is also language- and deploy-target-agnostic and must stay
+deterministic (pure file-ops, no network/LLM calls; ADR-001). It is consumed by a
+genuinely mixed, unknown population (libraries, deployed services, prototypes), so
+no single env model can be a fixed default — the model must be chosen by interview.
+
+## Decision
+
+### 1. Single trunk is the only default
+
+Every scaffolded project targets `main`. There are no environment branches. The
+generic `base_branch` abstraction (`main`) is retained and consumed by `ci.yml`,
+`validate-pr.yml`, and `start_issue.sh`.
+
+### 2. A delivery-type question drives a coherent bundle
+
+The wizard asks **"How is this delivered?"** → `library` / `service-or-app` /
+`prototype-or-none`. Delivery is a template **layer/variable**, not a replacement
+preset (it composes with preset × language).
+
+- **library** → release/versioning bundle (publish workflow shipped **disabled/TODO**
+  until registry + metadata + trusted-publishing are validated).
+- **service-or-app** → the **parity bundle** (§3). `service-or-app` + `--language none`
+  is **rejected** (no safe generic Dockerfile/test for an unknown runtime).
+- **prototype-or-none** → single trunk, nothing env-related.
+
+### 3. The local↔cloud unifier is the container image + a one-command interface
+
+Not Terraform (a cloud-only provisioning layer). The parity bundle is: a multi-stage
+`Dockerfile`, a Compose-Spec `compose.yaml` (explicit backing-service selection;
+optional `compose watch`), `devcontainer.json`, a deterministic non-interactive
+`justfile` (`up`/`test`/`lint`/`build`), `.env.example`, and a CI that reuses the
+same image with a **pinned** test-execution location. "Same image everywhere" holds;
+"same behavior everywhere" does not (IAM, managed services, networking break — test
+those against a real cloud dev project).
+
+### 4. Deploy and IaC are opt-in per-target overlays (default OFF)
+
+Managed PaaS usually owns the deploy last-mile better than scaffolded YAML, so the
+default stops at the cloud boundary. When opted in:
+
+- **Deploy** builds once and promotes the **same immutable artifact by digest, not
+  tag**, through **GitHub Environments**. Three target classes: container-deploy,
+  registry-publish-only (publication, not deploy), and source/PaaS (routed to a
+  "platform owns deploy" path). `environments.yaml` declares the model in **fixed
+  shapes** (the renderer is pure `.tmpl` substitution with no loops).
+- **Prod gate tiered by profile:** `org` = a true human gate (required reviewers +
+  prevent-self-review + disallow-admin-bypass); `individual`/`standalone` = honestly
+  labeled **"delayed + advisory, not human-gated"** (no second approver exists solo).
+  The server-side GitHub Environment rule is the only boundary an agent cannot edit;
+  in-repo hooks are advisory defense-in-depth.
+- **IaC** emits plain **HCL defaulting to OpenTofu** (license-safe vs BUSL/IBM
+  Terraform), structural layer only, with **apply manual/environment-gated by
+  default** (no apply-on-merge).
+
+### 5. Cloud governance is a separate product
+
+GCP (or any cloud) governance, monitoring, IAM, and landing-zone are **out of this
+repo**. The scaffolder emits only an integration **seam** (OIDC trust + env
+contract) that a separate platform/landing-zone product plugs into. Keeping a thin
+agnostic "paved road" separate from a heavyweight landing zone is the documented
+platform-engineering standard (CNCF, IDP reference model, Team Topologies, Backstage).
+
+### 6. Determinism preserved
+
+The Python scaffolder still only writes files and config. All git/network side
+effects (branch protection, GitHub Environments, IaC apply) run **post-clone** via
+operator-run scripts (`setup_github.sh --protect`, the deploy/IaC overlay setup),
+never from the scaffolder core.
+
+## Consequences
+
+- Branch-per-env is removed (not demoted); ADR-014 is a superseded tombstone.
+- The reusable governance bits (squash-only merge policy, base-branch protection,
+  org rulesets) are centralized in `setup_github.sh --protect`.
+- Child tickets implement the pieces under epic #316 (wizard delivery question,
+  parity bundle, CI, guardrails, library path, deploy overlay, IaC overlay,
+  integration seam, config schema + upgrade backfill, consistency sweep).
+
+## Out of scope
+
+- Cloud governance/monitoring/landing-zone (separate product; seam only).
+- Adopting env branches or containers in **this** repo (project-init stays a
+  single-trunk Python scaffolder).
+- Kubernetes/GitOps as a default; single-vendor abstraction tools (Score/Encore)
+  as defaults.
+
+## Open questions
+
+- Whether to later offer a first-class PaaS-native deploy sub-type per platform
+  (Vercel/Render/Fly) beyond the generic "platform owns deploy" pointer.
+- Whether `environments.yaml` ever needs dynamic N-environment generation (would
+  require a deterministic, pure-file-ops code-gen render step).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,8 @@ nav:
     - PyPI trusted publishing: adr/adr-011-pypi-trusted-publishing.md
     - Prod-safety guard: adr/adr-012-prod-safety-guard.md
     - Distribution & governance model: adr/adr-013-distribution-governance-model.md
-    - Environment promotion chains: adr/adr-014-environment-promotion-chains.md
+    - Environment promotion chains (superseded): adr/adr-014-environment-promotion-chains.md
+    - Env & deploy model: adr/adr-015-env-deploy-model.md
   - Development:
     - Template system: development/template-system.md
     - Testing: development/testing.md

--- a/templates/base/dot_claude/docs/guides/environments.md
+++ b/templates/base/dot_claude/docs/guides/environments.md
@@ -24,8 +24,10 @@ are only fast-feedback defense-in-depth.
 
 The unifier is the **container image + the `justfile`**, not Terraform:
 
-- **Local:** `just up` (Compose), `just test`, `just lint`, `just build`. One `.env`
-  for *your* dev config.
+- **Local:** your project's `justfile` runs the task commands (`just test`,
+  `just lint`, …). A **deployed service** additionally gets `just up` (Compose) and
+  `just build` from the **container parity bundle**, so the same image runs locally
+  and in cloud. One `.env` for *your* dev config.
 - **Cloud:** the *same image* is deployed; per-environment config/secrets live in
   **GitHub Environment secrets/variables**, injected at deploy — **never** in a
   local `.env` and never baked into the image.
@@ -43,5 +45,5 @@ The unifier is the **container image + the `justfile`**, not Terraform:
 - If a managed platform (Vercel/Netlify/Render/…) owns your deploy, let it — this
   project points at its native flow rather than fighting it.
 
-See [ADR-015](../../../docs/adr/adr-015-env-deploy-model.md) in the project-init
-source for the full rationale.
+For the full rationale, see ADR-015 (env & deploy model) in the project-init
+source repository.

--- a/templates/base/dot_claude/docs/guides/environments.md
+++ b/templates/base/dot_claude/docs/guides/environments.md
@@ -1,0 +1,47 @@
+# Environments & deployment — how this project is set up
+
+This project uses the **single-trunk + deploy-environments** model. Environments
+are a **deploy-time concern** (config + deploy target), **not** a branching concern.
+There are no `dev`/`test`/`prod` branches — feature PRs target `main` and squash-merge.
+
+## The one rule that matters for AI agents
+
+**An agent works on feature/PR branches and never pushes to the production ref.**
+On any auto-deploy platform, write access to the production branch *is* production
+deploy access. The real production gate lives **server-side** (GitHub Environment
+protection rules or branch protection), which an agent cannot edit — in-repo hooks
+are only fast-feedback defense-in-depth.
+
+## Decision guide — which path is this project?
+
+| You are building… | Model | What ships |
+|---|---|---|
+| A **library / package** (PyPI, npm, crate) | Release/versioning | A tag-triggered publish workflow (disabled until you wire the registry + metadata) |
+| A **deployed service / app** | Single-trunk + build-once-promote | The container parity bundle + opt-in deploy/IaC overlays |
+| A **prototype / not sure yet** | Single trunk | Nothing env-related until you grow into one of the above |
+
+## Local ↔ cloud
+
+The unifier is the **container image + the `justfile`**, not Terraform:
+
+- **Local:** `just up` (Compose), `just test`, `just lint`, `just build`. One `.env`
+  for *your* dev config.
+- **Cloud:** the *same image* is deployed; per-environment config/secrets live in
+  **GitHub Environment secrets/variables**, injected at deploy — **never** in a
+  local `.env` and never baked into the image.
+- "Same image everywhere" is true; "same behavior everywhere" is not — IAM, managed
+  services (DBs/queues), and networking differ. Test those against a real cloud dev
+  project, not a local emulator.
+
+## Deploying (only if the deploy overlay is enabled)
+
+- Build the artifact **once**; promote the **same digest** dev → staging → prod.
+- Production is gated by a **GitHub Environment** rule. In an `org` setup that's a
+  required reviewer (who cannot be you); solo, it's a delayed/advisory gate — add a
+  second approver or move to the org tier for a true human gate.
+- Rollback = redeploy the previous digest. No git surgery.
+- If a managed platform (Vercel/Netlify/Render/…) owns your deploy, let it — this
+  project points at its native flow rather than fighting it.
+
+See [ADR-015](../../../docs/adr/adr-015-env-deploy-model.md) in the project-init
+source for the full rationale.

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -210,6 +210,13 @@ class TestScaffoldObsidianOnly:
         assert (docs / "development" / "conventions.md").is_file()
         assert (docs / "development" / "testing.md").is_file()
         assert (docs / "guides" / "using-memory.md").is_file()
+        # PI-317 (epic #316): the env/deploy decision guide ships with every scaffold
+        # and states the single-trunk + deploy-time-environments model.
+        env_guide = docs / "guides" / "environments.md"
+        assert env_guide.is_file()
+        env_text = env_guide.read_text()
+        assert "single-trunk" in env_text
+        assert "deploy-time concern" in env_text
         # PI-135: per-developer git hygiene lives in docs, not as scaffolder features
         onboarding = docs / "guides" / "developer-onboarding.md"
         assert onboarding.is_file()


### PR DESCRIPTION
Records the epic #316 architecture and ships the operator-facing decision guide.

- **ADR-015** — single-trunk default; delivery-type question; container image + `justfile` as the local↔cloud unifier (not Terraform); deploy + IaC opt-in overlays; tiered prod gate; OpenTofu/HCL; GCP governance as a separate product. Supersedes ADR-014.
- **`environments.md` guide** (scaffolded into every project) — the decision table (library/service/prototype), the agent rule (never push prod ref), and local↔cloud config.
- Wired ADR-015 into `mkdocs.yml` nav (`test_all_adrs_in_mkdocs_nav`); added a scaffold assertion for the guide.

Closes #317
Part of #316