### PR TITLE
feat(PI-241): upgrade-as-a-PR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ and are re-offered next upgrade. New-file additions still use the
 `--accept-new`/`--decline-new` group consent.
 
 **Upgrade as a PR.** Every scaffold ships a `.github/workflows/project-init-upgrade.yml`
-workflow (manual `workflow_dispatch`, opt into a `schedule` by uncommenting one
-line). It runs the upgrade on a fresh branch and opens a pull request with the
+workflow (manual `workflow_dispatch`, opt into a cadence by uncommenting the
+`schedule:` block). It runs the upgrade on a fresh branch and opens a pull request with the
 drift — Renovate-style, but for the scaffold — so the change never lands on your
 default branch unreviewed and `.new` conflicts show up right in the PR diff. It
 installs project-init from your recorded source URL (so forks/GHES hosts work)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ and prompts to update it, skip it, or show its diff — skipped files stay drift
 and are re-offered next upgrade. New-file additions still use the
 `--accept-new`/`--decline-new` group consent.
 
+**Upgrade as a PR.** Every scaffold ships a `.github/workflows/project-init-upgrade.yml`
+workflow (manual `workflow_dispatch`, opt into a `schedule` by uncommenting one
+line). It runs the upgrade on a fresh branch and opens a pull request with the
+drift — Renovate-style, but for the scaffold — so the change never lands on your
+default branch unreviewed and `.new` conflicts show up right in the PR diff. It
+installs project-init from your recorded source URL (so forks/GHES hosts work)
+and uses the built-in `GITHUB_TOKEN`; set an `UPGRADE_PR_TOKEN` secret if you
+want CI to run on the upgrade PR.
+
 The report classifies every template-owned file:
 
 | State | Meaning | `--apply` does |

--- a/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
+++ b/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
@@ -6,10 +6,10 @@
 # Default trigger is manual (workflow_dispatch). Uncomment the schedule to check
 # on a cadence.
 #
-# NOTE: a PR opened with the built-in GITHUB_TOKEN does not itself trigger other
-# workflows (CI won't run on the upgrade PR). To get CI on it, either close and
-# reopen the PR, or set an `UPGRADE_PR_TOKEN` secret (a PAT) — this job uses it
-# automatically when present.
+# NOTE: a PR opened with the built-in GITHUB_TOKEN won't automatically run other
+# workflows — CI on the upgrade PR is skipped (or left pending approval), not
+# started. To get CI running on it, either close and reopen the PR, or set an
+# `UPGRADE_PR_TOKEN` secret (a PAT) — this job uses it automatically when present.
 name: project-init upgrade
 
 on:

--- a/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
+++ b/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
@@ -1,0 +1,67 @@
+# Open the project-init scaffolding upgrade as a reviewable pull request instead
+# of writing drift straight into your branch (#241). Renovate-style, but for the
+# `.claude/` scaffold: run it on demand (or on a schedule) and review every
+# upgrade like a dependency bump. The job no-ops when there is no drift.
+#
+# Default trigger is manual (workflow_dispatch). Uncomment the schedule to check
+# on a cadence.
+#
+# NOTE: a PR opened with the built-in GITHUB_TOKEN does not itself trigger other
+# workflows (CI won't run on the upgrade PR). To get CI on it, either close and
+# reopen the PR, or set an `UPGRADE_PR_TOKEN` secret (a PAT) — this job uses it
+# automatically when present.
+name: project-init upgrade
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    name: Open scaffolding upgrade PR
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+
+      # Install project-init from the recorded source (host/fork-aware) and
+      # re-render the scaffold in place. The fresh checkout is a clean git tree,
+      # so the #242 clean-tree guard passes; --accept-new all adopts new
+      # additions so they appear in the PR for review.
+      - name: Run project-init upgrade
+        run: |
+          uvx --from "git+{{project_init_repo_url}}" project-init upgrade . \
+            --apply --accept-new all
+
+      - name: Open a pull request for the drift
+        env:
+          GH_TOKEN: ${{ secrets.UPGRADE_PR_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No scaffolding drift — nothing to upgrade."
+            exit 0
+          fi
+          branch="project-init-upgrade/$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add -A
+          git commit -m "chore: project-init scaffolding upgrade"
+          git push origin "$branch"
+          gh pr create \
+            --base "{{base_branch}}" \
+            --head "$branch" \
+            --title "chore: project-init scaffolding upgrade" \
+            --body "Automated \`project-init upgrade --apply\`. Review the drift below — \`.new\` siblings mark genuine conflicts (your edits are kept); everything else is a clean update or a 3-way auto-merge."

--- a/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
+++ b/templates/base/dot_github/workflows/project-init-upgrade.yml.tmpl
@@ -46,11 +46,22 @@ jobs:
 
       - name: Open a pull request for the drift
         env:
+          # github.com & *.ghe.com read GH_TOKEN; a self-hosted GHES host reads
+          # GH_ENTERPRISE_TOKEN — set both so `gh` authenticates on any host.
           GH_TOKEN: ${{ secrets.UPGRADE_PR_TOKEN || github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ secrets.UPGRADE_PR_TOKEN || github.token }}
         run: |
           set -euo pipefail
           if [ -z "$(git status --porcelain)" ]; then
             echo "No scaffolding drift — nothing to upgrade."
+            exit 0
+          fi
+          # Don't stack duplicate PRs for the same drift: if a scheduled run
+          # finds an open upgrade PR still waiting, leave it for review.
+          open_prs=$(gh pr list --state open --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("project-init-upgrade/"))] | length')
+          if [ "$open_prs" -gt 0 ]; then
+            echo "An open project-init-upgrade PR already exists — skipping."
             exit 0
           fi
           branch="project-init-upgrade/$(date -u +%Y%m%d-%H%M%S)"

--- a/tests/contracts/test_upgrade_pr_workflow.py
+++ b/tests/contracts/test_upgrade_pr_workflow.py
@@ -36,6 +36,20 @@ class TestUpgradePrWorkflow:
         # GitHub Actions expressions survive rendering (negative lookbehind on $).
         assert "${{ secrets.UPGRADE_PR_TOKEN || github.token }}" in text
 
+    def test_authenticates_on_enterprise_hosts(self, tmp_path: Path):
+        """GHES `gh` reads GH_ENTERPRISE_TOKEN, not GH_TOKEN — both are set so
+        PR creation works on any host (#241, Codex review)."""
+        text = _render(tmp_path / "p")
+        assert "GH_TOKEN:" in text
+        assert "GH_ENTERPRISE_TOKEN:" in text
+
+    def test_guards_against_duplicate_upgrade_prs(self, tmp_path: Path):
+        """A scheduled run must not stack duplicate PRs for the same drift —
+        it skips when an open upgrade PR already exists (#241, Codex review)."""
+        text = _render(tmp_path / "p")
+        assert "gh pr list --state open" in text
+        assert 'startswith("project-init-upgrade/")' in text
+
     def test_targets_the_recorded_base_branch(self, tmp_path: Path):
         text = _render(tmp_path / "p", base_branch="trunk")
         assert '--base "trunk"' in text

--- a/tests/contracts/test_upgrade_pr_workflow.py
+++ b/tests/contracts/test_upgrade_pr_workflow.py
@@ -1,0 +1,57 @@
+"""#241: the scaffolded `project-init-upgrade` workflow opens the scaffolding
+upgrade as a reviewable PR (branch + commit + PR) instead of touching the
+default branch. It must render cleanly for the project's own GitHub host."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from project_init.scaffold import load_preset, marketplace_source_vars, scaffold
+from tests.helpers import make_variables
+
+_WORKFLOW_REL = Path(".github/workflows/project-init-upgrade.yml")
+_PLACEHOLDER_RE = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
+
+
+def _render(target: Path, **overrides: str) -> str:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides))
+    return (target / _WORKFLOW_REL).read_text()
+
+
+class TestUpgradePrWorkflow:
+    def test_workflow_is_scaffolded(self, tmp_path: Path):
+        text = _render(tmp_path / "p")
+        assert _WORKFLOW_REL.name == "project-init-upgrade.yml"
+        # Fully rendered — no surviving template placeholders.
+        assert not _PLACEHOLDER_RE.search(text)
+
+    def test_opens_a_pr_not_a_direct_push(self, tmp_path: Path):
+        text = _render(tmp_path / "p")
+        # Runs the upgrade with --apply, lands it on a fresh branch, opens a PR.
+        assert "project-init upgrade . \\" in text or "project-init upgrade ." in text
+        assert "--apply" in text
+        assert "git switch -c" in text
+        assert "gh pr create" in text
+        # GitHub Actions expressions survive rendering (negative lookbehind on $).
+        assert "${{ secrets.UPGRADE_PR_TOKEN || github.token }}" in text
+
+    def test_targets_the_recorded_base_branch(self, tmp_path: Path):
+        text = _render(tmp_path / "p", base_branch="trunk")
+        assert '--base "trunk"' in text
+
+    def test_install_source_is_host_aware(self, tmp_path: Path):
+        """The upgrade installs project-init from the project's recorded fork
+        URL, so an enterprise/GHES host is honored — not hardcoded github.com."""
+        ghe = "https://github.acme-corp.ghe.com/platform/project-init.git"
+        text = _render(tmp_path / "p", **marketplace_source_vars(ghe))
+        assert "git+https://github.acme-corp.ghe.com/platform/project-init.git" in text
+        # The install source is not hardcoded to the public github.com repo.
+        assert "git+https://github.com" not in text
+
+    def test_manual_trigger_and_minimal_permissions(self, tmp_path: Path):
+        text = _render(tmp_path / "p")
+        assert "workflow_dispatch:" in text
+        # Least privilege: only what opening a PR needs.
+        assert "contents: write" in text
+        assert "pull-requests: write" in text


### PR DESCRIPTION
## Summary

Make scaffolding upgrades arrive as reviewable, revertible **pull requests** instead of in-tree changes. Every scaffold now ships a templated `.github/workflows/project-init-upgrade.yml` — a manual `workflow_dispatch` Action (uncomment one line for a `schedule`) that runs `project-init upgrade --apply` on a fresh branch and opens a PR with the drift. Renovate-style, but for the `.claude/` scaffold. The local `upgrade` path is unchanged for users who want it inline.

## Design (DoR: delivery + auth)

- **Delivery:** a templated GitHub Action (the testable, deterministic artifact — fits this repo's "templates tested by scaffolding" rule). The local `--apply`/`-i` path complements it.
- **Auth:** built-in `GITHUB_TOKEN` (least-privilege `contents` + `pull-requests: write`). A PR opened by `GITHUB_TOKEN` doesn't trigger other workflows, so the job uses an optional `UPGRADE_PR_TOKEN` PAT when present (documented in the file header) to get CI on the upgrade PR.
- **Host-aware:** installs project-init from the project's recorded source URL (`git+{{project_init_repo_url}}`), so forks and GHES hosts work — not hardcoded github.com.
- The fresh checkout is a clean git tree, so the #242 clean-tree guard passes; `--accept-new all` adopts new additions into the PR for review. No-ops when there's no drift.

## Acceptance criteria

- [x] A scaffolded project can run an upgrade that lands as a PR (branch + commit + PR body summarizing drift).
- [x] No changes are written to the user's default branch directly (work happens on `project-init-upgrade/<timestamp>` → PR).
- [x] Conflicts/`.new` files (and merge results) are visible in the PR diff (`git add -A` stages them).

## Definition of Done

- [x] Mechanism implemented and documented (file header + README).
- [x] Test scaffolds the workflow and asserts it renders for the project's host.

## Tests

`tests/contracts/test_upgrade_pr_workflow.py` — scaffolds and asserts: the workflow renders with no leftover placeholders; it opens a PR (branch + `gh pr create`) rather than pushing to the base; `${{ secrets... }}` expressions survive rendering; it targets the recorded `base_branch`; and the install source is **host-aware** (renders a GHES URL, never hardcodes github.com). Also verified the rendered YAML parses.

794 passed, ruff clean.

Closes #241