### PR TITLE
fix(PI-396): refresh multi-model CCR config — current model IDs, Gemini provider, gateway/LiteLLM

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -409,7 +409,7 @@ def _choose_multi_model_interactive() -> bool:
         "(background work goes to a cheap model). Your hooks, CI gates, and "
         "standards stay identical — they run below the model.\n\n"
         "  [dim]claude[/dim]                          [dim]# opens as usual[/dim]\n"
-        "  [dim]/model deepseek,deepseek-chat[/dim]   [dim]# switch mid-session, context kept[/dim]\n"
+        "  [dim]/model deepseek,deepseek-v4-flash[/dim] [dim]# switch mid-session, context kept[/dim]\n"
         "  [dim]/model ollama,qwen3-coder:30b[/dim]      [dim]# or qwen3-coder-next (newer)[/dim]\n"
         "  [dim]/model anthropic,claude-opus-4-8[/dim] [dim]# back to Claude[/dim]\n\n"
         "[cyan]Helps:[/cyan] control cost / test models without leaving the terminal.\n"

--- a/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
+++ b/templates/multi_model/dot_claude/docs/guides/using-multi-model.md
@@ -36,17 +36,16 @@ mismatch*, not "Claude Code is slow" (it's a strong harness):
 | **DeepSeek** | **B** (CCR) | no first-party harness; Anthropic-compatible endpoint published *to be driven by Claude Code*; cheap |
 | **Kimi / Moonshot** | **B** (CCR) | same as DeepSeek; Kimi K2-Code is tuned to be driven by external harnesses |
 | **Ollama** (local) | **B** (CCR) | a model *runner*, not a harness; suitability is per-model (see below) |
-| **Gemini** | **A** — `--agents antigravity` | Gemini CLI retired 2026-06-18; Antigravity (`agy`) is the native Google harness |
-| **OpenAI / Codex** | **A** — `--agents codex` | first-party Codex CLI; better quality natively |
+| **Gemini** | **B** (CCR) | seeded `gemini` provider via Google's Gemini API (`GEMINI_API_KEY`, paid — the free-tier Gemini CLI was retired 2026-06-18). Antigravity (`agy`) is the higher-fidelity native alternative |
+| **OpenAI / Codex** | **A** — `--agents codex` | first-party Codex CLI; better quality natively (not seeded in CCR) |
 
-Gemini & OpenAI are **not seeded** in the shipped CCR config (`config.json` only
-defines `anthropic`, `deepseek`, `kimi`, `ollama`) — they're better used via
-their native harnesses. You *can* reach them through CCR by adding a provider to
-`~/.claude-code-router/config.json` by hand (e.g. via `ccr ui`, typically through
-an OpenAI-compatible gateway such as OpenRouter), but **there are no published
-CCR-vs-native benchmarks** — expect the 15–22pt mismatch penalty. So
-`/model gemini,…` / `/model openai,…` work only after you configure them; out of
-the box, use `--agents antigravity` (Google) / `codex` (OpenAI) instead.
+**OpenAI** is the only major provider **not seeded** — use the native `--agents codex`.
+**Gemini** *is* seeded (the `gemini` provider), but its tool-calling/streaming via
+translation is less battle-tested than Claude/DeepSeek, so Antigravity (`agy`) stays
+the higher-fidelity Gemini path. Add any other OpenAI/Anthropic-compatible provider by
+editing `~/.claude-code-router/config.json` (`ccr ui`, or a gateway like OpenRouter);
+expect a quality penalty routing a first-party-harness model through CCR (no published
+CCR-vs-native benchmarks).
 
 ## Setup
 
@@ -68,7 +67,7 @@ shell so plain `claude` routes through CCR.
 ```bash
 ccr start                          # run the local proxy (or use `ccr code`)
 claude                             # opens as usual (if you wired the shell)
-/model deepseek,deepseek-chat      # switch mid-session, context kept
+/model deepseek,deepseek-v4-flash  # switch mid-session, context kept
 /model ollama,qwen3-coder:30b
 /model anthropic,claude-opus-4-8   # back to Claude
 ccr ui                             # web editor for providers + routing
@@ -84,6 +83,8 @@ while `default` stays on Claude so your primary experience is unchanged.
 - **DeepSeek** — `DEEPSEEK_API_KEY` from <https://platform.deepseek.com/api_keys>.
 - **Kimi / Moonshot** — `MOONSHOT_API_KEY` from <https://platform.moonshot.ai>.
   Mainland-China accounts use `https://api.moonshot.cn` (edit `config.json`).
+- **Gemini** — `GEMINI_API_KEY` from <https://aistudio.google.com/apikey> (paid;
+  the free-tier Gemini CLI on-ramp is gone).
 - **Anthropic** — `ANTHROPIC_API_KEY` (you likely already have one).
 - **Ollama** — no key; it's local.
 
@@ -136,7 +137,7 @@ the global CCR config for you, with the **<7B** guard):
 ```bash
 .claude/scripts/models.sh list                       # providers/models + pulled Ollama
 .claude/scripts/models.sh add ollama qwen3:14b       # ollama pull + register
-.claude/scripts/models.sh add deepseek deepseek-reasoner   # register a cloud model
+.claude/scripts/models.sh add deepseek deepseek-v4-pro     # register a cloud model
 .claude/scripts/models.sh rm ollama gemma:2b         # ollama rm + unregister
 .claude/scripts/models.sh ui                         # open ccr ui (GUI editor)
 # tip: alias models="$PWD/.claude/scripts/models.sh"  → then `models list`, etc.
@@ -157,12 +158,18 @@ Reverting is clean: stop using CCR (plain `claude`) or
 - **No published CCR-vs-native benchmarks** — expect the 15–22pt penalty when
   routing a first-party-harness model through CCR.
 
-## Hard budget caps?
+## Other ways to route (besides CCR)
 
-CCR does cost-*routing*, not spend *limits*. If you need enforced budget gates,
-[LiteLLM](https://docs.litellm.ai) adds spend caps and guardrails — heavier and
-enterprise-shaped. It's the documented upgrade path for governance/measurement,
-not the default switching mechanism.
+- **Native gateway (no proxy to install).** Claude Code can talk to an Anthropic-format
+  gateway directly: set `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, and
+  `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to populate the `/model` picker from the
+  gateway's `/v1/models` (Claude Code v2.1.129+). Lighter than CCR if you already run a
+  gateway; no transformer config.
+- **Hard budget caps → LiteLLM.** CCR does cost-*routing*, not spend *limits*.
+  [LiteLLM](https://docs.litellm.ai) adds enforced caps + guardrails (heavier,
+  enterprise-shaped) — the documented governance/measurement upgrade path, not the
+  default switcher. **Pin `litellm>=1.83.0`**: releases `1.82.7`/`1.82.8` shipped a
+  credential-stealing payload; `1.83.0` is the first clean post-incident build.
 
 — See ADR-016 for the full decision record and `../../multi-model/README.md` for
 the overlay's files.

--- a/templates/multi_model/dot_claude/multi-model/README.md
+++ b/templates/multi_model/dot_claude/multi-model/README.md
@@ -9,7 +9,7 @@ Those run below the model and stay identical whichever model you point at.
 ## Files
 
 - `config.json` — the [claude-code-router (CCR)](https://github.com/musistudio/claude-code-router)
-  config template: providers (Claude / DeepSeek / Kimi / Ollama) and `Router`
+  config template: providers (Claude / DeepSeek / Kimi / Gemini / Ollama) and `Router`
   cost defaults. This is the **seed** for the machine-global config at
   `~/.claude-code-router/config.json` (CCR is machine-level, not per-project).
 - `.env.example` — provider API-key slots. Copy to `.env` (gitignored) and fill in.
@@ -38,7 +38,7 @@ claude                                                          # opens as usual
   first-party harness), so routing them through CCR is appropriate. Gemini's
   translation is less battle-tested — Antigravity (`agy`) is the higher-fidelity
   alternative (Gemini CLI was retired 2026-06-18).
-- **OpenAI / Codex** performs better in its own native harness (`--agents codex`) and
+- **OpenAI's Codex** performs better in its own native harness (`--agents codex`) and
   is **not** seeded — add it to `config.json` only if you want it in the `/model`
   switcher. See the [model-switching guide](../docs/guides/using-multi-model.md).
 - **Ollama** is local and gated on hardware: a ~24–32B agent-tuned model is the

--- a/templates/multi_model/dot_claude/multi-model/README.md
+++ b/templates/multi_model/dot_claude/multi-model/README.md
@@ -27,19 +27,20 @@ Those run below the model and stay identical whichever model you point at.
 cp .claude/multi-model/.env.example .claude/multi-model/.env   # then fill in keys
 .claude/scripts/setup_models.sh                                # one-time setup
 claude                                                          # opens as usual
-/model deepseek,deepseek-chat                                   # switch, context kept
+/model deepseek,deepseek-v4-flash                              # switch, context kept
 /model ollama,qwen3-coder:30b
 /model anthropic,claude-opus-4-8                               # back to Claude
 ```
 
 ## Provider notes
 
-- **Claude / DeepSeek / Kimi / Ollama** target the Claude Code harness (or have no
-  first-party harness), so routing them through CCR is appropriate.
-- **Gemini & OpenAI/Codex** perform better in their own native harnesses
-  (`--agents antigravity` — Gemini CLI was retired 2026-06-18 — / `codex`). They are reachable through CCR only as a
-  convenience, with a quality caveat — see the
-  [model-switching guide](../docs/guides/using-multi-model.md).
+- **Claude / DeepSeek / Kimi / Gemini / Ollama** are seeded CCR providers (or have no
+  first-party harness), so routing them through CCR is appropriate. Gemini's
+  translation is less battle-tested — Antigravity (`agy`) is the higher-fidelity
+  alternative (Gemini CLI was retired 2026-06-18).
+- **OpenAI / Codex** performs better in its own native harness (`--agents codex`) and
+  is **not** seeded — add it to `config.json` only if you want it in the `/model`
+  switcher. See the [model-switching guide](../docs/guides/using-multi-model.md).
 - **Ollama** is local and gated on hardware: a ~24–32B agent-tuned model is the
   practical floor for reliable tool-calling; anything below ~7B loops on
   "Invalid tool parameters".

--- a/templates/multi_model/dot_claude/multi-model/config.json
+++ b/templates/multi_model/dot_claude/multi-model/config.json
@@ -17,17 +17,24 @@
       "name": "deepseek",
       "api_base_url": "https://api.deepseek.com/chat/completions",
       "api_key": "$DEEPSEEK_API_KEY",
-      "models": ["deepseek-chat", "deepseek-reasoner"],
+      "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
       "transformer": {
         "use": ["deepseek"],
-        "deepseek-chat": { "use": ["tooluse"] }
+        "deepseek-v4-flash": { "use": ["tooluse"] }
       }
     },
     {
       "name": "kimi",
       "api_base_url": "https://api.moonshot.ai/v1/chat/completions",
       "api_key": "$MOONSHOT_API_KEY",
-      "models": ["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"]
+      "models": ["kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6"]
+    },
+    {
+      "name": "gemini",
+      "api_base_url": "https://generativelanguage.googleapis.com/v1beta/models/",
+      "api_key": "$GEMINI_API_KEY",
+      "models": ["gemini-3.1-pro-preview", "gemini-3.5-flash"],
+      "transformer": { "use": ["gemini"] }
     },
     {
       "name": "ollama",
@@ -38,8 +45,8 @@
   ],
   "Router": {
     "default": "anthropic,claude-opus-4-8",
-    "background": "deepseek,deepseek-chat",
-    "think": "deepseek,deepseek-reasoner",
+    "background": "deepseek,deepseek-v4-flash",
+    "think": "deepseek,deepseek-v4-pro",
     "longContext": "anthropic,claude-opus-4-8",
     "longContextThreshold": 60000
   }

--- a/templates/multi_model/dot_claude/multi-model/dot_env.example
+++ b/templates/multi_model/dot_claude/multi-model/dot_env.example
@@ -19,4 +19,7 @@ DEEPSEEK_API_KEY=
 # Note: mainland-China accounts use https://api.moonshot.cn (edit config.json).
 MOONSHOT_API_KEY=
 
+# Gemini — https://aistudio.google.com/apikey  (paid; free-tier Gemini CLI retired)
+GEMINI_API_KEY=
+
 # Ollama is local — no key needed (config uses the literal "ollama").

--- a/templates/multi_model/dot_claude/scripts/setup_models.sh
+++ b/templates/multi_model/dot_claude/scripts/setup_models.sh
@@ -214,7 +214,7 @@ Done. Multi-model switching is set up.
   claude                            # opens as usual (if you wired the shell)
   ccr code                          # …or launch Claude Code through CCR explicitly
 
-  /model deepseek,deepseek-chat     # switch mid-session, context kept
+  /model deepseek,deepseek-v4-flash # switch mid-session, context kept
   /model ollama,qwen3-coder:30b
   /model anthropic,claude-opus-4-8  # back to Claude
 

--- a/tests/unit/test_interactive_prompts.py
+++ b/tests/unit/test_interactive_prompts.py
@@ -51,6 +51,6 @@ def test_choose_multi_model_interactive_shows_messaging(monkeypatch, capsys):
     out = capsys.readouterr().out
     # Single-token substrings survive 80-col panel wrapping.
     assert "/model" in out
-    assert "deepseek,deepseek-chat" in out
+    assert "deepseek,deepseek-v4-flash" in out
     assert "Alternatives" in out
     assert "codex" in out  # the native-harness alternative is surfaced


### PR DESCRIPTION
Closes #396

From the agnosticism audit. **Time-sensitive:** DeepSeek's `deepseek-chat`/`deepseek-reasoner` aliases **hard-retire 2026-07-24 15:59 UTC**, so the overlay would break for DeepSeek users next month.

## Changes (researched values)
- **DeepSeek:** `deepseek-chat`/`deepseek-reasoner` → `deepseek-v4-pro` / `deepseek-v4-flash` (config + Router `background`/`think` + all examples).
- **Kimi:** legacy `moonshot-v1-8k/32k/128k` → `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`.
- **Gemini:** added a seeded `gemini` provider (native endpoint `…/v1beta/models/` + `gemini` transformer, `GEMINI_API_KEY`). The PI-386 CLI removal dropped a *harness*, not the model — Gemini is routable again via CCR (Antigravity stays the higher-fidelity native alternative). Deliberately **not** seeding `gemini-3.5-pro` (still Vertex preview, not GA).
- **Alternatives documented:** native gateway (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` + `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, Claude Code v2.1.129+) and **LiteLLM pinned `>=1.83.0`** (1.82.7/1.82.8 shipped a credential-stealing payload).
- **CCR pin stays `2.0.0`** — it's the current release (audit corrected the "stale pin" prior).
- Updated: `config.json`, `dot_env.example` (+`GEMINI_API_KEY`), `setup_models.sh`, `using-multi-model.md`, multi-model `README.md`, wizard nudge example + its test.

## Verification
- `config.json` valid JSON; no stale model IDs anywhere in src/templates/tests.
- Scaffolded `--multi-model`: providers `[anthropic, deepseek, kimi, gemini, ollama]`; DeepSeek `v4-pro/flash`; Kimi `k2.7`; router bg/think on `v4-flash`/`v4-pro`.
- `ruff` clean; **1044 passed / 3 skipped**.