### PR TITLE
docs(PI-328): document delivery/deploy/iac flags in README + consistency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ After the **git install** (`install.sh`), a `/project-init` slash command is ava
 /project-init
 ```
 
-This runs the interactive wizard in the current project directory. It asks for project name, language, memory stack, and MCPs — then scaffolds `.claude/` for you.
+This runs the interactive wizard in the current project directory. It asks for project name, language, delivery model, memory stack, and MCPs — then scaffolds `.claude/` for you.
 
 ### Option 2: From a shell (non-interactive, for CI / scripts)
 
@@ -116,6 +116,9 @@ The wizard asks (interactive mode only):
 
 - Project name / description
 - Language (Python/Node/Go/none) — drives `lint_command`, `format_command`, `test_command`
+- Delivery model (`--delivery library|service|prototype`) — how the project ships, driving its env/CI/release bundle (ADR-015). `service` adds the container **parity bundle** (Dockerfile + `compose.yaml` + devcontainer + `just up`/`build`) and unlocks the deploy overlay; `library` adds a tag-triggered release workflow (publish **disabled** until you wire the registry); `prototype` (default) adds nothing env-specific. `service` requires a language.
+- Deploy overlay (`--deploy none|cloud-run|fly|k8s|registry|custom`) — opt-in, **service only**. Container targets scaffold a build-once-**by-digest** `deploy.yml` (GitHub Environments: staging auto-deploys, production is **gated**) + a declarative `deploy/environments.yaml`, plus `setup_env_protection.sh` (server-side prod gate, tiered by profile) and `whats_deployed.sh`. `none` (default) = your platform (Vercel/Render/Fly/…) owns deploy.
+- Infrastructure-as-Code (`--iac none|opentofu`) — opt-in OpenTofu/HCL skeleton under `infra/` + a plan-on-PR workflow (apply is **manual / environment-gated**, never apply-on-merge). Emits structure only — no resources or credentials.
 - Memory stack — Obsidian-only or Obsidian + Graphify (recommended for code-heavy projects)
 - Core MCPs (Context7)
 - Database MCP — none / Postgres / SQLite

--- a/tests/integration/test_readme_examples.py
+++ b/tests/integration/test_readme_examples.py
@@ -83,8 +83,6 @@ def test_readme_layout_has_no_phantom_examples_dir():
 def test_readme_documents_env_model_flags():
     """PI-328 (epic #316): README must document the delivery/deploy/iac flags so
     the user-facing docs don't drift from the wizard surface."""
-    from pathlib import Path
-
-    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text()
+    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
     for flag in ("--delivery", "--deploy", "--iac"):
         assert flag in readme, f"README.md missing {flag}"

--- a/tests/integration/test_readme_examples.py
+++ b/tests/integration/test_readme_examples.py
@@ -78,3 +78,13 @@ def test_readme_layout_has_no_phantom_examples_dir():
     readme = (repo / "README.md").read_text(encoding="utf-8")
     if "examples/" in readme:
         assert (repo / "examples").is_dir(), "README references examples/ but it doesn't exist"
+
+
+def test_readme_documents_env_model_flags():
+    """PI-328 (epic #316): README must document the delivery/deploy/iac flags so
+    the user-facing docs don't drift from the wizard surface."""
+    from pathlib import Path
+
+    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text()
+    for flag in ("--delivery", "--deploy", "--iac"):
+        assert flag in readme, f"README.md missing {flag}"


### PR DESCRIPTION
Final consistency sweep for epic #316.

- **README** — the wizard-flags list documented every flag *except* the three new ones. Added `--delivery`, `--deploy`, `--iac` (with the parity-bundle / deploy-overlay / IaC behavior), and updated the intro line.
- **Consistency test** — `test_readme_documents_env_model_flags` asserts README mentions all three, so docs can't drift from the wizard surface.
- **Already aligned (verified):** `copilot-instructions.md` (single-trunk; environments = deploy-time concern) and the github_workflow skill across all copies (synced; the production-boundary section from #321); the operator `project-init.md` (single-trunk note). `sync_plugin` reports no drift.

769 tests pass; ruff clean.

Closes #328
Part of #316