### PR TITLE
chore(PI-385): fix GUI-surface hook stdin parsing + deny shapes (Cursor, Antigravity)

### DIFF
--- a/docs/development/non-cli-surface-matrix.md
+++ b/docs/development/non-cli-surface-matrix.md
@@ -76,7 +76,7 @@ and `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`.
 |---|---|---|
 | Claude Code VS Code ext | hooks, skills, CLAUDE.md (same `.claude/`) | **shared project MCP**: emit a root `.mcp.json` (`mcpServers`) when MCPs are configured — `.claude/` alone does not carry shareable MCP (bare `claude mcp add` writes a private `~/.claude.json` entry) |
 | Copilot agent mode | CLAUDE.md, `.claude/skills`, hooks (matcher-blind), AGENTS.md | `.vscode/mcp.json` (`servers` map) if MCPs are configured; document that matchers are advisory here |
-| Cursor | `.claude/skills` (skills), AGENTS.md | `.cursor/hooks.json` (translate `PreToolUse(Bash)`→`beforeShellExecution`, `UserPromptSubmit`→`beforeSubmitPrompt`); `.cursor/mcp.json` (≈copy of `mcpServers`) |
+| Cursor | `.claude/skills` (skills), AGENTS.md | `.cursor/hooks.json` (`PreToolUse(Bash)`→`beforeShellExecution`, deny via `{"permission":"deny","user_message"}`; PI-385); `.cursor/mcp.json` (≈copy of `mcpServers`) |
 | Codex (CLI/IDE) | `.codex/hooks.json` ✅, `.agents/skills` ✅, AGENTS.md ✅ | MCP → `.codex/config.toml` `[mcp_servers.*]` if MCPs are configured |
 | Antigravity | `.agents/skills` ✅, `.agents/hooks.json` ✅, `.agents/mcp_config.json` ✅, AGENTS.md ✅ (PI-386) | hook blocking-contract still experimental — live-verify in #385 |
 

--- a/docs/development/non-cli-surface-matrix.md
+++ b/docs/development/non-cli-surface-matrix.md
@@ -46,6 +46,17 @@ project-init can decide what to emit beyond `.claude/` (epic #359, workstream B)
    for skills, AGENTS.md native (v1.20.3+), MCP at `~/.gemini/config/mcp_config.json`.
    Only `PreToolUse` is confirmed; the full event set is unverified.
 
+   > **Update — PI-385 (2026-06-22):** the deny **contracts** are now confirmed from
+   > vendor docs and the adapter parses/emits them, pinned by simulation tests
+   > (`TestAgentGuardAdapter`): **Cursor** `beforeShellExecution` — top-level
+   > `{"command"}` stdin → `{"permission":"deny","user_message","agent_message"}`;
+   > **Antigravity** `PreToolUse` — `toolCall.args.CommandLine` stdin →
+   > `{"decision":"deny","reason"}`; **Antigravity** project MCP at
+   > `.agents/mcp_config.json` (PI-386). Both stay **fail-open** by design (no Cursor
+   > `failClosed`) — a hook crash must not wedge a shell; git/CI is the boundary
+   > (ADR-007). Antigravity remains flagged `experimental` only because it isn't yet
+   > verified against a live `agy` binary (the contract itself is doc-confirmed).
+
 ## What project-init emits today vs. what each surface needs
 
 > **Update — PI-386 (2026-06-22):** Gemini CLI was removed. Google sunset its

--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -88,16 +88,17 @@ def render_mcp_toml(servers: dict[str, dict]) -> str:
 def render_cursor_hooks() -> str:
     """Render `.cursor/hooks.json` (version 1).
 
-    Maps the shared guard onto Cursor's camelCase events: the shell guard to
-    ``beforeShellExecution`` and the workflow reminder to ``beforeSubmitPrompt``.
+    Wires the shared command guard onto Cursor's ``beforeShellExecution`` event
+    (top-level ``command`` stdin → ``{"permission": "deny", ...}`` stdout; PI-385,
+    confirmed from docs). No ``beforeSubmitPrompt`` hook: that event carries no
+    shell command and uses a different deny shape (``{"continue": false}``), so the
+    command guard can't act on it. Fail-open (no ``failClosed``) — git/CI is the
+    real boundary (ADR-007).
     """
     config = {
         "version": 1,
         "hooks": {
             "beforeShellExecution": [
-                {"command": f"{_GUARD} cursor", "type": "command"}
-            ],
-            "beforeSubmitPrompt": [
                 {"command": f"{_GUARD} cursor", "type": "command"}
             ],
         },
@@ -108,8 +109,11 @@ def render_cursor_hooks() -> str:
 def render_antigravity_hooks() -> str:
     """Render `.agents/hooks.json` for Antigravity's ``safety-gate`` model.
 
-    EXPERIMENTAL — only ``PreToolUse`` is confirmed; the exact decision I/O is
-    unverified, so the adapter stays fail-open.
+    PI-385: the ``PreToolUse`` path + stdout deny shape (``{"decision":"deny"}``)
+    and the stdin command location (``toolCall.args.CommandLine``) are confirmed
+    from Google's migration docs, and the adapter parses/emits them. Still flagged
+    ``experimental`` because the official rendered docs were un-fetchable and this
+    isn't verified against a live ``agy`` binary; adapter stays fail-open.
     """
     config = {
         "safety-gate": {

--- a/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
+++ b/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
@@ -9,11 +9,16 @@ guard, and translates the verdict to the caller's dialect:
 
   codex  -> {"hookSpecificOutput": {permissionDecision: "deny", ...}}
             (the documented PreToolUse schema; Codex accepts it)
-  cursor -> {"permission": "deny", ...}      (PI-385: shape unverified)
-  antigravity -> {"decision": "deny", ...}   (PI-385: experimental)
+  cursor -> {"permission": "deny", "user_message": ...}  (beforeShellExecution)
+  antigravity -> {"decision": "deny", "reason": ...}      (safety-gate PreToolUse)
 
-Fail-open by design: on any parse error the command proceeds — git hooks
-and CI remain the real enforcement boundary (ADR-007).
+Stdin differs per surface too (PI-385, confirmed from vendor docs): Codex/Claude
+send {"tool_input": {"command"}}, Cursor beforeShellExecution sends a top-level
+{"command"}, Antigravity sends {"toolCall": {"args": {"CommandLine"}}}.
+
+Fail-open by design: on any parse error the command proceeds — git hooks and CI
+remain the real enforcement boundary (ADR-007). The GUI surfaces keep this posture
+(no Cursor `failClosed`): a hook crash must never wedge a user's shell.
 
 Usage (wired by the scaffolded hook configs): agent_guard_adapter.py <dialect>
 """
@@ -25,8 +30,19 @@ from pathlib import Path
 
 
 def _extract_command(payload: dict) -> str:
+    """Pull the shell command out of whichever stdin shape the surface sent."""
     tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
-    command = tool_input.get("command") or tool_input.get("cmd") or ""
+    tool_call = payload.get("toolCall")
+    call_args = tool_call.get("args") if isinstance(tool_call, dict) else None
+    call_args = call_args or {}
+    command = (
+        tool_input.get("command")
+        or tool_input.get("cmd")
+        or payload.get("command")  # Cursor beforeShellExecution (top-level)
+        or call_args.get("CommandLine")  # Antigravity shell tool
+        or call_args.get("command")
+        or ""
+    )
     if isinstance(command, list):
         command = " ".join(str(part) for part in command)
     return str(command)
@@ -66,11 +82,12 @@ def main() -> int:
     if denied:
         reason = hso.get("permissionDecisionReason") or verdict.get("reason", "")
         if dialect == "cursor":
-            # Cursor signals a block via permission=deny (PI-366; exact schema
-            # unverified — fail-open means a wrong guess degrades safely).
-            out = {"permission": "deny", "userMessage": reason}
+            # Cursor beforeShellExecution deny (PI-385: confirmed from docs —
+            # permission + snake_case user_message/agent_message).
+            out = {"permission": "deny", "user_message": reason, "agent_message": reason}
         elif dialect == "antigravity":
-            # Antigravity safety-gate deny (experimental; unverified shape).
+            # Antigravity safety-gate deny (PI-385: stdout confirmed from docs;
+            # surface still flagged experimental pending live-binary verification).
             out = {"decision": "deny", "reason": reason}
         else:
             # codex: the documented PreToolUse schema (Codex accepts it).

--- a/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
+++ b/templates/base/dot_claude/hooks/agent_guard_adapter.py.tmpl
@@ -30,11 +30,20 @@ from pathlib import Path
 
 
 def _extract_command(payload: dict) -> str:
-    """Pull the shell command out of whichever stdin shape the surface sent."""
+    """Pull the shell command out of whichever stdin shape the surface sent.
+
+    Type-guards every level: malformed JSON (non-dict payload/tool_input/args)
+    yields "" rather than raising, keeping the hook fail-open.
+    """
+    if not isinstance(payload, dict):
+        return ""
     tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
     tool_call = payload.get("toolCall")
     call_args = tool_call.get("args") if isinstance(tool_call, dict) else None
-    call_args = call_args or {}
+    if not isinstance(call_args, dict):
+        call_args = {}
     command = (
         tool_input.get("command")
         or tool_input.get("cmd")

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -235,6 +235,7 @@ class TestAgentGuardAdapter:
         out = self._run_adapter(target, "cursor", "git push origin main")
         assert out["permission"] == "deny"
         assert "main/master" in out["user_message"]
+        assert "main/master" in out["agent_message"]
 
     def test_antigravity_emits_decision_deny(self, tmp_path: Path):
         """PI-385: `toolCall.args.CommandLine` stdin → `{decision: deny, reason}`."""
@@ -246,3 +247,17 @@ class TestAgentGuardAdapter:
     def test_innocuous_command_not_blocked(self, tmp_path: Path):
         target = _scaffold_agents(tmp_path / "p", "codex")
         assert self._run_adapter(target, "codex", "ls -la") is None
+
+    def test_malformed_payload_is_fail_open(self, tmp_path: Path):
+        """PI-385: non-dict JSON stdin must not crash the hook (stays fail-open)."""
+        target = _scaffold_agents(tmp_path / "p", "codex")
+        adapter = target / ".claude" / "hooks" / "agent_guard_adapter.py"
+        proc = subprocess.run(
+            [sys.executable, str(adapter), "codex"],
+            input="[]",
+            capture_output=True,
+            text=True,
+            cwd=target,
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -197,13 +197,20 @@ class TestSyncedCopiesInRepo:
 
 
 class TestAgentGuardAdapter:
-    """PI-388: the shared adapter translates a dag_workflow deny into each
-    surface's dialect, sourced from the documented PreToolUse hookSpecificOutput
-    shape. `git push origin main` blocks unconditionally (no redirect script)."""
+    """PI-385/388: the shared adapter parses each surface's REAL stdin shape and
+    translates a dag_workflow deny into that surface's dialect. `git push origin
+    main` blocks unconditionally (no redirect script)."""
 
     def _run_adapter(self, target: Path, dialect: str, command: str) -> dict | None:
         adapter = target / ".claude" / "hooks" / "agent_guard_adapter.py"
-        payload = json.dumps({"tool_input": {"command": command}})
+        # Each surface sends its own stdin shape (PI-385, confirmed from docs).
+        surface_payloads = {
+            "cursor": {"command": command},  # beforeShellExecution: top-level
+            "antigravity": {"toolCall": {"args": {"CommandLine": command}}},
+        }
+        payload = json.dumps(
+            surface_payloads.get(dialect, {"tool_input": {"command": command}})
+        )
         proc = subprocess.run(
             [sys.executable, str(adapter), dialect],
             input=payload,
@@ -222,7 +229,15 @@ class TestAgentGuardAdapter:
         assert hso["permissionDecision"] == "deny"
         assert "main/master" in hso["permissionDecisionReason"]
 
+    def test_cursor_emits_permission_deny(self, tmp_path: Path):
+        """PI-385: top-level `command` stdin → `{permission: deny, user_message}`."""
+        target = _scaffold_agents(tmp_path / "p", "cursor")
+        out = self._run_adapter(target, "cursor", "git push origin main")
+        assert out["permission"] == "deny"
+        assert "main/master" in out["user_message"]
+
     def test_antigravity_emits_decision_deny(self, tmp_path: Path):
+        """PI-385: `toolCall.args.CommandLine` stdin → `{decision: deny, reason}`."""
         target = _scaffold_agents(tmp_path / "p", "antigravity")
         out = self._run_adapter(target, "antigravity", "git push origin main")
         assert out["decision"] == "deny"

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -65,7 +65,8 @@ def test_cursor_hooks_use_camelcase_events_and_adapter():
     cfg = json.loads(surfaces.render_cursor_hooks())
     assert cfg["version"] == 1
     assert "beforeShellExecution" in cfg["hooks"]
-    assert "beforeSubmitPrompt" in cfg["hooks"]
+    # PI-385: beforeSubmitPrompt dropped (no command; different deny shape).
+    assert "beforeSubmitPrompt" not in cfg["hooks"]
     cmd = cfg["hooks"]["beforeShellExecution"][0]["command"]
     assert "agent_guard_adapter.py cursor" in cmd
 


### PR DESCRIPTION
Closes #385

## The bug
The shared guard adapter only parsed the Claude/Codex stdin shape (`tool_input.command`). Cursor sends the command **top-level** (`{"command"}`) and Antigravity sends it at `toolCall.args.CommandLine` — so for both GUI surfaces extraction returned empty and the hook fell open: **the Cursor and Antigravity command guards never actually blocked anything.**

## What this does
Contracts confirmed from vendor docs (Cursor `cursor.com/docs/hooks`; Antigravity via Google's migration guide), parsed/emitted, and pinned with simulation tests:
- **`_extract_command`** now handles Cursor's top-level `{"command"}` and Antigravity's `toolCall.args.CommandLine` (plus the existing Codex/Claude `tool_input` shape).
- **Cursor deny shape** corrected: `{"permission":"deny","user_message","agent_message"}` (was the wrong-case `userMessage`).
- **Dropped the dead `beforeSubmitPrompt` Cursor hook** — it carries no shell command and uses a different `{"continue":false}` deny shape the command guard can't produce, so it never did anything.
- **Antigravity** stdout `{"decision":"deny","reason"}` was already correct; now its stdin is parsed too.

## Decisions
- **Kept fail-open by design** (no Cursor `failClosed`). The ticket asked "promote from fail-open if confirmed" — the deliberate answer is *no*: per ADR-007 a hook crash must never wedge a user's shell; git/CI is the real boundary. Promoting to fail-closed would contradict the architecture.
- **Antigravity stays flagged `experimental`** — the *contract* is doc-confirmed and tested, but it isn't verified against a live `agy` binary.

## Tests
`TestAgentGuardAdapter` now feeds each surface's **real** stdin shape (Cursor top-level `command`; Antigravity `toolCall.args.CommandLine`; Codex `tool_input`) and adds a Cursor case proving `{permission:deny, user_message}`. `ruff` clean; **1043 passed / 3 skipped**.

## Honest limitation
I can't run Cursor/Antigravity binaries in this environment, so the contracts are **doc-confirmed + simulation-tested**, not live-binary-verified. If you want the live-binary check tracked, it's a small follow-up — but the never-blocked bug is fixed and the deny shapes match the published schemas.