### PR TITLE
feat(PI-245): per-file interactive apply for upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,15 @@ After updating the tool itself, re-render any project from its recorded
 config and see what changed:
 
 ```bash
-project-init upgrade /path/to/my-project           # drift report only, touches nothing
-project-init upgrade /path/to/my-project --apply   # apply the changes
+project-init upgrade /path/to/my-project              # drift report only, touches nothing
+project-init upgrade /path/to/my-project --apply      # apply the changes
+project-init upgrade /path/to/my-project --apply -i   # decide per file: update / skip / diff
 ```
+
+With `-i`/`--interactive`, `--apply` walks each changed/merged/conflicting file
+and prompts to update it, skip it, or show its diff — skipped files stay drifted
+and are re-offered next upgrade. New-file additions still use the
+`--accept-new`/`--decline-new` group consent.
 
 The report classifies every template-owned file:
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -858,7 +858,17 @@ def _upgrade_main(argv: list[str]) -> int:
     p.add_argument(
         "--non-interactive",
         action="store_true",
-        help="Accepted for CLI symmetry — upgrade never prompts",
+        help="Accepted for CLI symmetry — upgrade never prompts unless -i is given",
+    )
+    p.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help=(
+            "With --apply, walk each changed/merged/conflicting file and choose "
+            "update/skip/diff per file (#245). New-file additions still use "
+            "--accept-new/--decline-new."
+        ),
     )
     p.add_argument(
         "--accept-new",
@@ -907,6 +917,7 @@ def _upgrade_main(argv: list[str]) -> int:
         no_plugin=args.no_plugin,
         accept_new=args.accept_new,
         decline_new=args.decline_new,
+        interactive=args.interactive,
     )
     if args.apply and rc == 0:
         _print_undo_hint(git_status, target)

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -161,6 +161,7 @@ class DriftReport:
     changed: list[Path] = field(default_factory=list)
     conflicts: list[Path] = field(default_factory=list)
     merged: list[Path] = field(default_factory=list)  # user+upstream, 3-way auto-merged (#240)
+    skipped: list[Path] = field(default_factory=list)  # left drifted by interactive apply (#245)
     removed: list[Path] = field(default_factory=list)
     diffs: dict[Path, str] = field(default_factory=dict)
     merge_results: dict[Path, str] = field(default_factory=dict)  # merged text per #240 file
@@ -786,6 +787,24 @@ def apply_drift(
     write_base(target, base)
 
 
+def _print_clean_or_all_skipped(console, report: DriftReport) -> None:
+    """Report the no-drift case, distinguishing two outcomes.
+
+    A truly clean tree prints "No drift"; an interactive run that skipped every
+    drifted file leaves the project drifted (#245 review), so it must say so
+    rather than claim "No drift" when there still is.
+    """
+    if report.skipped:
+        console.print(
+            f"[yellow]Skipped all {len(report.skipped)} drifted file(s)[/yellow] — "
+            "left as-is; re-offered on the next upgrade:"
+        )
+        for rel in report.skipped:
+            console.print(f"  {rel}")
+        return
+    console.print("[green]No drift — project matches the current templates.[/green]")
+
+
 def _print_report(report: DriftReport, applied: bool) -> None:
     from rich.console import Console
 
@@ -797,7 +816,7 @@ def _print_report(report: DriftReport, applied: bool) -> None:
             " hashes every modified file is treated as a conflict.[/yellow]"
         )
     if not report.has_drift:
-        console.print("[green]No drift — project matches the current templates.[/green]")
+        _print_clean_or_all_skipped(console, report)
         return
 
     sections = (
@@ -817,6 +836,7 @@ def _print_report(report: DriftReport, applied: bool) -> None:
             if not applied
             else "locally edited — rendered as .new siblings",
         ),
+        ("skipped", report.skipped, "left drifted by interactive choice — re-offered next upgrade"),
         ("removed", report.removed, "no longer rendered (left in place)"),
     )
     for label, paths, note in sections:
@@ -1182,6 +1202,7 @@ def _interactive_select(report: DriftReport) -> None:
             else:
                 console.print(f"    [dim]skipped {rel}[/dim]")
                 report.merge_results.pop(rel, None)
+                report.skipped.append(rel)
         paths[:] = kept
 
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -162,6 +162,10 @@ class DriftReport:
     conflicts: list[Path] = field(default_factory=list)
     merged: list[Path] = field(default_factory=list)  # user+upstream, 3-way auto-merged (#240)
     skipped: list[Path] = field(default_factory=list)  # left drifted by interactive apply (#245)
+    # Skipped 'changed' files (unedited old render): their recorded hash must be
+    # carried into the new manifest so they stay a clean 'changed' next upgrade,
+    # not a dropped-record conflict (#245, Codex review).
+    skipped_unedited: list[Path] = field(default_factory=list)
     removed: list[Path] = field(default_factory=list)
     diffs: dict[Path, str] = field(default_factory=dict)
     merge_results: dict[Path, str] = field(default_factory=dict)  # merged text per #240 file
@@ -769,7 +773,11 @@ def apply_drift(
         for rel in report.rendered
         if (target / rel).is_file() and (target / rel).read_bytes() == (staging / rel).read_bytes()
     ]
-    write_scaffold_record(target, preset_name, variables, applied, write_merge_base=False)
+    # Carry the recorded hash of skipped-but-unedited files forward: they still
+    # hold their old render, so re-hashing the on-disk bytes preserves the entry
+    # and keeps them a clean 'changed' (not a dropped-record conflict) next time.
+    manifest_files = applied + [rel for rel in report.skipped_unedited if (target / rel).is_file()]
+    write_scaffold_record(target, preset_name, variables, manifest_files, write_merge_base=False)
 
     # The base advances to the new render for files now matching it (applied or
     # already unchanged) plus cleanly merged ones — making the new render the
@@ -1203,6 +1211,11 @@ def _interactive_select(report: DriftReport) -> None:
                 console.print(f"    [dim]skipped {rel}[/dim]")
                 report.merge_results.pop(rel, None)
                 report.skipped.append(rel)
+                # A skipped 'changed' file is unedited and stays at its recorded
+                # render, so its manifest entry must survive (#245, Codex review);
+                # merged/conflict skips are user-edited and stay unrecorded.
+                if label == "changed":
+                    report.skipped_unedited.append(rel)
         paths[:] = kept
 
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -751,22 +751,6 @@ def apply_drift(
         else:
             _copy_rendered(staging / rel, _new_sibling(target / rel, (staging / rel).read_bytes()))
 
-    # The base advances to the *new* render for every managed file whose upstream
-    # render is now the pristine baseline — not just files that drifted this run.
-    # Recording unchanged files too is what lets a project that predated the
-    # sidecar (or had it deleted) gain a full base after one --apply, so a later
-    # user+upstream edit can 3-way merge instead of falling back to .new (#240,
-    # Codex review). A still-conflicted file keeps its old base so its unresolved
-    # edit can merge again next time.
-    preserve_globs = read_preserve_globs(target)
-    conflicted = set(report.conflicts)
-    for rel in report.rendered:
-        if rel in conflicted or rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
-            continue
-        text = _decode((staging / rel).read_bytes())
-        if text is not None:
-            base[rel.as_posix()] = text
-
     # Targeted config.yaml updates: the human-readable version line, then the
     # scaffold record (variables + a manifest reflecting post-apply state).
     config_path = target / _CONFIG_REL
@@ -778,13 +762,27 @@ def apply_drift(
 
     # Only files whose on-disk content now equals the render are recorded —
     # conflicted/merged files stay user-owned, so the next upgrade flags them
-    # again (and the merge base above lets that flag become a clean re-merge).
+    # again (and the merge base below lets that flag become a clean re-merge).
     applied = [
         rel
         for rel in report.rendered
         if (target / rel).is_file() and (target / rel).read_bytes() == (staging / rel).read_bytes()
     ]
     write_scaffold_record(target, preset_name, variables, applied, write_merge_base=False)
+
+    # The base advances to the new render for files now matching it (applied or
+    # already unchanged) plus cleanly merged ones — making the new render the
+    # pristine baseline. This both backfills unchanged files for a project that
+    # predated the sidecar (#240, Codex review) and is correct when interactive
+    # apply (#245) skipped some drifted files: a skipped file is neither in
+    # ``applied`` nor ``merged``, so it keeps its old base and is re-offered.
+    preserve_globs = read_preserve_globs(target)
+    for rel in [*applied, *report.merged]:
+        if rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
+            continue
+        text = _decode((staging / rel).read_bytes())
+        if text is not None:
+            base[rel.as_posix()] = text
     write_base(target, base)
 
 
@@ -1139,19 +1137,84 @@ def _print_undo_hint(status: str | None, target: Path) -> None:
         )
 
 
-def run_upgrade(
+# --- Per-file interactive apply (#245) -------------------------------------
+
+# Drift categories the interactive walk covers — new files keep the separate
+# addition-consent gate (#249), so they are deliberately not prompted here.
+_INTERACTIVE_LABELS = (
+    ("changed", "update with the new render"),
+    ("merged", "apply the 3-way auto-merge"),
+    ("conflicts", "write the .new conflict sibling"),
+)
+
+
+def _interactive_select(report: DriftReport) -> None:
+    """Walk each changed/merged/conflicting file, keeping only chosen ones (#245).
+
+    Mutates *report* in place: a skipped file is removed from its category (and
+    from ``merge_results``) so :func:`apply_drift` never touches it — it stays
+    drifted and is re-offered next upgrade. ``new``/``removed`` are untouched.
+    Per file the user picks [u]pdate / [s]kip / [d]iff (diff re-prompts).
+    """
+    from rich.console import Console
+    from rich.prompt import Prompt
+
+    console = Console()
+    console.print(
+        "\n[bold]Interactive apply[/bold] (#245) — per file: "
+        "[bold]u[/bold]pdate · [bold]s[/bold]kip · [bold]d[/bold]iff"
+    )
+    for label, action in _INTERACTIVE_LABELS:
+        paths = getattr(report, label)
+        kept: list[Path] = []
+        for rel in paths:
+            choice = "d"
+            while choice == "d":
+                choice = Prompt.ask(
+                    f"  [cyan]{label}[/cyan] {rel} — {action}?",
+                    choices=["u", "s", "d"],
+                    default="u",
+                )
+                if choice == "d":
+                    _show_interactive_diff(console, report, rel)
+            if choice == "u":
+                kept.append(rel)
+            else:
+                console.print(f"    [dim]skipped {rel}[/dim]")
+                report.merge_results.pop(rel, None)
+        paths[:] = kept
+
+
+def _show_interactive_diff(console, report: DriftReport, rel: Path) -> None:
+    """Print the drift (and any merge result) for one file during the walk."""
+    diff = report.diffs.get(rel)
+    if diff:
+        console.print(diff, markup=False, highlight=False)
+    merged = report.merge_results.get(rel)
+    if merged is not None:
+        console.print(f"\n[dim]--- 3-way merge result for {rel} ---[/dim]")
+        console.print(merged, markup=False, highlight=False)
+    if not diff and merged is None:
+        console.print("    [dim](no textual diff available)[/dim]")
+
+
+def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     target: Path,
     *,
     apply: bool,
     no_plugin: bool = False,
     accept_new: list[str] | None = None,
     decline_new: list[str] | None = None,
+    interactive: bool = False,
 ) -> int:
     """Entry point for the upgrade subcommand; returns a process exit code.
 
     *no_plugin* switches the project to the fallback mode on this run:
     the re-render carries copied hooks/skills and local settings wiring,
     surfacing as new/changed files in the report.
+
+    *interactive* (with *apply*) walks each changed/merged/conflicting file and
+    lets the user update or skip it (#245); skipped files are left drifted.
 
     The clean-tree guard and post-apply undo hint (#242) live in the CLI layer
     (_upgrade_main), not here, so programmatic callers manage their own safety.
@@ -1214,6 +1277,11 @@ def run_upgrade(
         if apply:
             suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
             report.new = [rel for rel in report.new if rel not in suppressed]
+            # Per-file interactive walk (#245): drop the files the user skips so
+            # apply_drift only touches the chosen ones. New-file additions keep
+            # the group-level consent gate above, so they are not re-prompted.
+            if interactive and (report.changed or report.merged or report.conflicts):
+                _interactive_select(report)
             apply_drift(target, staging, report, preset_name, variables)
             _write_declined(target, gate["declined_map"])
         _print_report(report, applied=apply)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -902,6 +902,20 @@ class TestInteractiveApply:
         assert main(["upgrade", str(target), "--apply"]) == 0
         assert (target / "justfile").read_bytes() == rendered
 
+    def test_skip_all_reports_left_drifted_not_no_drift(self, tmp_path: Path, monkeypatch, capsys):
+        """Skipping every drifted file must not print 'No drift' — the project
+        is still drifted and the skips must be surfaced (#245 review)."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        _make_changed_justfile(target)
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "s")
+
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+        out = capsys.readouterr().out
+        assert "No drift" not in out
+        assert "Skipped all" in out
+        assert "justfile" in out
+
     def test_skip_of_conflict_writes_no_sibling(self, tmp_path: Path, monkeypatch):
         target = tmp_path / "p"
         _scaffold(target)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -916,6 +916,28 @@ class TestInteractiveApply:
         assert "Skipped all" in out
         assert "justfile" in out
 
+    def test_skipped_changed_file_keeps_manifest_entry(self, tmp_path: Path, monkeypatch):
+        """Skipping a clean 'changed' file must carry its manifest hash forward,
+        so next upgrade it is still a clean update — not a dropped-record
+        conflict, even with no merge base (binary/pre-sidecar) (#245, Codex)."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        rendered = (target / "justfile").read_bytes()  # the live render
+        old = _make_changed_justfile(target)
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "s")
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+
+        # The skipped file's recorded hash survived in the manifest.
+        _, _, manifest, _ = read_scaffold_record(target)
+        assert manifest["justfile"] == hashlib.sha256(old).hexdigest()
+
+        # Drop the sidecar to mimic a binary/pre-sidecar file (no 3-way base):
+        # the carried manifest hash alone must keep it a clean 'changed'.
+        (target / ".claude" / ".upgrade-base.json").unlink()
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        assert (target / "justfile").read_bytes() == rendered, "re-offered as a clean update"
+        assert not (target / "justfile.new").exists(), "not downgraded to a conflict"
+
     def test_skip_of_conflict_writes_no_sibling(self, tmp_path: Path, monkeypatch):
         target = tmp_path / "p"
         _scaffold(target)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -839,3 +839,76 @@ class TestThreeWayMergeApply:
         )
         base = read_base(target)
         assert base == {"justfile": "ok\n"}
+
+
+def _make_changed_justfile(target: Path, old: bytes = b"# old render\n") -> bytes:
+    """Turn justfile into a `changed` file (drifted, unedited) and return *old*.
+
+    Writes *old* and patches the recorded hash to match, so upgrade sees a file
+    the templates moved past but the user never touched.
+    """
+    (target / "justfile").write_bytes(old)
+    _patch_manifest(target, lambda m: m.__setitem__("justfile", hashlib.sha256(old).hexdigest()))
+    return old
+
+
+class TestInteractiveApply:
+    """#245: `upgrade --apply -i` walks each drifted file with update/skip/diff."""
+
+    def test_skip_leaves_file_unchanged(self, tmp_path: Path, monkeypatch):
+        target = tmp_path / "p"
+        _scaffold(target)
+        old = _make_changed_justfile(target)
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "s")
+
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+        assert (target / "justfile").read_bytes() == old, "skipped file must not change"
+        assert not (target / "justfile.new").exists()
+
+    def test_update_applies_file(self, tmp_path: Path, monkeypatch):
+        target = tmp_path / "p"
+        _scaffold(target)
+        rendered = (target / "justfile").read_bytes()  # the live render
+        _make_changed_justfile(target)
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "u")
+
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+        assert (target / "justfile").read_bytes() == rendered, "chosen file is updated"
+
+    def test_diff_choice_shows_diff_then_proceeds(self, tmp_path: Path, monkeypatch, capsys):
+        target = tmp_path / "p"
+        _scaffold(target)
+        rendered = (target / "justfile").read_bytes()
+        _make_changed_justfile(target)
+        answers = iter(["d", "u"])  # show diff, then update
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: next(answers))
+
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+        out = capsys.readouterr().out
+        assert "justfile" in out  # the diff was printed
+        assert (target / "justfile").read_bytes() == rendered
+
+    def test_non_interactive_apply_does_not_prompt(self, tmp_path: Path, monkeypatch):
+        """Without -i, --apply must never call the prompt (behavior unchanged)."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        rendered = (target / "justfile").read_bytes()
+        _make_changed_justfile(target)
+
+        def _boom(*a, **k):
+            raise AssertionError("non-interactive apply must not prompt")
+
+        monkeypatch.setattr("rich.prompt.Prompt.ask", _boom)
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        assert (target / "justfile").read_bytes() == rendered
+
+    def test_skip_of_conflict_writes_no_sibling(self, tmp_path: Path, monkeypatch):
+        target = tmp_path / "p"
+        _scaffold(target)
+        _set_base(target, "justfile", "# pristine base — shared by neither side\n")
+        (target / "justfile").write_text("# my local recipes\n")
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "s")
+
+        assert main(["upgrade", str(target), "--apply", "-i"]) == 0
+        assert (target / "justfile").read_text() == "# my local recipes\n"
+        assert not (target / "justfile.new").exists(), "skipped conflict drops no .new"


### PR DESCRIPTION
## Summary

`upgrade --apply` was all-or-nothing. Add an interactive mode (`-i`/`--interactive`) that walks each changed/merged/conflicting file and lets the user choose **update / skip / diff** per file — finer control than applying everything at once.

## Design

- New `_interactive_select(report)` walks `changed`, `merged`, and `conflicts`, mutating the report so `apply_drift` only touches kept files. A skipped file is removed from its category (and `merge_results`) — it stays drifted and is re-offered next upgrade.
- **New-file additions are out of scope** — they keep the existing `--accept-new`/`--decline-new` group consent gate (#249) rather than being re-prompted per file. This matches the AC ("walks each changed/conflicting file").
- Composes with #240: the `d` choice shows both the drift diff and the 3-way merge result.
- **Bookkeeping fix:** refactored `apply_drift`'s base-advance to key off `applied + merged` (files now matching the render, plus clean merges) instead of "all rendered minus conflicts". Equivalent in non-interactive mode, but now correct when a skipped file must keep its old base and manifest entry.

## Acceptance criteria

- [x] An interactive flag walks each drifted file with update/skip/diff choices.
- [x] Non-interactive `--apply` behavior is unchanged.

## Definition of Done

- [x] Interactive apply implemented (`-i`/`--interactive`).
- [x] Test drives the prompt loop with scripted choices.

## Tests

`TestInteractiveApply` — scripted `rich.prompt.Prompt.ask`: skip leaves a file unchanged (no `.new`); update applies it; `d` prints the diff then proceeds; **non-interactive `--apply` never prompts** (asserts the prompt is not called); skipping a conflict drops no `.new`.

787 passed, ruff clean. README updated with the `-i` example.

Closes #245