### PR TITLE
fix(PI-296): preserve hand-edited config.yaml on re-scaffold

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -35,6 +35,11 @@ _ANY_PLACEHOLDER_RE = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
 _PRESERVE_DIRS = {"memory", "vault"}
 # Except READMEs — those are always refreshed.
 _ALWAYS_OVERWRITE = {"README.md"}
+# The owner-edited record file. On a re-scaffold it is preserved (not re-rendered)
+# once it carries the scaffold record, so hand-edits — preserve list, project_key,
+# declined_additions, safety.allow — survive (#296); write_scaffold_record then
+# updates the record block in place. A first scaffold (no record) renders it.
+_CONFIG_REL = Path(".claude/config.yaml")
 # Marker that write_scaffold_record (upgrade.py) appends to .claude/config.yaml
 # after a real project-init scaffold. Its PRESENCE — not the file merely
 # existing — distinguishes a re-run from a first scaffold (PI-196).
@@ -313,6 +318,11 @@ def _should_preserve(rel_path: Path, target: Path, preserve_globs: list[str] | N
         return False
     if rel_path.name in _ALWAYS_OVERWRITE:
         return False
+    # A re-scaffold must not clobber a hand-edited config.yaml that already
+    # carries a scaffold record (#296); write_scaffold_record updates the record
+    # block in place afterwards. A first scaffold (no record) still renders it.
+    if rel_path == _CONFIG_REL and _has_scaffold_record(dest):
+        return True
     if any(part in _PRESERVE_DIRS for part in rel_path.parts):
         return True
     return _matches_preserve_glob(rel_path, preserve_globs or [])

--- a/tests/integration/test_overwrite_protection.py
+++ b/tests/integration/test_overwrite_protection.py
@@ -173,6 +173,56 @@ class TestFirstScaffoldProtectsExistingFiles:
         assert not spurious, f"layer overwrites must not create siblings: {spurious}"
 
 
+class TestReScaffoldPreservesConfig:
+    """#296: re-running project-init must not clobber a hand-edited config.yaml
+    that already carries a scaffold record — the record block is updated in
+    place, every hand-edited human field survives."""
+
+    def test_hand_edits_survive_a_re_scaffold(self, tmp_path: Path):
+        target = tmp_path / "proj"
+        assert _run(target) == 0
+        config = target / ".claude" / "config.yaml"
+
+        # Hand-edit the fields the issue calls out, in the human section.
+        text = config.read_text()
+        text = text.replace('project_key: ""', 'project_key: "PI"')
+        text = text.replace("  allow: []", '  allow: ["kubectl --context dev-.*"]')
+        text = text.replace("declined_additions: {}", 'declined_additions: {"docs": "abc123"}')
+        # Uncomment the preserve example in the human section (where users edit it).
+        text = text.replace(
+            '# preserve: ["ci.yml", "justfile", "docs/*.md"]',
+            'preserve: ["ci.yml", "justfile"]',
+        )
+        config.write_text(text)
+
+        # Re-scaffold: config.yaml must be preserved, not re-rendered.
+        assert _run(target) == 0
+
+        result = config.read_text()
+        assert 'project_key: "PI"' in result
+        assert 'allow: ["kubectl --context dev-.*"]' in result
+        assert 'declined_additions: {"docs": "abc123"}' in result
+        assert 'preserve: ["ci.yml", "justfile"]' in result
+        # No .new sibling — preservation is silent, not a conflict.
+        assert not (target / ".claude" / "config.yaml.new").exists()
+        # The scaffold record is still present (updated in place by
+        # write_scaffold_record), so a later `upgrade` still works.
+        from project_init.scaffold import _RECORD_MARKER
+
+        assert _RECORD_MARKER in result
+
+    def test_first_scaffold_still_renders_config(self, tmp_path: Path):
+        """A first scaffold (no record) must render config.yaml from the
+        template — preservation only kicks in once a record exists."""
+        target = tmp_path / "proj"
+        assert _run(target) == 0
+        config = target / ".claude" / "config.yaml"
+        text = config.read_text()
+        # Template placeholders are resolved and the name we passed is present.
+        assert "{{" not in text
+        assert "owns" in text
+
+
 class TestStrictModeProtection:
     def test_strict_scaffold_protects_existing_file(self, tmp_path: Path):
         target = tmp_path / "proj"


### PR DESCRIPTION
## Summary

Re-running `project-init` on an already-scaffolded project re-rendered `.claude/config.yaml` from the template and **silently clobbered hand-edits** (`preserve:` list, `project_key`, `declined_additions`, `safety.allow`) with no `.new` sibling — contradicting the file's own *"Safe to hand-edit; re-running project-init will reconcile with this file"* promise. The `upgrade` path was unaffected; this was specific to the **re-scaffold** path.

## Fix

Treat an existing `config.yaml` that already carries a scaffold record as **preserved** on re-scaffold, via `_should_preserve` so both the strict and non-strict scaffold paths are covered. `write_scaffold_record` then updates the record block in place, so a later `upgrade` still works. A **first** scaffold (no record marker) still renders `config.yaml` from the template.

## Acceptance criteria

- [x] Re-running `project-init` preserves hand-edited `config.yaml` content (no silent clobber, no `.new` sibling).
- [x] `project_key`, `declined_additions`, `safety.allow`, and a `preserve:` list survive a re-scaffold.
- [x] First scaffold still renders `config.yaml` from the template.

## Tests

`TestReScaffoldPreservesConfig` in `tests/integration/test_overwrite_protection.py`:
- hand-edits to all four called-out fields survive a re-scaffold; record block stays present; no `.new` sibling
- first scaffold still renders from the template (placeholders resolved)

Full suite: 771 passed, ruff clean.

Closes #296