### PR TITLE
feat(PI-325): opt-in IaC overlay — OpenTofu/HCL skeleton, gated apply

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -54,6 +54,8 @@ class ScaffoldInputs:
     # Deploy target (epic #316, ADR-015): opt-in deploy overlay for services.
     # "none" = my platform owns deploy, or not deployed via Actions yet.
     deploy: str = "none"
+    # IaC overlay (ADR-015, opt-in): none | opentofu. Independent of delivery.
+    iac: str = "none"
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -102,6 +104,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "Deploy overlay for a service (ADR-015, opt-in): none (default — your "
             "platform/PaaS owns deploy, or not yet), cloud-run, fly, k8s, registry "
             "(publish image only), or custom. Requires --delivery service."
+        ),
+    )
+    p.add_argument(
+        "--iac",
+        metavar="TOOL",
+        default=None,
+        # Validated by resolve_iac(); independent of delivery.
+        help=(
+            "Infrastructure-as-Code overlay (ADR-015, opt-in): none (default) or "
+            "opentofu (emits an HCL skeleton + plan-on-PR workflow; apply is "
+            "manual/gated). OpenTofu is the license-safe default vs BUSL Terraform."
         ),
     )
     p.add_argument(
@@ -458,14 +471,27 @@ def _select_preset(
         parser.error(str(e))
 
 
+def _resolve_iac_interactive(iac: str | None) -> str:
+    """Resolve the IaC overlay for the interactive path: validate a flag, else prompt."""
+    if iac:
+        try:
+            return resolve_iac(iac)
+        except ValueError as e:
+            from rich.console import Console
+
+            Console().print(f"[red]{e}[/red]")
+    return _choose_iac_interactive()
+
+
 def _resolve_overlays_interactive(
-    language: str, delivery: str | None, deploy: str | None
-) -> tuple[str, str]:
-    """Resolve (delivery, deploy) for the interactive path.
+    language: str, delivery: str | None, deploy: str | None, iac: str | None
+) -> tuple[str, str, str]:
+    """Resolve (delivery, deploy, iac) for the interactive path.
 
     A passed flag is validated; on a conflict (e.g. service + language none) or
     no flag, we prompt — never crash (the non-interactive path turns the same
-    error into a parser.error). Deploy applies only to services.
+    error into a parser.error). Deploy applies only to services; IaC is
+    independent of delivery.
     """
     from rich.console import Console
 
@@ -478,19 +504,24 @@ def _resolve_overlays_interactive(
     if resolved_delivery is None:
         resolved_delivery = _choose_delivery_interactive(language)
 
+    resolved_iac = _resolve_iac_interactive(iac)
+
     if resolved_delivery != "service":
         if deploy and deploy.strip().lower() not in ("", "none"):
             Console().print(
                 f"[yellow]--deploy {deploy} ignored: deploy targets apply only to "
                 f"delivery=service (this is {resolved_delivery}).[/yellow]"
             )
-        return resolved_delivery, "none"
+        return resolved_delivery, "none", resolved_iac
+    resolved_deploy = None
     if deploy:
         try:
-            return resolved_delivery, resolve_deploy(deploy, resolved_delivery)
+            resolved_deploy = resolve_deploy(deploy, resolved_delivery)
         except ValueError as e:
             Console().print(f"[red]{e}[/red]")
-    return resolved_delivery, _choose_deploy_interactive()
+    if resolved_deploy is None:
+        resolved_deploy = _choose_deploy_interactive()
+    return resolved_delivery, resolved_deploy, resolved_iac
 
 
 def _gather_inputs_interactive(
@@ -499,12 +530,12 @@ def _gather_inputs_interactive(
     no_plugin: bool,
     profile: str | None,
     no_egress: bool = False,
-    cli_overlays: tuple[str | None, str | None] = (None, None),
+    cli_overlays: tuple[str | None, str | None, str | None] = (None, None, None),
 ) -> ScaffoldInputs:
     """Prompt for the profile, project basics, MCPs, governance, and overlays.
 
-    ``cli_overlays`` pre-seeds (delivery, deploy) from flags; either may be None
-    to prompt.
+    ``cli_overlays`` pre-seeds (delivery, deploy, iac) from flags; any may be
+    None to prompt.
     """
     resolved_profile = profile or _choose_profile_interactive()
     no_plugin = _profile_delivery_no_plugin(resolved_profile, no_plugin)
@@ -513,9 +544,9 @@ def _gather_inputs_interactive(
     language = _prompt("Language (python/node/go/none)", default="none")
     if language not in {"python", "node", "go", "none"}:
         language = "none"
-    delivery_flag, deploy_flag = cli_overlays
-    resolved_delivery, resolved_deploy = _resolve_overlays_interactive(
-        language, delivery_flag, deploy_flag
+    delivery_flag, deploy_flag, iac_flag = cli_overlays
+    resolved_delivery, resolved_deploy, resolved_iac = _resolve_overlays_interactive(
+        language, delivery_flag, deploy_flag, iac_flag
     )
 
     # MCP selection — three steps.
@@ -567,6 +598,7 @@ def _gather_inputs_interactive(
         no_egress=no_egress,
         delivery=resolved_delivery,
         deploy=resolved_deploy,
+        iac=resolved_iac,
     )
 
 
@@ -679,6 +711,44 @@ def _choose_deploy_interactive() -> str:
         console.print("[red]Invalid choice. Using none.[/red]")
         return "none"
     return _DEPLOY_TARGETS[choice - 1]
+
+
+_IAC_OPTIONS = ("none", "opentofu")
+_IAC_ALIASES = {"tofu": "opentofu", "terraform": "opentofu"}
+_IAC_SUMMARY = {
+    "none": "no infrastructure-as-code scaffolding",
+    "opentofu": "OpenTofu (HCL) skeleton + plan-on-PR workflow; apply manual/gated",
+}
+
+
+def resolve_iac(raw: str | None) -> str:
+    """Normalize an --iac value; default 'none'. Raises ValueError on an unknown tool.
+
+    `tofu`/`terraform` alias to `opentofu` (we always emit plain HCL run by the
+    OpenTofu binary — the license-safe default; ADR-015).
+    """
+    value = (raw or "").strip().lower() or "none"
+    value = _IAC_ALIASES.get(value, value)
+    if value not in _IAC_OPTIONS:
+        valid = ", ".join(_IAC_OPTIONS)
+        raise ValueError(f"invalid iac tool '{raw}'. Choose one of: {valid}")
+    return value
+
+
+def _choose_iac_interactive() -> str:
+    """Present the IaC options (ADR-015); default none."""
+    from rich.console import Console
+    from rich.prompt import IntPrompt
+
+    console = Console()
+    console.print("\n[bold]Infrastructure-as-Code overlay?[/bold]")
+    for i, name in enumerate(_IAC_OPTIONS, 1):
+        console.print(f"  {i}. [cyan]{name}[/cyan] — {_IAC_SUMMARY[name]}")
+    choice = IntPrompt.ask("Choose an IaC overlay", default=1)
+    if choice < 1 or choice > len(_IAC_OPTIONS):
+        console.print("[red]Invalid choice. Using none.[/red]")
+        return "none"
+    return _IAC_OPTIONS[choice - 1]
 
 
 _VALID_AGENTS = ("claude", "codex", "gemini", "ollama")
@@ -885,6 +955,9 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         "deploy_cloud_run": "true" if inputs.deploy == "cloud-run" else "",
         "deploy_fly": "true" if inputs.deploy == "fly" else "",
         "deploy_k8s": "true" if inputs.deploy == "k8s" else "",
+        # IaC overlay (ADR-015, opt-in): infra/ HCL skeleton + infra.yml gate on this.
+        "iac": inputs.iac,
+        "iac_enabled": "true" if inputs.iac != "none" else "",
         "memory_stack": preset.get("vars", {}).get("memory_stack", "obsidian-only"),
         "installed_mcps": format_installed_mcps(selected_mcps),
         "installed_mcps_yaml": format_installed_mcps_yaml(selected_mcps),
@@ -964,6 +1037,7 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
     try:
         delivery = resolve_delivery(args.delivery, args.language or "none")
         deploy = resolve_deploy(args.deploy, delivery)
+        iac = resolve_iac(args.iac)
     except ValueError as e:
         parser.error(str(e))
     _print_profile_notice(profile, no_plugin=no_plugin, no_egress=args.no_egress)
@@ -983,6 +1057,7 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
         no_egress=args.no_egress,
         delivery=delivery,
         deploy=deploy,
+        iac=iac,
     )
 
 
@@ -1052,7 +1127,7 @@ def main(argv: list[str] | None = None) -> int:
             no_plugin=args.no_plugin,
             profile=args.profile,
             no_egress=args.no_egress,
-            cli_overlays=(args.delivery, args.deploy),
+            cli_overlays=(args.delivery, args.deploy, args.iac),
         )
     target.mkdir(parents=True, exist_ok=True)
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -129,6 +129,9 @@ def _overlay_off_defaults() -> dict[str, str]:
         "deploy_cloud_run": "",
         "deploy_fly": "",
         "deploy_k8s": "",
+        # IaC overlay (ADR-015): off for records predating the iac question.
+        "iac": "none",
+        "iac_enabled": "",
         "want_devcontainer": "",
         "project_owner": "",
         "license": "none",

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -17,6 +17,7 @@ language: {{language}}            # python | node | go | none
 
 delivery: {{delivery}}            # library | service | prototype — how this ships (ADR-015)
 deploy: {{deploy_target}}            # none | cloud-run | fly | k8s | registry | custom — service deploy overlay (ADR-015)
+iac: {{iac}}            # none | opentofu — infrastructure-as-code overlay (ADR-015)
 
 memory:
   stack: {{memory_stack}}         # obsidian-only | obsidian-graphify

--- a/templates/base/dot_github/workflows/infra.yml.tmpl
+++ b/templates/base/dot_github/workflows/infra.yml.tmpl
@@ -1,0 +1,64 @@
+{{#if iac_enabled}}# Infrastructure CI (ADR-015, OpenTofu). Plan on PRs; apply is MANUAL and
+# environment-gated — never apply-on-merge. Auth via OIDC (no long-lived keys).
+name: Infra
+
+on:
+  pull_request:
+    paths: ["infra/**"]
+  workflow_dispatch:        # apply is run manually (see the apply job)
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: tofu plan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write       # OIDC to your cloud (configure below)
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      # TODO: authenticate to your cloud via OIDC, e.g.
+      #   aws-actions/configure-aws-credentials@v4 with role-to-assume, or
+      #   google-github-actions/auth@v2 with workload_identity_provider.
+      - name: Format check
+        run: tofu fmt -check -recursive
+      - name: Init
+        run: tofu init -backend=false
+      - name: Validate
+        run: tofu validate
+      - name: Plan
+        run: tofu plan -input=false
+
+  apply:
+    name: tofu apply (manual, gated)
+    if: github.event_name == 'workflow_dispatch'
+    needs: plan
+    runs-on: ubuntu-24.04
+    # The infra-apply GitHub Environment is the human gate (required reviewers /
+    # wait timer). An agent cannot apply to prod infra without clearing it.
+    environment: infra-apply
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+      # TODO: OIDC cloud auth (as above).
+      - name: Init
+        run: tofu init
+      - name: Apply
+        run: tofu apply -input=false -auto-approve
+{{/if iac_enabled}}

--- a/templates/base/dot_github/workflows/infra.yml.tmpl
+++ b/templates/base/dot_github/workflows/infra.yml.tmpl
@@ -31,8 +31,11 @@ jobs:
       #   google-github-actions/auth@v2 with workload_identity_provider.
       - name: Format check
         run: tofu fmt -check -recursive
+      # Uses whatever infra/backend.tf configures (an empty scaffold has none →
+      # local backend, which inits without credentials); once a remote backend +
+      # OIDC auth are wired above, plans run against real state.
       - name: Init
-        run: tofu init -backend=false
+        run: tofu init
       - name: Validate
         run: tofu validate
       - name: Plan

--- a/templates/base/infra/README.md.tmpl
+++ b/templates/base/infra/README.md.tmpl
@@ -1,0 +1,17 @@
+{{#if iac_enabled}}# Infrastructure ({{project_name}})
+
+An **OpenTofu** (HCL) skeleton — structural only, no real resources yet.
+
+```bash
+tofu init      # after configuring backend.tf
+tofu plan      # preview
+tofu apply     # apply (manual / environment-gated in CI — never on merge)
+```
+
+- Engine: **OpenTofu** (`tofu`), the license-safe HCL tool (ADR-015). The files
+  are plain HCL, so Terraform reads them too.
+- **Commit `.terraform.lock.hcl`** (provider checksums). Never commit `*.tfstate`,
+  `*.tfvars`, or credentials.
+- CI (`.github/workflows/infra.yml`) runs `fmt`/`validate`/`plan` on PRs; apply is
+  manual and gated by the `infra-apply` environment.
+{{/if iac_enabled}}

--- a/templates/base/infra/backend.tf.tmpl
+++ b/templates/base/infra/backend.tf.tmpl
@@ -1,0 +1,14 @@
+{{#if iac_enabled}}# Remote state backend — UNCOMMENT and configure once, then `tofu init`.
+# Left commented because the backend is account-specific and has a bootstrap
+# chicken-and-egg (the bucket/table must exist before init). Never commit
+# credentials; supply them via the environment / OIDC.
+#
+# terraform {
+#   backend "s3" {
+#     bucket       = "your-tf-state-bucket"
+#     key          = "{{project_name}}/terraform.tfstate"
+#     region       = "your-region"
+#     use_lockfile = true   # native S3 state locking (TF 1.10+/OpenTofu)
+#   }
+# }
+{{/if iac_enabled}}

--- a/templates/base/infra/dot_gitignore.tmpl
+++ b/templates/base/infra/dot_gitignore.tmpl
@@ -1,0 +1,8 @@
+{{#if iac_enabled}}.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+crash.log
+# NOT ignored: .terraform.lock.hcl is committed (provider checksum pinning).
+{{/if iac_enabled}}

--- a/templates/base/infra/dot_pre-commit-config.yaml.tmpl
+++ b/templates/base/infra/dot_pre-commit-config.yaml.tmpl
@@ -1,0 +1,13 @@
+{{#if iac_enabled}}# Pre-commit hooks for the infra/ HCL. Requires the OpenTofu binary (`tofu`),
+# NOT `terraform` — export PCT_TFPATH=tofu so the hooks invoke OpenTofu
+# (antonbabenko/pre-commit-terraform reads PCT_TFPATH). Run: pre-commit run -a.
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.99.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_trivy
+      - id: terraform_docs
+{{/if iac_enabled}}

--- a/templates/base/infra/main.tf.tmpl
+++ b/templates/base/infra/main.tf.tmpl
@@ -1,0 +1,4 @@
+{{#if iac_enabled}}# Declare your infrastructure resources here.
+# Structural skeleton only — project-init ships no real resources, account IDs,
+# regions, or credentials. Keep state in a remote backend (see backend.tf).
+{{/if iac_enabled}}

--- a/templates/base/infra/outputs.tf.tmpl
+++ b/templates/base/infra/outputs.tf.tmpl
@@ -1,0 +1,5 @@
+{{#if iac_enabled}}# Module outputs. Example:
+# output "endpoint" {
+#   value = "..."
+# }
+{{/if iac_enabled}}

--- a/templates/base/infra/variables.tf.tmpl
+++ b/templates/base/infra/variables.tf.tmpl
@@ -1,0 +1,6 @@
+{{#if iac_enabled}}# Input variables for this module. Example:
+# variable "region" {
+#   description = "Cloud region"
+#   type        = string
+# }
+{{/if iac_enabled}}

--- a/templates/base/infra/versions.tf.tmpl
+++ b/templates/base/infra/versions.tf.tmpl
@@ -1,0 +1,14 @@
+{{#if iac_enabled}}# Provider + version constraints. Runs on OpenTofu (the `tofu` binary) — the
+# license-safe HCL engine (ADR-015). Plain Terraform also reads this file.
+terraform {
+  required_version = ">= 1.6"
+
+  # Declare your providers here with pessimistic (~>) version pins, e.g.:
+  # required_providers {
+  #   aws = {
+  #     source  = "hashicorp/aws"
+  #     version = "~> 5.0"
+  #   }
+  # }
+}
+{{/if iac_enabled}}

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -58,6 +58,7 @@ class TestAgentSelection:
         monkeypatch.setattr(cli, "_choose_db_interactive", lambda: None)
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
         monkeypatch.setattr(cli, "_choose_delivery_interactive", lambda language: "prototype")
+        monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 
         result = cli._gather_inputs_interactive(

--- a/tests/contracts/test_iac_overlay.py
+++ b/tests/contracts/test_iac_overlay.py
@@ -28,10 +28,14 @@ class TestIacOverlayPresent:
 
     def test_backend_is_commented_stub(self, tmp_path: Path):
         backend = (_iac(tmp_path / "p") / "infra" / "backend.tf").read_text()
-        # Every backend line is commented — no uncommented backend block.
+        # Every backend line is commented — no uncommented backend/terraform block
+        # anywhere, including the file's first line (column 0).
         assert 'backend "s3"' in backend
         assert '# terraform {' in backend
-        assert "\nterraform {" not in backend  # not uncommented
+        for line in backend.splitlines():
+            stripped = line.lstrip()
+            assert not stripped.startswith("terraform {"), f"uncommented: {line!r}"
+            assert not stripped.startswith("backend "), f"uncommented: {line!r}"
 
     def test_gitignore_keeps_lockfile_tracked(self, tmp_path: Path):
         gi = (_iac(tmp_path / "p") / "infra" / ".gitignore").read_text()

--- a/tests/contracts/test_iac_overlay.py
+++ b/tests/contracts/test_iac_overlay.py
@@ -1,0 +1,80 @@
+"""PI-325 (epic #316, ADR-015): opt-in IaC overlay — OpenTofu (HCL) skeleton +
+plan-on-PR workflow (apply manual/gated). Default OFF; emits no real resources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+def _iac(target: Path) -> Path:
+    return _scaffold(target, iac="opentofu", iac_enabled="true")
+
+
+class TestIacOverlayPresent:
+    def test_hcl_skeleton_renders(self, tmp_path: Path):
+        t = _iac(tmp_path / "p")
+        for f in ("versions.tf", "main.tf", "variables.tf", "outputs.tf", "backend.tf", "README.md"):
+            assert (t / "infra" / f).is_file(), f"missing infra/{f}"
+
+    def test_backend_is_commented_stub(self, tmp_path: Path):
+        backend = (_iac(tmp_path / "p") / "infra" / "backend.tf").read_text()
+        # Every backend line is commented — no uncommented backend block.
+        assert 'backend "s3"' in backend
+        assert '# terraform {' in backend
+        assert "\nterraform {" not in backend  # not uncommented
+
+    def test_gitignore_keeps_lockfile_tracked(self, tmp_path: Path):
+        gi = (_iac(tmp_path / "p") / "infra" / ".gitignore").read_text()
+        assert "*.tfstate" in gi
+        assert ".terraform.lock.hcl" not in gi.replace("# NOT ignored: .terraform.lock.hcl is committed (provider checksum pinning).", "")
+
+    def test_workflow_uses_opentofu_and_gated_apply(self, tmp_path: Path):
+        wf = (_iac(tmp_path / "p") / ".github" / "workflows" / "infra.yml").read_text()
+        assert "opentofu/setup-opentofu" in wf
+        assert "tofu plan" in wf and "tofu validate" in wf
+        assert "environment: infra-apply" in wf          # gated apply
+        assert "workflow_dispatch" in wf                  # manual, not on merge
+        assert "id-token: write" in wf                    # OIDC
+
+    def test_precommit_targets_tofu(self, tmp_path: Path):
+        pc = (_iac(tmp_path / "p") / "infra" / ".pre-commit-config.yaml").read_text()
+        assert "pre-commit-terraform" in pc
+        assert "terraform_trivy" in pc
+        assert "PCT_TFPATH=tofu" in pc  # invoke OpenTofu, not terraform
+
+
+class TestIacOverlayAbsent:
+    def test_none_emits_no_infra(self, tmp_path: Path):
+        t = _scaffold(tmp_path / "p", iac="none")
+        assert not (t / "infra").exists()
+        assert not (t / ".github" / "workflows" / "infra.yml").exists()
+
+
+class TestResolveIac:
+    def test_default_none(self):
+        from project_init.__main__ import resolve_iac
+
+        assert resolve_iac(None) == "none"
+        assert resolve_iac("") == "none"
+
+    def test_aliases(self):
+        from project_init.__main__ import resolve_iac
+
+        assert resolve_iac("tofu") == "opentofu"
+        assert resolve_iac("terraform") == "opentofu"
+
+    def test_rejects_unknown(self):
+        from project_init.__main__ import resolve_iac
+
+        with pytest.raises(ValueError, match="invalid iac tool"):
+            resolve_iac("pulumi")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,6 +49,8 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "deploy_cloud_run": "",
         "deploy_fly": "",
         "deploy_k8s": "",
+        "iac": "none",
+        "iac_enabled": "",
         "want_devcontainer": "",
         "memory_stack": "obsidian-only",
         "installed_mcps": "none",


### PR DESCRIPTION
ADR-015 IaC overlay (opt-in, default OFF). New `--iac` (`none` / `opentofu`; aliases `tofu`/`terraform` → opentofu).

- **`infra/`** HCL skeleton (all `*.tf.tmpl`, gated `{{#if iac_enabled}}`): `versions.tf` (OpenTofu `required_version` + commented `~>` provider example), empty `main/variables/outputs`, **fully-commented `backend.tf`** stub + bootstrap note, README, and a `.gitignore` that ignores state/tfvars but **keeps `.terraform.lock.hcl`** (committed). No real resources, account IDs, or credentials.
- **`infra.yml`** — `plan` on PRs (`tofu fmt/init/validate/plan`, OIDC) via `opentofu/setup-opentofu`; **`apply` is manual + `environment: infra-apply`-gated — never apply-on-merge** (the env is the human gate an agent can't clear).
- **pre-commit** — `fmt/validate/tflint/trivy/docs` wired to **`tofu`** (`PCT_TFPATH=tofu`), not the Terraform binary.
- Default **OpenTofu** for license safety (BUSL/IBM Terraform avoided).

763 tests pass (+9 IaC tests); renovate-pin test green; ruff clean; no drift. `iac=none` → no `infra/`, no workflow.

Closes #325
Part of #316