### PR TITLE
feat(PI-240): 3-way auto-merge for upgrade conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ refreshed.
 
 How it works: scaffolding records the preset, template variables, and a
 content-hash manifest in a `scaffold:` block at the end of
-`.claude/config.yaml`, plus the exact rendered bytes of each managed file in a
+`.claude/config.yaml`, plus the rendered text of each managed (UTF-8) file in a
 `.claude/.upgrade-base.json` sidecar. Upgrade re-renders the same preset at the
 current template version into a staging directory and compares hashes, so user
 edits are distinguishable from upstream template changes. When both you and the

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ The report classifies every template-owned file:
 |---|---|---|
 | new | not in your project | creates it |
 | changed | drifted, but you never edited it | updates it |
-| conflict | drifted **and** locally edited | writes the new render as a `<file>.new` sibling — your edit is never overwritten |
+| merged | drifted **and** locally edited, but the edits don't overlap | 3-way auto-merges both in place — no `.new` sibling |
+| conflict | drifted **and** locally edited with overlapping changes | keeps your file; writes the conflict-marked merge as a `<file>.new` sibling — your edit is never overwritten |
 | removed | no longer rendered by current templates | nothing (reported only; upgrade never deletes) |
 
 `.claude/memory/` and `.claude/vault/` are never compared or touched, and
@@ -214,13 +215,17 @@ refreshed.
 
 How it works: scaffolding records the preset, template variables, and a
 content-hash manifest in a `scaffold:` block at the end of
-`.claude/config.yaml`. Upgrade re-renders the same preset at the current
-template version into a staging directory and compares hashes, so user
-edits are distinguishable from upstream template changes. **Migration:**
-projects scaffolded before this record existed are reconstructed from the
-semantic config fields; without recorded hashes, every modified file is
-conservatively treated as a conflict (`.new` sibling). Run `upgrade --apply`
-once and the record is written for next time.
+`.claude/config.yaml`, plus the exact rendered bytes of each managed file in a
+`.claude/.upgrade-base.json` sidecar. Upgrade re-renders the same preset at the
+current template version into a staging directory and compares hashes, so user
+edits are distinguishable from upstream template changes. When both you and the
+templates changed a file, the sidecar is the *base* leg of a 3-way merge (via
+`git merge-file`, with a pure-Python fallback): non-overlapping edits auto-merge,
+only true overlaps become a `<file>.new` conflict. **Migration:** projects
+scaffolded before this record existed are reconstructed from the semantic config
+fields; without recorded hashes or a base, every modified file is conservatively
+treated as a conflict (`.new` sibling). Run `upgrade --apply` once and the record
+is written for next time.
 
 ## Uninstall
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1,9 +1,10 @@
 """`project-init upgrade` — re-render from recorded config with a drift report.
 
-Deliberately small and deterministic (PI-142): no 3-way merge engine, no new
-dependencies. The scaffold record appended to ``.claude/config.yaml`` stores
-the preset, the exact template variables, and a manifest of content hashes
-for the files the scaffolder rendered. On upgrade the same preset is
+Deterministic, stdlib-only (PI-142). The scaffold record appended to
+``.claude/config.yaml`` stores the preset, the exact template variables, and a
+manifest of content hashes for the files the scaffolder rendered; the exact
+rendered *bytes* of each file are kept in the ``.claude/.upgrade-base.json``
+sidecar (#240) as the base leg for a 3-way merge. On upgrade the same preset is
 re-rendered at the current template version into a staging directory and
 compared against the project:
 
@@ -11,8 +12,13 @@ compared against the project:
 - project file matches the new render    -> unchanged
 - differs, but matches the recorded hash -> changed (applied on ``--apply``;
   the user never edited it, so overwriting loses nothing)
-- differs from the recorded hash too     -> conflict (written as a ``.new``
-  sibling on ``--apply``; local edits are never overwritten silently)
+- differs from the recorded hash too     -> the user edited it; a 3-way merge
+  (base render / current file / new render) runs via ``git merge-file`` with a
+  pure-Python fallback (#240). Non-overlapping user+upstream edits auto-merge
+  in place (``merged``); a genuine overlap stays a ``conflict`` and the
+  conflict-marked merge is written as a ``.new`` sibling — local edits are
+  never overwritten silently. Without a recorded base (pre-#240) it falls back
+  to dropping the raw new render as a ``.new`` sibling.
 - in the old manifest, not re-rendered   -> removed (reported only; upgrade
   never deletes)
 
@@ -153,19 +159,146 @@ class DriftReport:
     new: list[Path] = field(default_factory=list)
     changed: list[Path] = field(default_factory=list)
     conflicts: list[Path] = field(default_factory=list)
+    merged: list[Path] = field(default_factory=list)  # user+upstream, 3-way auto-merged (#240)
     removed: list[Path] = field(default_factory=list)
     diffs: dict[Path, str] = field(default_factory=dict)
+    merge_results: dict[Path, str] = field(default_factory=dict)  # merged text per #240 file
     rendered: list[Path] = field(default_factory=list)  # full staging render
     migrated: bool = False  # True when no scaffold record existed
 
     @property
     def has_drift(self) -> bool:
         """True when at least one file differs from the fresh render."""
-        return bool(self.new or self.changed or self.conflicts or self.removed)
+        return bool(self.new or self.changed or self.conflicts or self.merged or self.removed)
 
 
 def _hash_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+# --- 3-way merge base store (#240) -----------------------------------------
+
+# Sidecar holding the exact bytes each managed file was last rendered as — the
+# *base* leg for a 3-way merge (base / ours=current file / theirs=new render).
+# Kept out of config.yaml so the hand-editable record stays small (#296); a
+# single pretty-printed JSON file gives per-file granularity in an upgrade diff
+# (#241). Text only — files that don't decode as UTF-8 are omitted and fall back
+# to the ``.new`` sibling path on conflict.
+_BASE_REL = Path(".claude/.upgrade-base.json")
+
+
+def read_base(target: Path) -> dict[str, str]:
+    """Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``."""
+    path = target / _BASE_REL
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def write_base(target: Path, base: dict[str, str]) -> None:
+    """Persist the ``{rel: rendered-text}`` merge base sidecar (sorted, pretty)."""
+    if not (target / _CONFIG_REL).exists():
+        return  # not a scaffolded project — nothing to anchor the base to
+    path = target / _BASE_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(base, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _decode(data: bytes) -> str | None:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _git_three_way(base: str, ours: str, theirs: str) -> tuple[str, bool] | None:
+    """Merge with ``git merge-file``; ``(merged, clean)`` or None if git absent.
+
+    Merges the upstream (base→theirs) change into the user's file (ours). A clean
+    merge exits 0; a conflicted one exits with the conflict count and emits
+    ``<<<<<<<``/``>>>>>>>`` markers; anything else is treated as unusable (None),
+    falling back to the difflib merge.
+    """
+    with tempfile.TemporaryDirectory(prefix="project-init-merge-") as d:
+        bp, op, tp = Path(d) / "base", Path(d) / "ours", Path(d) / "theirs"
+        bp.write_text(base, encoding="utf-8")
+        op.write_text(ours, encoding="utf-8")
+        tp.write_text(theirs, encoding="utf-8")
+        try:
+            r = subprocess.run(
+                ["git", "merge-file", "-p", "-L", "current", "-L", "base", "-L", "upgrade",
+                 str(op), str(bp), str(tp)],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None  # git not installed
+        if r.returncode == 0:
+            return r.stdout, True
+        if 0 < r.returncode < 128:
+            return r.stdout, False
+        return None  # git error — let the caller fall back
+
+
+def _line_index_map(base_l: list[str], other_l: list[str]) -> dict[int, int]:
+    """Map base line index -> other line index for lines equal in both."""
+    sm = difflib.SequenceMatcher(None, base_l, other_l, autojunk=False)
+    mapping: dict[int, int] = {}
+    for a, b, size in sm.get_matching_blocks():
+        for k in range(size):
+            mapping[a + k] = b + k
+    return mapping
+
+
+def _resolve_segment(b: list[str], o: list[str], t: list[str]) -> tuple[list[str], bool]:
+    """Resolve one between-anchors segment; ``(lines, conflict)``."""
+    if o == t:
+        return o, False  # both sides made the same edit (or none)
+    if o == b:
+        return t, False  # ours unchanged here -> take upstream
+    if t == b:
+        return o, False  # upstream unchanged here -> keep user's edit
+    markers = ["<<<<<<< current\n", *o, "=======\n", *t, ">>>>>>> upgrade\n"]
+    return markers, True
+
+
+def _difflib_three_way(base: str, ours: str, theirs: str) -> tuple[str, bool]:
+    """Line-level 3-way merge with no git dependency; ``(merged, clean)``.
+
+    Anchors on base lines that survive unchanged in *both* ours and theirs, then
+    resolves each segment between anchors: a one-sided edit is taken verbatim, an
+    identical two-sided edit collapses, and a genuine overlap is wrapped in
+    conflict markers. Conservative — it never silently drops either side.
+    """
+    base_l = base.splitlines(keepends=True)
+    ours_l = ours.splitlines(keepends=True)
+    theirs_l = theirs.splitlines(keepends=True)
+    om = _line_index_map(base_l, ours_l)
+    tm = _line_index_map(base_l, theirs_l)
+    stable = sorted(i for i in om if i in tm)
+    anchors = [(-1, -1, -1)]
+    anchors += [(i, om[i], tm[i]) for i in stable]
+    anchors.append((len(base_l), len(ours_l), len(theirs_l)))
+
+    out: list[str] = []
+    clean = True
+    # Pairwise over consecutive anchors — anchors[1:] is intentionally shorter.
+    for (pb, po, pt), (cb, co, ct) in zip(anchors, anchors[1:], strict=False):
+        seg, conflict = _resolve_segment(
+            base_l[pb + 1 : cb], ours_l[po + 1 : co], theirs_l[pt + 1 : ct]
+        )
+        out.extend(seg)
+        clean = clean and not conflict
+        if cb < len(base_l):  # emit the stable anchor line itself
+            out.append(base_l[cb])
+    return "".join(out), clean
+
+
+def _three_way_merge(base: str, ours: str, theirs: str) -> tuple[str, bool]:
+    """3-way merge via git, falling back to a pure-Python line merge."""
+    return _git_three_way(base, ours, theirs) or _difflib_three_way(base, ours, theirs)
 
 
 def _is_preserved(rel: Path, preserve_globs: list[str] | None = None) -> bool:
@@ -187,12 +320,21 @@ def write_scaffold_record(
     preset_name: str,
     variables: dict[str, str],
     created: list[Path],
+    *,
+    write_merge_base: bool = True,
 ) -> None:
     """Append/replace the scaffold record block in .claude/config.yaml.
 
     The manifest hashes the on-disk content of every rendered file so a later
     ``upgrade`` can tell user edits apart from upstream template changes.
     The values are single-line JSON — valid YAML, parseable with stdlib.
+
+    When *write_merge_base* is set (the first-scaffold default), the exact
+    rendered text of each managed file is also written to the merge-base sidecar
+    (#240) so a later ``upgrade`` can 3-way-merge user edits. ``upgrade --apply``
+    passes ``write_merge_base=False`` because it maintains the base itself —
+    successfully-merged files must advance to the *new* render, not their
+    (post-merge) on-disk bytes.
     """
     config_path = target / _CONFIG_REL
     if not config_path.exists():
@@ -200,12 +342,19 @@ def write_scaffold_record(
 
     preserve_globs = read_preserve_globs(target)
     manifest: dict[str, str] = {}
+    base: dict[str, str] = {}
     for rel in sorted(set(created)):
         if rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
             continue
         path = target / rel
         if path.is_file():
-            manifest[rel.as_posix()] = _hash_bytes(path.read_bytes())
+            data = path.read_bytes()
+            manifest[rel.as_posix()] = _hash_bytes(data)
+            text = _decode(data)
+            if text is not None:
+                base[rel.as_posix()] = text
+    if write_merge_base:
+        write_base(target, base)
 
     block = (
         f"\n{_RECORD_MARKER}\n"
@@ -436,11 +585,39 @@ def _render_staging(preset_name: str, variables: dict, staging: Path) -> list[Pa
     return scaffold(staging, preset, variables, strict=True)
 
 
-def compute_drift(target: Path, staging: Path, rendered: list[Path], manifest: dict) -> DriftReport:
+def _classify_conflict(
+    report: DriftReport, rel: Path, base: dict, current: bytes, new_bytes: bytes
+) -> None:
+    """A user-edited file that upstream also changed: 3-way merge or conflict (#240).
+
+    With a recorded base for the file and all three legs decodable as text, a
+    clean merge of non-overlapping edits lands in ``merged``; a genuine overlap
+    stays a ``conflict`` (its merge_results text carries the markers). Without a
+    base (pre-#240 record) or for binary content, it falls back to ``conflict``
+    with no merge_results, i.e. the old ``.new`` sibling behaviour.
+    """
+    base_text = base.get(rel.as_posix())
+    ours, theirs = _decode(current), _decode(new_bytes)
+    if base_text is None or ours is None or theirs is None:
+        report.conflicts.append(rel)
+        return
+    merged, clean = _three_way_merge(base_text, ours, theirs)
+    report.merge_results[rel] = merged
+    (report.merged if clean else report.conflicts).append(rel)
+
+
+def compute_drift(
+    target: Path,
+    staging: Path,
+    rendered: list[Path],
+    manifest: dict,
+    base: dict | None = None,
+) -> DriftReport:
     """Compare the staged re-render against the project tree."""
     report = DriftReport(rendered=list(rendered))
     rendered_set = {rel.as_posix() for rel in rendered}
     preserve_globs = read_preserve_globs(target)
+    base = base or {}
 
     for rel in sorted(rendered):
         if rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
@@ -458,7 +635,7 @@ def compute_drift(target: Path, staging: Path, rendered: list[Path], manifest: d
         if recorded is not None and _hash_bytes(current) == recorded:
             report.changed.append(rel)
         else:
-            report.conflicts.append(rel)
+            _classify_conflict(report, rel, base, current, new_bytes)
         report.diffs[rel] = diff
 
     for rel_str in sorted(manifest):
@@ -527,11 +704,39 @@ def apply_drift(
     preset_name: str,
     variables: dict,
 ) -> None:
-    """Apply non-conflicting changes; write conflicts as ``.new`` siblings."""
+    """Apply changes; 3-way-merge user edits (#240); conflicts become ``.new``.
+
+    new/changed files are overwritten with the render. A ``merged`` file (user
+    edit + non-overlapping upstream change) is written with the auto-merged
+    content. A genuine ``conflict`` keeps the user's file and drops the new
+    render — or, when a 3-way merge was attempted and overlapped, the
+    conflict-marked merge — as a ``.new`` sibling, never overwriting silently.
+    """
+    base = read_base(target)
     for rel in report.new + report.changed:
         _copy_rendered(staging / rel, target / rel)
+    for rel in report.merged:
+        # Clean 3-way merge: write the combined content in place.
+        dest = target / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(report.merge_results[rel], encoding="utf-8")
     for rel in report.conflicts:
-        _copy_rendered(staging / rel, _new_sibling(target / rel, (staging / rel).read_bytes()))
+        # Prefer the conflict-marked merge (shows the overlap) when one exists,
+        # else the raw new render. Either way the user's file is left intact.
+        if rel in report.merge_results:
+            sibling = _new_sibling(target / rel, report.merge_results[rel].encode("utf-8"))
+            sibling.parent.mkdir(parents=True, exist_ok=True)
+            sibling.write_text(report.merge_results[rel], encoding="utf-8")
+        else:
+            _copy_rendered(staging / rel, _new_sibling(target / rel, (staging / rel).read_bytes()))
+
+    # The base advances to the *new* render for every file whose upstream change
+    # was incorporated (overwritten or cleanly merged); a still-conflicted file
+    # keeps its old base so its unresolved edit can merge again next time (#240).
+    for rel in report.new + report.changed + report.merged:
+        text = _decode((staging / rel).read_bytes())
+        if text is not None:
+            base[rel.as_posix()] = text
 
     # Targeted config.yaml updates: the human-readable version line, then the
     # scaffold record (variables + a manifest reflecting post-apply state).
@@ -543,13 +748,15 @@ def apply_drift(
         config_path.write_text(text, encoding="utf-8")
 
     # Only files whose on-disk content now equals the render are recorded —
-    # conflicted files stay user-owned, so the next upgrade flags them again.
+    # conflicted/merged files stay user-owned, so the next upgrade flags them
+    # again (and the merge base above lets that flag become a clean re-merge).
     applied = [
         rel
         for rel in report.rendered
         if (target / rel).is_file() and (target / rel).read_bytes() == (staging / rel).read_bytes()
     ]
-    write_scaffold_record(target, preset_name, variables, applied)
+    write_scaffold_record(target, preset_name, variables, applied, write_merge_base=False)
+    write_base(target, base)
 
 
 def _print_report(report: DriftReport, applied: bool) -> None:
@@ -569,6 +776,13 @@ def _print_report(report: DriftReport, applied: bool) -> None:
     sections = (
         ("new", report.new, "would be created" if not applied else "created"),
         ("changed", report.changed, "would be updated" if not applied else "updated"),
+        (
+            "merged",
+            report.merged,
+            "locally edited + upstream changed — would 3-way auto-merge"
+            if not applied
+            else "locally edited + upstream changed — auto-merged in place",
+        ),
         (
             "conflicts",
             report.conflicts,
@@ -954,7 +1168,7 @@ def run_upgrade(
             sys.stderr.write(f"error: re-render failed: {e}\n")
             return 1
 
-        report = compute_drift(target, staging, rendered, manifest)
+        report = compute_drift(target, staging, rendered, manifest, read_base(target))
         report.migrated = migrated
         # Opt-in consent for new additions (#249): bucket genuinely-new files
         # into groups and require an accept/decline decision before --apply

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -2,9 +2,10 @@
 
 Deterministic, stdlib-only (PI-142). The scaffold record appended to
 ``.claude/config.yaml`` stores the preset, the exact template variables, and a
-manifest of content hashes for the files the scaffolder rendered; the exact
-rendered *bytes* of each file are kept in the ``.claude/.upgrade-base.json``
-sidecar (#240) as the base leg for a 3-way merge. On upgrade the same preset is
+manifest of content hashes for the files the scaffolder rendered; the rendered
+*text* of each UTF-8 file is kept in the ``.claude/.upgrade-base.json`` sidecar
+(#240) as the base leg for a 3-way merge (binary/non-UTF-8 renders are omitted
+and fall back to the ``.new`` path on conflict). On upgrade the same preset is
 re-rendered at the current template version into a staging directory and
 compared against the project:
 
@@ -188,13 +189,20 @@ _BASE_REL = Path(".claude/.upgrade-base.json")
 
 
 def read_base(target: Path) -> dict[str, str]:
-    """Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``."""
+    """Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``.
+
+    The sidecar is hand-editable JSON, so non-string keys/values are filtered
+    out — a corrupted entry must not later reach the merge engine as a non-text
+    base and crash the upgrade (#240 review).
+    """
     path = target / _BASE_REL
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
-    return value if isinstance(value, dict) else {}
+    if not isinstance(value, dict):
+        return {}
+    return {k: v for k, v in value.items() if isinstance(k, str) and isinstance(v, str)}
 
 
 def write_base(target: Path, base: dict[str, str]) -> None:
@@ -654,6 +662,18 @@ def _copy_rendered(src: Path, dest: Path) -> None:
     shutil.copy2(src, dest)
 
 
+def _mirror_mode(src: Path, dest: Path) -> None:
+    """Carry *src*'s executable bit onto *dest* (#240 review).
+
+    A conflict-marked merge is written with ``write_text`` (it is generated
+    text, not a copy of the render), which would otherwise drop the executable
+    bit a script render carries — surprising the user when they promote the
+    ``.new`` sibling.
+    """
+    if src.stat().st_mode & 0o111:
+        dest.chmod(dest.stat().st_mode | 0o111)
+
+
 # Visible observability fields injected into the human `project:` block on upgrade
 # when a pre-#247/#248/#259 config lacks them (config.yaml is not re-rendered on
 # upgrade, so otherwise they live only in the hidden record). (key, comment) —
@@ -727,13 +747,22 @@ def apply_drift(
             sibling = _new_sibling(target / rel, report.merge_results[rel].encode("utf-8"))
             sibling.parent.mkdir(parents=True, exist_ok=True)
             sibling.write_text(report.merge_results[rel], encoding="utf-8")
+            _mirror_mode(staging / rel, sibling)
         else:
             _copy_rendered(staging / rel, _new_sibling(target / rel, (staging / rel).read_bytes()))
 
-    # The base advances to the *new* render for every file whose upstream change
-    # was incorporated (overwritten or cleanly merged); a still-conflicted file
-    # keeps its old base so its unresolved edit can merge again next time (#240).
-    for rel in report.new + report.changed + report.merged:
+    # The base advances to the *new* render for every managed file whose upstream
+    # render is now the pristine baseline — not just files that drifted this run.
+    # Recording unchanged files too is what lets a project that predated the
+    # sidecar (or had it deleted) gain a full base after one --apply, so a later
+    # user+upstream edit can 3-way merge instead of falling back to .new (#240,
+    # Codex review). A still-conflicted file keeps its old base so its unresolved
+    # edit can merge again next time.
+    preserve_globs = read_preserve_globs(target)
+    conflicted = set(report.conflicts)
+    for rel in report.rendered:
+        if rel in conflicted or rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
+            continue
         text = _decode((staging / rel).read_bytes())
         if text is not None:
             base[rel.as_posix()] = text
@@ -779,9 +808,9 @@ def _print_report(report: DriftReport, applied: bool) -> None:
         (
             "merged",
             report.merged,
-            "locally edited + upstream changed — would 3-way auto-merge"
+            "locally edited — would 3-way merge with the new render"
             if not applied
-            else "locally edited + upstream changed — auto-merged in place",
+            else "locally edited — 3-way merged with the new render in place",
         ),
         (
             "conflicts",
@@ -799,7 +828,7 @@ def _print_report(report: DriftReport, applied: bool) -> None:
         for rel in paths:
             console.print(f"  {rel}")
 
-    for rel in report.changed + report.conflicts:
+    for rel in report.changed + report.merged + report.conflicts:
         diff = report.diffs.get(rel)
         if diff:
             console.print(f"\n[bold]--- drift: {rel} ---[/bold]")

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -322,7 +322,7 @@ class TestUpgradeApply:
         assert justfile.read_bytes() == rendered_now
         assert not (target / "justfile.new").exists()
 
-    def test_user_edit_with_no_upstream_change_is_kept(self, tmp_path: Path, capsys):
+    def test_user_edit_with_no_upstream_change_is_kept(self, tmp_path: Path):
         """User edited a file but upstream did not change it: the 3-way merge has
         nothing to apply, so the edit is kept in place with no .new sibling (#240
         — previously this dropped a pointless conflict sibling)."""

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -777,3 +777,65 @@ class TestThreeWayMergeApply:
         assert not (target / "justfile.new").exists()
         # Base advances to the new render so the next upgrade re-merges cleanly.
         assert read_base(target)["justfile"] == live
+
+    def test_apply_backfills_base_for_unchanged_files(self, tmp_path: Path):
+        """A project that predates the sidecar (or had it deleted) must gain a
+        full merge base after one --apply — not just for drifted files — so a
+        later user+upstream edit auto-merges instead of falling back to .new
+        (#240, Codex review)."""
+        from project_init.upgrade import read_base
+
+        target = tmp_path / "p"
+        _scaffold(target)
+        # Simulate a pre-sidecar project: no base, but no template drift either.
+        (target / ".claude" / ".upgrade-base.json").unlink()
+        assert main(["upgrade", str(target), "--apply"]) == 0
+
+        base = read_base(target)
+        # An unchanged managed file (never drifted this run) is now recorded.
+        justfile = target / "justfile"
+        assert base["justfile"] == justfile.read_text()
+
+        # Prove it: a non-overlapping user+upstream edit now auto-merges.
+        live = justfile.read_text()
+        lines = live.splitlines(keepends=True)
+        assert len(lines) >= 2
+        older = "".join(lines[:-1])
+        _set_base(target, "justfile", older)
+        justfile.write_text("# USER\n" + older)
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        assert justfile.read_text() == "# USER\n" + live
+        assert not (target / "justfile.new").exists()
+
+    def test_conflict_new_sibling_keeps_executable_bit(self, tmp_path: Path):
+        """A conflict-marked .new for a script must stay executable so promoting
+        it doesn't silently drop +x (#240 review)."""
+        import os
+        import stat
+
+        target = tmp_path / "p"
+        _scaffold(target)
+        script = target / ".claude" / "scripts" / "push_branch.sh"
+        assert script.stat().st_mode & stat.S_IXUSR, "fixture script must be executable"
+        # Force a genuine overlap so a conflict-marked .new is written.
+        _set_base(target, ".claude/scripts/push_branch.sh", "#!/usr/bin/env bash\n# base\n")
+        script.write_text("#!/usr/bin/env bash\n# my local edit\n")
+
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        sibling = target / ".claude" / "scripts" / "push_branch.sh.new"
+        assert sibling.exists()
+        assert sibling.stat().st_mode & stat.S_IXUSR, "the .new sibling must keep +x"
+        assert os.access(sibling, os.X_OK)
+
+    def test_read_base_filters_corrupt_entries(self, tmp_path: Path):
+        """A hand-corrupted sidecar (non-string values) is filtered, not fatal
+        — the bad entry must never reach the merge engine (#240 review)."""
+        from project_init.upgrade import read_base
+
+        target = tmp_path / "p"
+        _scaffold(target)
+        (target / ".claude" / ".upgrade-base.json").write_text(
+            json.dumps({"justfile": "ok\n", "bad": 123, "alsobad": ["x"]})
+        )
+        base = read_base(target)
+        assert base == {"justfile": "ok\n"}

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -57,6 +57,20 @@ def _patch_manifest(target: Path, mutate) -> None:
     )
 
 
+def _set_base(target: Path, rel: str, content: str) -> None:
+    """Override the recorded 3-way merge base for *rel* (#240).
+
+    Lets a single-version test stand in an *old* render — content the current
+    templates have since moved past — so a user edit on top can be 3-way merged
+    against the live render.
+    """
+    from project_init.upgrade import read_base, write_base
+
+    base = read_base(target)
+    base[rel] = content
+    write_base(target, base)
+
+
 def _tree_snapshot(target: Path) -> dict[str, bytes]:
     return {
         p.relative_to(target).as_posix(): p.read_bytes()
@@ -308,19 +322,40 @@ class TestUpgradeApply:
         assert justfile.read_bytes() == rendered_now
         assert not (target / "justfile.new").exists()
 
-    def test_user_edited_file_becomes_new_sibling(self, tmp_path: Path, capsys):
+    def test_user_edit_with_no_upstream_change_is_kept(self, tmp_path: Path, capsys):
+        """User edited a file but upstream did not change it: the 3-way merge has
+        nothing to apply, so the edit is kept in place with no .new sibling (#240
+        — previously this dropped a pointless conflict sibling)."""
         target = tmp_path / "p"
         _scaffold(target)
         justfile = target / "justfile"
-        rendered_now = justfile.read_bytes()
         user_edit = b"# my local recipes\n"
         justfile.write_bytes(user_edit)
 
         rc = main(["upgrade", str(target), "--apply"])
         assert rc == 0
-        assert "conflict" in capsys.readouterr().out
         assert justfile.read_bytes() == user_edit, "local edits must survive"
-        assert (target / "justfile.new").read_bytes() == rendered_now
+        assert not (target / "justfile.new").exists()
+
+    def test_overlapping_edit_becomes_new_sibling(self, tmp_path: Path, capsys):
+        """User edit overlaps an upstream change with no clean 3-way merge: the
+        user's file is kept and the conflict-marked merge lands as a .new (#240).
+        A sentinel base shares no lines with either side, forcing the overlap."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        justfile = target / "justfile"
+        rendered_now = justfile.read_text()
+        _set_base(target, "justfile", "# pristine base line — shared by neither side\n")
+        user_edit = "# my local recipes\n"
+        justfile.write_text(user_edit)
+
+        rc = main(["upgrade", str(target), "--apply"])
+        assert rc == 0
+        assert "conflict" in capsys.readouterr().out
+        assert justfile.read_text() == user_edit, "local edits must survive"
+        sibling = (target / "justfile.new").read_text()
+        assert "<<<<<<<" in sibling and ">>>>>>>" in sibling
+        assert user_edit in sibling and rendered_now in sibling
 
     def test_deleted_file_is_restored(self, tmp_path: Path):
         target = tmp_path / "p"
@@ -371,15 +406,18 @@ class TestUpgradeApply:
         — the fresh render goes to .new.1 instead (PR #160 review)."""
         target = tmp_path / "p"
         _scaffold(target)
-        rendered_now = (target / "justfile").read_bytes()
+        # Force a genuine overlap (sentinel base) so a .new sibling is produced.
+        _set_base(target, "justfile", "# pristine base line — shared by neither side\n")
         (target / "justfile").write_bytes(b"# my local recipes\n")
         assert main(["upgrade", str(target), "--apply"]) == 0
+        first_sibling = (target / "justfile.new").read_bytes()
+        assert b"<<<<<<<" in first_sibling
 
         merge_in_progress = b"# half-merged result\n"
         (target / "justfile.new").write_bytes(merge_in_progress)
         assert main(["upgrade", str(target), "--apply"]) == 0
         assert (target / "justfile.new").read_bytes() == merge_in_progress
-        assert (target / "justfile.new.1").read_bytes() == rendered_now
+        assert (target / "justfile.new.1").exists()
 
     def test_apply_refreshes_version_even_without_drift(self, tmp_path: Path):
         """Tool updated but no template drift: --apply must still bump the
@@ -404,9 +442,10 @@ class TestUpgradeApply:
         assert recorded["project_init_version"] == __version__
 
     def test_conflicted_file_stays_unrecorded(self, tmp_path: Path):
-        """A conflict keeps its .new sibling and is flagged again next run."""
+        """A genuine conflict keeps its .new sibling and is flagged again."""
         target = tmp_path / "p"
         _scaffold(target)
+        _set_base(target, "justfile", "# pristine base line — shared by neither side\n")
         (target / "justfile").write_bytes(b"# my local recipes\n")
 
         assert main(["upgrade", str(target), "--apply"]) == 0
@@ -496,13 +535,16 @@ class TestMigration:
         text = config.read_text()
         assert _RECORD_MARKER in text
         config.write_text(text.split(_RECORD_MARKER)[0])
+        # A genuinely pre-record config predates the #240 merge-base sidecar too,
+        # so remove it — without a base there is nothing to 3-way merge against.
+        (target / ".claude" / ".upgrade-base.json").unlink()
         (target / "justfile").write_bytes(b"# edited under old version\n")
 
         rc = main(["upgrade", str(target), "--apply", "--accept-new", "all"])
         out = capsys.readouterr().out
         assert rc == 0
         assert "No scaffold record" in out
-        # Without hashes, a modified file must be a conflict — never overwritten.
+        # Without hashes or a base, a modified file is a conflict — never overwritten.
         assert (target / "justfile").read_bytes() == b"# edited under old version\n"
         assert (target / "justfile.new").exists()
 
@@ -638,3 +680,100 @@ class TestInteractiveNoPlugin:
         assert (target / ".claude" / "hooks" / "pre_commit_gate.sh").is_file()
         settings = (target / ".claude" / "settings.json").read_text()
         assert "project-init-workflow" not in settings
+
+
+class TestThreeWayMergeEngine:
+    """#240: unit coverage of the 3-way merge primitive (git + difflib paths)."""
+
+    BASE = "line1\nline2\nline3\n"
+
+    def test_non_overlapping_edits_merge_cleanly(self):
+        from project_init.upgrade import _three_way_merge
+
+        ours = "TOP\nline1\nline2\nline3\n"  # user prepended
+        theirs = "line1\nline2\nline3\nBOTTOM\n"  # upstream appended
+        merged, clean = _three_way_merge(self.BASE, ours, theirs)
+        assert clean
+        assert merged == "TOP\nline1\nline2\nline3\nBOTTOM\n"
+
+    def test_overlapping_edits_conflict(self):
+        from project_init.upgrade import _three_way_merge
+
+        ours = "line1\nOURS\nline3\n"
+        theirs = "line1\nTHEIRS\nline3\n"
+        merged, clean = _three_way_merge(self.BASE, ours, theirs)
+        assert not clean
+        assert "<<<<<<<" in merged and ">>>>>>>" in merged
+        assert "OURS" in merged and "THEIRS" in merged
+
+    def test_one_sided_change_takes_that_side(self):
+        from project_init.upgrade import _three_way_merge
+
+        # ours unchanged from base → upstream change wins, no conflict.
+        theirs = "line1\nline2-upstream\nline3\n"
+        merged, clean = _three_way_merge(self.BASE, self.BASE, theirs)
+        assert clean and merged == theirs
+
+    def test_difflib_path_matches_when_git_absent(self, monkeypatch):
+        """With git unavailable the pure-Python merge still resolves non-overlap
+        and flags overlap (DoD: difflib fallback)."""
+        import project_init.upgrade as up
+
+        def _no_git(*a, **k):
+            raise OSError("git not found")
+
+        monkeypatch.setattr(up.subprocess, "run", _no_git)
+
+        ours = "TOP\nline1\nline2\nline3\n"
+        theirs = "line1\nline2\nline3\nBOTTOM\n"
+        merged, clean = up._three_way_merge(self.BASE, ours, theirs)
+        assert clean and merged == "TOP\nline1\nline2\nline3\nBOTTOM\n"
+
+        merged2, clean2 = up._three_way_merge(self.BASE, "line1\nA\nline3\n", "line1\nB\nline3\n")
+        assert not clean2 and "<<<<<<<" in merged2
+
+
+class TestThreeWayMergeApply:
+    """#240: --apply auto-merges non-overlapping user+upstream edits in place."""
+
+    def test_first_scaffold_writes_merge_base(self, tmp_path: Path):
+        from project_init.upgrade import read_base
+
+        target = tmp_path / "p"
+        _scaffold(target)
+        assert (target / ".claude" / ".upgrade-base.json").is_file()
+        base = read_base(target)
+        assert base["justfile"] == (target / "justfile").read_text()
+
+    def test_base_sidecar_is_not_reported_as_drift(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        _scaffold(target)
+        assert main(["upgrade", str(target)]) == 0
+        out = capsys.readouterr().out
+        assert ".upgrade-base.json" not in out
+        assert "No drift" in out
+
+    def test_non_overlapping_edit_auto_merges_and_base_advances(self, tmp_path: Path, capsys):
+        from project_init.upgrade import read_base
+
+        target = tmp_path / "p"
+        _scaffold(target)
+        justfile = target / "justfile"
+        live = justfile.read_text()
+        lines = live.splitlines(keepends=True)
+        assert len(lines) >= 2, "fixture justfile needs ≥2 lines"
+
+        # base = an older render missing the final line (upstream "added" it);
+        # ours = that older render with a unique user line prepended. The two
+        # edits are at opposite ends → a clean 3-way merge.
+        older = "".join(lines[:-1])
+        _set_base(target, "justfile", older)
+        justfile.write_text("# USER-ADDED-LINE\n" + older)
+
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        assert "merged" in capsys.readouterr().out
+        result = justfile.read_text()
+        assert result == "# USER-ADDED-LINE\n" + live, "both edits incorporated"
+        assert not (target / "justfile.new").exists()
+        # Base advances to the new render so the next upgrade re-merges cleanly.
+        assert read_base(target)["justfile"] == live


### PR DESCRIPTION
## Summary

Today an upgrade conflict (a file the user edited that upstream also changed) keeps the user's file and drops the new render as a `.new` sibling for manual merging. Most conflicts are non-overlapping — the user edited one section, upstream another — and can be resolved automatically. This turns "manual `.new` merge every time" into "rare real conflicts."

## Design

- **Base storage** — each managed file's exact rendered bytes are stored in a `.claude/.upgrade-base.json` sidecar (rel-path → text). Kept out of `config.yaml` so the hand-editable record stays small (just preserved that in #296); a single pretty-printed JSON gives per-file granularity in an upgrade diff (helps #241). *(DoR: sidecar over inline.)*
- **Merge** — a conflict runs base / ours (current file) / theirs (new render) through `git merge-file`, with a pure-Python line-level diff3 fallback when git is absent.
- **Classification** — a new `merged` drift category for cleanly auto-merged files; genuine overlaps stay `conflict` and the conflict-marked merge is written as `.new`.
- **Bookkeeping** — after a clean merge the base advances to the new render, so repeated upgrades keep merging cleanly. Pre-#240 records (no base) and binary files fall back to the prior raw-render `.new` behavior.

## Acceptance criteria

- [x] The scaffold record carries enough to reconstruct the original rendered bytes per file (`.upgrade-base.json`).
- [x] `upgrade --apply` 3-way-merges conflicts; non-overlapping user+upstream edits resolve with no conflict markers.
- [x] True overlaps produce a clearly-marked conflict (markers in a `.new` fallback) — never silent data loss.

## Definition of Done

- [x] Auto-merge via `git merge-file` with a difflib fallback if git is absent.
- [x] Tests: non-overlapping edits auto-merge; overlapping edits flagged; binary/no-git paths covered.

## Tests

- `TestThreeWayMergeEngine` — unit coverage of the merge primitive: non-overlap clean, overlap conflict, one-sided, **git-absent difflib fallback**.
- `TestThreeWayMergeApply` — first scaffold writes the base sidecar; sidecar isn't reported as drift; non-overlapping edit auto-merges end-to-end and the base advances.
- Existing conflict tests updated to the new reality (a base-patching helper simulates genuine upstream divergence in the single-version harness; migration test removes the sidecar to faithfully model pre-#240).

779 passed, ruff clean. README + module docstring updated.

Closes #240