### PR TITLE
feat(PI-324): tiered prod gate + setup_env_protection.sh + whats_deployed.sh

### DIFF
--- a/templates/base/dot_claude/docs/guides/environments.md
+++ b/templates/base/dot_claude/docs/guides/environments.md
@@ -44,6 +44,17 @@ The unifier is the **container image + the `justfile`**, not Terraform:
 - Rollback = redeploy the previous digest. No git surgery.
 - If a managed platform (Vercel/Netlify/Render/…) owns your deploy, let it — this
   project points at its native flow rather than fighting it.
+- Arm the server-side gate with `.claude/scripts/setup_env_protection.sh`
+  (`--reviewer @org/team` for a true human gate on `org`); see what's live with
+  `.claude/scripts/whats_deployed.sh`.
+
+### Platform owns deploy (no GitHub Actions deploy)
+
+When the deploy target is `none`, your PaaS (Vercel/Render/Fly/…) deploys on push
+and **project-init scaffolds no deploy workflow** — wire your platform's native
+git integration and read deploy state from its dashboard/CLI (GitHub won't have
+Deployment records, so `whats_deployed.sh` will report none). Keep the prod gate
+in the platform (require a deploy approval / protect the production branch there).
 
 For the full rationale, see ADR-015 (env & deploy model) in the project-init
 source repository.

--- a/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
+++ b/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
@@ -30,8 +30,8 @@ WAIT_MIN=5
 REVIEWERS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --reviewer) REVIEWERS+=("$2"); shift 2 ;;
-    --wait) WAIT_MIN="$2"; shift 2 ;;
+    --reviewer) [ $# -ge 2 ] || { echo "Missing value for --reviewer" >&2; exit 1; }; REVIEWERS+=("$2"); shift 2 ;;
+    --wait) [ $# -ge 2 ] || { echo "Missing value for --wait" >&2; exit 1; }; WAIT_MIN="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -71,6 +71,7 @@ resolve_reviewer() {
 BODY=$(mktemp)
 trap 'rm -f "$BODY"' EXIT
 
+SKIP_PROD=0
 if [ "$PROFILE" = "org" ]; then
   reviewers_json="[]"
   if [ "${#REVIEWERS[@]}" -gt 0 ]; then
@@ -82,14 +83,19 @@ if [ "$PROFILE" = "org" ]; then
     reviewers_json="[$(IFS=,; echo "${parts[*]}")]"
   fi
   if [ "$reviewers_json" = "[]" ]; then
-    echo "WARNING: org profile but no --reviewer resolved — production has NO human reviewer yet." >&2
-    echo "  Re-run with: setup_env_protection.sh --reviewer @your-org/your-team" >&2
-  fi
-  cat > "$BODY" <<JSON
-{ "prevent_self_review": true, "reviewers": $reviewers_json,
+    # Do NOT PUT an empty-reviewers payload — that would WIPE any reviewers already
+    # configured on production, silently removing the gate. Leave production as-is.
+    echo "WARNING: org profile but no --reviewer resolved — leaving production protection" >&2
+    echo "  UNCHANGED (existing reviewers, if any, are preserved). Re-run with:" >&2
+    echo "    setup_env_protection.sh --reviewer @your-org/your-team" >&2
+    SKIP_PROD=1
+  else
+    cat > "$BODY" <<JSON
+{ "prevent_self_review": true, "can_admins_bypass": false, "reviewers": $reviewers_json,
   "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
 JSON
-  GATE_DESC="required reviewers + prevent-self-review (hard human gate)"
+    GATE_DESC="required reviewers + prevent-self-review + no admin bypass (hard human gate)"
+  fi
 else
   cat > "$BODY" <<JSON
 { "wait_timer": $WAIT_MIN,
@@ -98,7 +104,9 @@ JSON
   GATE_DESC="${WAIT_MIN}-min wait timer (DELAYED/ADVISORY — not a human gate)"
 fi
 
-if gh api "repos/$OWNER/$NAME/environments/production" -X PUT --input "$BODY" >/dev/null 2>&1; then
+if [ "$SKIP_PROD" = 1 ]; then
+  :  # production left untouched (see warning above)
+elif gh api "repos/$OWNER/$NAME/environments/production" -X PUT --input "$BODY" >/dev/null 2>&1; then
   echo "Environment 'production' ensured: $GATE_DESC"
   # Restrict production deploys to the base branch.
   if gh api "repos/$OWNER/$NAME/environments/production/deployment-branch-policies" \

--- a/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
+++ b/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
@@ -1,0 +1,123 @@
+{{#if deploy_container}}#!/bin/bash
+# setup_env_protection.sh — install SERVER-SIDE GitHub Environment protection on
+# the deploy environments (ADR-015, epic #316). The `production` environment is
+# the real boundary an agent cannot bypass; deploy.yml references it. Run once,
+# with repo admin rights, after the deploy overlay is configured.
+#
+# Tiered by distribution profile (.claude/config.yaml; ADR-013):
+#   org                   -> production requires human reviewers + prevent-self-review
+#                            (a TRUE human gate). Pass reviewers with --reviewer.
+#   individual/standalone -> production gets a wait timer only — a DELAYED/ADVISORY
+#                            gate, NOT a human gate (a solo account has no second
+#                            approver). Move to the org profile or add a reviewer.
+#
+# Setup contract:
+#   - Requires gh + repo ADMIN permission.
+#   - Idempotent: the environment PUT replaces existing settings.
+#   - Required reviewers + wait timers need a PUBLIC repo on GitHub Free/Pro, or
+#     GitHub Team/Enterprise for a private repo. On an unsupported plan the API
+#     rejects the call; this script WARNS and continues rather than failing.
+#
+# Usage: setup_env_protection.sh [--reviewer @user | @org/team]... [--wait MIN]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
+WAIT_MIN=5
+REVIEWERS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reviewer) REVIEWERS+=("$2"); shift 2 ;;
+    --wait) WAIT_MIN="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+HOST="$(gh_host)"
+if ! gh auth status -h "$HOST" >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated for $HOST. Run: gh auth login --hostname $HOST" >&2
+  exit 1
+fi
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+PROFILE="$(gh_profile)"
+BASE="$(base_branch)"
+
+echo "Configuring deploy environments for $REPO (profile=$PROFILE)"
+
+# --- staging: ensured, no gate (auto-deploy) ---
+if gh api "repos/$OWNER/$NAME/environments/staging" -X PUT >/dev/null 2>&1; then
+  echo "Environment 'staging' ensured (auto-deploy, no gate)"
+else
+  echo "WARNING: could not create the 'staging' environment (admin permission / plan?)." >&2
+fi
+
+# Resolve a @user / @org/team handle to {"type":...,"id":N} for the reviewers API.
+resolve_reviewer() {
+  local who="${1#@}" id
+  if [[ "$who" == */* ]]; then
+    id=$(gh api "orgs/${who%/*}/teams/${who#*/}" -q .id 2>/dev/null || true)
+    [ -n "$id" ] && printf '{"type":"Team","id":%s}' "$id"
+  else
+    id=$(gh api "users/$who" -q .id 2>/dev/null || true)
+    [ -n "$id" ] && printf '{"type":"User","id":%s}' "$id"
+  fi
+}
+
+BODY=$(mktemp)
+trap 'rm -f "$BODY"' EXIT
+
+if [ "$PROFILE" = "org" ]; then
+  reviewers_json="[]"
+  if [ "${#REVIEWERS[@]}" -gt 0 ]; then
+    parts=()
+    for r in "${REVIEWERS[@]}"; do
+      j=$(resolve_reviewer "$r") || true
+      if [ -n "$j" ]; then parts+=("$j"); else echo "WARNING: could not resolve reviewer '$r' — skipping." >&2; fi
+    done
+    reviewers_json="[$(IFS=,; echo "${parts[*]}")]"
+  fi
+  if [ "$reviewers_json" = "[]" ]; then
+    echo "WARNING: org profile but no --reviewer resolved — production has NO human reviewer yet." >&2
+    echo "  Re-run with: setup_env_protection.sh --reviewer @your-org/your-team" >&2
+  fi
+  cat > "$BODY" <<JSON
+{ "prevent_self_review": true, "reviewers": $reviewers_json,
+  "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
+JSON
+  GATE_DESC="required reviewers + prevent-self-review (hard human gate)"
+else
+  cat > "$BODY" <<JSON
+{ "wait_timer": $WAIT_MIN,
+  "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
+JSON
+  GATE_DESC="${WAIT_MIN}-min wait timer (DELAYED/ADVISORY — not a human gate)"
+fi
+
+if gh api "repos/$OWNER/$NAME/environments/production" -X PUT --input "$BODY" >/dev/null 2>&1; then
+  echo "Environment 'production' ensured: $GATE_DESC"
+  # Restrict production deploys to the base branch.
+  if gh api "repos/$OWNER/$NAME/environments/production/deployment-branch-policies" \
+       -X POST -f name="$BASE" >/dev/null 2>&1; then
+    echo "  production deploys restricted to '$BASE'"
+  else
+    echo "  (branch policy for '$BASE' may already exist)"
+  fi
+else
+  echo "WARNING: could not protect 'production'. Required reviewers/wait timers need a" >&2
+  echo "  PUBLIC repo on Free/Pro, or GitHub Team/Enterprise for a private repo." >&2
+fi
+
+if [ "$PROFILE" != "org" ]; then
+  echo ""
+  echo "NOTE: this is a delayed/advisory gate, not a human gate — a solo account has no"
+  echo "  second approver. For a real gate, use the org profile or add a reviewer."
+fi
+
+echo ""
+echo "Check live deploy state with: .claude/scripts/whats_deployed.sh"
+{{/if deploy_container}}

--- a/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
+++ b/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
@@ -32,16 +32,16 @@ fi
 
 printf '%-14s %-12s %-10s %s\n' "ENVIRONMENT" "STATE" "SHA" "WHEN"
 any=0
+# Uses gh's built-in jq (-q) — no external jq binary required.
 for env in "${ENVS[@]}"; do
-  dep=$(gh api "repos/$OWNER/$NAME/deployments?environment=$env&per_page=1" 2>/dev/null || echo '[]')
-  id=$(echo "$dep" | jq -r '.[0].id // empty')
-  if [ -z "$id" ]; then
+  line=$(gh api "repos/$OWNER/$NAME/deployments?environment=$env&per_page=1" \
+    -q '.[0] | "\(.id // "")\t\(.sha[0:7] // "?")\t\(.created_at // "?")"' 2>/dev/null || true)
+  IFS=$'\t' read -r id sha when <<< "$line"
+  if [ -z "${id:-}" ]; then
     printf '%-14s %-12s %-10s %s\n' "$env" "—" "—" "(no GitHub deployment)"
     continue
   fi
   any=1
-  sha=$(echo "$dep" | jq -r '.[0].sha[0:7] // "?"')
-  when=$(echo "$dep" | jq -r '.[0].created_at // "?"')
   state=$(gh api "repos/$OWNER/$NAME/deployments/$id/statuses?per_page=1" -q '.[0].state' 2>/dev/null || echo "?")
   printf '%-14s %-12s %-10s %s\n' "$env" "$state" "$sha" "$when"
 done

--- a/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
+++ b/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
@@ -1,0 +1,54 @@
+{{#if deploy_container}}#!/bin/bash
+# whats_deployed.sh — show what's deployed where, from the GitHub Deployments API
+# (ADR-015). The DESIRED model is deploy/environments.yaml; the ACTUAL state is
+# the latest deployment + status per environment. An agent reads this instead of
+# inferring deploy state from branch topology.
+#
+# Usage: whats_deployed.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/gh_host.sh"
+
+HOST="$(gh_host)"
+if ! gh auth status -h "$HOST" >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated for $HOST. Run: gh auth login --hostname $HOST" >&2
+  exit 1
+fi
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+
+# Desired environments from the declarative model (fixed shape; no yq needed).
+ENVS_FILE="$(cd "$SCRIPT_DIR/../.." && pwd)/deploy/environments.yaml"
+ENVS=()
+if [ -f "$ENVS_FILE" ]; then
+  while IFS= read -r e; do ENVS+=("$e"); done < <(
+    sed -n 's/^  \([a-z][a-z0-9_-]*\):$/\1/p' "$ENVS_FILE")
+fi
+[ "${#ENVS[@]}" -eq 0 ] && ENVS=(staging production)
+
+printf '%-14s %-12s %-10s %s\n' "ENVIRONMENT" "STATE" "SHA" "WHEN"
+any=0
+for env in "${ENVS[@]}"; do
+  dep=$(gh api "repos/$OWNER/$NAME/deployments?environment=$env&per_page=1" 2>/dev/null || echo '[]')
+  id=$(echo "$dep" | jq -r '.[0].id // empty')
+  if [ -z "$id" ]; then
+    printf '%-14s %-12s %-10s %s\n' "$env" "—" "—" "(no GitHub deployment)"
+    continue
+  fi
+  any=1
+  sha=$(echo "$dep" | jq -r '.[0].sha[0:7] // "?"')
+  when=$(echo "$dep" | jq -r '.[0].created_at // "?"')
+  state=$(gh api "repos/$OWNER/$NAME/deployments/$id/statuses?per_page=1" -q '.[0].state' 2>/dev/null || echo "?")
+  printf '%-14s %-12s %-10s %s\n' "$env" "$state" "$sha" "$when"
+done
+
+if [ "$any" -eq 0 ]; then
+  echo ""
+  echo "No GitHub Deployments found. If a platform (Vercel/Render/Fly/…) owns your"
+  echo "deploy, check its dashboard/CLI for live state — GitHub won't have records."
+fi
+{{/if deploy_container}}

--- a/tests/contracts/test_deploy_overlay.py
+++ b/tests/contracts/test_deploy_overlay.py
@@ -107,3 +107,39 @@ class TestResolveDeploy:
     def test_invalid_target(self):
         with pytest.raises(ValueError, match="invalid deploy target"):
             resolve_deploy("heroku", "service")
+
+
+def _envprot(t: Path) -> Path:
+    return t / ".claude" / "scripts" / "setup_env_protection.sh"
+
+
+def _whats(t: Path) -> Path:
+    return t / ".claude" / "scripts" / "whats_deployed.sh"
+
+
+class TestDeployGateScripts:
+    """PI-324: container-deploy services get the server-side gate + introspection
+    scripts; the gate is tiered (org hard / individual advisory)."""
+
+    def test_scripts_render_and_executable(self, tmp_path: Path):
+        import os
+
+        t = _service_deploy(tmp_path / "svc", "cloud-run")
+        for p in (_envprot(t), _whats(t)):
+            assert p.is_file(), p
+            assert os.access(p, os.X_OK), f"{p} not executable"
+
+    def test_gate_is_tiered(self, tmp_path: Path):
+        text = _envprot(_service_deploy(tmp_path / "svc", "cloud-run")).read_text()
+        assert "prevent_self_review" in text          # org: hard human gate
+        assert "reviewers" in text
+        assert "wait_timer" in text                   # individual/standalone: advisory
+        assert "PUBLIC repo" in text                  # plan caveat documented
+
+    def test_absent_for_registry_none_and_prototype(self, tmp_path: Path):
+        reg = _service_deploy(tmp_path / "reg", "registry")
+        none = _service_deploy(tmp_path / "none", "none")
+        proto = _scaffold(tmp_path / "proto", delivery="prototype")
+        for t in (reg, none, proto):
+            assert not _envprot(t).exists()
+            assert not _whats(t).exists()


### PR DESCRIPTION
Deploy overlay pt2 (ADR-015), gated on `deploy_container`.

- **`setup_env_protection.sh`** (human-run, server-side, idempotent): ensures `staging`/`production` environments, restricts production to the base branch, **tiered by profile** —
  - **org** → required reviewers (resolved from `--reviewer @user`/`@org/team`) + `prevent_self_review` = a **true human gate**; warns loudly if no reviewer resolves.
  - **individual/standalone** → `wait_timer` only, printed honestly as **delayed/advisory, not a human gate** (no second approver solo).
  - Header documents the repo-admin token, idempotency, and the **Free/Pro public-repo-only** limit; degrades gracefully on plan rejection.
- **`whats_deployed.sh`** — GitHub Deployments-API introspection (desired-vs-actual per env); points at the platform if no GitHub Deployments exist.
- **`environments.md`** — adds the "platform owns deploy" (PaaS) note.

Both scripts are `.sh.tmpl` so the `{{#if deploy_container}}` gate actually works (a plain `.sh` is copied verbatim) — absent for registry/none/prototype.

754 tests pass (+ gate-script tests); `bash -n` clean on rendered scripts; ruff clean; no drift.

Closes #324
Part of #316