### PR TITLE
docs(PI-353): model-switching user guide (providers, Ollama list, caveats)

### DIFF
--- a/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
+++ b/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
@@ -39,9 +39,14 @@ mismatch*, not "Claude Code is slow" (it's a strong harness):
 | **Gemini** | **A** — `--agents gemini` | first-party Gemini CLI; better quality natively |
 | **OpenAI / Codex** | **A** — `--agents codex` | first-party Codex CLI; better quality natively |
 
-Gemini & OpenAI are still reachable through CCR (`/model …`) for one-terminal
-convenience, but **there are no published CCR-vs-native benchmarks** — expect the
-mismatch penalty. Prefer their native harnesses for real work.
+Gemini & OpenAI are **not seeded** in the shipped CCR config (`config.json` only
+defines `anthropic`, `deepseek`, `kimi`, `ollama`) — they're better used via
+their native harnesses. You *can* reach them through CCR by adding a provider to
+`~/.claude-code-router/config.json` by hand (e.g. via `ccr ui`, typically through
+an OpenAI-compatible gateway such as OpenRouter), but **there are no published
+CCR-vs-native benchmarks** — expect the 15–22pt mismatch penalty. So
+`/model gemini,…` / `/model openai,…` work only after you configure them; out of
+the box, use `--agents gemini` / `codex` instead.
 
 ## Setup
 

--- a/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
+++ b/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
@@ -1,0 +1,152 @@
+# Multi-model switching — user guide
+
+This project has the opt-in **multi-model** overlay (ADR-016). It lets you run
+models other than Claude **from the same terminal**, to control cost and to test
+models — without changing any of the project's standards. The deterministic
+guardrails (git hooks, pre-commit secret scan, CI gates, the workflow DAG) run
+**below** the model, so they hold identically whichever model you point at. What
+you *don't* get is identical model behaviour — agentic quality tracks the model's
+own tool-use capability; the scaffold provides structure, not capability.
+
+## Two ways to run another model
+
+There are two fundamentally different architectures, with opposite trade-offs:
+
+| | **A. Native harness per model** (`--agents`) | **B. One harness, swap the endpoint** (this overlay) |
+|---|---|---|
+| How | launch that model's own CLI (Codex, Gemini CLI) | stay in Claude Code, route the model behind it via CCR |
+| Switching | start a different tool | live `/model provider,model`, context kept |
+| Skills | re-authored per harness | one Claude-format set |
+| Model uses its… | **native** tool-call logic ✅ | **Claude's** tool-call format, imposed ⚠️ |
+
+**The harness matters more than the model.** Scaffold/format changes swing
+SWE-bench by 15–42 points on a *fixed* model. So the rule is about *format
+mismatch*, not "Claude Code is slow" (it's a strong harness):
+
+- A model **tuned for Claude-Code-shaped tool calls**, or with **no first-party
+  harness** → running it in Claude Code is fine, often optimal. **Use B.**
+- A model with its **own first-party harness** it was post-trained for → forcing
+  it through a translated format risks the wrong side of a 15–22pt swing. **Use A.**
+
+## Which provider goes where
+
+| Provider | Recommended path | Why |
+|---|---|---|
+| **Claude** | B (default) | the scaffold is built for it |
+| **DeepSeek** | **B** (CCR) | no first-party harness; Anthropic-compatible endpoint published *to be driven by Claude Code*; cheap |
+| **Kimi / Moonshot** | **B** (CCR) | same as DeepSeek; Kimi K2-Code is tuned to be driven by external harnesses |
+| **Ollama** (local) | **B** (CCR) | a model *runner*, not a harness; suitability is per-model (see below) |
+| **Gemini** | **A** — `--agents gemini` | first-party Gemini CLI; better quality natively |
+| **OpenAI / Codex** | **A** — `--agents codex` | first-party Codex CLI; better quality natively |
+
+Gemini & OpenAI are still reachable through CCR (`/model …`) for one-terminal
+convenience, but **there are no published CCR-vs-native benchmarks** — expect the
+mismatch penalty. Prefer their native harnesses for real work.
+
+## Setup
+
+One-time, from the project root:
+
+```bash
+cp .claude/multi-model/.env.example .claude/multi-model/.env   # fill in provider keys
+.claude/scripts/setup_models.sh
+```
+
+The installer (idempotent) installs [claude-code-router](https://github.com/musistudio/claude-code-router)
+at a **pinned** version (bun-preferred, npm fallback), seeds the machine-global
+config at `~/.claude-code-router/config.json` from this project's template + your
+`.env`, optionally pulls local Ollama models sized to your RAM, and can wire your
+shell so plain `claude` routes through CCR.
+
+### Daily use
+
+```bash
+ccr start                          # run the local proxy (or use `ccr code`)
+claude                             # opens as usual (if you wired the shell)
+/model deepseek,deepseek-chat      # switch mid-session, context kept
+/model ollama,qwen3-coder:30b
+/model anthropic,claude-opus-4-8   # back to Claude
+ccr ui                             # web editor for providers + routing
+```
+
+**Cost-routing is the big lever.** Claude Code fires *background* requests
+constantly (summaries, compaction). The shipped config routes `background` to a
+cheap model (DeepSeek) — a large, previously invisible chunk of spend removed,
+while `default` stays on Claude so your primary experience is unchanged.
+
+### Per-provider keys
+
+- **DeepSeek** — `DEEPSEEK_API_KEY` from <https://platform.deepseek.com/api_keys>.
+- **Kimi / Moonshot** — `MOONSHOT_API_KEY` from <https://platform.moonshot.ai>.
+  Mainland-China accounts use `https://api.moonshot.cn` (edit `config.json`).
+- **Anthropic** — `ANTHROPIC_API_KEY` (you likely already have one).
+- **Ollama** — no key; it's local.
+
+## Local models (Ollama)
+
+Ollama exposes an Anthropic-compatible API locally, so Claude Code can drive it.
+Suitability is purely the **model's tool-calling competence**:
+
+- **< 7B: excluded.** Malformed calls, confabulation — Claude Code loops on
+  *"Invalid tool parameters"*.
+- **Practical floor: a ~24–32B agent-tuned model.**
+
+Curated list (RAM = comfortable **Q4_K_M** load with working context; grows with
+context; Mac unified memory ≠ discrete VRAM; CPU-only works but is slow). The
+setup script auto-detects RAM and recommends only models that fit.
+
+| Model | Accuracy (SWE-bench V.) | Speed | RAM (Q4) | Pick if… |
+|---|---|---|---|---|
+| **qwen3-coder:30b** (30B-A3B MoE) | strong (family ~70%) | ⚡⚡⚡ | ~18GB | **daily driver** — best speed+quality balance |
+| **devstral:24b** (dense) | **68%** | ⚡ | ~16GB | **big multi-file refactors**; 4090 / 32GB Mac |
+| **qwen3-coder-next** (80B-A3B MoE) | **70.6%** | ⚡⚡⚡ | ~48GB+ | **top accuracy + speed if you have the RAM** |
+| **gpt-oss:20b** | reliable tool-caller | ⚡⚡ | ~14GB | **16GB GPU**; stable agent loops |
+| **glm-4.7-flash** (MoE) | clean tool-calls | ⚡⚡ | ~16–24GB | **easiest reliable start** |
+| **qwen3:14b** | mid | ⚡⚡ | ~10GB | **12GB card**, lighter tasks |
+| **qwen3:9b** | floor (~66% tool-use) | ⚡⚡ | ~8GB | **8GB** — smallest that still tool-calls |
+| **qwen3:32b** (dense) | high | ⚡ | ~24–32GB | **24–32GB quality** tier |
+| **gpt-oss:120b** | highest local | ⚡ | 80GB / 64GB+ Mac | **workstation**, max quality |
+
+**Quantization** (lower = smaller + faster, but flakier tool-calls):
+
+| Quant | Quality | Size vs F16 | When |
+|---|---|---|---|
+| **Q4_K_M** | 1–3% loss | ~30% | **default / floor** for reliable tool-calling |
+| **Q5_K_M** | sweet spot | ~35% | a little headroom |
+| **Q6_K** | near-lossless | ~40% | quality matters, RAM allows |
+| **Q8_0** | ≈ F16 | ~50% | quality baseline |
+
+Auto-suggest by headroom: 8–12GB → Q4_K_M · 12–16GB → Q5/Q6 · 16–24GB → Q8 ·
+24GB+ → F16. **Below Q4_K_M, agent loops get flaky — don't go lower.**
+Kimi/DeepSeek are **cloud-only** (hundreds of B) — the cheap *remote* option;
+the list above is the *local* option, cheap in $ but not in RAM.
+
+## Day-2: add / switch / remove models
+
+Setup isn't one-shot. Switch live with `/model provider,model`. To add a model
+you didn't pick at init (including your own Ollama models), edit
+`~/.claude-code-router/config.json` (or `ccr ui`) and `ollama pull` the model —
+keep the **<7B** floor in mind. Reverting is clean: stop using CCR (plain
+`claude`) or `rm ~/.claude-code-router/config.json` removes it entirely.
+
+## Caveats (any non-Claude model)
+
+- **Prompt caching is Anthropic-only.** Non-Claude models lose cache savings, so
+  real cost/latency is worse than raw token counts suggest.
+- **Agentic quality tracks the model**, not the scaffold. A weak model is weak
+  here too.
+- **Tool-call JSON + streaming edge cases differ** per provider; Gemini/OpenAI
+  *via translation* are the most fragile (hence: prefer their native harnesses).
+- **Thinking/reasoning blocks and refusal handling differ** across providers.
+- **No published CCR-vs-native benchmarks** — expect the 15–22pt penalty when
+  routing a first-party-harness model through CCR.
+
+## Hard budget caps?
+
+CCR does cost-*routing*, not spend *limits*. If you need enforced budget gates,
+[LiteLLM](https://docs.litellm.ai) adds spend caps and guardrails — heavier and
+enterprise-shaped. It's the documented upgrade path for governance/measurement,
+not the default switching mechanism.
+
+— See ADR-016 for the full decision record and `../../multi-model/README.md` for
+the overlay's files.

--- a/templates/multi_model/dot_claude/multi-model/README.md
+++ b/templates/multi_model/dot_claude/multi-model/README.md
@@ -35,7 +35,8 @@ claude                                                          # opens as usual
   first-party harness), so routing them through CCR is appropriate.
 - **Gemini & OpenAI/Codex** perform better in their own native harnesses
   (`--agents gemini` / `codex`). They are reachable through CCR only as a
-  convenience, with a quality caveat — see the model-switching guide.
+  convenience, with a quality caveat — see the
+  [model-switching guide](../docs/guides/using-multi-model.md).
 - **Ollama** is local and gated on hardware: a ~24–32B agent-tuned model is the
   practical floor for reliable tool-calling; anything below ~7B loops on
   "Invalid tool parameters".

--- a/tests/contracts/test_multi_model_overlay.py
+++ b/tests/contracts/test_multi_model_overlay.py
@@ -98,7 +98,7 @@ class TestMultiModelOn:
     def test_guide_renders_with_key_content(self):
         guide = self.target / ".claude" / "docs" / "guides" / "using-multi-model.md"
         assert guide.is_file()
-        text = guide.read_text()
+        text = guide.read_text(encoding="utf-8")
         # The guide must carry the load-bearing decisions: the two architectures,
         # the <7B Ollama floor, and the Anthropic-only caching caveat.
         assert "native harness" in text.lower()

--- a/tests/contracts/test_multi_model_overlay.py
+++ b/tests/contracts/test_multi_model_overlay.py
@@ -95,6 +95,17 @@ class TestMultiModelOn:
     def test_readme_present(self):
         assert (self.mm / "README.md").is_file()
 
+    def test_guide_renders_with_key_content(self):
+        guide = self.target / ".claude" / "docs" / "guides" / "using-multi-model.md"
+        assert guide.is_file()
+        text = guide.read_text()
+        # The guide must carry the load-bearing decisions: the two architectures,
+        # the <7B Ollama floor, and the Anthropic-only caching caveat.
+        assert "native harness" in text.lower()
+        assert "7B" in text or "7b" in text
+        assert "caching" in text.lower()
+        assert "setup_models.sh" in text
+
 
 class TestMultiModelOff:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Part of epic #315 (ADR-016). A user-facing guide scaffolded into target projects (graphify precedent) at `.claude/docs/guides/using-multi-model.md`.

Covers:
- **Two architectures** (native-harness `--agents` vs CCR swap-endpoint) and the harness-mismatch rule for when to use each.
- **Per-provider routing** — DeepSeek/Kimi/Ollama via CCR; Gemini/OpenAI better native.
- **Curated Ollama list** with SWE-bench/speed/RAM tiers + quant table, the **<7B exclusion** and ~24–32B floor.
- **Caveats** — Anthropic-only prompt caching, agentic quality tracks the model, tool-call/streaming quirks, no published CCR-vs-native benchmarks.
- **LiteLLM** as the hard-budget-cap upgrade path (#276/#269).

Linked from the overlay README; overlay test asserts the guide renders with the load-bearing content. Full suite 822 green.

Closes #353