### PR TITLE
chore(PI-354): de-hardcode Anthropic model IDs in doc examples

### DIFF
--- a/.claude/skills/add_command/SKILL.md
+++ b/.claude/skills/add_command/SKILL.md
@@ -23,7 +23,7 @@ description: <What it does and when to use it. Third person. Include trigger key
 when_to_use: <Extra trigger context — action phrases the user might say.>
 argument-hint: "<expected arguments>"
 allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
-model: sonnet                    # optional model override
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 effort: medium                   # low | medium | high | xhigh | max
 disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
 user-invocable: false            # false = Claude-only background knowledge

--- a/plugins/project-init-workflow/skills/add_command/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_command/SKILL.md
@@ -27,7 +27,7 @@ description: <What it does and when to use it. Third person. Include trigger key
 when_to_use: <Extra trigger context — action phrases the user might say.>
 argument-hint: "<expected arguments>"
 allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
-model: sonnet                    # optional model override
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 effort: medium                   # low | medium | high | xhigh | max
 disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
 user-invocable: false            # false = Claude-only background knowledge

--- a/templates/base/dot_claude/agents/README.md
+++ b/templates/base/dot_claude/agents/README.md
@@ -10,7 +10,7 @@ Claude Code subagent definitions. Define custom subagent personas here when you 
 ---
 name: agent-name
 description: What this agent does and when to invoke it
-model: sonnet                    # optional: sonnet or opus
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 tools:                           # list of tools this agent can use
   - Read
   - Grep

--- a/templates/codex/dot_agents/skills/add_command/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_command/SKILL.md
@@ -27,7 +27,7 @@ description: <What it does and when to use it. Third person. Include trigger key
 when_to_use: <Extra trigger context — action phrases the user might say.>
 argument-hint: "<expected arguments>"
 allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
-model: sonnet                    # optional model override
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 effort: medium                   # low | medium | high | xhigh | max
 disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
 user-invocable: false            # false = Claude-only background knowledge

--- a/templates/fallback/dot_claude/skills/add_command/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_command/SKILL.md
@@ -27,7 +27,7 @@ description: <What it does and when to use it. Third person. Include trigger key
 when_to_use: <Extra trigger context — action phrases the user might say.>
 argument-hint: "<expected arguments>"
 allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
-model: sonnet                    # optional model override
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 effort: medium                   # low | medium | high | xhigh | max
 disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
 user-invocable: false            # false = Claude-only background knowledge

--- a/templates/gemini/dot_agents/skills/add_command/SKILL.md
+++ b/templates/gemini/dot_agents/skills/add_command/SKILL.md
@@ -27,7 +27,7 @@ description: <What it does and when to use it. Third person. Include trigger key
 when_to_use: <Extra trigger context — action phrases the user might say.>
 argument-hint: "<expected arguments>"
 allowed-tools: Bash Read Write   # tools pre-approved while this skill is active
-model: sonnet                    # optional model override
+model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
 effort: medium                   # low | medium | high | xhigh | max
 disable-model-invocation: true   # true = user-only; Claude won't auto-invoke
 user-invocable: false            # false = Claude-only background knowledge


### PR DESCRIPTION
Part of epic #315 (ADR-016). Doc-consistency cleanup — **not** a portability bug: all hits are documentation code-fence *examples*; **zero live skill/agent frontmatter sets `model:`**, so nothing at runtime selects an Anthropic-only ID.

Changed the 6 `model: sonnet`/`opus` example lines to `model: <model-id>` with a 'provider-specific (e.g. sonnet/opus on Claude)' note:
- `add_command/SKILL.md` — edited the **fallback source of truth**; synced the plugin/codex/gemini copies via `tools/sync_plugin.py`.
- `templates/base/dot_claude/agents/README.md`.
- This repo's own `.claude/skills/add_command/SKILL.md`.

Left the `docs/research` mention (it discusses the issue itself). Plugin copies in sync (contract test green); full suite 823 passed, 3 skipped.

Closes #354