### PR TITLE
test(PI-363): cross-platform portability regression tests + macOS CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,106 @@ jobs:
       - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+  # PI-363 Layer 2: shellcheck the rendered scaffold output (quoting/SC2086 and
+  # general portability the denylist lint can't see). Cheap; runs every PR.
+  shellcheck:
+    name: ShellCheck (scaffolded scripts)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.12"
+
+      - name: Scaffold a project (templates -> real scripts)
+        run: |
+          uv run project-init /tmp/sc-target \
+            --non-interactive --preset obsidian-only --name sc \
+            --description "shellcheck" --language python --no-plugin --strict
+
+      - name: ShellCheck rendered shell scripts
+        run: |
+          set -euo pipefail
+          # Every rendered bash script (incl. extensionless git hooks); skip .md.
+          files=$(grep -rIl '^#!/usr/bin/env bash' /tmp/sc-target | grep -v '\.md$')
+          echo "$files"
+          # shellcheck-py pins the binary so CI matches local `uvx` runs.
+          uvx --from shellcheck-py shellcheck --severity=warning $files
+
+  # PI-363 Layer 3 gate: only spend the 10x-billed macOS minutes when shell or
+  # template files actually change. Ordinary PRs skip the macOS job entirely.
+  changes:
+    name: Detect shell/template changes
+    runs-on: ubuntu-24.04
+    outputs:
+      shell: ${{ steps.filter.outputs.shell }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shell:
+              - '**/*.sh'
+              - '**/*.sh.tmpl'
+              - 'templates/**/hooks/**'
+              - 'templates/**/scripts/**'
+
+  # PI-363 Layer 3: the real bash-3.2 oracle. macos-latest ships bash 3.2 as
+  # /bin/bash and BSD coreutils — the genuine stock-Mac environment — so it
+  # catches behavioral breakage (sha256sum/shasum, mapfile, _py.sh resolution)
+  # the static denylist can't. Gated to shell/template changes.
+  macos-portability:
+    name: macOS bash-3.2 portability
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+
+      - name: Confirm the stock-Mac bash is 3.2
+        run: /bin/bash --version | head -1
+
+      - name: Scaffold a project
+        run: |
+          uv run project-init /tmp/macos-target \
+            --non-interactive --preset obsidian-only --name mac \
+            --description "macos portability" --language python --no-plugin --strict
+
+      - name: SessionStart bootstrap runs under bash 3.2 (sha256sum->shasum)
+        run: |
+          cd /tmp/macos-target
+          # Force the stock bash 3.2; the hook must never exit non-zero.
+          /bin/bash .claude/hooks/session_setup.sh
+          test -f .claude/.session_setup_stamp
+
+      - name: Commit gate runs under bash 3.2 against a staged file
+        run: |
+          cd /tmp/macos-target
+          git init -q
+          git config user.email ci@example.com
+          git config user.name ci
+          printf 'x = 1\n' > sample.py
+          git add sample.py
+          # PreToolUse hook: reads tool JSON on stdin, must exit 0 for a clean file.
+          printf '%s' '{"tool_input":{"command":"git commit -m test"}}' \
+            | /bin/bash .claude/hooks/pre_commit_gate.sh
+          echo "pre_commit_gate.sh exit: $?"
+
+      - name: _py.sh resolves an interpreter on macOS
+        run: |
+          cd /tmp/macos-target
+          out=$(/bin/bash .claude/hooks/_py.sh -c "print('resolver-ok')")
+          test "$out" = "resolver-ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,20 @@ jobs:
       - name: ShellCheck rendered shell scripts
         run: |
           set -euo pipefail
-          # Every rendered bash script (incl. extensionless git hooks); skip .md.
-          files=$(grep -rIl '^#!/usr/bin/env bash' /tmp/sc-target | grep -v '\.md$')
-          echo "$files"
-          # shellcheck-py pins the binary so CI matches local `uvx` runs.
-          uvx --from shellcheck-py shellcheck --severity=warning $files
+          # Collect every rendered bash script (incl. extensionless git hooks),
+          # skipping docs. Read into a quoted array so word-splitting can't bite;
+          # scaffold paths never contain spaces/newlines. shellcheck-py is pinned
+          # so CI is deterministic and matches local `uvx` runs.
+          files=()
+          while IFS= read -r f; do files+=("$f"); done < <(
+            grep -rIl '^#!/usr/bin/env bash' /tmp/sc-target | grep -v '\.md$'
+          )
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "error: no scaffolded shell scripts found" >&2
+            exit 1
+          fi
+          printf '%s\n' "${files[@]}"
+          uvx --from 'shellcheck-py==0.11.0.1' shellcheck --severity=warning "${files[@]}"
 
   # PI-363 Layer 3 gate: only spend the 10x-billed macOS minutes when shell or
   # template files actually change. Ordinary PRs skip the macOS job entirely.

--- a/templates/base/dot_github/hooks/pre-push
+++ b/templates/base/dot_github/hooks/pre-push
@@ -11,7 +11,9 @@ set -e
 
 ZERO_SHA="0000000000000000000000000000000000000000"
 
-while read local_ref local_sha remote_ref remote_sha; do
+# git feeds "<local_ref> <local_sha> <remote_ref> <remote_sha>" per ref; we only
+# use local_sha + remote_ref, so the other two fields go to `_`. -r per SC2162.
+while read -r _ local_sha remote_ref _; do
   # Branch deletions are always allowed (cleaning up misnamed branches).
   if [[ "$local_sha" == "$ZERO_SHA" ]]; then
     continue

--- a/tests/unit/test_shell_portability.py
+++ b/tests/unit/test_shell_portability.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TEMPLATES = _REPO_ROOT / "templates"
 
@@ -31,14 +34,27 @@ _IF_GUARD = re.compile(r"^\{\{#if [^}]+\}\}")
 
 
 def _shell_templates() -> list[Path]:
-    out: list[Path] = []
+    out: set[Path] = set()
     for pattern in ("*.sh", "*.sh.tmpl"):
-        out += _TEMPLATES.rglob(pattern)
+        out.update(_TEMPLATES.rglob(pattern))
+    # Extensionless git hooks (pre-push, commit-msg, pre-commit) are bash too,
+    # so the denylist catches them in `uv run pytest`, not only the CI jobs.
+    for p in _TEMPLATES.rglob("*"):
+        if p.is_file() and p.suffix == "" and "hooks" in p.parts:
+            first = _IF_GUARD.sub("", p.read_text().splitlines()[0])
+            if first.startswith("#!"):
+                out.add(p)
     return sorted(out)
 
 
 def _is_comment(line: str) -> bool:
     return line.lstrip().startswith("#")
+
+
+def _code_text(text: str) -> str:
+    """File text with comment-only lines removed, so a keyword in a comment
+    can't satisfy a guard requirement."""
+    return "\n".join(ln for ln in text.splitlines() if not _is_comment(ln))
 
 
 _SHELL_TEMPLATES = _shell_templates()
@@ -48,10 +64,11 @@ def _id(p: Path) -> str:
     return str(p.relative_to(_TEMPLATES))
 
 
-@pytest.fixture(scope="module")
-def templates() -> list[Path]:
+def test_templates_discovered():
+    """Guard against a wrong glob silently parametrizing zero cases."""
+    names = {p.name for p in _SHELL_TEMPLATES}
     assert _SHELL_TEMPLATES, "no shell templates found — wrong path?"
-    return _SHELL_TEMPLATES
+    assert {"pre_commit_gate.sh", "_py.sh", "pre-push"} <= names
 
 
 @pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
@@ -62,11 +79,12 @@ def test_shebang_is_env_bash(tmpl: Path):
 
 
 # (pattern, label, predicate) — predicate(line, text) True ⇒ violation.
-def _bare_sha256(line: str, text: str) -> bool:
+def _bare_sha256(line: str, code_text: str) -> bool:
     # Allowed when the file also offers a non-GNU fallback (shasum/cksum, #360).
+    # code_text excludes comments so a comment can't "bless" an unguarded call.
     if "sha256sum" not in line:
         return False
-    return "shasum" not in text and "cksum" not in text
+    return "shasum" not in code_text and "cksum" not in code_text
 
 
 def _stat_c_without_bsd(line: str, _text: str) -> bool:
@@ -86,12 +104,13 @@ _DENYLIST = [
 @pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
 def test_no_forbidden_constructs(tmpl: Path):
     text = tmpl.read_text()
+    code_text = _code_text(text)
     for n, line in enumerate(text.splitlines(), 1):
         if _is_comment(line):
             continue
         for pat, label in _DENYLIST:
             assert not pat.search(line), f"{_id(tmpl)}:{n} {label}: {line.strip()!r}"
-        assert not _bare_sha256(line, text), (
+        assert not _bare_sha256(line, code_text), (
             f"{_id(tmpl)}:{n} unguarded sha256sum (add a shasum/cksum fallback): {line.strip()!r}"
         )
         assert not _stat_c_without_bsd(line, text), (
@@ -133,3 +152,20 @@ def test_python_only_via_resolver(tmpl: Path):
             pytest.fail(
                 f"{_id(tmpl)}:{n} Python invoked directly — route via _py.sh: {line.strip()!r}"
             )
+
+
+def test_scaffolded_pre_push_hook_is_portable(tmp_path: Path):
+    """Scaffold-into-temp coverage for the pre-push templates/ change
+    (.github/copilot-instructions.md requires a rendered-output test)."""
+    target = tmp_path / "p"
+    scaffold(
+        target,
+        load_preset("obsidian-only"),
+        make_variables(plugin_mode="true", no_plugin=""),
+        strict=True,
+    )
+    hook = target / ".github" / "hooks" / "pre-push"
+    assert hook.exists(), "scaffolded project must ship the pre-push hook"
+    text = hook.read_text()
+    assert text.splitlines()[0] == "#!/usr/bin/env bash"
+    assert "read -r" in text, "read must use -r (SC2162)"

--- a/tests/unit/test_shell_portability.py
+++ b/tests/unit/test_shell_portability.py
@@ -1,0 +1,135 @@
+"""PI-363 Layer 1: denylist lint over every scaffolded shell template.
+
+The broad backstop guarding #360 (bash 3.2 / BSD coreutils), #361 (interpreter
+resolution via _py.sh) and #362 (hardening sweep) against regression. Scans
+templates/**/*.sh and *.sh.tmpl and fails with the offending file:line, so
+reintroducing any forbidden construct breaks an ordinary PR (no new CI infra —
+this runs in `just test`).
+
+Scope: this repo's templates (the scaffolder's *output*). Scaffolded projects'
+own ci.yml.tmpl is deliberately out of scope.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATES = _REPO_ROOT / "templates"
+
+# The one file allowed to name Python interpreters: the resolver itself (#361).
+_RESOLVER = "_py.sh"
+# Opt-in day-2 CCR config editor: a JSON manipulator that declares its own
+# dependency (`have jq || die`). jq-removal was scoped to setup_github.sh (#362);
+# rewriting this jq-native script is out of scope.
+_JQ_ALLOWED = {"models.sh"}
+
+_IF_GUARD = re.compile(r"^\{\{#if [^}]+\}\}")
+
+
+def _shell_templates() -> list[Path]:
+    out: list[Path] = []
+    for pattern in ("*.sh", "*.sh.tmpl"):
+        out += _TEMPLATES.rglob(pattern)
+    return sorted(out)
+
+
+def _is_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+_SHELL_TEMPLATES = _shell_templates()
+
+
+def _id(p: Path) -> str:
+    return str(p.relative_to(_TEMPLATES))
+
+
+@pytest.fixture(scope="module")
+def templates() -> list[Path]:
+    assert _SHELL_TEMPLATES, "no shell templates found — wrong path?"
+    return _SHELL_TEMPLATES
+
+
+@pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
+def test_shebang_is_env_bash(tmpl: Path):
+    first = tmpl.read_text().splitlines()[0]
+    shebang = _IF_GUARD.sub("", first)  # strip a leading {{#if …}} render guard
+    assert shebang == "#!/usr/bin/env bash", f"{_id(tmpl)}: bad shebang {first!r}"
+
+
+# (pattern, label, predicate) — predicate(line, text) True ⇒ violation.
+def _bare_sha256(line: str, text: str) -> bool:
+    # Allowed when the file also offers a non-GNU fallback (shasum/cksum, #360).
+    if "sha256sum" not in line:
+        return False
+    return "shasum" not in text and "cksum" not in text
+
+
+def _stat_c_without_bsd(line: str, _text: str) -> bool:
+    return "stat -c" in line and "stat -f" not in line
+
+
+_DENYLIST = [
+    (re.compile(r"\b(mapfile|readarray)\b"), "bash-4 mapfile/readarray"),
+    (re.compile(r"\bdeclare\s+-A\b"), "bash-4 declare -A"),
+    (re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*(\^\^|,,)"), "bash-4 case modification"),
+    (re.compile(r"\bsed\s+-i\b"), "GNU sed -i (BSD needs -i '')"),
+    (re.compile(r"\breadlink\s+-f\b"), "GNU readlink -f"),
+    (re.compile(r"\bgrep\s+-P\b"), "GNU grep -P"),
+]
+
+
+@pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
+def test_no_forbidden_constructs(tmpl: Path):
+    text = tmpl.read_text()
+    for n, line in enumerate(text.splitlines(), 1):
+        if _is_comment(line):
+            continue
+        for pat, label in _DENYLIST:
+            assert not pat.search(line), f"{_id(tmpl)}:{n} {label}: {line.strip()!r}"
+        assert not _bare_sha256(line, text), (
+            f"{_id(tmpl)}:{n} unguarded sha256sum (add a shasum/cksum fallback): {line.strip()!r}"
+        )
+        assert not _stat_c_without_bsd(line, text), (
+            f"{_id(tmpl)}:{n} `stat -c` without `|| stat -f` fallback: {line.strip()!r}"
+        )
+
+
+# external jq, allowing gh's `--jq`/`-q` (not the standalone `jq` binary).
+_JQ = re.compile(r"(?<![\w-])jq\s")
+
+
+@pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
+def test_no_external_jq(tmpl: Path):
+    if tmpl.name in _JQ_ALLOWED:
+        return
+    for n, line in enumerate(tmpl.read_text().splitlines(), 1):
+        if _is_comment(line):
+            continue
+        assert not _JQ.search(line), f"{_id(tmpl)}:{n} external jq: {line.strip()!r}"
+
+
+# Python invoked as a command: `python`/`python3` followed by an argument.
+# `have python3` / `command -v python` (existence probes) are not invocations.
+_PY_INVOCATION = re.compile(r"""(?<![\w-])python3?\s+(?:-|["'<]|\S*\.py\b)""")
+_PY_PROBE = re.compile(r"(?:have|command\s+-v)\s+python3?\b")
+
+
+@pytest.mark.parametrize("tmpl", _SHELL_TEMPLATES, ids=_id)
+def test_python_only_via_resolver(tmpl: Path):
+    if tmpl.name == _RESOLVER:
+        return  # the resolver is the one place allowed to name interpreters
+    for n, line in enumerate(tmpl.read_text().splitlines(), 1):
+        if _is_comment(line):
+            continue
+        probe_spans = [m.span() for m in _PY_PROBE.finditer(line)]
+        for m in _PY_INVOCATION.finditer(line):
+            if any(s <= m.start() < e for s, e in probe_spans):
+                continue
+            pytest.fail(
+                f"{_id(tmpl)}:{n} Python invoked directly — route via _py.sh: {line.strip()!r}"
+            )


### PR DESCRIPTION
## What

Final child of epic #359 workstream A — the backstop that guards #360/#361/#362 against regression. Three layers, cheap+broad → expensive+real.

### Layer 1 — denylist lint (pytest, every PR)
`tests/unit/test_shell_portability.py` scans every `templates/**/*.sh` + `*.sh.tmpl` and fails with the offending `file:line`:
- bash-4+: `mapfile`/`readarray`, `declare -A`, `${var^^}`/`${var,,}`
- GNU-only: unguarded `sha256sum` (allowed with a `shasum`/`cksum` fallback), `stat -c` without `|| stat -f`, `sed -i`, `readlink -f`, `grep -P`
- external `jq` (gh's `-q`/`--jq` allowed; `models.sh` exempt — the opt-in jq-native CCR editor that declares `have jq || die`)
- shebang must be `#!/usr/bin/env bash` (strips a leading `{{#if …}}` guard)
- `python3`/`python` invoked as a command — forbidden outside `_py.sh`

Verified it both passes on current templates (100 cases) and catches every forbidden construct.

### Layer 2 — shellcheck (CI, every PR)
`shellcheck --severity=warning` over the rendered scaffold output (via `uvx shellcheck-py`, pinned). Surfaced one real warning — fixed: `pre-push` now `read -r` with unused positional fields bound to `_`.

### Layer 3 — macOS runner (CI, gated)
`macos-latest` (genuine bash **3.2** + BSD coreutils) scaffolds a project and runs `session_setup.sh` (exercises the `sha256sum`→`shasum` fallback), `pre_commit_gate.sh` (the `mapfile`-free array build), and `_py.sh` under `/bin/bash`. **Gated** by a `dorny/paths-filter` job to shell/template changes, so ordinary PRs skip the 10×-billed macOS minutes; Layers 1+2 always run.

## Scope

Guards this repo's templates (the scaffolder's output). Scaffolded projects' own `ci.yml.tmpl` is out of scope.

## Tests

Full suite **1004 passed, 3 skipped**; lint clean. This PR touches `.sh` files, so the new macOS job runs live here and validates Layer 3.

Part of #359.
Closes #363