### PR TITLE
feat(PI-358): day-2 models helper — add/switch/remove models after setup

### DIFF
--- a/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
+++ b/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
@@ -128,11 +128,22 @@ the list above is the *local* option, cheap in $ but not in RAM.
 
 ## Day-2: add / switch / remove models
 
-Setup isn't one-shot. Switch live with `/model provider,model`. To add a model
-you didn't pick at init (including your own Ollama models), edit
-`~/.claude-code-router/config.json` (or `ccr ui`) and `ollama pull` the model —
-keep the **<7B** floor in mind. Reverting is clean: stop using CCR (plain
-`claude`) or `rm ~/.claude-code-router/config.json` removes it entirely.
+Setup isn't one-shot. Switch live with `/model provider,model`. To add, list, or
+remove models afterwards — including models you didn't pick at init or your own
+Ollama ones — use the scaffolded helper (it pulls/removes Ollama models and edits
+the global CCR config for you, with the **<7B** guard):
+
+```bash
+.claude/scripts/models.sh list                       # providers/models + pulled Ollama
+.claude/scripts/models.sh add ollama qwen3:14b       # ollama pull + register
+.claude/scripts/models.sh add deepseek deepseek-reasoner   # register a cloud model
+.claude/scripts/models.sh rm ollama gemma:2b         # ollama rm + unregister
+.claude/scripts/models.sh ui                         # open ccr ui (GUI editor)
+# tip: alias models="$PWD/.claude/scripts/models.sh"  → then `models list`, etc.
+```
+
+Reverting is clean: stop using CCR (plain `claude`) or
+`rm ~/.claude-code-router/config.json` removes it entirely.
 
 ## Caveats (any non-Claude model)
 

--- a/templates/multi_model/dot_claude/multi-model/README.md
+++ b/templates/multi_model/dot_claude/multi-model/README.md
@@ -17,6 +17,9 @@ Those run below the model and stay identical whichever model you point at.
   seeds the global config from `config.json` + your `.env`, optionally pulls local
   Ollama models sized to your RAM, and wires your shell so plain `claude` routes
   through CCR.
+- `../scripts/models.sh` — day-2 helper: `list` / `add` / `rm` models (Ollama +
+  cloud) after setup, editing the global CCR config via `jq` (needs `jq`; warns
+  below the ~7B tool-calling floor).
 
 ## Quick start
 

--- a/templates/multi_model/dot_claude/scripts/models.sh
+++ b/templates/multi_model/dot_claude/scripts/models.sh
@@ -39,10 +39,14 @@ models — day-2 model management for claude-code-router
 EOF
 }
 
-# Atomically rewrite the config with a jq program (temp file + mv).
+# Atomically rewrite the config with a jq program (temp file + mv), preserving
+# the file's permissions — it holds substituted API keys (setup_models.sh chmods
+# it 600), so the replacement must not inherit a looser umask (e.g. 0644).
 _jq_write() {
-  local tmp="$CONFIG.tmp.$$"
+  local tmp="$CONFIG.tmp.$$" mode
+  mode=$(stat -c '%a' "$CONFIG" 2>/dev/null || stat -f '%Lp' "$CONFIG" 2>/dev/null || echo 600)
   if jq "$@" "$CONFIG" >"$tmp"; then
+    chmod "$mode" "$tmp" 2>/dev/null || chmod 600 "$tmp" 2>/dev/null || true
     mv "$tmp" "$CONFIG"
   else
     rm -f "$tmp"

--- a/templates/multi_model/dot_claude/scripts/models.sh
+++ b/templates/multi_model/dot_claude/scripts/models.sh
@@ -43,8 +43,11 @@ EOF
 # the file's permissions — it holds substituted API keys (setup_models.sh chmods
 # it 600), so the replacement must not inherit a looser umask (e.g. 0644).
 _jq_write() {
-  local tmp="$CONFIG.tmp.$$" mode
+  local tmp mode
   mode=$(stat -c '%a' "$CONFIG" 2>/dev/null || stat -f '%Lp' "$CONFIG" 2>/dev/null || echo 600)
+  # mktemp (next to the config, so mv is atomic same-fs) avoids the predictable
+  # "$$"-name symlink race and starts at 0600.
+  tmp=$(mktemp "$CONFIG.XXXXXX") || die "could not create a temp file next to $CONFIG."
   if jq "$@" "$CONFIG" >"$tmp"; then
     chmod "$mode" "$tmp" 2>/dev/null || chmod 600 "$tmp" 2>/dev/null || true
     mv "$tmp" "$CONFIG"

--- a/templates/multi_model/dot_claude/scripts/models.sh
+++ b/templates/multi_model/dot_claude/scripts/models.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# models.sh — day-2 management for the multi-model (CCR) overlay (ADR-016, #358).
+#
+# Add / switch / remove models after the initial setup_models.sh run — including
+# models you didn't pick at init, or your own Ollama models. Wraps Ollama + edits
+# to the machine-global CCR config (~/.claude-code-router/config.json) via jq.
+# Deterministic, no LLM. Switching itself is live in Claude Code: /model prov,model.
+#
+# Tip: alias it for the bare `models …` form the docs use:
+#   alias models="$PWD/.claude/scripts/models.sh"
+set -euo pipefail
+
+CONFIG="${CCR_CONFIG:-$HOME/.claude-code-router/config.json}"
+OLLAMA_BASE_URL="http://localhost:11434/v1/chat/completions"
+
+info() { printf '\033[0;36m›\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[0;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+ask()  { [ -t 0 ] || return 1; local r=""; read -r -p "$1 [y/N] " r || true; [[ "$r" =~ ^[Yy]$ ]]; }
+
+have jq || die "jq is required. Install jq (https://jqlang.github.io/jq/) and re-run."
+[ -f "$CONFIG" ] || die "no CCR config at $CONFIG — run setup_models.sh first."
+
+usage() {
+  cat <<'EOF'
+models — day-2 model management for claude-code-router
+
+  models list                          configured providers/models + pulled Ollama models
+  models add ollama <model>[:tag]      ollama pull + register (warns if <7B)
+  models add <provider> <model>        register a cloud model (provider must exist)
+  models rm   ollama <model>           ollama rm + unregister
+  models rm   <provider> <model>       unregister from the config
+  models ui                            open CCR's web editor (ccr ui)
+
+  Switch live in Claude Code:  /model <provider>,<model>
+EOF
+}
+
+# Atomically rewrite the config with a jq program (temp file + mv).
+_jq_write() {
+  local tmp="$CONFIG.tmp.$$"
+  if jq "$@" "$CONFIG" >"$tmp"; then
+    mv "$tmp" "$CONFIG"
+  else
+    rm -f "$tmp"
+    die "jq edit failed — config left unchanged."
+  fi
+}
+
+_provider_exists() { jq -e --arg p "$1" '.Providers[]? | select(.name==$p)' "$CONFIG" >/dev/null 2>&1; }
+
+# Warn/confirm when an Ollama model looks smaller than the ~7B tool-calling floor.
+_guard_small() {
+  local model="$1" size
+  size=$(printf '%s' "$model" | grep -oiE '[0-9]+(\.[0-9]+)?b' | head -1 | sed 's/[bB]//') || true
+  [ -n "$size" ] || return 0  # no size in the name — can't tell, allow
+  # integer compare on the whole-billions part
+  if [ "${size%%.*}" -lt 7 ] 2>/dev/null; then
+    warn "$model looks <7B. Models below ~7B loop on 'Invalid tool parameters' in agent use."
+    ask "Add it anyway?" || die "Aborted."
+  fi
+}
+
+cmd_list() {
+  info "Providers (from $CONFIG):"
+  jq -r '.Providers[]? | "  \(.name): \((.models // []) | join(", "))"' "$CONFIG"
+  echo
+  info "Router:"
+  jq -r '.Router // {} | to_entries[] | select(.value|type=="string") | "  \(.key): \(.value)"' "$CONFIG"
+  if have ollama; then
+    echo; info "Pulled Ollama models:"; ollama list 2>/dev/null | tail -n +2 | awk '{print "  "$1}' || true
+  fi
+}
+
+cmd_add() {
+  local provider="${1:-}" model="${2:-}"
+  [ -n "$provider" ] && [ -n "$model" ] || { usage; die "add needs <provider> <model>."; }
+  if [ "$provider" = "ollama" ]; then
+    _guard_small "$model"
+    if ! _provider_exists ollama; then
+      info "Adding an 'ollama' provider to the config."
+      _jq_write --arg url "$OLLAMA_BASE_URL" \
+        '.Providers += [{"name":"ollama","api_base_url":$url,"api_key":"ollama","models":[]}]'
+    fi
+    if have ollama; then info "Pulling $model…"; ollama pull "$model"; else warn "ollama not installed — registering anyway."; fi
+  else
+    _provider_exists "$provider" || die "provider '$provider' not in config. Add it via 'models ui' / config.json first."
+  fi
+  _jq_write --arg p "$provider" --arg m "$model" \
+    '(.Providers[] | select(.name==$p) | .models) |= ((. // []) + [$m] | unique)'
+  ok "Registered $model under $provider. Switch with: /model $provider,$model"
+}
+
+cmd_rm() {
+  local provider="${1:-}" model="${2:-}"
+  [ -n "$provider" ] && [ -n "$model" ] || { usage; die "rm needs <provider> <model>."; }
+  _provider_exists "$provider" || die "provider '$provider' not in config."
+  if jq -e --arg m "$model" '.Router // {} | to_entries[] | select(.value==($m|tostring) or (.value|type=="string" and endswith(","+$m)))' "$CONFIG" >/dev/null 2>&1; then
+    warn "$model is still referenced in Router — update routing ('models ui') or it will fail when hit."
+  fi
+  _jq_write --arg p "$provider" --arg m "$model" \
+    '(.Providers[] | select(.name==$p) | .models) |= ((. // []) - [$m])'
+  if [ "$provider" = "ollama" ] && have ollama; then
+    info "Removing local model $model…"; ollama rm "$model" 2>/dev/null || warn "ollama rm $model failed (not pulled?)."
+  fi
+  ok "Unregistered $model from $provider."
+}
+
+case "${1:-}" in
+  list|ls|"")     cmd_list ;;
+  add)            shift; cmd_add "$@" ;;
+  rm|remove)      shift; cmd_rm "$@" ;;
+  ui)             have ccr && exec ccr ui || die "ccr not found." ;;
+  -h|--help|help) usage ;;
+  *)              usage; die "unknown command: $1" ;;
+esac

--- a/templates/multi_model/dot_claude/scripts/setup_models.sh
+++ b/templates/multi_model/dot_claude/scripts/setup_models.sh
@@ -216,6 +216,9 @@ Done. Multi-model switching is set up.
   ccr ui                            # web editor for providers + routing
   ccr model                         # interactive model management
 
+  .claude/scripts/models.sh list                  # day-2: list configured + pulled models
+  .claude/scripts/models.sh add ollama qwen3:14b  # add/remove models after setup (needs jq)
+
 Background requests auto-route to DeepSeek (cheap) — the biggest silent saver.
 Edit providers/keys in ~/.claude-code-router/config.json (or .claude/multi-model/.env, then re-run).
 EOF

--- a/tests/contracts/test_multi_model_overlay.py
+++ b/tests/contracts/test_multi_model_overlay.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -87,6 +89,18 @@ class TestMultiModelOn:
         assert '. "$ENV_FILE"' not in content
         assert 'mv "$tmp" "$GLOBAL_CONFIG"' in content
 
+    def test_day2_helper_present_executable_and_documented(self):
+        helper = self.target / ".claude" / "scripts" / "models.sh"
+        assert helper.is_file()
+        assert os.access(helper, os.X_OK)
+        content = helper.read_text(encoding="utf-8")
+        for cmd in ("models list", "add ollama", "rm   ollama", "ccr ui"):
+            assert cmd in content
+        # The <7B tool-calling floor guard must be present (issue #358).
+        assert "7B" in content
+        # Edits must be atomic (temp file + mv), never an in-place truncate.
+        assert 'mv "$tmp" "$CONFIG"' in content
+
     def test_env_example_has_key_slots(self):
         env = (self.mm / ".env.example").read_text()
         for key in ("ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "MOONSHOT_API_KEY"):
@@ -105,6 +119,53 @@ class TestMultiModelOn:
         assert "7B" in text or "7b" in text
         assert "caching" in text.lower()
         assert "setup_models.sh" in text
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="models.sh needs jq at runtime")
+class TestDay2HelperRuntime:
+    """Exercise the day-2 helper's jq edits end-to-end (#358). Runs wherever jq is
+    available (e.g. CI); skipped otherwise. Ollama is absent in CI, so the script's
+    `have ollama` branch degrades to register-only — exactly the path we assert."""
+
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", multi_model=True)
+        self.helper = target / ".claude" / "scripts" / "models.sh"
+        self.cfg = tmp_path / "ccr.json"
+        self.cfg.write_text(
+            (target / ".claude" / "multi-model" / "config.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    def _run(self, *args: str):
+        return subprocess.run(
+            ["bash", str(self.helper), *args],
+            env={**os.environ, "CCR_CONFIG": str(self.cfg)},
+            capture_output=True,
+            text=True,
+        )
+
+    def _models(self, provider: str) -> list[str]:
+        cfg = json.loads(self.cfg.read_text(encoding="utf-8"))
+        return next(p["models"] for p in cfg["Providers"] if p["name"] == provider)
+
+    def test_add_then_remove_cloud_model(self):
+        assert self._run("add", "deepseek", "deepseek-coder").returncode == 0
+        assert "deepseek-coder" in self._models("deepseek")
+        assert self._run("rm", "deepseek", "deepseek-coder").returncode == 0
+        assert "deepseek-coder" not in self._models("deepseek")
+        # config stays valid JSON throughout
+        json.loads(self.cfg.read_text(encoding="utf-8"))
+
+    def test_add_unknown_provider_fails(self):
+        r = self._run("add", "openai", "gpt-5")
+        assert r.returncode != 0
+        assert "not in config" in (r.stdout + r.stderr)
+
+    def test_register_ollama_model_without_pull(self):
+        # ollama is absent in CI → registers in config without pulling.
+        assert self._run("add", "ollama", "qwen3:14b").returncode == 0
+        assert "qwen3:14b" in self._models("ollama")
 
 
 class TestMultiModelOff:


### PR DESCRIPTION
Part of epic #315 (ADR-016). After `setup_models.sh`, users need to add/switch/remove models — including ones not picked at init or their own Ollama models — without hand-editing JSON.

## `.claude/scripts/models.sh` (bash + jq, no LLM)
- `models list` — configured providers/models + pulled Ollama models.
- `models add ollama <model>` — `ollama pull` + register (auto-creates the ollama provider if missing; **warns/confirms below ~7B**).
- `models add <provider> <model>` — register a cloud model (refuses unknown providers).
- `models rm ollama|<provider> <model>` — `ollama rm` + unregister; warns if the model is still referenced in Router.
- `models ui` → `ccr ui`. Switching stays live via `/model provider,model`.
- Config edits are **atomic** (temp file + `mv`); only state touched is the global `~/.claude-code-router/config.json` (reversible).

Wired into the guide's day-2 section, the overlay README, and the installer cheat-sheet.

## Tests
- Structural (always): present, executable, commands + <7B guard + atomic write.
- **jq-gated runtime** (runs in CI, where jq is preinstalled; skipped locally): scaffolds the overlay and drives `add`/`rm`/`list` against a temp config, asserting the real jq edits and that unknown providers fail. Full suite 823 green, 3 skipped (jq).

Closes #358