### PR TITLE
feat(PI-352): init-step messaging for the multi-model wizard prompt

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -415,6 +415,47 @@ def _print_profile_notice(profile: str, *, no_plugin: bool, no_egress: bool) -> 
     )
 
 
+def _choose_multi_model_interactive() -> bool:
+    """Explain multi-model switching + the alternatives, then ask (ADR-016, #352).
+
+    States plainly what the overlay does, how it helps, and the honest
+    alternatives (Gemini/OpenAI are better in their native --agents harnesses;
+    Ollama runs locally), so the user makes an informed choice or declines —
+    declining leaves a clean project. Non-interactive callers pass the flag and
+    never reach here.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Confirm
+
+    console = Console()
+    body = (
+        "Run other models [bold]through the Claude Code harness[/bold] — one "
+        "terminal, live switching, and automatic [bold]cost-routing[/bold] "
+        "(background work goes to a cheap model). Your hooks, CI gates, and "
+        "standards stay identical — they run below the model.\n\n"
+        "  [dim]claude[/dim]                          [dim]# opens as usual[/dim]\n"
+        "  [dim]/model deepseek,deepseek-chat[/dim]   [dim]# switch mid-session, context kept[/dim]\n"
+        "  [dim]/model ollama,qwen3-coder:30b[/dim]\n"
+        "  [dim]/model anthropic,claude-opus-4-8[/dim] [dim]# back to Claude[/dim]\n\n"
+        "[cyan]Helps:[/cyan] control cost / test models without leaving the terminal.\n"
+        "[cyan]Alternatives:[/cyan]\n"
+        "  • [bold]Gemini & OpenAI/Codex[/bold] already have native harnesses "
+        "([dim]--agents gemini[/dim] / [dim]codex[/dim]) — better quality there; "
+        "route them through CCR only for one-terminal convenience.\n"
+        "  • [bold]Ollama[/bold] models also run natively/locally.\n"
+        "  • Say yes and the scaffolded [dim]setup_models.sh[/dim] installs CCR "
+        "(pinned), seeds the config, and can pull local models for you.\n\n"
+        "[cyan]Updates:[/cyan] the pinned CCR version flows from project-init via "
+        "upgrade-as-PR; set up another way and you update it yourself.\n"
+        "Clean by default — decline and nothing is added."
+    )
+    console.print(
+        Panel(body, title="Multi-model switching (claude-code-router)", border_style="cyan")
+    )
+    return Confirm.ask("Set up multi-model switching via claude-code-router?", default=False)
+
+
 def _print_conflicts(conflicts: list[tuple[Path, Path]]) -> None:
     """Warn that user-owned files were kept; renders landed as .new siblings."""
     from rich.console import Console
@@ -584,13 +625,9 @@ def _gather_inputs_interactive(
     )
     mise = Confirm.ask("Pin toolchain versions with mise (mise.toml)?", default=False)
     vscode = Confirm.ask("Add shared VS Code config (extensions + format-on-save)?", default=False)
-    # Multi-model switching overlay (ADR-016, #351). The flag pre-accepts it; the
-    # richer init-step messaging lands in #352.
-    resolved_multi_model = multi_model_flag or Confirm.ask(
-        "Set up multi-model switching via claude-code-router "
-        "(run DeepSeek/Kimi/Ollama through Claude Code, with cost-routing)?",
-        default=False,
-    )
+    # Multi-model switching overlay (ADR-016, #351/#352). The flag pre-accepts it;
+    # otherwise the wizard explains what it does + the alternatives, then asks.
+    resolved_multi_model = multi_model_flag or _choose_multi_model_interactive()
     while True:
         agents_raw = _prompt(
             "Agents to support (claude always; add codex/gemini/ollama, comma-separated)",

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -421,8 +421,9 @@ def _choose_multi_model_interactive() -> bool:
     States plainly what the overlay does, how it helps, and the honest
     alternatives (Gemini/OpenAI are better in their native --agents harnesses;
     Ollama runs locally), so the user makes an informed choice or declines —
-    declining leaves a clean project. Non-interactive callers pass the flag and
-    never reach here.
+    declining leaves a clean project. Passing --multi-model (in either mode)
+    pre-accepts via the flag and skips this; only an interactive run without the
+    flag reaches here.
     """
     from rich.console import Console
     from rich.panel import Panel

--- a/tests/unit/test_interactive_prompts.py
+++ b/tests/unit/test_interactive_prompts.py
@@ -48,3 +48,22 @@ def test_choose_db_interactive_maps_choices(monkeypatch, choice, expected):
         assert result is None
     else:
         assert result["id"] == expected
+
+
+@pytest.mark.parametrize("answer", [True, False])
+def test_choose_multi_model_interactive_returns_confirm(monkeypatch, answer):
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: answer)
+    assert __main__._choose_multi_model_interactive() is answer
+
+
+def test_choose_multi_model_interactive_shows_messaging(monkeypatch, capsys):
+    """#352: the wizard must explain what it does + the native alternatives before
+    asking, so the choice is informed."""
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+    __main__._choose_multi_model_interactive()
+    out = capsys.readouterr().out
+    # Single-token substrings survive 80-col panel wrapping.
+    assert "/model" in out
+    assert "deepseek,deepseek-chat" in out
+    assert "Alternatives" in out
+    assert "gemini" in out  # the native-harness alternative is surfaced


### PR DESCRIPTION
Part of epic #315 (ADR-016). Makes the `--multi-model` wizard branch let the user make an *informed* choice.

Replaces the bare confirm added in #351 with a rich panel (`_choose_multi_model_interactive`) that states:
- **What:** run other models through the Claude Code harness — one terminal, live `/model` switching, background **cost-routing** — guardrails unchanged (they run below the model), with the concrete `claude` + `/model` example.
- **How it helps:** control cost / test models without leaving the terminal.
- **Alternatives (surfaced honestly):** Gemini & OpenAI/Codex are better in their native `--agents` harnesses; Ollama runs locally; saying yes lets `setup_models.sh` install CCR + pull local models.
- **Updates:** the pinned CCR version flows from project-init via upgrade-as-PR.

Declining leaves a clean project. The `--multi-model` flag still pre-accepts (skips the panel); non-interactive callers never reach it.

Unit tests: returns the confirm value (yes/no) and the messaging surfaces `/model`, the example, and the native-harness alternative. Full suite 821 green, ruff clean.

Closes #352