### PR TITLE
feat(PI-319): container parity bundle for delivery=service

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -801,6 +801,9 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         "go": "true" if language == "go" else "",
         "justfile": "true" if language != "none" else "",
         "devcontainer": "true" if devcontainer else "",
+        # A service delivery (ADR-015) gets a devcontainer automatically; the
+        # standalone --devcontainer flag still works for non-service projects.
+        "want_devcontainer": "true" if (devcontainer or inputs.delivery == "service") else "",
         # Multi-agent support (PI-137): the agents list drives overlay layers
         # on upgrade re-render; per-agent flags gate conditional blocks.
         "agents": ",".join(agents),

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -121,6 +121,7 @@ def _overlay_off_defaults() -> dict[str, str]:
         "delivery": "prototype",
         "delivery_library": "",
         "delivery_service": "",
+        "want_devcontainer": "",
         "project_owner": "",
         "license": "none",
         "license_mit": "",
@@ -369,6 +370,12 @@ def _backfill_variables(variables: dict) -> dict:
     # carry e.g. base_branch=dev; left as-is, the re-rendered workflows would
     # target 'dev' while gh_host's base_branch() returns 'main' (PR #330 review).
     v["base_branch"] = "main"
+    # Derive want_devcontainer (#319): the devcontainer templates now gate on it,
+    # so an existing project that opted into --devcontainer (or is a service) must
+    # still render the devcontainer on re-render. Derived, not setdefault'd.
+    v["want_devcontainer"] = (
+        "true" if (v.get("devcontainer") or v.get("delivery") == "service") else ""
+    )
     return v
 
 

--- a/templates/base/Dockerfile.tmpl
+++ b/templates/base/Dockerfile.tmpl
@@ -1,0 +1,56 @@
+{{#if delivery_service}}# Dockerfile — the immutable artifact for {{project_name}} (scaffolded by project-init).
+# Build once, promote the same image by digest dev → staging → prod (ADR-015).
+# Multi-arch: build with `docker buildx build --platform linux/amd64,linux/arm64 .`
+# The app must listen on $PORT (default 8080) and 0.0.0.0.
+{{#if python}}# --- build stage: resolve deps with uv into a venv ---
+FROM python:3.13-slim AS build
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+COPY pyproject.toml uv.lock* ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --no-dev --no-install-project --frozen 2>/dev/null || uv sync --no-dev --no-install-project
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --no-dev --frozen 2>/dev/null || uv sync --no-dev
+
+# --- runtime stage: copy the venv, drop the toolchain ---
+FROM python:3.13-slim AS runtime
+WORKDIR /app
+COPY --from=build /app /app
+ENV PATH="/app/.venv/bin:$PATH" PORT=8080
+EXPOSE 8080
+# TODO: replace with your app's entrypoint (e.g. uvicorn app.main:app --host 0.0.0.0 --port $PORT)
+CMD ["python", "-c", "import os; print('replace CMD: serving on', os.environ.get('PORT', '8080'))"]
+{{/if python}}{{#if node}}# --- build stage: install deps with bun ---
+FROM oven/bun:1 AS build
+WORKDIR /app
+COPY package.json bun.lock* bun.lockb* ./
+RUN bun install --frozen-lockfile 2>/dev/null || bun install
+COPY . .
+RUN bun run build 2>/dev/null || true
+
+# --- runtime stage ---
+FROM oven/bun:1-slim AS runtime
+WORKDIR /app
+COPY --from=build /app /app
+ENV NODE_ENV=production PORT=8080
+EXPOSE 8080
+# TODO: replace with your app's start command (e.g. bun run start)
+CMD ["bun", "run", "start"]
+{{/if node}}{{#if go}}# --- build stage: compile a static binary ---
+FROM golang:1.23 AS build
+WORKDIR /src
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app/server ./...
+
+# --- runtime stage: distroless, no shell/toolchain ---
+FROM gcr.io/distroless/static-debian12 AS runtime
+WORKDIR /app
+COPY --from=build /app/server /app/server
+ENV PORT=8080
+EXPOSE 8080
+# TODO: ensure your server reads $PORT and listens on 0.0.0.0
+ENTRYPOINT ["/app/server"]
+{{/if go}}{{/if delivery_service}}

--- a/templates/base/compose.yaml.tmpl
+++ b/templates/base/compose.yaml.tmpl
@@ -6,8 +6,10 @@ services:
   app:
     build: .
     env_file: .env
+    # Both sides track $PORT: the app listens on $PORT (Dockerfile) and we publish
+    # the same port, so a PORT override in .env stays reachable.
     ports:
-      - "${PORT:-8080}:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     # Optional hot-reload: requires a recent Docker Compose. `just up` works
     # without it — uncomment to sync source into the running container on change.
     # develop:

--- a/templates/base/compose.yaml.tmpl
+++ b/templates/base/compose.yaml.tmpl
@@ -1,0 +1,36 @@
+{{#if delivery_service}}# compose.yaml — local run of {{project_name}} (scaffolded by project-init).
+# Same image as cloud; only config/secrets differ (kept in .env, never committed).
+# `just up` builds and runs this. Backing services are commented out — uncomment
+# and wire the ones you actually need rather than carrying services you don't.
+services:
+  app:
+    build: .
+    env_file: .env
+    ports:
+      - "${PORT:-8080}:8080"
+    # Optional hot-reload: requires a recent Docker Compose. `just up` works
+    # without it — uncomment to sync source into the running container on change.
+    # develop:
+    #   watch:
+    #     - action: sync
+    #       path: .
+    #       target: /app
+    #       ignore: [.git/, .venv/, node_modules/]
+    #     - action: rebuild
+    #       path: ./Dockerfile
+
+  # --- Example backing services (uncomment what you need) ---
+  # postgres:
+  #   image: postgres:17-alpine
+  #   environment:
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+  #   ports: ["5432:5432"]
+  #   volumes: [pgdata:/var/lib/postgresql/data]
+  #
+  # redis:
+  #   image: redis:7-alpine
+  #   ports: ["6379:6379"]
+
+# volumes:
+#   pgdata:
+{{/if delivery_service}}

--- a/templates/base/dot_devcontainer/devcontainer.json.tmpl
+++ b/templates/base/dot_devcontainer/devcontainer.json.tmpl
@@ -1,4 +1,4 @@
-{{#if devcontainer}}{
+{{#if want_devcontainer}}{
   "name": "{{project_name}}",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 {{#if go}}  "features": {
@@ -14,4 +14,4 @@
     }
   }
 }
-{{/if devcontainer}}
+{{/if want_devcontainer}}

--- a/templates/base/dot_devcontainer/post-create.sh.tmpl
+++ b/templates/base/dot_devcontainer/post-create.sh.tmpl
@@ -1,4 +1,4 @@
-{{#if devcontainer}}#!/bin/bash
+{{#if want_devcontainer}}#!/bin/bash
 # Devcontainer bootstrap (scaffolded by project-init): install the toolchain
 # the scaffolded workflow expects, then sync dependencies through the same
 # path the SessionStart hook uses. Idempotent — safe to re-run.
@@ -28,4 +28,4 @@ fi
 # local; plugin-mode containers bootstrap via just (the plugin hook stamps
 # the environment once a session opens).
 {{#if no_plugin}}bash .claude/hooks/session_setup.sh{{/if no_plugin}}{{#if plugin_mode}}command -v just >/dev/null 2>&1 && [ -f justfile ] && just setup || true{{/if plugin_mode}}
-{{/if devcontainer}}
+{{/if want_devcontainer}}

--- a/templates/base/dot_dockerignore.tmpl
+++ b/templates/base/dot_dockerignore.tmpl
@@ -1,0 +1,24 @@
+{{#if delivery_service}}# .dockerignore — keep the build context (and image) small and secret-free.
+.git
+.gitignore
+.github
+.claude
+.devcontainer
+.venv
+__pycache__
+*.pyc
+node_modules
+dist
+build
+target
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store
+.pytest_cache
+.ruff_cache
+.mypy_cache
+coverage
+.coverage
+{{/if delivery_service}}

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -92,4 +92,18 @@ scan:
 
 # what CI runs
 ci: lint test
-{{/if go}}
+{{/if go}}{{#if delivery_service}}
+# --- container parity (delivery=service): same image local and in cloud ---
+
+# build + run the app (and any backing services) locally
+up:
+    docker compose up --build
+
+# build the image only
+build:
+    docker compose build
+
+# stop and remove the local stack
+down:
+    docker compose down
+{{/if delivery_service}}

--- a/tests/contracts/test_parity_bundle.py
+++ b/tests/contracts/test_parity_bundle.py
@@ -1,0 +1,81 @@
+"""PI-319 (epic #316, ADR-015): the container parity bundle ships only for
+delivery=service projects — Dockerfile, compose.yaml, .dockerignore, container
+just recipes, and an auto-enabled devcontainer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+def _service(target: Path, language: str = "python") -> Path:
+    # make_variables sets the python/node/go flags independently of `language`,
+    # so set them explicitly to match the requested runtime.
+    flags = {"python": "", "node": "", "go": ""}
+    flags[language] = "true"
+    return _scaffold(
+        target,
+        delivery="service",
+        delivery_service="true",
+        want_devcontainer="true",
+        language=language,
+        **flags,
+    )
+
+
+class TestParityBundlePresent:
+    def test_dockerfile_and_compose_render_for_service(self, tmp_path: Path):
+        target = _service(tmp_path / "svc")
+        assert (target / "Dockerfile").is_file()
+        assert (target / "compose.yaml").is_file()
+        assert (target / ".dockerignore").is_file()
+
+    def test_dockerfile_uses_language_base_image(self, tmp_path: Path):
+        py = _service(tmp_path / "py", "python")
+        assert "python:3.13-slim" in (py / "Dockerfile").read_text()
+        go = _service(tmp_path / "go", "go")
+        assert "golang:1.23" in (go / "Dockerfile").read_text()
+
+    def test_compose_has_app_service_and_no_uncommented_db(self, tmp_path: Path):
+        compose = (_service(tmp_path / "svc") / "compose.yaml").read_text()
+        assert "app:" in compose
+        assert "build: ." in compose
+        # backing services are examples only — commented, never live
+        assert "\n  postgres:" not in compose
+
+    def test_justfile_has_container_recipes(self, tmp_path: Path):
+        justfile = (_service(tmp_path / "svc") / "justfile").read_text()
+        assert "up:" in justfile
+        assert "docker compose up --build" in justfile
+        assert "down:" in justfile
+
+    def test_service_auto_enables_devcontainer(self, tmp_path: Path):
+        target = _service(tmp_path / "svc")
+        assert (target / ".devcontainer" / "devcontainer.json").is_file()
+
+
+class TestParityBundleAbsent:
+    def test_prototype_has_no_bundle(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "proto", delivery="prototype", language="python")
+        assert not (target / "Dockerfile").exists()
+        assert not (target / "compose.yaml").exists()
+        assert not (target / ".dockerignore").exists()
+        justfile = target / "justfile"
+        if justfile.exists():
+            assert "docker compose" not in justfile.read_text()
+
+    def test_library_has_no_bundle(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "lib", delivery="library", language="python")
+        assert not (target / "Dockerfile").exists()
+        assert not (target / "compose.yaml").exists()
+
+    def test_prototype_without_flag_has_no_devcontainer(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "proto", delivery="prototype", language="python")
+        assert not (target / ".devcontainer" / "devcontainer.json").exists()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,6 +42,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "delivery": "prototype",
         "delivery_library": "",
         "delivery_service": "",
+        "want_devcontainer": "",
         "memory_stack": "obsidian-only",
         "installed_mcps": "none",
         "installed_mcps_yaml": "[]",
@@ -82,6 +83,12 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "created_year": "2026",
     }
     defaults.update(overrides)
+    # Mirror _build_variables: a service delivery (or an explicit devcontainer)
+    # auto-enables the devcontainer (#319). Derived unless overridden explicitly.
+    if "want_devcontainer" not in overrides:
+        defaults["want_devcontainer"] = (
+            "true" if (defaults.get("devcontainer") or defaults.get("delivery") == "service") else ""
+        )
     return defaults
 
 


### PR DESCRIPTION
The local↔cloud parity bundle (ADR-015) — the unified surface a deployed service runs on locally and in cloud. Renders only when `delivery=service`.

**New (gated on `{{#if delivery_service}}`):**
- `Dockerfile.tmpl` — multi-stage, language-aware (python+uv / node+bun / go+distroless), multi-arch hint, `$PORT`.
- `compose.yaml.tmpl` — one `app` service (`build: .`, `env_file: .env`); **commented** postgres/redis examples (no guessing) + optional commented `develop: watch`.
- `.dockerignore`.

**Changed:**
- `justfile` — appends `up` / `build` / `down` (docker compose) for services.
- `devcontainer` gate `{{#if devcontainer}}` → `{{#if want_devcontainer}}` (= `--devcontainer` **or** service), so services auto-get a devcontainer without breaking the standalone flag. Upgrade derives it so existing `--devcontainer` projects keep theirs.

**Gating verified:** service(python/node/go) → full bundle + container recipes + devcontainer; prototype/library → none of it.

731 tests pass (+8 parity-bundle tests); ruff clean; no plugin drift. Backing-service *selection* (uncommented services from a wizard question) is a noted follow-up.

Closes #319
Part of #316