### PR TITLE
docs(PI-367): local-vs-cloud enforcement boundary + surface support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Which scaffolded config each surface actually reads (full detail + sources:
 | VS Code Copilot | `CLAUDE.md`/`AGENTS.md` | `.claude/skills` | Claude hooks (matchers ignored) | `.vscode/mcp.json` (`servers`) | yes |
 | Cursor | `AGENTS.md` | `.claude/skills` | `.cursor/hooks.json` (best-effort) | `.cursor/mcp.json` | yes |
 | Codex (CLI + IDE) | `AGENTS.md` | `.agents/skills` | `.codex/hooks.json` | `.codex/config.toml` | yes |
-| Antigravity (experimental) | `AGENTS.md` | `.agents/skills` | `.agents/hooks.json` (best-effort) | `~/.gemini` (global) | yes |
+| Antigravity (experimental) | `AGENTS.md` / `GEMINI.md` | `.agents/skills` | `.agents/hooks.json` (best-effort) | `~/.gemini/config/mcp_config.json` (global) | yes |
 | Ollama-based | `AGENTS.md` | — | — | — | yes |
 
 `AGENTS.md` is the portability backbone (every surface reads it); `CLAUDE.md`

--- a/README.md
+++ b/README.md
@@ -37,18 +37,50 @@ that is cheap, but it is not natively so — be explicit about what each agent g
 
 | Tier | What you get | Applies to |
 |---|---|---|
-| **Native (Claude Code)** | Everything: deterministic hooks (lifecycle guard, pre-commit gate), skills invoked as `/commands`, settings wiring | Claude Code only |
-| **Instructions-only** | `AGENTS.md` / `GEMINI.md` redirect to the canonical `CLAUDE.md`; agents read conventions but **no hook fires and nothing is enforced** for them | Codex, Gemini CLI, Cursor, and other AGENTS.md-aware tools |
-| **Portable regardless** | Lifecycle scripts (plain bash), memory and vault (plain markdown), git hooks (`commit-msg`, `pre-push`) — agent-independent by construction; git hooks bind once `.claude/scripts/install_hooks.sh` has run in the clone (server-side actions need branch protection) | Everything, including Ollama-based agents |
+| **Native** | Everything: deterministic hooks (lifecycle guard, pre-commit gate), skills invoked as `/commands`, settings wiring — read directly from `.claude/` | Claude Code (CLI + the Anthropic VS Code extension) |
+| **Generated per-surface config** | One canonical hook/MCP spec rendered to each surface's native files (ADR-017): Codex `.codex/`, Cursor `.cursor/`, Antigravity `.agents/` (experimental), VS Code `.vscode/mcp.json`. Skills cross-read natively. GUI hooks are **best-effort/fail-open** | Codex (CLI+IDE), Cursor, Antigravity, VS Code Copilot |
+| **Instructions + portable** | `AGENTS.md`/`GEMINI.md` redirect to `CLAUDE.md`; lifecycle scripts (plain bash), memory/vault (markdown), git hooks (`commit-msg`, `pre-push`) — agent-independent; git hooks bind once `.claude/scripts/install_hooks.sh` has run (server-side actions need branch protection) | Everything, including Ollama-based agents |
 
-Two honest caveats:
+### Surface support matrix
 
-- Hook enforcement and skill invocation **do not exist outside Claude Code**. An
-  agent reading `AGENTS.md` is asked to follow the rules; nothing makes it.
-  The git hooks and CI checks are the only enforcement that binds all agents.
-- **Automated testing covers the Claude Code artifacts only.** The test suite
-  validates settings schema, skills, hooks, and rendered files; no other agent
-  is exercised in CI.
+Which scaffolded config each surface actually reads (full detail + sources:
+[`docs/development/non-cli-surface-matrix.md`](docs/development/non-cli-surface-matrix.md)):
+
+| Surface | Instructions | Skills | Hooks | MCP | Local shell |
+|---|---|---|---|---|---|
+| Claude Code CLI / VS Code ext | `CLAUDE.md` | `.claude/skills` | `.claude/settings.json` (honored) | root `.mcp.json` | yes |
+| VS Code Copilot | `CLAUDE.md`/`AGENTS.md` | `.claude/skills` | Claude hooks (matchers ignored) | `.vscode/mcp.json` (`servers`) | yes |
+| Cursor | `AGENTS.md` | `.claude/skills` | `.cursor/hooks.json` (best-effort) | `.cursor/mcp.json` | yes |
+| Codex (CLI + IDE) | `AGENTS.md` | `.agents/skills` | `.codex/hooks.json` | `.codex/config.toml` | yes |
+| Antigravity (experimental) | `AGENTS.md` | `.agents/skills` | `.agents/hooks.json` (best-effort) | `~/.gemini` (global) | yes |
+| Ollama-based | `AGENTS.md` | — | — | — | yes |
+
+`AGENTS.md` is the portability backbone (every surface reads it); `CLAUDE.md`
+rides alongside for Claude + VS Code. The generated `.claude/CAPABILITIES.md`
+lists exactly what a given scaffold exposes, on any surface.
+
+### Local vs. cloud: where enforcement actually runs (ADR-007)
+
+The execution model — not the surface name — decides what binds:
+
+- **Local-execution surfaces** (Claude Desktop-local, VS Code, Codex IDE, Cursor,
+  Antigravity, Gemini Code Assist): bash hooks + git hooks + MCP stdio servers all
+  run on your machine, so the enforcement layer is live (subject to the
+  per-surface fidelity above — some drop hook matchers).
+- **Cloud-sandbox surfaces** (Claude web, Codex cloud, Jules): only
+  **repo-committed** config runs; user-level `~/.claude` is dropped, hooks run
+  inside the VM, and git goes through a push-restricted proxy — the local
+  enforcement layer is replaced by the sandbox's.
+
+Two honest caveats hold across all of it:
+
+- **GUI hook enforcement is best-effort, not a guarantee.** Generated hooks are
+  fail-open and some surfaces ignore matchers; an agent reading `AGENTS.md` is
+  *asked* to follow the rules. The **git hooks + CI checks are the only
+  enforcement that binds every surface** — that is the real boundary (ADR-007).
+- **Automated testing covers the Claude Code artifacts + the rendered per-surface
+  files.** The suite validates settings/skills/hooks/MCP and the generated
+  surface configs; no GUI agent is driven live in CI.
 
 ## Install (one-time)
 

--- a/docs/adr/adr-007-security-enforcement-layers.md
+++ b/docs/adr/adr-007-security-enforcement-layers.md
@@ -69,3 +69,11 @@ slipped past a clone without hooks.)
   (free; personal accounts need none) — noted in the CI template.
 - Once #139 lands, the pre-commit gate should call `just scan` instead of
   invoking gitleaks directly.
+- **Non-CLI surfaces don't move this boundary (#359 / ADR-017).** The
+  per-surface hook configs generated for Cursor/Codex/Antigravity/VS Code are
+  **best-effort and fail-open** — fidelity varies (e.g. VS Code Copilot ignores
+  hook matchers), and cloud-sandbox surfaces (Claude web, Codex cloud, Jules)
+  honor only repo-committed config with no local `~/.claude`. So the in-editor
+  hooks are advisory; **git hooks + CI remain the only enforcement that binds
+  every surface.** Surface fidelity + the local-vs-cloud split are documented in
+  `docs/development/non-cli-surface-matrix.md` and the README's surface matrix.


### PR DESCRIPTION
## What

Final child of epic #359 (workstream B). Documents the **execution-model fault line** so users know what actually carries over to each surface, and refreshes the agent-support story for the post-#366 reality.

## Changes

- **README "Agent support tiers" rewritten** — the old "Instructions-only (Cursor/Codex…)" tier was outdated after #366. Now: **Native** (Claude CLI + VS Code ext) / **Generated per-surface config** (Codex, Cursor, Antigravity exp., VS Code) / **Instructions + portable**.
- **New surface-support matrix** — instructions / skills / hooks / MCP / local-shell per surface, with `AGENTS.md` as the portability backbone; links the #365 matrix doc and the generated `CAPABILITIES.md`.
- **Local-vs-cloud boundary** — local-execution surfaces run the full enforcement layer (subject to per-surface fidelity); cloud-sandbox surfaces (Claude web, Codex cloud, Jules) honor only repo-committed config (no `~/.claude`). GUI hooks are best-effort/fail-open → **git hooks + CI are the only enforcement that binds every surface** (ADR-007).
- **ADR-007 note** tying the enforcement boundary explicitly to non-CLI surfaces (ADR-017).

Docs-only. Full suite **1045 passed**; lint clean.

Part of #359.
Closes #367