### PR TITLE
chore(PI-388): migrate hooks to documented PreToolUse decision schema + Codex MCP secret passthrough

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -5,8 +5,9 @@ Subcommands:
   check <node>          exit 0 if every prerequisite of <node> is satisfied,
                         exit 2 otherwise (with reason on stdout).
   guard                 read PreToolUse hook input JSON from stdin, map the
-                        Bash command to a target node, emit
-                        {decision: block, reason: ...} if disallowed.
+                        Bash command to a target node, emit a PreToolUse
+                        hookSpecificOutput with permissionDecision: deny if
+                        disallowed (the documented Claude Code schema).
   nodes                 list every DAG node and its prerequisites.
   push [<branch>] [N]   push current (or named) branch with retry + remote-SHA
                         verification (handles transient GitHub 5xx).
@@ -329,7 +330,13 @@ def guard(payload: dict) -> dict | None:
             ok, why = prereqs_satisfied(target)
             if not ok:
                 reason = f"{message}\n\nDAG prerequisite for {target} not met: {why}."
-        return {"decision": "block", "reason": reason}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
     return None
 
 

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -5,8 +5,9 @@ Subcommands:
   check <node>          exit 0 if every prerequisite of <node> is satisfied,
                         exit 2 otherwise (with reason on stdout).
   guard                 read PreToolUse hook input JSON from stdin, map the
-                        Bash command to a target node, emit
-                        {decision: block, reason: ...} if disallowed.
+                        Bash command to a target node, emit a PreToolUse
+                        hookSpecificOutput with permissionDecision: deny if
+                        disallowed (the documented Claude Code schema).
   nodes                 list every DAG node and its prerequisites.
   push [<branch>] [N]   push current (or named) branch with retry + remote-SHA
                         verification (handles transient GitHub 5xx).
@@ -329,7 +330,13 @@ def guard(payload: dict) -> dict | None:
             ok, why = prereqs_satisfied(target)
             if not ok:
                 reason = f"{message}\n\nDAG prerequisite for {target} not met: {why}."
-        return {"decision": "block", "reason": reason}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
     return None
 
 

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -135,12 +135,11 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
                 "(Guardrail only — real protection is credential separation, "
                 "see .claude/docs/guides/secrets.md.)"
             )
-            if permission_mode in _AUTONOMOUS_MODES:
-                return {"decision": "block", "reason": reason}
+            decision = "deny" if permission_mode in _AUTONOMOUS_MODES else "ask"
             return {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
-                    "permissionDecision": "ask",
+                    "permissionDecision": decision,
                     "permissionDecisionReason": reason,
                 }
             }

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -50,7 +50,8 @@ INPUT=$(cat)
 PY="$(dirname "$0")/_py.sh"
 
 # exit 0 = allow (or no-op for non-blocking events)
-# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# PreToolUse block: stdout JSON {"hookSpecificOutput":{"hookEventName":
+#   "PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
 # stdout JSON with {"additionalContext":"..."} = inject context
 # Always exit 0 — exit 1 means hook error, not a block
 
@@ -67,7 +68,7 @@ print((data.get('tool_input', {}) or {}).get('command', '') or '')
 [ -z "$CMD" ] && exit 0
 
 if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
-  "$PY" -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+  "$PY" -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','permissionDecision':'deny','permissionDecisionReason':sys.argv[1]}}))" \
     "Direct push to main is not allowed. Use a branch and PR."
   exit 0
 fi

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -439,7 +439,7 @@ def _choose_multi_model_interactive() -> bool:
         "standards stay identical — they run below the model.\n\n"
         "  [dim]claude[/dim]                          [dim]# opens as usual[/dim]\n"
         "  [dim]/model deepseek,deepseek-chat[/dim]   [dim]# switch mid-session, context kept[/dim]\n"
-        "  [dim]/model ollama,qwen3-coder:30b[/dim]\n"
+        "  [dim]/model ollama,qwen3-coder:30b[/dim]      [dim]# or qwen3-coder-next (newer)[/dim]\n"
         "  [dim]/model anthropic,claude-opus-4-8[/dim] [dim]# back to Claude[/dim]\n\n"
         "[cyan]Helps:[/cyan] control cost / test models without leaving the terminal.\n"
         "[cyan]Alternatives:[/cyan]\n"

--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -54,26 +54,29 @@ def render_mcp_json(servers: dict[str, dict], *, key: str) -> str:
 def render_mcp_toml(servers: dict[str, dict]) -> str:
     """MCP config as Codex ``config.toml`` ``[mcp_servers.<name>]`` tables.
 
-    Stdlib only (no toml writer): values are simple strings/lists/inline tables,
-    so manual emission is safe and keeps the scaffolder dependency-free. Passes
-    through ``env`` (stdio) and ``bearer_token_env_var`` (HTTP) so servers that
-    need a secret aren't silently dropped (PI-388).
+    Stdlib only (no toml writer): every string is emitted via ``json.dumps`` —
+    TOML basic strings share JSON's escaping for quotes, backslashes, and
+    control chars — so values can't produce invalid TOML. Passes through ``env``
+    (stdio) and ``bearer_token_env_var`` (HTTP) so servers that need a secret
+    aren't silently dropped (PI-388).
     """
     lines: list[str] = []
     for name in sorted(servers):
         spec = servers[name]
         lines.append(f"[mcp_servers.{name}]")
         if "command" in spec:
-            lines.append(f'command = "{spec["command"]}"')
+            lines.append(f"command = {json.dumps(spec['command'])}")
             if spec.get("args"):
-                rendered = ", ".join(f'"{a}"' for a in spec["args"])
+                rendered = ", ".join(json.dumps(a) for a in spec["args"])
                 lines.append(f"args = [{rendered}]")
         if "url" in spec:
-            lines.append(f'url = "{spec["url"]}"')
+            lines.append(f"url = {json.dumps(spec['url'])}")
             if spec.get("bearer_token_env_var"):
-                lines.append(f'bearer_token_env_var = "{spec["bearer_token_env_var"]}"')
+                lines.append(f"bearer_token_env_var = {json.dumps(spec['bearer_token_env_var'])}")
         if spec.get("env"):
-            rendered_env = ", ".join(f'"{k}" = "{v}"' for k, v in spec["env"].items())
+            rendered_env = ", ".join(
+                f"{json.dumps(k)} = {json.dumps(v)}" for k, v in spec["env"].items()
+            )
             lines.append(f"env = {{{rendered_env}}}")
         lines.append("")
     return "\n".join(lines)

--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -54,8 +54,10 @@ def render_mcp_json(servers: dict[str, dict], *, key: str) -> str:
 def render_mcp_toml(servers: dict[str, dict]) -> str:
     """MCP config as Codex ``config.toml`` ``[mcp_servers.<name>]`` tables.
 
-    Stdlib only (no toml writer): values are simple strings/lists, so manual
-    emission is safe and keeps the scaffolder dependency-free.
+    Stdlib only (no toml writer): values are simple strings/lists/inline tables,
+    so manual emission is safe and keeps the scaffolder dependency-free. Passes
+    through ``env`` (stdio) and ``bearer_token_env_var`` (HTTP) so servers that
+    need a secret aren't silently dropped (PI-388).
     """
     lines: list[str] = []
     for name in sorted(servers):
@@ -68,6 +70,11 @@ def render_mcp_toml(servers: dict[str, dict]) -> str:
                 lines.append(f"args = [{rendered}]")
         if "url" in spec:
             lines.append(f'url = "{spec["url"]}"')
+            if spec.get("bearer_token_env_var"):
+                lines.append(f'bearer_token_env_var = "{spec["bearer_token_env_var"]}"')
+        if spec.get("env"):
+            rendered_env = ", ".join(f'"{k}" = "{v}"' for k, v in spec["env"].items())
+            lines.append(f"env = {{{rendered_env}}}")
         lines.append("")
     return "\n".join(lines)
 

--- a/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
+++ b/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
@@ -7,8 +7,11 @@ from github_command_guard.sh. Payloads differ slightly per agent, so this
 shim extracts the shell command, feeds a Claude-shaped payload into
 dag_workflow.py guard, and translates the verdict to the caller's dialect:
 
-  codex  -> {"decision": "block", ...} (Codex accepts Claude's shape)
+  codex  -> {"hookSpecificOutput": {permissionDecision: "deny", ...}}
+            (the documented PreToolUse schema; Codex accepts it)
   gemini -> {"decision": "deny",  ...}
+  cursor -> {"permission": "deny", ...}      (PI-385: shape unverified)
+  antigravity -> {"decision": "deny", ...}   (PI-385: experimental)
 
 Fail-open by design: on any parse error the command proceeds — git hooks
 and CI remain the real enforcement boundary (ADR-007).
@@ -52,18 +55,33 @@ def main() -> int:
         verdict = json.loads(proc.stdout.strip() or "null")
     except json.JSONDecodeError:
         return 0
-    if isinstance(verdict, dict) and verdict.get("decision") == "block":
-        reason = verdict.get("reason", "")
+    if not isinstance(verdict, dict):
+        return 0
+    # dag_workflow.py emits the documented PreToolUse shape; tolerate the
+    # legacy {"decision": "block"} form too in case of version skew.
+    hso = verdict.get("hookSpecificOutput") or {}
+    denied = hso.get("permissionDecision") == "deny" or verdict.get("decision") == "block"
+    if denied:
+        reason = hso.get("permissionDecisionReason") or verdict.get("reason", "")
         if dialect == "gemini":
-            verdict = {"decision": "deny", "reason": reason}
+            out = {"decision": "deny", "reason": reason}
         elif dialect == "cursor":
             # Cursor signals a block via permission=deny (PI-366; exact schema
             # unverified — fail-open means a wrong guess degrades safely).
-            verdict = {"permission": "deny", "userMessage": reason}
+            out = {"permission": "deny", "userMessage": reason}
         elif dialect == "antigravity":
             # Antigravity safety-gate deny (experimental; unverified shape).
-            verdict = {"decision": "deny", "reason": reason}
-        sys.stdout.write(json.dumps(verdict))
+            out = {"decision": "deny", "reason": reason}
+        else:
+            # codex: the documented PreToolUse schema (Codex accepts it).
+            out = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        sys.stdout.write(json.dumps(out))
     return 0
 
 

--- a/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
+++ b/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
@@ -58,8 +58,11 @@ def main() -> int:
     if not isinstance(verdict, dict):
         return 0
     # dag_workflow.py emits the documented PreToolUse shape; tolerate the
-    # legacy {"decision": "block"} form too in case of version skew.
-    hso = verdict.get("hookSpecificOutput") or {}
+    # legacy {"decision": "block"} form too in case of version skew. Guard the
+    # type so a corrupt hookSpecificOutput can't raise (stay fail-open).
+    hso = verdict.get("hookSpecificOutput")
+    if not isinstance(hso, dict):
+        hso = {}
     denied = hso.get("permissionDecision") == "deny" or verdict.get("decision") == "block"
     if denied:
         reason = hso.get("permissionDecisionReason") or verdict.get("reason", "")

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -5,8 +5,9 @@ Subcommands:
   check <node>          exit 0 if every prerequisite of <node> is satisfied,
                         exit 2 otherwise (with reason on stdout).
   guard                 read PreToolUse hook input JSON from stdin, map the
-                        Bash command to a target node, emit
-                        {decision: block, reason: ...} if disallowed.
+                        Bash command to a target node, emit a PreToolUse
+                        hookSpecificOutput with permissionDecision: deny if
+                        disallowed (the documented Claude Code schema).
   nodes                 list every DAG node and its prerequisites.
   push [<branch>] [N]   push current (or named) branch with retry + remote-SHA
                         verification (handles transient GitHub 5xx).
@@ -329,7 +330,13 @@ def guard(payload: dict) -> dict | None:
             ok, why = prereqs_satisfied(target)
             if not ok:
                 reason = f"{message}\n\nDAG prerequisite for {target} not met: {why}."
-        return {"decision": "block", "reason": reason}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
     return None
 
 

--- a/templates/codex/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_hook/SKILL.md
@@ -50,7 +50,8 @@ INPUT=$(cat)
 PY="$(dirname "$0")/_py.sh"
 
 # exit 0 = allow (or no-op for non-blocking events)
-# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# PreToolUse block: stdout JSON {"hookSpecificOutput":{"hookEventName":
+#   "PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
 # stdout JSON with {"additionalContext":"..."} = inject context
 # Always exit 0 — exit 1 means hook error, not a block
 
@@ -67,7 +68,7 @@ print((data.get('tool_input', {}) or {}).get('command', '') or '')
 [ -z "$CMD" ] && exit 0
 
 if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
-  "$PY" -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+  "$PY" -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','permissionDecision':'deny','permissionDecisionReason':sys.argv[1]}}))" \
     "Direct push to main is not allowed. Use a branch and PR."
   exit 0
 fi

--- a/templates/fallback/dot_claude/hooks/prod_guard.py
+++ b/templates/fallback/dot_claude/hooks/prod_guard.py
@@ -135,12 +135,11 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
                 "(Guardrail only — real protection is credential separation, "
                 "see .claude/docs/guides/secrets.md.)"
             )
-            if permission_mode in _AUTONOMOUS_MODES:
-                return {"decision": "block", "reason": reason}
+            decision = "deny" if permission_mode in _AUTONOMOUS_MODES else "ask"
             return {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
-                    "permissionDecision": "ask",
+                    "permissionDecision": decision,
                     "permissionDecisionReason": reason,
                 }
             }

--- a/templates/fallback/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_hook/SKILL.md
@@ -50,7 +50,8 @@ INPUT=$(cat)
 PY="$(dirname "$0")/_py.sh"
 
 # exit 0 = allow (or no-op for non-blocking events)
-# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# PreToolUse block: stdout JSON {"hookSpecificOutput":{"hookEventName":
+#   "PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
 # stdout JSON with {"additionalContext":"..."} = inject context
 # Always exit 0 — exit 1 means hook error, not a block
 
@@ -67,7 +68,7 @@ print((data.get('tool_input', {}) or {}).get('command', '') or '')
 [ -z "$CMD" ] && exit 0
 
 if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
-  "$PY" -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+  "$PY" -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','permissionDecision':'deny','permissionDecisionReason':sys.argv[1]}}))" \
     "Direct push to main is not allowed. Use a branch and PR."
   exit 0
 fi

--- a/templates/gemini/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/gemini/dot_agents/skills/add_hook/SKILL.md
@@ -50,7 +50,8 @@ INPUT=$(cat)
 PY="$(dirname "$0")/_py.sh"
 
 # exit 0 = allow (or no-op for non-blocking events)
-# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# PreToolUse block: stdout JSON {"hookSpecificOutput":{"hookEventName":
+#   "PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
 # stdout JSON with {"additionalContext":"..."} = inject context
 # Always exit 0 — exit 1 means hook error, not a block
 
@@ -67,7 +68,7 @@ print((data.get('tool_input', {}) or {}).get('command', '') or '')
 [ -z "$CMD" ] && exit 0
 
 if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
-  "$PY" -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+  "$PY" -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','permissionDecision':'deny','permissionDecisionReason':sys.argv[1]}}))" \
     "Direct push to main is not allowed. Use a branch and PR."
   exit 0
 fi

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -194,3 +196,40 @@ class TestSyncedCopiesInRepo:
         template_names = {p.parent.name for p in _TEMPLATE_SKILLS.glob("*/SKILL.md")}
         command_names = {p.stem for p in _GEMINI_COMMANDS.glob("*.toml")}
         assert command_names == template_names, "run `just sync-plugin`"
+
+
+class TestAgentGuardAdapter:
+    """PI-388: the shared adapter translates a dag_workflow deny into each
+    surface's dialect, sourced from the documented PreToolUse hookSpecificOutput
+    shape. `git push origin main` blocks unconditionally (no redirect script)."""
+
+    def _run_adapter(self, target: Path, dialect: str, command: str) -> dict | None:
+        adapter = target / ".claude" / "hooks" / "agent_guard_adapter.py"
+        payload = json.dumps({"tool_input": {"command": command}})
+        proc = subprocess.run(
+            [sys.executable, str(adapter), dialect],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=target,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(proc.stdout) if proc.stdout.strip() else None
+
+    def test_codex_emits_documented_pretooluse_schema(self, tmp_path: Path):
+        target = _scaffold_agents(tmp_path / "p", "codex")
+        out = self._run_adapter(target, "codex", "git push origin main")
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "main/master" in hso["permissionDecisionReason"]
+
+    def test_gemini_emits_decision_deny(self, tmp_path: Path):
+        target = _scaffold_agents(tmp_path / "p", "gemini")
+        out = self._run_adapter(target, "gemini", "git push origin main")
+        assert out["decision"] == "deny"
+        assert "main/master" in out["reason"]
+
+    def test_innocuous_command_not_blocked(self, tmp_path: Path):
+        target = _scaffold_agents(tmp_path / "p", "codex")
+        assert self._run_adapter(target, "codex", "ls -la") is None

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -78,9 +78,10 @@ class TestVerdicts:
     @pytest.mark.parametrize("command", DESTRUCTIVE)
     def test_destructive_blocks_in_autonomous(self, tmp_path: Path, command: str):
         verdict = _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path)
-        assert verdict == {"decision": "block", "reason": verdict["reason"]}
-        assert "prod_guard" in verdict["reason"]
-        assert "credential separation" in verdict["reason"]
+        hso = verdict["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "deny"
+        assert "prod_guard" in hso["permissionDecisionReason"]
+        assert "credential separation" in hso["permissionDecisionReason"]
 
     @pytest.mark.parametrize("command", SAFE)
     def test_safe_commands_pass(self, tmp_path: Path, command: str):

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -43,6 +43,15 @@ def _run_guard(payload: dict, cwd: Path | None = None) -> dict | None:
     return json.loads(proc.stdout) if proc.stdout.strip() else None
 
 
+def _denied(out: dict | None) -> bool:
+    """True if the guard denied via the documented PreToolUse schema (PI-388)."""
+    return bool(out) and out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+
+def _deny_reason(out: dict | None) -> str:
+    return (out or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
 def test_root_monitor_pr_checks_merge_exit_code():
     """PI-203: the repo's own monitor_pr.sh must check the merge exit code
     (via _run_gh) and not report false success — it had gone stale, piping the
@@ -115,14 +124,12 @@ class TestGuardSteering:
 
     def test_blocks_push_to_main(self, tmp_path: Path):
         out = _run_guard({"tool_input": {"command": "git push origin main"}}, cwd=tmp_path)
-        assert out is not None
-        assert out["decision"] == "block"
-        assert "main/master" in out["reason"]
+        assert _denied(out)
+        assert "main/master" in _deny_reason(out)
 
     def test_blocks_push_to_master(self, tmp_path: Path):
         out = _run_guard({"tool_input": {"command": "git push master"}}, cwd=tmp_path)
-        assert out is not None
-        assert out["decision"] == "block"
+        assert _denied(out)
 
     def test_blocks_gh_pr_merge(self, tmp_path: Path):
         # No scripts dir in tmp_path → message references monitor_pr.sh which
@@ -133,7 +140,7 @@ class TestGuardSteering:
         (scripts / "monitor_pr.sh").write_text("#!/bin/sh\nexit 0\n")
         out = _run_guard({"tool_input": {"command": "gh pr merge 42"}}, cwd=tmp_path)
         assert out is not None
-        assert "monitor_pr.sh" in out["reason"]
+        assert "monitor_pr.sh" in _deny_reason(out)
 
     def test_blocks_gh_api_merge(self, tmp_path: Path):
         scripts = tmp_path / ".claude" / "scripts"
@@ -144,7 +151,7 @@ class TestGuardSteering:
             cwd=tmp_path,
         )
         assert out is not None
-        assert "monitor_pr.sh" in out["reason"]
+        assert "monitor_pr.sh" in _deny_reason(out)
 
     def test_blocks_raw_git_push_when_wrapper_exists(self, tmp_path: Path):
         scripts = tmp_path / ".claude" / "scripts"
@@ -152,7 +159,7 @@ class TestGuardSteering:
         (scripts / "push_branch.sh").write_text("#!/bin/sh\nexit 0\n")
         out = _run_guard({"tool_input": {"command": "git push -u origin feat/x"}}, cwd=tmp_path)
         assert out is not None
-        assert "push_branch.sh" in out["reason"]
+        assert "push_branch.sh" in _deny_reason(out)
 
     def test_no_redirect_when_wrapper_missing(self, tmp_path: Path):
         # No .claude/scripts dir → suppress redirect for raw git push

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -139,7 +139,7 @@ class TestGuardSteering:
         scripts.mkdir(parents=True)
         (scripts / "monitor_pr.sh").write_text("#!/bin/sh\nexit 0\n")
         out = _run_guard({"tool_input": {"command": "gh pr merge 42"}}, cwd=tmp_path)
-        assert out is not None
+        assert _denied(out)
         assert "monitor_pr.sh" in _deny_reason(out)
 
     def test_blocks_gh_api_merge(self, tmp_path: Path):
@@ -150,7 +150,7 @@ class TestGuardSteering:
             {"tool_input": {"command": "gh api repos/foo/bar/pulls/42/merge -X PUT"}},
             cwd=tmp_path,
         )
-        assert out is not None
+        assert _denied(out)
         assert "monitor_pr.sh" in _deny_reason(out)
 
     def test_blocks_raw_git_push_when_wrapper_exists(self, tmp_path: Path):
@@ -158,7 +158,7 @@ class TestGuardSteering:
         scripts.mkdir(parents=True)
         (scripts / "push_branch.sh").write_text("#!/bin/sh\nexit 0\n")
         out = _run_guard({"tool_input": {"command": "git push -u origin feat/x"}}, cwd=tmp_path)
-        assert out is not None
+        assert _denied(out)
         assert "push_branch.sh" in _deny_reason(out)
 
     def test_no_redirect_when_wrapper_missing(self, tmp_path: Path):

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -209,6 +209,15 @@ class TestCreateIssueSkill:
         assert 'pr", "create"' in dag or "pr_create" in dag
 
 
+def _denied(out: dict | None) -> bool:
+    """True if the guard denied via the documented PreToolUse schema (PI-388)."""
+    return bool(out) and out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+
+def _deny_reason(out: dict | None) -> str:
+    return (out or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
 class TestGitHubWorkflowHooks:
     @pytest.fixture(autouse=True)
     def _scaffold(self, tmp_target: Path):
@@ -233,15 +242,15 @@ class TestGitHubWorkflowHooks:
 
     def test_github_command_guard_blocks_raw_issue_create(self):
         out = self._run_hook("github_command_guard.sh", "gh issue create --title X")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_raw_pr_merge(self):
         out = self._run_hook("github_command_guard.sh", "gh pr merge 42 --squash")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_raw_pr_merge_auto(self):
         out = self._run_hook("github_command_guard.sh", "gh pr merge 42 --auto")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_gh_api_merge_with_flags(self):
         """PI-198: a `--method PUT` before the endpoint (the natural way to
@@ -250,7 +259,7 @@ class TestGitHubWorkflowHooks:
             "github_command_guard.sh",
             "gh api --method PUT repos/o/r/pulls/42/merge",
         )
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_gh_api_merge_with_jq_pipe(self):
         """PI-198 review: a pipe inside a quoted flag (e.g. `--jq '.a|.b'`) before
@@ -259,27 +268,27 @@ class TestGitHubWorkflowHooks:
             "github_command_guard.sh",
             "gh api --jq '.a|.b' --method PUT repos/o/r/pulls/42/merge",
         )
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_raw_pr_create(self):
         out = self._run_hook(
             "github_command_guard.sh",
             'gh pr create --title "[PI-42][fix] Example" --body "Closes #42"',
         )
-        assert out is not None and out["decision"] == "block"
-        assert "create_nojira_pr.sh" in out["reason"]
+        assert _denied(out)
+        assert "create_nojira_pr.sh" in _deny_reason(out)
 
     def test_github_command_guard_blocks_raw_pr_ready(self):
         out = self._run_hook("github_command_guard.sh", "gh pr ready 42")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_raw_git_push(self):
         out = self._run_hook("github_command_guard.sh", "git push -u origin fix/PI-42-example")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_blocks_pr_checks_watch(self):
         out = self._run_hook("github_command_guard.sh", "gh pr checks 42 --watch")
-        assert out is not None and out["decision"] == "block"
+        assert _denied(out)
 
     def test_github_command_guard_allows_monitor_pr_merge(self):
         out = self._run_hook(

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -51,10 +51,14 @@ def test_render_mcp_toml_passes_env_and_bearer_token():
 
 
 def test_render_mcp_toml_escapes_special_characters():
-    """Quotes/backslashes in values must yield valid TOML (json.dumps escaping)."""
-    servers = {"srv": {"command": "bunx", "args": ['a"b', "c\\d"]}}
+    """Quotes/backslashes in values (incl. env keys/values) must yield valid
+    TOML (json.dumps escaping) — Codex P2: `env = {"TOKEN" = "a"b"}` is invalid."""
+    servers = {
+        "srv": {"command": "bunx", "args": ['a"b', "c\\d"], "env": {"TOKEN": 'a"b'}},
+    }
     parsed = tomllib.loads(surfaces.render_mcp_toml(servers))
     assert parsed["mcp_servers"]["srv"]["args"] == ['a"b', "c\\d"]
+    assert parsed["mcp_servers"]["srv"]["env"] == {"TOKEN": 'a"b'}
 
 
 def test_cursor_hooks_use_camelcase_events_and_adapter():

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -7,6 +7,7 @@ project_init.surfaces and the MCP server-spec lookup in project_init.mcps.
 from __future__ import annotations
 
 import json
+import tomllib
 
 from project_init import surfaces
 from project_init.mcps import servers_for_ids
@@ -36,6 +37,24 @@ def test_render_mcp_toml_codex_shape():
     assert 'command = "bunx"' in toml
     assert 'args = ["@upstash/context7-mcp"]' in toml
     assert "[mcp_servers.postgres]" in toml
+
+
+def test_render_mcp_toml_passes_env_and_bearer_token():
+    """PI-388: secrets must not be dropped — env (stdio) + bearer (HTTP)."""
+    servers = {
+        "stdio_srv": {"command": "bunx", "args": ["pkg"], "env": {"API_KEY": "v"}},
+        "http_srv": {"url": "https://mcp.example.com/", "bearer_token_env_var": "TOK"},
+    }
+    parsed = tomllib.loads(surfaces.render_mcp_toml(servers))
+    assert parsed["mcp_servers"]["stdio_srv"]["env"] == {"API_KEY": "v"}
+    assert parsed["mcp_servers"]["http_srv"]["bearer_token_env_var"] == "TOK"
+
+
+def test_render_mcp_toml_escapes_special_characters():
+    """Quotes/backslashes in values must yield valid TOML (json.dumps escaping)."""
+    servers = {"srv": {"command": "bunx", "args": ['a"b', "c\\d"]}}
+    parsed = tomllib.loads(surfaces.render_mcp_toml(servers))
+    assert parsed["mcp_servers"]["srv"]["args"] == ['a"b', "c\\d"]
 
 
 def test_cursor_hooks_use_camelcase_events_and_adapter():


### PR DESCRIPTION
Closes #388

Currency-hardening from the 2026-06-22 per-surface audit. No active bugs — the legacy shape still works (verified empirically) — but standardizes on the **documented** Claude Code PreToolUse hook schema and fixes a real Codex MCP gap.

## Changes
- **Documented hook decision schema (item 1):** `dag_workflow.py`, `prod_guard.py`, and `agent_guard_adapter.py` now emit `hookSpecificOutput.permissionDecision` (`deny`/`ask`) instead of legacy top-level `{"decision":"block"}`. `prod_guard` was internally inconsistent (documented shape for `ask`, legacy for block) and is now uniform. The adapter still *tolerates* the legacy shape (version-skew safety); the `codex` dialect emits the documented shape (Codex accepts it).
- **Codex MCP secrets (item 2):** `surfaces.py render_mcp_toml` passes through `env` (stdio) and `bearer_token_env_var` (HTTP) — previously dropped silently.
- **Ollama (item 4):** wizard model panel mentions `qwen3-coder-next`.
- **Docs:** `add_hook` skill teaches the documented block shape.
- **Tests:** assertions updated in `test_dag_workflow.py`, `test_issue_metadata_workflow.py`, `test_prod_guard.py`; **new adapter contract test** pins per-dialect output. Synced plugin/codex/gemini copies.

## Verification
- `ruff` clean; **1048 passed / 3 skipped**.
- **Empirical:** after migrating the live guard, `git push origin main --dry-run` is still blocked → current Claude Code honors `permissionDecision:"deny"`. Enforcement intact.

## Deferred (documented in #388)
- VS Code `type:"stdio"` — explicitly optional, broad churn for ~zero gain.
- Context7 HTTP transport — overlaps #387, better done there.