### PR TITLE
chore(PI-387): remove postgres + sqlite DB MCP entries

### DIFF
--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -46,7 +46,6 @@ Available flags:
 | `--preset` | `obsidian-only`, `obsidian-graphify` | (asked interactively) |
 | `--language` | `python`, `node`, `go`, `none` | `none` |
 | `--mcps` | `context7` (comma-separated) | none |
-| `--db` | `none`, `postgres`, `sqlite` | `none` |
 | `--browser` | flag (Playwright MCP) | off |
 | `--strict` | flag (fail on unrendered placeholders) | off |
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from project_init import __plugin_version__, __repo_url__, __version__
 from project_init.mcps import (
-    DB_CATALOG,
     MCP_CATALOG,
     PLAYWRIGHT_MCP,
     format_installed_mcps,
@@ -134,12 +133,6 @@ def _build_parser() -> argparse.ArgumentParser:
         "--mcps",
         default="",
         help="Comma-separated MCP IDs from the core catalog (e.g. context7)",
-    )
-    p.add_argument(
-        "--db",
-        choices=["none", "postgres", "sqlite"],
-        default="none",
-        help="Database MCP to add (default: none)",
     )
     p.add_argument(
         "--browser",
@@ -289,25 +282,6 @@ def _choose_mcps_interactive(catalog: list[dict]) -> list[dict]:
     return selected
 
 
-def _choose_db_interactive() -> dict | None:
-    from rich.console import Console
-    from rich.prompt import IntPrompt
-
-    console = Console()
-    console.print("\n[bold]Database MCP:[/bold]")
-    console.print("  [cyan]1[/cyan]. None")
-    console.print("  [cyan]2[/cyan]. Postgres")
-    console.print("  [cyan]3[/cyan]. SQLite")
-    console.print()
-
-    choice = IntPrompt.ask("Choose", default=1)
-    if choice == 2:
-        return DB_CATALOG["postgres"]
-    if choice == 3:
-        return DB_CATALOG["sqlite"]
-    return None
-
-
 def _choose_browser_interactive() -> bool:
     from rich.prompt import Confirm
 
@@ -333,7 +307,6 @@ def _choose_profile_interactive() -> str:
 
 def _resolve_mcps_non_interactive(
     mcps_arg: str,
-    db_arg: str,
     browser_arg: bool,
 ) -> list[dict]:
     """Parse non-interactive MCP flags into a flat list of selected MCPs.
@@ -361,9 +334,6 @@ def _resolve_mcps_non_interactive(
         valid = ", ".join(catalog_by_id.keys())
         msg = f"unknown MCP id(s): {', '.join(unknown)}. Valid: {valid}"
         raise ValueError(msg)
-
-    if db_arg and db_arg != "none" and db_arg in DB_CATALOG:
-        selected.append(DB_CATALOG[db_arg])
 
     if browser_arg:
         selected.append(PLAYWRIGHT_MCP)
@@ -607,11 +577,8 @@ def _gather_inputs_interactive(
         language, delivery_flag, deploy_flag, iac_flag
     )
 
-    # MCP selection — three steps.
+    # MCP selection — catalog multi-select + optional browser MCP.
     selected_mcps = _choose_mcps_interactive(MCP_CATALOG)
-    db_mcp = _choose_db_interactive()
-    if db_mcp:
-        selected_mcps = selected_mcps + [db_mcp]
     if _choose_browser_interactive():
         selected_mcps = selected_mcps + [PLAYWRIGHT_MCP]
 
@@ -1130,7 +1097,7 @@ def _resolve_inputs(args, parser, target: Path) -> ScaffoldInputs | None:
     if not args.non_interactive:
         return None
     try:
-        selected_mcps = _resolve_mcps_non_interactive(args.mcps, args.db, args.browser)
+        selected_mcps = _resolve_mcps_non_interactive(args.mcps, args.browser)
         agents = resolve_agents(args.agents)
     except ValueError as e:
         parser.error(str(e))

--- a/src/project_init/mcps.py
+++ b/src/project_init/mcps.py
@@ -16,34 +16,23 @@ MCP_CATALOG: list[dict] = [
         "id": "context7",
         "name": "Context7",
         "description": "Live library documentation lookup",
-        "command": "claude mcp add context7 bunx @upstash/context7-mcp",
+        "command": "claude mcp add context7 -- bunx @upstash/context7-mcp",
         # Canonical server spec (PI-366): the stdio invocation behind the
         # install command, rendered per-surface into mcpServers / servers / TOML.
         "server": {"command": "bunx", "args": ["@upstash/context7-mcp"]},
     },
 ]
 
-# Database MCPs — mutually exclusive, offered as a single-choice follow-up.
-DB_CATALOG: dict[str, dict] = {
-    "postgres": {
-        "id": "postgres",
-        "name": "Postgres",
-        "command": "claude mcp add postgres bunx @modelcontextprotocol/server-postgres",
-        "server": {"command": "bunx", "args": ["@modelcontextprotocol/server-postgres"]},
-    },
-    "sqlite": {
-        "id": "sqlite",
-        "name": "SQLite",
-        "command": "claude mcp add sqlite bunx mcp-server-sqlite",
-        "server": {"command": "bunx", "args": ["mcp-server-sqlite"]},
-    },
-}
+# Database MCPs are intentionally absent (PI-387): the reference postgres/sqlite
+# servers were archived with unpatched SQL-injection CVEs, and a DB MCP overlaps
+# with the agent's native Bash psql/sqlite3 access (same rationale that excludes
+# filesystem above). Projects needing one can add it themselves.
 
 # Browser automation MCP — offered as a yes/no follow-up.
 PLAYWRIGHT_MCP: dict = {
     "id": "playwright",
     "name": "Playwright",
-    "command": "claude mcp add playwright bunx @playwright/mcp",
+    "command": "claude mcp add playwright -- bunx @playwright/mcp",
     "server": {"command": "bunx", "args": ["@playwright/mcp"]},
 }
 
@@ -55,7 +44,6 @@ def servers_for_ids(ids: list[str]) -> dict[str, dict]:
     generators render from (PI-366).
     """
     by_id: dict[str, dict] = {m["id"]: m for m in MCP_CATALOG}
-    by_id.update(DB_CATALOG)
     by_id[PLAYWRIGHT_MCP["id"]] = PLAYWRIGHT_MCP
     out: dict[str, dict] = {}
     for i in ids:

--- a/templates/base/dot_claude/docs/adr/adr-002-mcp-choices.md.tmpl
+++ b/templates/base/dot_claude/docs/adr/adr-002-mcp-choices.md.tmpl
@@ -16,17 +16,19 @@ Three MCPs are intentionally absent to reduce token overhead:
 | GitHub MCP (~35 tools) | ~2000 tokens | `gh` CLI built-in |
 | Linear MCP (~15 tools) | ~800 tokens | `gh` CLI + GitHub Issues |
 | Filesystem MCP (~10 tools) | ~500 tokens | Claude Code built-in Read/Write/Edit/Glob/Grep |
+| Postgres / SQLite DB MCP | — | native `psql`/`sqlite3` via Bash |
+
+The DB MCPs were removed in PI-387: the reference servers (`@modelcontextprotocol/server-postgres`, `mcp-server-sqlite`) were archived with unpatched SQL-injection CVEs, and a DB MCP overlaps with the agent's native shell access — the same rationale as Filesystem above. A project that wants structured, guard-railed DB access can add a maintained server (e.g. `@bytebase/dbhub`) itself.
 
 **Selected at init:** {{installed_mcps}}
 
 Retained MCPs:
-- **Context7** — targeted library doc lookups; no CLI equivalent
+- **Context7** — targeted library doc lookups; no CLI equivalent. Default install is stdio (`bunx`); for Claude web/mobile (which support HTTP MCP only) use the hosted endpoint: `claude mcp add --transport http context7 https://mcp.context7.com/mcp`.
 - **Playwright** — browser automation; no CLI equivalent
-- **Postgres / SQLite** — direct DB access; no CLI equivalent
 
 ## Consequences
 
 - Agents use `gh issue list`, `gh pr create`, etc. for project management
 - File ops use Claude Code built-ins — no MCP config needed
 - Token budget stays ~3300 tokens lower per session; more context for actual work
-- `MCP_CATALOG` in project-init contains only context7 (and optional DB/browser)
+- `MCP_CATALOG` in project-init contains only context7 (plus the optional Playwright browser MCP)

--- a/templates/base/dot_claude/docs/adr/adr-002-mcp-choices.md.tmpl
+++ b/templates/base/dot_claude/docs/adr/adr-002-mcp-choices.md.tmpl
@@ -9,7 +9,7 @@ Model Context Protocol (MCP) servers extend Claude Code's toolset. Each server l
 
 ## Decision
 
-Three MCPs are intentionally absent to reduce token overhead:
+The following MCPs are intentionally absent — to reduce token overhead, and (for the DB MCPs) to avoid an unmaintained, CVE-prone dependency:
 
 | MCP | Tokens saved | Replacement |
 |---|---|---|

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -57,7 +57,6 @@ class TestAgentSelection:
         )
         monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(answers))
         monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
-        monkeypatch.setattr(cli, "_choose_db_interactive", lambda: None)
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
         monkeypatch.setattr(cli, "_choose_delivery_interactive", lambda language: "prototype")
         monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")

--- a/tests/unit/test_interactive_prompts.py
+++ b/tests/unit/test_interactive_prompts.py
@@ -37,19 +37,6 @@ def test_choose_mcps_interactive_empty_skips(monkeypatch):
     assert __main__._choose_mcps_interactive(MCP_CATALOG) == []
 
 
-@pytest.mark.parametrize(
-    ("choice", "expected"),
-    [(1, None), (2, "postgres"), (3, "sqlite")],
-)
-def test_choose_db_interactive_maps_choices(monkeypatch, choice, expected):
-    monkeypatch.setattr("rich.prompt.IntPrompt.ask", lambda *a, **k: choice)
-    result = __main__._choose_db_interactive()
-    if expected is None:
-        assert result is None
-    else:
-        assert result["id"] == expected
-
-
 @pytest.mark.parametrize("answer", [True, False])
 def test_choose_multi_model_interactive_returns_confirm(monkeypatch, answer):
     monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: answer)

--- a/tests/unit/test_mcps.py
+++ b/tests/unit/test_mcps.py
@@ -25,10 +25,10 @@ class TestMCPs:
         assert "github" not in ids
         assert "filesystem" not in ids
 
-    def test_db_catalog_has_postgres_and_sqlite(self):
-        from project_init.mcps import DB_CATALOG
-        assert "postgres" in DB_CATALOG
-        assert "sqlite" in DB_CATALOG
+    def test_no_db_catalog(self):
+        """PI-387: postgres/sqlite DB MCPs removed (archived + unpatched CVEs)."""
+        import project_init.mcps as mcps
+        assert not hasattr(mcps, "DB_CATALOG")
 
     def test_playwright_mcp_defined(self):
         from project_init.mcps import PLAYWRIGHT_MCP
@@ -36,25 +36,19 @@ class TestMCPs:
         assert "command" in PLAYWRIGHT_MCP
 
     def test_no_npx_in_any_command(self):
-        from project_init.mcps import DB_CATALOG, MCP_CATALOG, PLAYWRIGHT_MCP
-        all_commands = (
-            [m["command"] for m in MCP_CATALOG]
-            + [m["command"] for m in DB_CATALOG.values()]
-            + [PLAYWRIGHT_MCP["command"]]
-        )
+        from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP
+        all_commands = [m["command"] for m in MCP_CATALOG] + [PLAYWRIGHT_MCP["command"]]
         for cmd in all_commands:
             assert "npx" not in cmd, f"npx found in command: {cmd}"
             assert "npm" not in cmd, f"npm found in command: {cmd}"
 
-    def test_all_commands_use_bunx(self):
-        from project_init.mcps import DB_CATALOG, MCP_CATALOG, PLAYWRIGHT_MCP
-        all_commands = (
-            [m["command"] for m in MCP_CATALOG]
-            + [m["command"] for m in DB_CATALOG.values()]
-            + [PLAYWRIGHT_MCP["command"]]
-        )
+    def test_all_commands_use_bunx_with_separator(self):
+        from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP
+        all_commands = [m["command"] for m in MCP_CATALOG] + [PLAYWRIGHT_MCP["command"]]
         for cmd in all_commands:
             assert "bunx" in cmd, f"bunx not found in command: {cmd}"
+            # PI-387: current `claude mcp add <name> -- <cmd>` separator form.
+            assert " -- " in cmd, f"missing `--` separator in command: {cmd}"
 
     def test_format_installed_mcps_empty(self):
         from project_init.mcps import format_installed_mcps
@@ -66,10 +60,10 @@ class TestMCPs:
         assert format_installed_mcps([context7]) == "context7"
 
     def test_format_installed_mcps_multiple(self):
-        from project_init.mcps import DB_CATALOG, MCP_CATALOG, format_installed_mcps
-        subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), DB_CATALOG["postgres"]]
+        from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, format_installed_mcps
+        subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), PLAYWRIGHT_MCP]
         result = format_installed_mcps(subset)
-        assert "context7" in result and "postgres" in result
+        assert "context7" in result and "playwright" in result
 
     def test_format_installed_mcps_yaml_empty(self):
         from project_init.mcps import format_installed_mcps_yaml
@@ -81,15 +75,15 @@ class TestMCPs:
         assert format_installed_mcps_yaml([context7]) == '["context7"]'
 
     def test_format_installed_mcps_yaml_multiple(self):
-        from project_init.mcps import DB_CATALOG, MCP_CATALOG, format_installed_mcps_yaml
-        subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), DB_CATALOG["postgres"]]
+        from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, format_installed_mcps_yaml
+        subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), PLAYWRIGHT_MCP]
         result = format_installed_mcps_yaml(subset)
         assert result.startswith("[") and result.endswith("]")
-        assert '"context7"' in result and '"postgres"' in result
+        assert '"context7"' in result and '"playwright"' in result
 
 
 class TestMCPsNonInteractive:
-    """Test --mcps / --db / --browser flags via non-interactive CLI."""
+    """Test --mcps / --browser flags via non-interactive CLI."""
 
     def test_mcps_flag_context7(self, tmp_path: Path):
         from project_init.__main__ import main
@@ -106,20 +100,13 @@ class TestMCPsNonInteractive:
         config = (target / ".claude" / "config.yaml").read_text()
         assert "context7" in config
 
-    def test_db_postgres_flag(self, tmp_path: Path):
+    def test_db_flag_removed(self):
+        """PI-387: --db is gone; passing it must be a CLI error."""
         from project_init.__main__ import main
-        target = tmp_path / "p"
-        rc = main([
-            str(target), "--non-interactive",
-            "--preset", "obsidian-only",
-            "--name", "db-test",
-            "--description", "test",
-            "--language", "python",
-            "--db", "postgres",
-        ])
-        assert rc == 0
-        config = (target / ".claude" / "config.yaml").read_text()
-        assert "postgres" in config
+        with pytest.raises(SystemExit):
+            main(["x", "--non-interactive", "--preset", "obsidian-only",
+                   "--name", "n", "--description", "d", "--language", "python",
+                   "--db", "postgres"])
 
     def test_browser_flag_adds_playwright(self, tmp_path: Path):
         from project_init.__main__ import main

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -14,11 +14,11 @@ from project_init.mcps import servers_for_ids
 
 
 def test_servers_for_ids_resolves_catalog_specs():
-    servers = servers_for_ids(["context7", "postgres", "sqlite", "playwright"])
-    assert set(servers) == {"context7", "postgres", "sqlite", "playwright"}
+    servers = servers_for_ids(["context7", "playwright"])
+    assert set(servers) == {"context7", "playwright"}
     assert servers["context7"] == {"command": "bunx", "args": ["@upstash/context7-mcp"]}
-    # Unknown ids are dropped, not errors.
-    assert servers_for_ids(["nope"]) == {}
+    # Unknown ids (incl. the removed postgres/sqlite, PI-387) are dropped, not errors.
+    assert servers_for_ids(["nope", "postgres", "sqlite"]) == {}
     assert servers_for_ids([]) == {}
 
 
@@ -32,11 +32,11 @@ def test_render_mcp_json_mcpservers_and_servers_keys():
 
 
 def test_render_mcp_toml_codex_shape():
-    toml = surfaces.render_mcp_toml(servers_for_ids(["context7", "postgres"]))
+    toml = surfaces.render_mcp_toml(servers_for_ids(["context7", "playwright"]))
     assert "[mcp_servers.context7]" in toml
     assert 'command = "bunx"' in toml
     assert 'args = ["@upstash/context7-mcp"]' in toml
-    assert "[mcp_servers.postgres]" in toml
+    assert "[mcp_servers.playwright]" in toml
 
 
 def test_render_mcp_toml_passes_env_and_bearer_token():


### PR DESCRIPTION
Closes #387

From the 2026-06-22 currency audit: the reference DB MCP servers (`@modelcontextprotocol/server-postgres`, `mcp-server-sqlite`) are **archived with unpatched SQL-injection CVEs**. After discussion the decision was to **remove DB MCPs entirely** rather than adopt a replacement.

## Rationale
- A DB MCP in a *scaffolded* project overlaps with the agent's native Bash `psql`/`sqlite3` access — the same redundancy logic that already excludes the `filesystem` MCP.
- project-init has no database of its own; these were opt-in catalog entries with no downstream dependency.
- Not shipping a server in the CVE-prone DB-MCP category is the safest default.

## Changes
- **`mcps.py`** — delete `DB_CATALOG`; drop it from `servers_for_ids`; add the `--` separator to the surviving context7/playwright `claude mcp add` strings.
- **`__main__.py`** — remove the `--db` flag, `_choose_db_interactive`, and the `db_arg` path in `_resolve_mcps_non_interactive`.
- **ADR-002** — document the removal + security reason; note Context7's hosted HTTP transport (`claude mcp add --transport http context7 https://mcp.context7.com/mcp`) for Claude web/mobile.
- **docs guide** — drop the `--db` row.
- **tests** — remove DB asserts/tests; pin the `--` separator; assert `--db` now errors and `DB_CATALOG` is gone.

## Descoped
The "per-tool runner (bunx/uvx/docker)" sub-task of #387 is unnecessary: the remaining servers are bunx-runnable, so the bunx-only invariant + its tests stay intact and the render layer is unchanged.

## Upgrade behavior
Graceful — `servers_for_ids` already silently drops unknown ids, and `surfaces.emit` never clobbers (writes a `.new` sibling). Existing scaffolds with a stale `postgres`/`sqlite` id simply stop emitting that server on re-render.

## Verification
- `ruff` clean; **1047 passed / 3 skipped**.
- `--help` shows no `--db`.
- Scaffolded a temp project (`--mcps context7 --browser`): `.mcp.json` contains only context7 + playwright, no postgres/sqlite.