### PR TITLE
feat(PI-356): scheduled third-party update + security-review task

### DIFF
--- a/.github/workflows/third-party-updates.yml
+++ b/.github/workflows/third-party-updates.yml
@@ -1,0 +1,38 @@
+name: Third-party updates
+
+# Checks the pinned third-party tools project-init vets (CCR first; ADR-016 §5,
+# #356) for newer upstream releases, security-scans each candidate, and opens a
+# PR proposing the bump. Never auto-merges — a human reviews the changelog/diff.
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-propose:
+    name: Check pinned third-party tools
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+
+      - name: Detect available updates
+        run: |
+          uv run python tools/check_third_party_updates.py check --json | tee updates.json
+
+      - name: Security-scan candidates and open PRs (no auto-merge)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bash tools/propose_third_party_bumps.sh updates.json

--- a/tests/contracts/test_third_party_pin_contract.py
+++ b/tests/contracts/test_third_party_pin_contract.py
@@ -1,0 +1,34 @@
+"""#356: cross-file contract — the vetted pin must not drift from what ships.
+
+Lives under tests/contracts/ (auto-marked ``contract``) because it asserts a
+template/manifest relationship, not pure logic (per docs/development/testing.md).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module():
+    path = REPO_ROOT / "tools" / "check_third_party_updates.py"
+    spec = importlib.util.spec_from_file_location("check_third_party_updates", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_manifest_pin_matches_installer_version():
+    """The manifest pin and CCR_VERSION in the scaffolded installer must stay in
+    lockstep — the whole point of `apply`. Guards silent drift (#356)."""
+    mod = _load_module()
+    pinned = mod.load_manifest()["ccr"]["pinned"]
+    installer = (
+        REPO_ROOT / "templates" / "multi_model" / "dot_claude" / "scripts" / "setup_models.sh"
+    ).read_text(encoding="utf-8")
+    assert f'CCR_VERSION="{pinned}"' in installer, (
+        f"manifest pins ccr at {pinned} but setup_models.sh disagrees — run "
+        "tools/check_third_party_updates.py apply ccr <version>"
+    )

--- a/tests/unit/test_third_party_updates.py
+++ b/tests/unit/test_third_party_updates.py
@@ -8,7 +8,7 @@ and the scaffolded installer's version can never silently drift apart.
 from __future__ import annotations
 
 import importlib.util
-import re
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -76,13 +76,15 @@ def test_apply_bumps_manifest_and_used_in(tmp_path, monkeypatch):
     # Build a self-contained fake repo so apply touches only temp files.
     (tmp_path / "tools").mkdir()
     manifest = tmp_path / "tools" / "pinned_third_party.toml"
+    # used_in (an array with '[') deliberately precedes `pinned` to lock the
+    # ordering-robustness of _replace_in_toml (Copilot review on #373).
     manifest.write_text(
         "[tools.ccr]\n"
         'package = "@x/ccr"\n'
         'ecosystem = "npm"\n'
-        'pinned = "2.0.0"\n'
-        'version_var = "CCR_VERSION"\n'
         'used_in = ["setup.sh"]\n'
+        'version_var = "CCR_VERSION"\n'
+        'pinned = "2.0.0"\n'
         "\n"
         "[tools.other]\n"
         'package = "@x/other"\n'
@@ -97,26 +99,11 @@ def test_apply_bumps_manifest_and_used_in(tmp_path, monkeypatch):
 
     assert script in changed and manifest in changed
     assert 'CCR_VERSION="2.1.0"' in script.read_text(encoding="utf-8")
-    text = manifest.read_text(encoding="utf-8")
-    assert re.search(r"\[tools\.ccr\][^\[]*pinned = \"2\.1\.0\"", text, re.DOTALL)
-    # The other tool's pin must be untouched (scoped replacement).
-    assert 'pinned = "1.0.0"' in text
+    tools = tomllib.loads(manifest.read_text(encoding="utf-8"))["tools"]
+    assert tools["ccr"]["pinned"] == "2.1.0"
+    assert tools["other"]["pinned"] == "1.0.0"  # scoped replacement — untouched
 
 
 def test_apply_unknown_tool_raises():
     with pytest.raises(KeyError):
         mod.apply("nope", "1.0.0")
-
-
-def test_manifest_pin_matches_installer_version():
-    """Contract: the manifest pin and CCR_VERSION in the scaffolded installer must
-    stay in lockstep — the whole point of `apply`. Guards silent drift (#356)."""
-    manifest = mod.load_manifest()
-    pinned = manifest["ccr"]["pinned"]
-    installer = (
-        REPO_ROOT / "templates" / "multi_model" / "dot_claude" / "scripts" / "setup_models.sh"
-    ).read_text(encoding="utf-8")
-    assert f'CCR_VERSION="{pinned}"' in installer, (
-        f"manifest pins ccr at {pinned} but setup_models.sh disagrees — run "
-        "tools/check_third_party_updates.py apply ccr <version>"
-    )

--- a/tests/unit/test_third_party_updates.py
+++ b/tests/unit/test_third_party_updates.py
@@ -1,0 +1,122 @@
+"""#356: the scheduled third-party update/security task — detection + lockstep bump.
+
+The networked path (`fetch_latest`) is exercised with an injected ``get_json`` so
+these never touch the registry. A separate contract test asserts the manifest pin
+and the scaffolded installer's version can never silently drift apart.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module():
+    path = REPO_ROOT / "tools" / "check_third_party_updates.py"
+    spec = importlib.util.spec_from_file_location("check_third_party_updates", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+@pytest.mark.parametrize(
+    ("candidate", "pinned", "expected"),
+    [
+        ("2.0.1", "2.0.0", True),
+        ("2.1.0", "2.0.99", True),
+        ("2.0.10", "2.0.9", True),  # numeric, not lexicographic
+        ("10.0.0", "9.9.9", True),
+        ("2.0.0", "2.0.0", False),
+        ("1.9.0", "2.0.0", False),
+        ("2.0.0-beta.1", "2.0.0", False),  # pre-release tail ignored → equal
+    ],
+)
+def test_is_newer(candidate, pinned, expected):
+    assert mod.is_newer(candidate, pinned) is expected
+
+
+def test_check_reports_update():
+    manifest = {"ccr": {"package": "@x/ccr", "ecosystem": "npm", "pinned": "2.0.0"}}
+    rows = mod.check(manifest, get_json=lambda url: {"dist-tags": {"latest": "2.1.0"}})
+    assert rows[0]["latest"] == "2.1.0"
+    assert rows[0]["update_available"] is True
+
+
+def test_check_no_update():
+    manifest = {"ccr": {"package": "@x/ccr", "ecosystem": "npm", "pinned": "2.0.0"}}
+    rows = mod.check(manifest, get_json=lambda url: {"dist-tags": {"latest": "2.0.0"}})
+    assert rows[0]["update_available"] is False
+
+
+def test_check_survives_network_error():
+    manifest = {"ccr": {"package": "@x/ccr", "ecosystem": "npm", "pinned": "2.0.0"}}
+
+    def boom(url):
+        raise OSError("registry unreachable")
+
+    rows = mod.check(manifest, get_json=boom)
+    assert rows[0]["update_available"] is False
+    assert "error" in rows[0]
+
+
+def test_fetch_latest_rejects_unknown_ecosystem():
+    with pytest.raises(ValueError, match="ecosystem"):
+        mod.fetch_latest({"package": "x", "ecosystem": "cargo"}, get_json=lambda u: {})
+
+
+def test_apply_bumps_manifest_and_used_in(tmp_path, monkeypatch):
+    # Build a self-contained fake repo so apply touches only temp files.
+    (tmp_path / "tools").mkdir()
+    manifest = tmp_path / "tools" / "pinned_third_party.toml"
+    manifest.write_text(
+        "[tools.ccr]\n"
+        'package = "@x/ccr"\n'
+        'ecosystem = "npm"\n'
+        'pinned = "2.0.0"\n'
+        'version_var = "CCR_VERSION"\n'
+        'used_in = ["setup.sh"]\n'
+        "\n"
+        "[tools.other]\n"
+        'package = "@x/other"\n'
+        'pinned = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    script = tmp_path / "setup.sh"
+    script.write_text('CCR_VERSION="2.0.0"\necho hi\n', encoding="utf-8")
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    changed = mod.apply("ccr", "2.1.0", manifest_path=manifest)
+
+    assert script in changed and manifest in changed
+    assert 'CCR_VERSION="2.1.0"' in script.read_text(encoding="utf-8")
+    text = manifest.read_text(encoding="utf-8")
+    assert re.search(r"\[tools\.ccr\][^\[]*pinned = \"2\.1\.0\"", text, re.DOTALL)
+    # The other tool's pin must be untouched (scoped replacement).
+    assert 'pinned = "1.0.0"' in text
+
+
+def test_apply_unknown_tool_raises():
+    with pytest.raises(KeyError):
+        mod.apply("nope", "1.0.0")
+
+
+def test_manifest_pin_matches_installer_version():
+    """Contract: the manifest pin and CCR_VERSION in the scaffolded installer must
+    stay in lockstep — the whole point of `apply`. Guards silent drift (#356)."""
+    manifest = mod.load_manifest()
+    pinned = manifest["ccr"]["pinned"]
+    installer = (
+        REPO_ROOT / "templates" / "multi_model" / "dot_claude" / "scripts" / "setup_models.sh"
+    ).read_text(encoding="utf-8")
+    assert f'CCR_VERSION="{pinned}"' in installer, (
+        f"manifest pins ccr at {pinned} but setup_models.sh disagrees — run "
+        "tools/check_third_party_updates.py apply ccr <version>"
+    )

--- a/tools/check_third_party_updates.py
+++ b/tools/check_third_party_updates.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Check pinned third-party tools for newer releases and bump them in lockstep.
+
+project-init owns a *vetted* pinned version of each external tool that sits on a
+scaffolded project's request path (CCR first; ADR-016 §5, #356). This script is
+the deterministic, no-LLM core of the scheduled "third-party-updates" workflow:
+
+  check               report which pinned tools have a newer upstream release
+  apply <tool> <ver>  bump the manifest pin + the version string in every file
+                      that carries it (kept in lockstep), so a proposed update is
+                      a single reviewable diff
+
+The workflow runs `check --json`, security-scans each candidate (npm audit), then
+`apply`s and opens a PR — never auto-merged. Stdlib only (tomllib + urllib); no
+new dependencies, no LLM (CLAUDE.md / ADR-001).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "tools" / "pinned_third_party.toml"
+_NPM_ACCEPT = "application/vnd.npm.install-v1+json"  # abbreviated metadata
+
+
+def load_manifest(path: Path = MANIFEST) -> dict:
+    """Parse the pinned-tools manifest into ``{tool_id: {...}}``."""
+    with path.open("rb") as fh:
+        return tomllib.load(fh).get("tools", {})
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    """Comparable key for a dotted version; pre-release suffix is dropped.
+
+    "2.0.10" > "2.0.9"; "2.1.0" > "2.0.99"; a "-beta" tail is ignored for ordering
+    (we only ever bump to stable dist-tag 'latest', so this is sufficient here).
+    """
+    core = re.split(r"[-+]", version.strip(), maxsplit=1)[0]
+    parts = []
+    for piece in core.split("."):
+        digits = re.sub(r"\D", "", piece)
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def is_newer(candidate: str, pinned: str) -> bool:
+    """True when ``candidate`` is a strictly newer version than ``pinned``."""
+    return _version_key(candidate) > _version_key(pinned)
+
+
+def _http_get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"Accept": _NPM_ACCEPT})
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 (https registry)
+        return json.load(resp)
+
+
+def fetch_latest(tool: dict, *, get_json=_http_get_json) -> str:
+    """Return the upstream 'latest' version for a manifest tool entry."""
+    ecosystem = tool.get("ecosystem", "npm")
+    if ecosystem != "npm":
+        raise ValueError(f"unsupported ecosystem: {ecosystem!r} (only npm so far)")
+    data = get_json(f"https://registry.npmjs.org/{tool['package']}")
+    return data["dist-tags"]["latest"]
+
+
+def check(manifest: dict, *, get_json=_http_get_json) -> list[dict]:
+    """Report pinned-vs-latest for each tool. Network errors → error field set."""
+    rows = []
+    for tool_id, tool in manifest.items():
+        row = {"tool": tool_id, "package": tool["package"], "pinned": tool["pinned"]}
+        try:
+            latest = fetch_latest(tool, get_json=get_json)
+            row["latest"] = latest
+            row["update_available"] = is_newer(latest, tool["pinned"])
+        except Exception as exc:  # noqa: BLE001 — report, don't crash the sweep
+            row["error"] = f"{type(exc).__name__}: {exc}"
+            row["update_available"] = False
+        rows.append(row)
+    return rows
+
+
+def _replace_in_toml(text: str, tool_id: str, version: str) -> str:
+    """Set ``pinned = "<version>"`` inside the ``[tools.<tool_id>]`` table only."""
+    pattern = re.compile(
+        r"(\[tools\." + re.escape(tool_id) + r"\][^\[]*?\bpinned\s*=\s*\")[^\"]*(\")",
+        re.DOTALL,
+    )
+    new_text, n = pattern.subn(rf"\g<1>{version}\g<2>", text, count=1)
+    if n != 1:
+        raise ValueError(f"could not find pinned for [tools.{tool_id}] in the manifest")
+    return new_text
+
+
+def _replace_version_var(text: str, var: str, version: str) -> tuple[str, int]:
+    """Set ``VAR="<version>"`` (shell assignment) wherever it appears."""
+    pattern = re.compile(r"(^\s*" + re.escape(var) + r'\s*=\s*")[^"]*(")', re.MULTILINE)
+    return pattern.subn(rf"\g<1>{version}\g<2>", text)
+
+
+def apply(tool_id: str, version: str, *, manifest_path: Path = MANIFEST) -> list[Path]:
+    """Bump the manifest pin and the version string in every used_in file.
+
+    Returns the list of files changed. Pure file ops — no network, no LLM.
+    """
+    manifest = load_manifest(manifest_path)
+    if tool_id not in manifest:
+        raise KeyError(f"unknown tool: {tool_id!r}")
+    tool = manifest[tool_id]
+    changed: list[Path] = []
+
+    manifest_path.write_text(
+        _replace_in_toml(manifest_path.read_text(encoding="utf-8"), tool_id, version),
+        encoding="utf-8",
+    )
+    changed.append(manifest_path)
+
+    var = tool.get("version_var")
+    for rel in tool.get("used_in", []):
+        if not var:
+            break
+        path = REPO_ROOT / rel
+        new_text, n = _replace_version_var(path.read_text(encoding="utf-8"), var, version)
+        if n == 0:
+            raise ValueError(f"{var} not found in {rel} — cannot bump in lockstep")
+        path.write_text(new_text, encoding="utf-8")
+        changed.append(path)
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``check [--json]`` to report updates, ``apply <tool> <version>`` to bump."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    c = sub.add_parser("check", help="report tools with a newer upstream release")
+    c.add_argument("--json", action="store_true", help="emit JSON (for the workflow)")
+    a = sub.add_parser("apply", help="bump a tool's pin + its version string in lockstep")
+    a.add_argument("tool")
+    a.add_argument("version")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "check":
+        rows = check(load_manifest())
+        if args.json:
+            print(json.dumps(rows, indent=2))
+        else:
+            for r in rows:
+                if r.get("error"):
+                    print(f"  {r['tool']}: ERROR {r['error']}")
+                elif r["update_available"]:
+                    print(f"  {r['tool']}: {r['pinned']} → {r['latest']}  UPDATE AVAILABLE")
+                else:
+                    print(f"  {r['tool']}: {r['pinned']} (up to date)")
+        return 0
+
+    changed = apply(args.tool, args.version)
+    for p in changed:
+        print(f"bumped {p.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_third_party_updates.py
+++ b/tools/check_third_party_updates.py
@@ -23,6 +23,7 @@ import re
 import tomllib
 import urllib.request
 from pathlib import Path
+from urllib.parse import quote
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = REPO_ROOT / "tools" / "pinned_third_party.toml"
@@ -65,7 +66,9 @@ def fetch_latest(tool: dict, *, get_json=_http_get_json) -> str:
     ecosystem = tool.get("ecosystem", "npm")
     if ecosystem != "npm":
         raise ValueError(f"unsupported ecosystem: {ecosystem!r} (only npm so far)")
-    data = get_json(f"https://registry.npmjs.org/{tool['package']}")
+    # Scoped packages need the "/" encoded as %2F for the registry doc endpoint
+    # (keep the leading "@"); the unencoded form happens to resolve too.
+    data = get_json(f"https://registry.npmjs.org/{quote(tool['package'], safe='@')}")
     return data["dist-tags"]["latest"]
 
 
@@ -86,15 +89,27 @@ def check(manifest: dict, *, get_json=_http_get_json) -> list[dict]:
 
 
 def _replace_in_toml(text: str, tool_id: str, version: str) -> str:
-    """Set ``pinned = "<version>"`` inside the ``[tools.<tool_id>]`` table only."""
-    pattern = re.compile(
-        r"(\[tools\." + re.escape(tool_id) + r"\][^\[]*?\bpinned\s*=\s*\")[^\"]*(\")",
-        re.DOTALL,
-    )
-    new_text, n = pattern.subn(rf"\g<1>{version}\g<2>", text, count=1)
-    if n != 1:
+    """Set ``pinned = "<version>"`` inside the ``[tools.<tool_id>]`` table only.
+
+    Scans line by line and tracks the active table, so it is robust to field
+    order within the block (a ``used_in = [...]`` array before ``pinned`` no
+    longer confuses it) and never touches another table's pin.
+    """
+    section_re = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+    pin_re = re.compile(r'^(\s*pinned\s*=\s*")[^"]*(")')
+    target = f"tools.{tool_id}"
+    out, in_section, done = [], False, False
+    for line in text.splitlines(keepends=True):
+        header = section_re.match(line)
+        if header:
+            in_section = header.group(1) == target
+        elif in_section and not done:
+            line, n = pin_re.subn(rf"\g<1>{version}\g<2>", line)
+            done = bool(n)
+        out.append(line)
+    if not done:
         raise ValueError(f"could not find pinned for [tools.{tool_id}] in the manifest")
-    return new_text
+    return "".join(out)
 
 
 def _replace_version_var(text: str, var: str, version: str) -> tuple[str, int]:

--- a/tools/pinned_third_party.toml
+++ b/tools/pinned_third_party.toml
@@ -1,0 +1,18 @@
+# Pinned third-party tools project-init owns the vetted version of (ADR-016 §5).
+#
+# These sit on the *request path* of a scaffolded project (CCR proxies model
+# traffic), so we never bump them blindly. The scheduled "third-party-updates"
+# workflow runs tools/check_third_party_updates.py to detect newer releases,
+# security-scans the candidate, and opens a PR proposing the bump — never
+# auto-merged. Downstream projects inherit the vetted pin via upgrade-as-PR
+# (PI-241). Add a [tools.<id>] block to bring another external tool under this.
+
+[tools.ccr]
+package = "@musistudio/claude-code-router"
+ecosystem = "npm"
+pinned = "2.0.0"
+# The shell variable carrying this version in each used_in file (kept in lockstep
+# with `pinned` by `check_third_party_updates.py apply`).
+version_var = "CCR_VERSION"
+used_in = ["templates/multi_model/dot_claude/scripts/setup_models.sh"]
+changelog = "https://github.com/musistudio/claude-code-router/releases"

--- a/tools/propose_third_party_bumps.sh
+++ b/tools/propose_third_party_bumps.sh
@@ -9,7 +9,10 @@
 set -euo pipefail
 
 UPDATES="${1:?usage: propose_third_party_bumps.sh <updates.json>}"
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Run from the repo root so the relative tool/manifest paths resolve regardless
+# of the caller's working directory. Resolve UPDATES first (it may be relative).
+UPDATES="$(cd "$(dirname "$UPDATES")" && pwd)/$(basename "$UPDATES")"
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 have gh || { echo "gh CLI required" >&2; exit 1; }
@@ -36,15 +39,22 @@ while read -r tool package pinned latest; do
   branch="chore/bump-${tool}-${latest}"
   echo "=== $tool: $pinned → $latest ==="
 
-  # Idempotent: skip if a branch/PR for this exact bump already exists.
+  # Idempotent: skip if a PR is open OR the remote branch already exists (e.g. a
+  # prior proposal was closed without deleting it) — recreating it would fail the
+  # push with a non-fast-forward.
   if gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q '[0-9]'; then
     echo "  PR for $branch already open — skipping."
     continue
   fi
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    echo "  remote branch $branch already exists (no open PR) — skipping; delete it to re-propose."
+    continue
+  fi
 
   # Security scan of the candidate (best-effort; never blocks the proposal).
-  scan="(npm not available — scan skipped)"
+  scan="(security scan unavailable — npm not installed)"
   if have npm; then
+    scan="(npm audit produced no report)"
     tmp="$(mktemp -d)"
     ( cd "$tmp" && npm init -y >/dev/null 2>&1 \
         && npm install "${package}@${latest}" --package-lock-only --no-audit >/dev/null 2>&1 \

--- a/tools/propose_third_party_bumps.sh
+++ b/tools/propose_third_party_bumps.sh
@@ -68,8 +68,17 @@ PY
 
   # Apply the bump (manifest pin + version string in lockstep) on a fresh branch.
   git checkout -b "$branch" >/dev/null 2>&1 || git checkout "$branch"
-  uv run python tools/check_third_party_updates.py apply "$tool" "$latest"
-  git add -A
+  # Stage ONLY the files apply changed (it prints "bumped <path>" per file), so
+  # the transient updates.json and any other workspace state never leak into the
+  # single-purpose bump PR.
+  mapfile -t bumped < <(uv run python tools/check_third_party_updates.py apply "$tool" "$latest" | sed -n 's/^bumped //p')
+  if [ "${#bumped[@]}" -eq 0 ]; then
+    echo "  apply changed nothing — skipping."
+    git checkout - >/dev/null 2>&1 || git checkout main >/dev/null 2>&1
+    continue
+  fi
+  printf '  bumped: %s\n' "${bumped[@]}"
+  git add -- "${bumped[@]}"
   git commit -q -m "chore: bump ${tool} ${pinned} → ${latest} (vetted pin)"
   git push -u origin "$branch" >/dev/null 2>&1
 

--- a/tools/propose_third_party_bumps.sh
+++ b/tools/propose_third_party_bumps.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# propose_third_party_bumps.sh — open a PR proposing each available pinned-tool
+# bump, with a security scan attached. Driven by the third-party-updates workflow
+# (ADR-016 §5, #356); deterministic, no LLM, never auto-merges.
+#
+# Usage: propose_third_party_bumps.sh <updates.json>
+#   where <updates.json> is the output of `check_third_party_updates.py check --json`.
+set -euo pipefail
+
+UPDATES="${1:?usage: propose_third_party_bumps.sh <updates.json>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+have gh || { echo "gh CLI required" >&2; exit 1; }
+have npm || echo "warning: npm not found — security scan will be skipped" >&2
+
+# Emit "tool package pinned latest" lines for entries with update_available=true.
+rows="$(python3 - "$UPDATES" <<'PY'
+import json, sys
+for r in json.load(open(sys.argv[1])):
+    if r.get("update_available"):
+        print(r["tool"], r["package"], r["pinned"], r["latest"])
+PY
+)"
+
+if [ -z "$rows" ]; then
+  echo "No third-party updates available — nothing to propose."
+  exit 0
+fi
+
+while read -r tool package pinned latest; do
+  [ -n "$tool" ] || continue
+  # No-issue maintenance: a non-issue-linked branch + scopeless title so PR
+  # validation skips the Closes-keyword check (these don't close an issue).
+  branch="chore/bump-${tool}-${latest}"
+  echo "=== $tool: $pinned → $latest ==="
+
+  # Idempotent: skip if a branch/PR for this exact bump already exists.
+  if gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q '[0-9]'; then
+    echo "  PR for $branch already open — skipping."
+    continue
+  fi
+
+  # Security scan of the candidate (best-effort; never blocks the proposal).
+  scan="(npm not available — scan skipped)"
+  if have npm; then
+    tmp="$(mktemp -d)"
+    ( cd "$tmp" && npm init -y >/dev/null 2>&1 \
+        && npm install "${package}@${latest}" --package-lock-only --no-audit >/dev/null 2>&1 \
+        && npm audit --json > audit.json 2>/dev/null ) || true
+    if [ -s "$tmp/audit.json" ]; then
+      scan="$(python3 - "$tmp/audit.json" <<'PY'
+import json, sys
+try:
+    a = json.load(open(sys.argv[1])).get("metadata", {}).get("vulnerabilities", {})
+    total = a.get("total", 0)
+    print(f"npm audit: {total} vulnerabilities "
+          f"(critical {a.get('critical',0)}, high {a.get('high',0)}, "
+          f"moderate {a.get('moderate',0)}, low {a.get('low',0)}).")
+except Exception as exc:
+    print(f"npm audit output unparseable: {exc}")
+PY
+)"
+    fi
+    rm -rf "$tmp"
+  fi
+
+  # Apply the bump (manifest pin + version string in lockstep) on a fresh branch.
+  git checkout -b "$branch" >/dev/null 2>&1 || git checkout "$branch"
+  uv run python tools/check_third_party_updates.py apply "$tool" "$latest"
+  git add -A
+  git commit -q -m "chore: bump ${tool} ${pinned} → ${latest} (vetted pin)"
+  git push -u origin "$branch" >/dev/null 2>&1
+
+  changelog="$(python3 - "$tool" <<'PY'
+import sys, tomllib
+t = tomllib.load(open("tools/pinned_third_party.toml", "rb"))["tools"][sys.argv[1]]
+print(t.get("changelog", ""))
+PY
+)"
+
+  gh pr create --base main --head "$branch" \
+    --title "chore: bump ${tool} ${pinned} → ${latest}" \
+    --body "$(cat <<EOF
+Automated proposal to bump the vetted pin for **${tool}** (\`${package}\`).
+
+- **${pinned} → ${latest}**
+- Security scan — ${scan}
+- Changelog: ${changelog:-n/a}
+
+This sits on a scaffolded project's request path, so **review the changelog/diff
+before merging** (ADR-016 §5). Not auto-merged. Downstream projects inherit the
+vetted pin via upgrade-as-PR (PI-241).
+EOF
+)"
+  git checkout - >/dev/null 2>&1 || git checkout main >/dev/null 2>&1
+done <<<"$rows"


### PR DESCRIPTION
Final piece of epic #315 (ADR-016 §5). CCR sits on a scaffolded project's request path, so project-init owns a **vetted pinned version** and must never bump it blindly. This adds the deterministic (no-LLM) machinery to detect, scan, and *propose* bumps.

## Pieces
- **`tools/pinned_third_party.toml`** — manifest of pinned externals (CCR now; add a `[tools.<id>]` block to generalize).
- **`tools/check_third_party_updates.py`** (stdlib: tomllib + urllib) — `check` reports newer npm releases; `apply <tool> <ver>` bumps the manifest pin **and** the version string in every `used_in` file in lockstep (so `setup_models.sh`'s `CCR_VERSION` can't drift from the manifest).
- **`tools/propose_third_party_bumps.sh`** — per available update: `npm audit` the candidate, then open a **no-issue PR** (scopeless title, non-issue branch) with the scan summary + changelog. **Never auto-merges**; idempotent (skips if a PR is already open).
- **`.github/workflows/third-party-updates.yml`** — weekly schedule + `workflow_dispatch`; `contents: write`, `pull-requests: write`.

Downstream projects inherit the vetted pin via upgrade-as-PR (PI-241).

## Tests
Numeric version compare (10>9, 2.0.10>2.0.9, pre-release tail ignored), `check` with a faked registry (update / no-update / network-error), `apply` lockstep bump + **scoped** TOML edit (other tools untouched), and a **contract** that the manifest pin equals `setup_models.sh`'s `CCR_VERSION` — guarding silent drift. Full suite 837 passed, 3 skipped.

Closes #356