### PR TITLE
test(PI-327): lock config.yaml env schema + upgrade backfill/normalization

### DIFF
--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -455,6 +455,21 @@ class TestRecordBackfill:
         rc = main(["upgrade", str(target)])
         assert rc == 0, "backfilled defaults must keep strict re-render working"
 
+    def test_pre_316_record_backfills_env_deploy_fields(self):
+        """A record predating epic #316 (no delivery/deploy/iac keys, and a
+        branch-per-env base_branch) backfills to the off state and normalizes
+        base_branch to single-trunk main (#329)."""
+        from project_init.upgrade import _backfill_variables
+
+        # An ex-promotion-chain record: has base_branch=dev, lacks the #316 keys.
+        old = {"language": "python", "base_branch": "dev", "memory_stack": "obsidian-only"}
+        out = _backfill_variables(old)
+        assert out["delivery"] == "prototype"
+        assert out["deploy_target"] == "none"
+        assert out["iac"] == "none"
+        assert out["cloud_oidc"] == ""
+        assert out["base_branch"] == "main", "ex-chain base_branch must normalize to main"
+
     def test_backfill_derives_repo_slug_from_recorded_url(self, tmp_path: Path):
         target = tmp_path / "p"
         _scaffold(target)

--- a/tests/unit/test_scaffold_inputs.py
+++ b/tests/unit/test_scaffold_inputs.py
@@ -105,3 +105,24 @@ class TestDeliveryModel:
         )
         # No SystemExit from argparse choices; resolver then normalizes the alias.
         assert resolve_delivery(args.delivery, args.language) == "service"
+
+
+class TestConfigSchemaEnvFields:
+    """PI-327 (epic #316): .claude/config.yaml records the delivery/deploy/iac
+    schema so `upgrade` can re-render and backfill faithfully."""
+
+    def test_config_records_all_three_overlays(self, tmp_path):
+        from project_init.scaffold import load_preset, scaffold
+        from tests.helpers import make_variables
+
+        target = tmp_path / "p"
+        scaffold(
+            target,
+            load_preset("obsidian-only"),
+            make_variables(delivery="service", deploy_target="cloud-run", iac="opentofu"),
+            strict=True,
+        )
+        config = (target / ".claude" / "config.yaml").read_text()
+        assert "delivery: service" in config
+        assert "deploy: cloud-run" in config
+        assert "iac: opentofu" in config


### PR DESCRIPTION
The `delivery`/`deploy`/`iac` config-schema keys and the `upgrade.py` off-state backfill landed **incrementally** across #318/#323/#325/#326. This ticket adds the **drift/upgrade tests** that lock the contract:

- `test_pre_316_record_backfills_env_deploy_fields` — a record predating epic #316 (no delivery/deploy/iac keys; an ex-promotion-chain `base_branch=dev`) backfills to the off state (`prototype`/`none`/`none`) **and normalizes `base_branch` → `main`** (#329).
- `test_config_records_all_three_overlays` — a scaffold records `delivery`/`deploy`/`iac` in `.claude/config.yaml` so `upgrade` can re-render faithfully.

767 tests pass; ruff clean.

Closes #327
Part of #316