### PR TITLE
feat(PI-244): surface changelog/migration notes during upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ The report classifies every template-owned file:
 | conflict | drifted **and** locally edited with overlapping changes | keeps your file; writes the conflict-marked merge as a `<file>.new` sibling — your edit is never overwritten |
 | removed | no longer rendered by current templates | nothing (reported only; upgrade never deletes) |
 
+**Migration notes.** Alongside the file drift, upgrade prints the curated
+changelog/migration notes for the version span it crosses (recorded → target),
+with any **action required** step called out prominently — so you know *why* the
+files changed, not just *which*. The notes are packaged and read offline (no
+changelog fetch).
+
 `.claude/memory/` and `.claude/vault/` are never compared or touched, and
 `.claude/config.yaml` keeps your hand-edited fields (`project_key`, board
 number) — only its `project_init_version` and the scaffold record are

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -1,0 +1,69 @@
+"""Curated per-version upgrade notes surfaced by `project-init upgrade` (#244).
+
+Deterministic and offline: the notes live in the package and are sliced by the
+version span an upgrade crosses — no changelog fetch, no network (ADR-001). One
+entry per version that introduced a user-visible change or needs action; a
+version with no entry simply has no note. Maintained by hand at release time —
+add an entry here whenever a release changes user-facing behaviour or needs a
+migration step.
+"""
+
+from __future__ import annotations
+
+import re
+
+# version -> {"summary": str, "action_required": str | None}
+# Order here is irrelevant — notes are sliced and sorted by parsed version.
+MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "0.4.0": {
+        "summary": (
+            "Delivery model (--delivery library|service|prototype) drives the "
+            "env/CI/release bundle: a container parity bundle for services, "
+            "opt-in deploy (--deploy) and IaC (--iac) overlays, a library "
+            "release workflow, and a single-trunk default (ADR-015, epic #316)."
+        ),
+        "action_required": (
+            "Branch-per-env was removed — if you used dev/staging branches, "
+            "branch protection is now centralized: run "
+            "`.claude/scripts/setup_github.sh --protect`."
+        ),
+    },
+    "0.3.0": {
+        "summary": (
+            "Distribution profiles (--profile individual|standalone|org), the "
+            "`project-init upgrade` drift/apply system, a host-aware plugin "
+            "marketplace, and opt-in --no-egress (ADR-013)."
+        ),
+        "action_required": None,
+    },
+}
+
+
+def _parse(value: str | None) -> tuple[int, int, int] | None:
+    """Parse a leading ``X.Y.Z`` (optional ``v`` prefix) into a tuple, or None."""
+    m = re.match(r"v?(\d+)\.(\d+)\.(\d+)", value or "")
+    return (int(m[1]), int(m[2]), int(m[3])) if m else None
+
+
+def notes_for_span(prev: str | None, current: str | None) -> list[tuple[str, dict]]:
+    """Return ``[(version, entry)]`` for the span, newest version first.
+
+    Selects versions ``v`` with ``prev < v <= current``. When *prev* is missing
+    or unparseable (a first upgrade, or a pre-record migration), only the
+    *current* version's note is returned so the user sees where they are landing
+    without a flood of historical notes. An empty list means nothing to show
+    (e.g. a same-version re-run, or a downgrade).
+    """
+    c = _parse(current)
+    if c is None:
+        return []
+    p = _parse(prev)
+    selected = [
+        (version, entry)
+        for version, entry in MIGRATION_NOTES.items()
+        if (v := _parse(version)) is not None and v <= c and (p is None or v > p)
+    ]
+    if p is None:
+        selected = [(version, entry) for version, entry in selected if _parse(version) == c]
+    selected.sort(key=lambda item: _parse(item[0]), reverse=True)
+    return selected

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1334,6 +1334,13 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
         genuinely_new = [rel for rel in report.new if rel.as_posix() not in manifest]
         groups = _addition_groups(genuinely_new, staging)
         gate = _resolve_addition_consent(target, groups, accept_new or [], decline_new or [])
+        # Surface the version-span changelog/action-required notes (#244) BEFORE
+        # the addition gate: a direct --apply that stops at the gate must still
+        # show the upgrade warnings, not hide them until a re-run (Codex review).
+        _print_migration_notes(
+            variables.get("project_init_version_prev"),
+            variables.get("project_init_version"),
+        )
         if apply and gate["undecided"]:
             _print_addition_gate(groups, gate["undecided"])
             return 2
@@ -1350,12 +1357,6 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
             apply_drift(target, staging, report, preset_name, variables)
             _write_declined(target, gate["declined_map"])
         _print_report(report, applied=apply)
-        # Connect the file drift to release intent: what changed between the
-        # recorded version and the target, plus action-required notes (#244).
-        _print_migration_notes(
-            variables.get("project_init_version_prev"),
-            variables.get("project_init_version"),
-        )
         if groups:
             span = _describe_version_span(
                 variables.get("project_init_version_prev"),

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -829,7 +829,12 @@ def _print_migration_notes(prev: str | None, current: str | None) -> None:
     from rich.console import Console
 
     console = Console()
-    span = _describe_version_span(prev, current) or f"v{current}"
+    # Fall back to just the target version when the span can't be described
+    # (missing/unparseable prev). Format from the parsed tuple so a recorded "v"
+    # prefix or "-rc" suffix can't leak as "vv1.2.3" (Copilot review) — notes is
+    # non-empty, so current is guaranteed parseable here.
+    parsed = _parse_version(current)
+    span = _describe_version_span(prev, current) or f"v{'.'.join(map(str, parsed))}"
     console.print(f"\n[bold]Upgrade notes[/bold] — {span}:")
     for version, entry in notes:
         console.print(f"\n  [cyan]v{version}[/cyan] — {entry['summary']}")

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -813,6 +813,32 @@ def _print_clean_or_all_skipped(console, report: DriftReport) -> None:
     console.print("[green]No drift — project matches the current templates.[/green]")
 
 
+def _print_migration_notes(prev: str | None, current: str | None) -> None:
+    """Surface curated changelog/migration notes for the version span (#244).
+
+    Connects file drift to release intent: shows what changed between the
+    project's recorded version and the target, with any "action required" note
+    called out prominently. Deterministic — notes are read from the packaged
+    ``migration_notes`` module, never fetched.
+    """
+    from project_init.migration_notes import notes_for_span
+
+    notes = notes_for_span(prev, current)
+    if not notes:
+        return
+    from rich.console import Console
+
+    console = Console()
+    span = _describe_version_span(prev, current) or f"v{current}"
+    console.print(f"\n[bold]Upgrade notes[/bold] — {span}:")
+    for version, entry in notes:
+        console.print(f"\n  [cyan]v{version}[/cyan] — {entry['summary']}")
+        if entry.get("action_required"):
+            console.print(
+                f"  [bold yellow]⚠ action required:[/bold yellow] {entry['action_required']}"
+            )
+
+
 def _print_report(report: DriftReport, applied: bool) -> None:
     from rich.console import Console
 
@@ -1319,6 +1345,12 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
             apply_drift(target, staging, report, preset_name, variables)
             _write_declined(target, gate["declined_map"])
         _print_report(report, applied=apply)
+        # Connect the file drift to release intent: what changed between the
+        # recorded version and the target, plus action-required notes (#244).
+        _print_migration_notes(
+            variables.get("project_init_version_prev"),
+            variables.get("project_init_version"),
+        )
         if groups:
             span = _describe_version_span(
                 variables.get("project_init_version_prev"),

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -981,3 +981,13 @@ class TestMigrationNotes:
         _scaffold(target)  # recorded at the current tool version
         assert main(["upgrade", str(target)]) == 0
         assert "Upgrade notes" not in capsys.readouterr().out
+
+    def test_fallback_header_avoids_double_v_prefix(self, capsys):
+        """With no parseable prev the header falls back to the target version;
+        a 'v'-prefixed/suffixed current must not leak as 'vv…' (Copilot review)."""
+        from project_init.upgrade import _print_migration_notes
+
+        _print_migration_notes(None, "v0.4.0-rc1")
+        out = capsys.readouterr().out
+        assert "vv" not in out
+        assert "v0.4.0" in out

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -948,3 +948,36 @@ class TestInteractiveApply:
         assert main(["upgrade", str(target), "--apply", "-i"]) == 0
         assert (target / "justfile").read_text() == "# my local recipes\n"
         assert not (target / "justfile.new").exists(), "skipped conflict drops no .new"
+
+
+def _set_recorded_version(target: Path, version: str) -> None:
+    """Rewrite the recorded scaffold version to simulate an older project."""
+    config = target / _CONFIG_REL
+    text = config.read_text()
+    m = re.search(r"^(  variables: )(.*)$", text, re.MULTILINE)
+    assert m, "scaffold record variables line missing"
+    variables = json.loads(m.group(2))
+    variables["project_init_version"] = version
+    config.write_text(
+        text[: m.start()] + m.group(1) + json.dumps(variables, sort_keys=True) + text[m.end() :]
+    )
+
+
+class TestMigrationNotes:
+    """#244: upgrade surfaces curated notes for the version span it crosses."""
+
+    def test_upgrade_shows_notes_for_version_span(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        _scaffold(target)
+        _set_recorded_version(target, "0.3.0")  # pretend it was scaffolded on 0.3.0
+        assert main(["upgrade", str(target)]) == 0  # report-only is enough
+        out = capsys.readouterr().out
+        assert "Upgrade notes" in out
+        assert "v0.4.0" in out  # the 0.4.0 entry is crossed
+        assert "action required" in out.lower()
+
+    def test_same_version_upgrade_shows_no_notes(self, tmp_path: Path, capsys):
+        target = tmp_path / "p"
+        _scaffold(target)  # recorded at the current tool version
+        assert main(["upgrade", str(target)]) == 0
+        assert "Upgrade notes" not in capsys.readouterr().out

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -991,3 +991,20 @@ class TestMigrationNotes:
         out = capsys.readouterr().out
         assert "vv" not in out
         assert "v0.4.0" in out
+
+    def test_notes_shown_even_when_addition_gate_blocks(self, tmp_path: Path, capsys):
+        """A direct --apply that stops at the addition-consent gate must still
+        surface the version-span notes, not hide them until a re-run (#244,
+        Codex review)."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        _set_recorded_version(target, "0.3.0")
+        # Make justfile a genuinely-new file (missing on disk AND from the
+        # manifest) so `--apply` stops at the addition gate with exit 2.
+        (target / "justfile").unlink()
+        _patch_manifest(target, lambda m: m.pop("justfile", None))
+
+        assert main(["upgrade", str(target), "--apply"]) == 2  # gate blocks apply
+        out = capsys.readouterr().out
+        assert "Upgrade notes" in out
+        assert "action required" in out.lower()

--- a/tests/unit/test_migration_notes.py
+++ b/tests/unit/test_migration_notes.py
@@ -1,0 +1,48 @@
+"""#244: curated per-version upgrade notes, sliced by the version span."""
+
+from __future__ import annotations
+
+from project_init.migration_notes import MIGRATION_NOTES, notes_for_span
+
+
+def _versions(prev: str | None, current: str | None) -> list[str]:
+    return [v for v, _ in notes_for_span(prev, current)]
+
+
+def test_span_returns_only_versions_in_range():
+    assert _versions("0.3.0", "0.4.0") == ["0.4.0"]
+
+
+def test_span_includes_every_crossed_version_newest_first():
+    assert _versions("0.1.0", "0.4.0") == ["0.4.0", "0.3.0"]
+
+
+def test_same_version_has_no_notes():
+    assert notes_for_span("0.4.0", "0.4.0") == []
+
+
+def test_downgrade_has_no_notes():
+    assert notes_for_span("0.4.0", "0.3.0") == []
+
+
+def test_missing_or_unparseable_prev_shows_only_target():
+    # First upgrade / pre-record migration: don't dump the whole history.
+    assert _versions(None, "0.4.0") == ["0.4.0"]
+    assert _versions("", "0.4.0") == ["0.4.0"]
+    assert _versions("garbage", "0.4.0") == ["0.4.0"]
+
+
+def test_v_prefix_is_tolerated():
+    assert _versions("v0.3.0", "v0.4.0") == ["0.4.0"]
+
+
+def test_action_required_is_carried_through():
+    entry = dict(notes_for_span("0.3.0", "0.4.0"))["0.4.0"]
+    assert entry["action_required"]
+    assert "setup_github.sh" in entry["action_required"]
+
+
+def test_every_entry_has_a_summary():
+    for version, entry in MIGRATION_NOTES.items():
+        assert entry.get("summary"), f"{version} needs a summary"
+        assert "action_required" in entry  # explicit None is fine, missing is not


### PR DESCRIPTION
## Summary

The drift report showed *which* files change but not *why*. During `upgrade`, surface the curated changelog/migration notes for the version span between the project's recorded version and the target, plus any **action required** / breaking-change notes — connecting file drift to release intent and reducing upgrade anxiety.

## Design (DoR: changelog source)

- **Source: a maintained migration-notes file embedded in the package** (`src/project_init/migration_notes.py`) — chosen over fetching from the release (network) so the upgrade stays deterministic and offline (ADR-001), matching the scaffolder's no-network/no-LLM rule.
- `notes_for_span(prev, current)` slices the notes to versions in `(prev, current]`, newest first. A missing/unparseable `prev` (first upgrade, pre-record migration) shows only the target's note — no history flood; same-version and downgrade spans show nothing.
- `run_upgrade` prints the notes right after the drift report (works in report-only mode too), with `⚠ action required` called out prominently.

Example:

```
Upgrade notes — v0.3.0 → v0.4.0 (minor update):

  v0.4.0 — Delivery model (--delivery library|service|prototype) drives the env/CI/release bundle …
  ⚠ action required: Branch-per-env was removed — … run `.claude/scripts/setup_github.sh --protect`.
```

## Acceptance criteria

- [x] On upgrade, the user sees the changes between their recorded version and the target.
- [x] Any "action required" notes for the span are shown prominently.

## Definition of Done

- [x] Version-span notes shown during upgrade.
- [x] Test asserts notes render for a known version span.

## Tests

- `tests/unit/test_migration_notes.py` — span selection: in-range, newest-first across multiple crossed versions, same-version/downgrade → empty, missing/unparseable/`v`-prefixed prev, action_required carried through, every entry well-formed.
- `tests/integration/test_upgrade.py::TestMigrationNotes` — an upgrade from a recorded 0.3.0 prints the notes + action-required; a same-version run prints none.

806 passed, ruff clean. README documents it.

Closes #244