### PR TITLE
fix(PI-360): macOS bash-3.2/BSD breakage in always-on hooks (mapfile, sha256sum)

### DIFF
--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -28,7 +28,11 @@ ERRORS=""
 # Lint and auto-fix staged Python files. Prefer 'uv run ruff' inside a
 # uv-managed project so the hook uses the same ruff the project itself uses;
 # fall back to a system ruff binary.
-mapfile -t STAGED_PY < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
+# bash 3.2 (macOS /bin/bash) has no `mapfile`/`readarray` — read into the array
+# with a portable while-loop so the always-on commit gate runs everywhere.
+STAGED_PY=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_PY+=("$_f"); done \
+    < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
 if [ "${#STAGED_PY[@]}" -gt 0 ]; then
     LINT_OUT=""
     if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
@@ -49,7 +53,9 @@ fi
 
 # Lint and auto-fix staged JS/TS files
 # Use bunx (bun's package runner) — consistent with project convention (PI-15).
-mapfile -t STAGED_JS < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(js|ts|jsx|tsx)$' || true)
+STAGED_JS=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_JS+=("$_f"); done \
+    < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(js|ts|jsx|tsx)$' || true)
 if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
     bunx eslint --fix --quiet "${STAGED_JS[@]}" 2>/dev/null || true
     LINT_OUT=$(bunx eslint --quiet "${STAGED_JS[@]}" 2>&1 || true)

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -11,9 +11,17 @@ STAMP=".claude/.session_setup_stamp"
 LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
+# macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
+# host provides so the always-on bootstrap fingerprint works everywhere.
+if command -v sha256sum >/dev/null 2>&1; then
+  _sha256() { sha256sum; }
+else
+  _sha256() { shasum -a 256; }
+fi
+
 fingerprint() {
   cat pyproject.toml uv.lock package.json bun.lock bun.lockb go.mod go.sum 2>/dev/null \
-    | sha256sum | cut -d' ' -f1
+    | _sha256 | cut -d' ' -f1
 }
 
 # The stamp alone is not enough: an ephemeral container can restore the repo

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -12,11 +12,16 @@ LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
-# host provides so the always-on bootstrap fingerprint works everywhere.
+# host provides; fall back to POSIX `cksum` so the fingerprint is always defined
+# even on a minimal host with neither hasher (an empty fingerprint would force a
+# re-bootstrap every session). cksum isn't cryptographic, but a stable content
+# digest is all this stamp needs.
 if command -v sha256sum >/dev/null 2>&1; then
   _sha256() { sha256sum; }
-else
+elif command -v shasum >/dev/null 2>&1; then
   _sha256() { shasum -a 256; }
+else
+  _sha256() { cksum; }
 fi
 
 fingerprint() {

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -28,7 +28,11 @@ ERRORS=""
 # Lint and auto-fix staged Python files. Prefer 'uv run ruff' inside a
 # uv-managed project so the hook uses the same ruff the project itself uses;
 # fall back to a system ruff binary.
-mapfile -t STAGED_PY < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
+# bash 3.2 (macOS /bin/bash) has no `mapfile`/`readarray` — read into the array
+# with a portable while-loop so the always-on commit gate runs everywhere.
+STAGED_PY=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_PY+=("$_f"); done \
+    < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
 if [ "${#STAGED_PY[@]}" -gt 0 ]; then
     LINT_OUT=""
     if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
@@ -49,7 +53,9 @@ fi
 
 # Lint and auto-fix staged JS/TS files
 # Use bunx (bun's package runner) — consistent with project convention (PI-15).
-mapfile -t STAGED_JS < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(js|ts|jsx|tsx)$' || true)
+STAGED_JS=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_JS+=("$_f"); done \
+    < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(js|ts|jsx|tsx)$' || true)
 if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
     bunx eslint --fix --quiet "${STAGED_JS[@]}" 2>/dev/null || true
     LINT_OUT=$(bunx eslint --quiet "${STAGED_JS[@]}" 2>&1 || true)

--- a/templates/fallback/dot_claude/hooks/session_setup.sh
+++ b/templates/fallback/dot_claude/hooks/session_setup.sh
@@ -11,9 +11,17 @@ STAMP=".claude/.session_setup_stamp"
 LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
+# macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
+# host provides so the always-on bootstrap fingerprint works everywhere.
+if command -v sha256sum >/dev/null 2>&1; then
+  _sha256() { sha256sum; }
+else
+  _sha256() { shasum -a 256; }
+fi
+
 fingerprint() {
   cat pyproject.toml uv.lock package.json bun.lock bun.lockb go.mod go.sum 2>/dev/null \
-    | sha256sum | cut -d' ' -f1
+    | _sha256 | cut -d' ' -f1
 }
 
 # The stamp alone is not enough: an ephemeral container can restore the repo

--- a/templates/fallback/dot_claude/hooks/session_setup.sh
+++ b/templates/fallback/dot_claude/hooks/session_setup.sh
@@ -12,11 +12,16 @@ LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
-# host provides so the always-on bootstrap fingerprint works everywhere.
+# host provides; fall back to POSIX `cksum` so the fingerprint is always defined
+# even on a minimal host with neither hasher (an empty fingerprint would force a
+# re-bootstrap every session). cksum isn't cryptographic, but a stable content
+# digest is all this stamp needs.
 if command -v sha256sum >/dev/null 2>&1; then
   _sha256() { sha256sum; }
-else
+elif command -v shasum >/dev/null 2>&1; then
   _sha256() { shasum -a 256; }
+else
+  _sha256() { cksum; }
 fi
 
 fingerprint() {

--- a/tests/contracts/test_hook_portability.py
+++ b/tests/contracts/test_hook_portability.py
@@ -1,0 +1,63 @@
+"""PI-360: always-on hooks must run on macOS /bin/bash (bash 3.2) + BSD coreutils.
+
+The commit gate and the SessionStart bootstrap fire on first commit / first
+session, so a bash-4-only builtin or a GNU-only tool there breaks a macOS user
+on contact. These are content contracts over both the source-of-truth fallback
+templates and the derived plugin payload (kept in sync by tools/sync_plugin.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Both trees that ship the always-on hooks: the --no-plugin fallback source of
+# truth and the default plugin payload derived from it.
+_HOOK_DIRS = (
+    _REPO_ROOT / "templates" / "fallback" / "dot_claude" / "hooks",
+    _REPO_ROOT / "plugins" / "project-init-workflow" / "hooks",
+)
+_ALWAYS_ON = ("pre_commit_gate.sh", "session_setup.sh")
+
+# bash-4+ builtins absent from macOS's stock bash 3.2 (shell policy: floor 3.2).
+_BASH4_BUILTINS = ("mapfile", "readarray", "declare -A")
+
+
+def _hook_files(name: str) -> list[Path]:
+    return [d / name for d in _HOOK_DIRS]
+
+
+def _code_lines(text: str) -> str:
+    """Strip comment-only lines so a builtin named in a comment doesn't trip."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+@pytest.mark.parametrize("name", _ALWAYS_ON)
+@pytest.mark.parametrize("builtin", _BASH4_BUILTINS)
+def test_no_bash4_builtins(name: str, builtin: str):
+    for path in _hook_files(name):
+        assert path.exists(), f"missing always-on hook: {path}"
+        assert builtin not in _code_lines(path.read_text()), (
+            f"{path} uses bash-4 builtin {builtin!r} — breaks macOS bash 3.2"
+        )
+
+
+def test_session_setup_fingerprint_is_shasum_aware():
+    """The bootstrap fingerprint must not assume GNU sha256sum exists."""
+    for path in _hook_files("session_setup.sh"):
+        text = path.read_text()
+        assert "shasum -a 256" in text, f"{path}: no BSD shasum fallback for sha256"
+        assert "command -v sha256sum" in text, f"{path}: must probe for sha256sum"
+
+
+def test_commit_gate_builds_arrays_portably():
+    """Staged-file lists are read with a while-loop, not mapfile."""
+    for path in _hook_files("pre_commit_gate.sh"):
+        code = _code_lines(path.read_text())
+        assert "while IFS= read -r" in code, f"{path}: expected portable read loop"
+        assert "STAGED_PY+=(" in code and "STAGED_JS+=(" in code

--- a/tests/contracts/test_hook_portability.py
+++ b/tests/contracts/test_hook_portability.py
@@ -48,11 +48,14 @@ def test_no_bash4_builtins(name: str, builtin: str):
 
 
 def test_session_setup_fingerprint_is_shasum_aware():
-    """The bootstrap fingerprint must not assume GNU sha256sum exists."""
+    """The bootstrap fingerprint must not assume GNU sha256sum exists, and must
+    stay defined on a host with neither hasher (POSIX cksum fallback)."""
     for path in _hook_files("session_setup.sh"):
         text = path.read_text()
-        assert "shasum -a 256" in text, f"{path}: no BSD shasum fallback for sha256"
         assert "command -v sha256sum" in text, f"{path}: must probe for sha256sum"
+        assert "command -v shasum" in text, f"{path}: must probe for shasum"
+        assert "shasum -a 256" in text, f"{path}: no BSD shasum fallback for sha256"
+        assert "cksum" in text, f"{path}: no POSIX cksum fallback when neither exists"
 
 
 def test_commit_gate_builds_arrays_portably():

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -103,9 +103,11 @@ class TestScaffoldObsidianOnly:
 
     def test_pre_commit_gate_quotes_staged_file_paths(self):
         content = (self.target / ".claude" / "hooks" / "pre_commit_gate.sh").read_text()
-        assert "mapfile -t STAGED_PY" in content
+        # PI-360: staged lists are built with a portable read loop (bash 3.2 has
+        # no mapfile), and the expanded arrays stay quoted to handle spaces.
+        assert "STAGED_PY+=(" in content
         assert '"${STAGED_PY[@]}"' in content
-        assert "mapfile -t STAGED_JS" in content
+        assert "STAGED_JS+=(" in content
         assert '"${STAGED_JS[@]}"' in content
 
     def test_legacy_safety_hooks_not_scaffolded(self):


### PR DESCRIPTION
## What

Workstream A of epic #359 (OS-agnostic scaffolded output). Fixes the two macOS correctness blockers wired into **always-on** hooks, so a macOS user (stock `/bin/bash` = bash 3.2, BSD coreutils) hits zero friction on first commit / first session.

- **`pre_commit_gate.sh`** — `mapfile` is a bash-4+ builtin absent from macOS bash 3.2. Replaced both `mapfile -t STAGED_PY` / `mapfile -t STAGED_JS` with a portable `while IFS= read -r` loop that builds the arrays; expanded arrays stay quoted.
- **`session_setup.sh`** — the bootstrap fingerprint used GNU `sha256sum`, which macOS does not ship. Now probes for `sha256sum` and falls back to BSD `shasum -a 256`.
- Synced the derived plugin payload via `tools/sync_plugin.py`.

## Shell policy

Floor = bash 3.2 (universal macOS bash). No POSIX-sh rewrite; only bash-4+ builtins forbidden.

## Tests

- New `tests/contracts/test_hook_portability.py` — asserts no bash-4 builtins in the always-on hooks (both fallback source + plugin payload), shasum-aware fingerprint, portable array build.
- Updated `test_scaffold_obsidian.py` gate assertion to the portable construct.
- Full suite: 845 passed, 3 skipped. `bash -n` syntax-clean; functional checks confirm equivalent behavior.

Part of #359.
Closes #360