### PR TITLE
feat(PI-320): CI build-once image job for delivery=service

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -255,6 +255,32 @@ jobs:
   #     - cron: "0 3 * * *"
 {{/if python}}
 
+  {{#if delivery_service}}
+  # Build-once (ADR-015): build the SAME immutable image CI tests against and the
+  # deploy overlay promotes. Tests are pinned HOST-based above (the language
+  # matrix); this job validates the Dockerfile builds and produces the artifact,
+  # tagged by the commit SHA. Pushing the digest to a registry is wired by the
+  # deploy overlay (#323) — here we only build (push: false).
+  build-image:
+    name: Build image (build-once)
+    runs-on: ubuntu-24.04
+    needs: lint-and-test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the immutable artifact (tagged by SHA)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+{{/if delivery_service}}
+
   # ADR-007: agent-agnostic secret-scanning backstop. The pre-commit git hook
   # gives fast local feedback but is fail-open; this job is the hard gate.
   secret-scan:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -256,27 +256,32 @@ jobs:
 {{/if python}}
 
   {{#if delivery_service}}
-  # Build-once (ADR-015): build the SAME immutable image CI tests against and the
-  # deploy overlay promotes. Tests are pinned HOST-based above (the language
-  # matrix); this job validates the Dockerfile builds and produces the artifact,
-  # tagged by the commit SHA. Pushing the digest to a registry is wired by the
-  # deploy overlay (#323) — here we only build (push: false).
+  # Build-once (ADR-015): validate the Dockerfile builds and warm the layer cache
+  # for the SAME image the deploy overlay promotes. Tests are pinned HOST-based
+  # above (the language matrix). This job only builds (push: false) — the deploy
+  # overlay (#323) builds and pushes the real digest to a registry.
   build-image:
     name: Build image (build-once)
     runs-on: ubuntu-24.04
     needs: lint-and-test
+    permissions:
+      contents: read
+      actions: write   # required to save the type=gha build cache
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build the immutable artifact (tagged by SHA)
+      # Static lowercase tag — ${{ github.repository }} may contain uppercase
+      # (invalid in a Docker ref). The real registry name is set by the deploy
+      # overlay; here the tag only needs to be valid and SHA-pinned.
+      - name: Build the image (SHA-pinned, cached)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
-          tags: ${{ github.repository }}:${{ github.sha }}
+          tags: app:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 {{/if delivery_service}}

--- a/tests/contracts/test_parity_bundle.py
+++ b/tests/contracts/test_parity_bundle.py
@@ -99,3 +99,9 @@ class TestBuildOnceCI:
         ci = self._ci(_scaffold(tmp_path / "proto", delivery="prototype"))
         assert "build-image:" not in ci
         assert "build-push-action" not in ci
+
+    def test_library_ci_has_no_image_build(self, tmp_path: Path):
+        # delivery_service must never leak true for a library (PR #334 review).
+        ci = self._ci(_scaffold(tmp_path / "lib", delivery="library"))
+        assert "build-image:" not in ci
+        assert "build-push-action" not in ci

--- a/tests/contracts/test_parity_bundle.py
+++ b/tests/contracts/test_parity_bundle.py
@@ -79,3 +79,23 @@ class TestParityBundleAbsent:
     def test_prototype_without_flag_has_no_devcontainer(self, tmp_path: Path):
         target = _scaffold(tmp_path / "proto", delivery="prototype", language="python")
         assert not (target / ".devcontainer" / "devcontainer.json").exists()
+
+
+class TestBuildOnceCI:
+    """PI-320: service CI builds the same image once (tagged by SHA); host-based
+    tests stay the pinned location. Prototype/library CI has no image build."""
+
+    def _ci(self, target: Path) -> str:
+        return (target / ".github" / "workflows" / "ci.yml").read_text()
+
+    def test_service_ci_builds_image_once(self, tmp_path: Path):
+        ci = self._ci(_service(tmp_path / "svc"))
+        assert "build-image:" in ci
+        assert "docker/build-push-action" in ci
+        assert "${{ github.sha }}" in ci
+        assert "push: false" in ci  # deploy overlay (#323) wires the push-by-digest
+
+    def test_prototype_ci_has_no_image_build(self, tmp_path: Path):
+        ci = self._ci(_scaffold(tmp_path / "proto", delivery="prototype"))
+        assert "build-image:" not in ci
+        assert "build-push-action" not in ci


### PR DESCRIPTION
ADR-015 build-once in CI: services build the SAME immutable image once.

- New **`build-image`** job (gated `{{#if delivery_service}}`, `needs: lint-and-test`): `docker/build-push-action` builds the Dockerfile tagged by `${{ github.sha }}`, gha-cached, **`push: false`** (the deploy overlay #323 wires push-by-digest to a registry).
- **Test location pinned host-based** — the existing language matrix stays the test path; this job validates the artifact builds, it doesn't containerize the test loop.
- Prototype/library CI is unchanged (no image build).

733 tests pass (+2); rendered service `ci.yml` validated as well-formed YAML with the new job; ruff clean.

Closes #320
Part of #316