### PR TITLE
feat(PI-326): cloud-integration seam — OIDC + env contract

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -668,6 +668,10 @@ _DEPLOY_TARGETS = ("none", "cloud-run", "fly", "k8s", "registry", "custom")
 # Container-deploy targets get the build-once-by-digest deploy graph; registry is
 # publication only; none = no Actions deploy overlay.
 _DEPLOY_CONTAINER = ("cloud-run", "fly", "k8s", "custom")
+# Targets whose scaffolded workflow uses cloud OIDC federation (GCP WIF / AWS
+# role) — the cloud-integration seam doc (#326) applies. fly is token-based and
+# k8s/custom auth varies, so they're excluded (the doc says others can reuse it).
+_DEPLOY_OIDC = ("cloud-run",)
 
 _DEPLOY_SUMMARY = {
     "none": "my platform/PaaS deploys it, or not deployed via Actions yet (default)",
@@ -962,7 +966,7 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         # authenticates to a cloud via OIDC, so the contract doc ships for them.
         "cloud_oidc": (
             "true"
-            if (inputs.deploy in _DEPLOY_CONTAINER or inputs.iac != "none")
+            if (inputs.deploy in _DEPLOY_OIDC or inputs.iac != "none")
             else ""
         ),
         "memory_stack": preset.get("vars", {}).get("memory_stack", "obsidian-only"),

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -958,6 +958,13 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         # IaC overlay (ADR-015, opt-in): infra/ HCL skeleton + infra.yml gate on this.
         "iac": inputs.iac,
         "iac_enabled": "true" if inputs.iac != "none" else "",
+        # Cloud-OIDC integration seam (#326): set whenever a deploy or IaC workflow
+        # authenticates to a cloud via OIDC, so the contract doc ships for them.
+        "cloud_oidc": (
+            "true"
+            if (inputs.deploy in _DEPLOY_CONTAINER or inputs.iac != "none")
+            else ""
+        ),
         "memory_stack": preset.get("vars", {}).get("memory_stack", "obsidian-only"),
         "installed_mcps": format_installed_mcps(selected_mcps),
         "installed_mcps_yaml": format_installed_mcps_yaml(selected_mcps),

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -132,6 +132,7 @@ def _overlay_off_defaults() -> dict[str, str]:
         # IaC overlay (ADR-015): off for records predating the iac question.
         "iac": "none",
         "iac_enabled": "",
+        "cloud_oidc": "",
         "want_devcontainer": "",
         "project_owner": "",
         "license": "none",

--- a/templates/base/dot_claude/docs/guides/cloud-integration.md.tmpl
+++ b/templates/base/dot_claude/docs/guides/cloud-integration.md.tmpl
@@ -38,6 +38,10 @@ your cloud setup provides the values. The deploy (`deploy.yml`) and infra
    workflow deploys — and *no* standing credentials handed to the repo.
 3. The variable values above.
 
+> Shipped for OIDC-backed targets (Cloud Run, cloud IaC). Other targets — `fly`
+> (API token), `k8s`/`custom` (auth varies) — can reuse this same contract if they
+> authenticate to a cloud via OIDC.
+
 ## Boundary
 
 Governance, monitoring, IAM, org policies, and the landing zone are **out of

--- a/templates/base/dot_claude/docs/guides/cloud-integration.md.tmpl
+++ b/templates/base/dot_claude/docs/guides/cloud-integration.md.tmpl
@@ -1,0 +1,47 @@
+{{#if cloud_oidc}}# Cloud integration seam — OIDC + env contract
+
+This project's deploy/infra workflows authenticate to your cloud with **OpenID
+Connect (OIDC)** — short-lived, federated tokens, **no long-lived keys in repo
+secrets**. project-init scaffolds the *workflow side* of that handshake and stops
+at the cloud boundary. The *cloud side* — the workload-identity provider, the
+service account/role, org policies, monitoring, and the rest of the landing zone
+— is a **separate concern** (a platform/landing-zone product or your own setup),
+not something this scaffolder provisions. This file is the **contract** between
+the two.
+
+## What the workflows expect (the env contract)
+
+Set these as **repo (or environment) variables/secrets** — the landing zone /
+your cloud setup provides the values. The deploy (`deploy.yml`) and infra
+(`infra.yml`) workflows read them in their OIDC auth step (marked `# TODO` there).
+
+**GCP (workload identity federation):**
+| Name | Kind | Meaning |
+|------|------|---------|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | variable | full WIF provider resource name |
+| `GCP_SERVICE_ACCOUNT` | variable | service account email the workflow impersonates |
+| `GCP_PROJECT_ID` | variable | target project |
+| `GCP_REGION` | variable | deploy region (e.g. Cloud Run) |
+
+**AWS (OIDC role):**
+| Name | Kind | Meaning |
+|------|------|---------|
+| `AWS_ROLE_ARN` | variable | role the workflow assumes via OIDC |
+| `AWS_REGION` | variable | target region |
+
+## What the cloud side must provide (the OIDC trust contract)
+
+1. An OIDC trust between the cloud and GitHub's token issuer
+   (`https://token.actions.githubusercontent.com`), scoped to **this repository**
+   (and ideally to the `production` / `infra-apply` environments).
+2. A service account / role with **least-privilege** permissions for what the
+   workflow deploys — and *no* standing credentials handed to the repo.
+3. The variable values above.
+
+## Boundary
+
+Governance, monitoring, IAM, org policies, and the landing zone are **out of
+scope for project-init** (ADR-015). They belong to a separate platform product
+that this contract plugs into — keep that product's lifecycle independent of this
+repo. The scaffolded workflows are the consumer; the landing zone is the provider.
+{{/if cloud_oidc}}

--- a/tests/contracts/test_integration_seam.py
+++ b/tests/contracts/test_integration_seam.py
@@ -1,0 +1,44 @@
+"""PI-326 (epic #316, ADR-015): the cloud-integration seam doc ships whenever a
+deploy or IaC workflow uses OIDC, documenting the OIDC + env contract a separate
+landing-zone product fills. Governance itself stays out of project-init."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+def _seam(t: Path) -> Path:
+    return t / ".claude" / "docs" / "guides" / "cloud-integration.md"
+
+
+class TestIntegrationSeam:
+    def test_present_for_container_deploy(self, tmp_path: Path):
+        t = _scaffold(
+            tmp_path / "svc",
+            delivery="service",
+            delivery_service="true",
+            deploy="cloud-run",
+            deploy_container="true",
+            deploy_enabled="true",
+            cloud_oidc="true",
+        )
+        text = _seam(t).read_text()
+        assert "OIDC" in text
+        assert "GCP_WORKLOAD_IDENTITY_PROVIDER" in text
+        assert "out of scope for project-init" in text.lower() or "separate" in text.lower()
+
+    def test_present_for_iac(self, tmp_path: Path):
+        t = _scaffold(tmp_path / "iac", iac="opentofu", iac_enabled="true", cloud_oidc="true")
+        assert _seam(t).is_file()
+
+    def test_absent_without_deploy_or_iac(self, tmp_path: Path):
+        t = _scaffold(tmp_path / "plain")  # defaults: no deploy, no iac
+        assert not _seam(t).exists()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,6 +51,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "deploy_k8s": "",
         "iac": "none",
         "iac_enabled": "",
+        "cloud_oidc": "",
         "want_devcontainer": "",
         "memory_stack": "obsidian-only",
         "installed_mcps": "none",


### PR DESCRIPTION
The seam a separate GCP/landing-zone product plugs into (ADR-015) — project-init stays out of governance.

- New **`cloud-integration.md`** guide (gated `{{#if cloud_oidc}}`, set when a deploy or IaC workflow uses OIDC): documents the **env contract** (GCP WIF / AWS role variables the scaffolded workflows read) and the **OIDC trust contract** the cloud side must provide (repo-scoped trust, least-privilege SA/role, no standing keys).
- States the **boundary** explicitly: governance, monitoring, IAM, org policies, landing zone are **out of scope for project-init** — a separate platform product is the provider; the scaffolded workflows are the consumer.
- `cloud_oidc` render var = deploy-container OR iac-enabled; off-state backfilled on upgrade.

766 tests pass (+3); ruff clean; no drift. Absent when neither deploy nor IaC is enabled.

Closes #326
Part of #316