### PR TITLE
feat(PI-321): document agent production-ref boundary in github_workflow skill

### DIFF
--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -24,6 +24,13 @@ Types: `feat` `fix` `chore` `docs` `test`
 
 **Branch model:** single-trunk — feature PRs target the repo default branch (`main`) and squash-merge. Environments are a deploy-time concern (config + deploy target), not a branching concern.
 
+## Agent safety — the production boundary
+
+You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
+
+- **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
+- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -29,7 +29,7 @@ Types: `feat` `fix` `chore` `docs` `test`
 You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
 
 - **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
-- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+- **The real boundary (server-side), tiered by profile (ADR-013):** run `.claude/scripts/setup_github.sh --protect` once with admin rights. For the **`org`** profile it installs rulesets with an *empty bypass list* (plus GitHub Environment reviewers for services) — a **hard** boundary no agent can edit or bypass. For **`individual`/`standalone`** it installs classic branch protection that is **advisory** (`enforce_admins=false`, so an admin-capable token can override it) — useful, but not a hard production gate; move to the `org` profile (or add a second human approver / Environment reviewer) when you need one.
 
 ## Standard lifecycle
 

--- a/templates/codex/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/codex/dot_agents/skills/github_workflow/SKILL.md
@@ -24,6 +24,13 @@ Types: `feat` `fix` `chore` `docs` `test`
 
 **Branch model:** single-trunk — feature PRs target the repo default branch (`main`) and squash-merge. Environments are a deploy-time concern (config + deploy target), not a branching concern.
 
+## Agent safety — the production boundary
+
+You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
+
+- **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
+- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/codex/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/codex/dot_agents/skills/github_workflow/SKILL.md
@@ -29,7 +29,7 @@ Types: `feat` `fix` `chore` `docs` `test`
 You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
 
 - **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
-- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+- **The real boundary (server-side), tiered by profile (ADR-013):** run `.claude/scripts/setup_github.sh --protect` once with admin rights. For the **`org`** profile it installs rulesets with an *empty bypass list* (plus GitHub Environment reviewers for services) — a **hard** boundary no agent can edit or bypass. For **`individual`/`standalone`** it installs classic branch protection that is **advisory** (`enforce_admins=false`, so an admin-capable token can override it) — useful, but not a hard production gate; move to the `org` profile (or add a second human approver / Environment reviewer) when you need one.
 
 ## Standard lifecycle
 

--- a/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
@@ -24,6 +24,13 @@ Types: `feat` `fix` `chore` `docs` `test`
 
 **Branch model:** single-trunk — feature PRs target the repo default branch (`main`) and squash-merge. Environments are a deploy-time concern (config + deploy target), not a branching concern.
 
+## Agent safety — the production boundary
+
+You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
+
+- **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
+- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
@@ -29,7 +29,7 @@ Types: `feat` `fix` `chore` `docs` `test`
 You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
 
 - **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
-- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+- **The real boundary (server-side), tiered by profile (ADR-013):** run `.claude/scripts/setup_github.sh --protect` once with admin rights. For the **`org`** profile it installs rulesets with an *empty bypass list* (plus GitHub Environment reviewers for services) — a **hard** boundary no agent can edit or bypass. For **`individual`/`standalone`** it installs classic branch protection that is **advisory** (`enforce_admins=false`, so an admin-capable token can override it) — useful, but not a hard production gate; move to the `org` profile (or add a second human approver / Environment reviewer) when you need one.
 
 ## Standard lifecycle
 

--- a/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
@@ -24,6 +24,13 @@ Types: `feat` `fix` `chore` `docs` `test`
 
 **Branch model:** single-trunk — feature PRs target the repo default branch (`main`) and squash-merge. Environments are a deploy-time concern (config + deploy target), not a branching concern.
 
+## Agent safety — the production boundary
+
+You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
+
+- **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
+- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+
 ## Standard lifecycle
 
 1. **Start work** — use the `start_task` skill. It runs `start_issue.sh` which creates

--- a/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/gemini/dot_agents/skills/github_workflow/SKILL.md
@@ -29,7 +29,7 @@ Types: `feat` `fix` `chore` `docs` `test`
 You (the agent) work on **feature/PR branches only — never push or commit to the production ref (`main`)**. On any auto-deploy platform, write access to the production branch *is* production-deploy access. This is enforced two ways:
 
 - **Fast-feedback (in-repo):** the command guard blocks `git push main`/`master`, `gh pr merge`, and `gh api .../merge` — but a hook is editable, so treat it as a guard rail, not the boundary.
-- **The real boundary (server-side):** branch protection installed by `.claude/scripts/setup_github.sh --protect` (squash-only, required CI, required review, no force-push) — and, for deployed services, GitHub Environment protection rules. These live server-side and an agent cannot edit them. Run `setup_github.sh --protect` once with admin rights to arm them.
+- **The real boundary (server-side), tiered by profile (ADR-013):** run `.claude/scripts/setup_github.sh --protect` once with admin rights. For the **`org`** profile it installs rulesets with an *empty bypass list* (plus GitHub Environment reviewers for services) — a **hard** boundary no agent can edit or bypass. For **`individual`/`standalone`** it installs classic branch protection that is **advisory** (`enforce_admins=false`, so an admin-capable token can override it) — useful, but not a hard production gate; move to the `org` profile (or add a second human approver / Environment reviewer) when you need one.
 
 ## Standard lifecycle
 

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -92,3 +92,26 @@ class TestSkillNeutrality:
         content = (self._SKILLS / "github_workflow" / "SKILL.md").read_text()
         frontmatter = content.split("---")[1]
         assert "Claude" not in frontmatter, "lifecycle skill must not be Claude-scoped"
+
+
+class TestGithubWorkflowProductionBoundary:
+    """PI-321 (epic #316): the github_workflow skill must make the agent's
+    production-ref boundary explicit, and all copies must stay in sync."""
+
+    _REPO = Path(__file__).resolve().parents[2]
+    _SKILLS = [
+        _REPO / "templates/fallback/dot_claude/skills/github_workflow/SKILL.md",
+        _REPO / "templates/codex/dot_agents/skills/github_workflow/SKILL.md",
+        _REPO / "templates/gemini/dot_agents/skills/github_workflow/SKILL.md",
+        _REPO / "plugins/project-init-workflow/skills/github_workflow/SKILL.md",
+    ]
+
+    def test_skill_documents_production_boundary(self):
+        text = self._SKILLS[0].read_text()
+        assert "production boundary" in text.lower()
+        assert "never push or commit to the production ref" in text
+        assert "setup_github.sh --protect" in text
+
+    def test_all_copies_carry_the_boundary(self):
+        for skill in self._SKILLS:
+            assert "production boundary" in skill.read_text().lower(), f"{skill} out of sync"


### PR DESCRIPTION
The guardrails' *enforcement* already exists — the command guard blocks `git push main`/`master`, `gh pr merge`, `gh api .../merge` (tested: `test_blocks_push_to_main/_master`), and `setup_github.sh --protect` (extracted in #330) installs the server-side branch protection. This PR closes the **legibility** gap.

- New **"Agent safety — the production boundary"** section in the `github_workflow` skill: the agent works on PR branches only, never pushes/commits to the prod ref; the in-repo guard is *fast-feedback*, the **server-side** protection (`setup_github.sh --protect`, plus GitHub Environment rules for services) is the **real boundary** an agent can't edit.
- Synced to all 4 skill copies (fallback source → codex / gemini / plugin); contract test asserts the boundary text + copy parity.

736 tests pass (+2); ruff clean.

Closes #321
Part of #316