### PR TITLE
feat(PI-395): ship reusable subagent specs (code-reviewer, explore) + refresh agents README

### DIFF
--- a/templates/base/dot_claude/agents/README.md
+++ b/templates/base/dot_claude/agents/README.md
@@ -1,30 +1,53 @@
 # `.claude/agents/`
 
-Claude Code subagent definitions. Define custom subagent personas here when you need specialized agents for repeatable tasks (e.g., a code reviewer, a documentation specialist, a performance analyzer).
+Claude Code subagent definitions — specialized personas for repeatable tasks.
+They're version-controlled, team-shared, and double as teammate roles for agent
+teams. Two ready-to-use specs ship here:
+
+- **`code-reviewer.md`** — read-only review of the current diff.
+- **`explore.md`** — read-only codebase research.
+
+Both use `model: inherit` (run on whatever model the session uses) and a
+read-only-ish tool set, so they work the same on any model and in both plugin
+and non-plugin layouts.
 
 ## How to create a subagent
 
-1. Create a `.md` file with a frontmatter block:
+Create a `<name>.md` file with YAML frontmatter, then a markdown body that is the
+agent's system prompt. **Only `name` and `description` are required.**
 
 ```yaml
 ---
-name: agent-name
-description: What this agent does and when to invoke it
-model: <model-id>                # optional override — provider-specific (e.g. sonnet/opus on Claude)
-tools:                           # list of tools this agent can use
-  - Read
-  - Grep
-  - Bash
-maxTurns: 15                     # optional: max conversation depth
+name: agent-name                 # lowercase + hyphens; hooks see this as agent_type
+description: What this agent does and when to delegate to it
+model: inherit                   # sonnet | opus | haiku | fable | <full-id> | inherit (default)
+tools: Read, Grep, Glob, Bash    # comma-separated; inherits all if omitted
+# --- all optional below ---
+# disallowedTools: Write, Edit   # deny specific tools
+# permissionMode: default        # default|acceptEdits|auto|dontAsk|bypassPermissions|plan
+# maxTurns: 15                   # cap agentic turns
+# skills: [name, ...]            # preload skill content into context
+# mcpServers: [name, ...]        # MCP servers available to this agent
+# hooks: { ... }                 # lifecycle hooks scoped to this agent
+# memory: project                # user|project|local — cross-session memory
+# background: true               # always run as a background task
+# effort: medium                 # low|medium|high|xhigh|max
+# isolation: worktree            # run in a throwaway git worktree
+# color: cyan                    # task-list display color
+# initialPrompt: "..."           # first user turn when run as the main agent
 ---
 
-<Detailed instructions for the agent's behavior, role, and approach>
+<Detailed instructions for the agent's role, behavior, and approach.>
 ```
 
-2. Name the file after the agent (e.g., `reviewer.md` for a `reviewer` agent)
+**Plugin caveat:** subagents distributed via a plugin ignore `hooks`,
+`mcpServers`, and `permissionMode` for security. The shipped specs omit those so
+they behave identically whether scaffolded directly or via the plugin.
 
-3. Invoke the agent in skills or from the CLI using `Agent({"description": "...", "subagent_type": "agent-name", "prompt": "..."})`
+Invoke from a skill or the CLI: `Agent({"description": "...", "subagent_type":
+"agent-name", "prompt": "..."})`.
 
 ## Reference
 
-See the [Claude Code subagents documentation](https://docs.claude.com/en/docs/claude-code/sub-agents) for full details on agent capabilities, tool access, and context management.
+[Claude Code subagents documentation](https://code.claude.com/docs/en/sub-agents)
+— full field reference, tool access, and agent-team usage.

--- a/templates/base/dot_claude/agents/README.md
+++ b/templates/base/dot_claude/agents/README.md
@@ -18,7 +18,7 @@ agent's system prompt. **Only `name` and `description` are required.**
 
 ```yaml
 ---
-name: agent-name                 # lowercase + hyphens; hooks see this as agent_type
+name: agent-name                 # lowercase + hyphens; this is the subagent_type
 description: What this agent does and when to delegate to it
 model: inherit                   # sonnet | opus | haiku | fable | <full-id> | inherit (default)
 tools: Read, Grep, Glob, Bash    # comma-separated; inherits all if omitted

--- a/templates/base/dot_claude/agents/code-reviewer.md
+++ b/templates/base/dot_claude/agents/code-reviewer.md
@@ -1,0 +1,16 @@
+---
+name: code-reviewer
+description: Expert code review specialist. Use immediately after writing or modifying code to review for quality, security, and maintainability.
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: green
+---
+
+You are a code review specialist. When invoked, review the changed code for
+correctness, security, and maintainability, and report concrete, actionable
+findings. Do **not** modify files — your job is to assess, not to fix.
+
+- Start from the diff (`git diff`), then read surrounding context as needed.
+- Prioritize: correctness bugs > security issues > maintainability > style.
+- Cite `file:line` for each finding and suggest a fix, but leave applying it to
+  the caller. Call out what you checked and found clean, not just the problems.

--- a/templates/base/dot_claude/agents/code-reviewer.md
+++ b/templates/base/dot_claude/agents/code-reviewer.md
@@ -10,7 +10,8 @@ You are a code review specialist. When invoked, review the changed code for
 correctness, security, and maintainability, and report concrete, actionable
 findings. Do **not** modify files — your job is to assess, not to fix.
 
-- Start from the diff (`git diff`), then read surrounding context as needed.
+- Start from the full diff — `git diff HEAD` (covers staged *and* unstaged), or the
+  branch/PR diff — then read surrounding context as needed.
 - Prioritize: correctness bugs > security issues > maintainability > style.
 - Cite `file:line` for each finding and suggest a fix, but leave applying it to
   the caller. Call out what you checked and found clean, not just the problems.

--- a/templates/base/dot_claude/agents/explore.md
+++ b/templates/base/dot_claude/agents/explore.md
@@ -1,0 +1,14 @@
+---
+name: explore
+description: Read-only codebase researcher. Use to locate code, trace behavior across files, and answer "where/how is X implemented" without making changes.
+tools: Read, Grep, Glob
+model: inherit
+color: cyan
+---
+
+You are a read-only codebase researcher. Investigate the question and return a
+concise, `file:path`-cited answer — what exists, where it lives, and how the
+pieces connect. Never modify files.
+
+- Prefer reading targeted excerpts over whole files; cast a wide net with Grep/Glob first.
+- Report the conclusion and the key paths, not a file dump.

--- a/tests/contracts/test_subagent_specs.py
+++ b/tests/contracts/test_subagent_specs.py
@@ -1,0 +1,35 @@
+"""PI-395: the scaffolder ships reusable `.claude/agents/` subagent specs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    assert text.startswith("---\n"), "spec must open with YAML frontmatter"
+    block = text.split("---\n", 2)[1]
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" in line and not line.startswith((" ", "#")):
+            key, _, value = line.partition(":")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def test_ships_reusable_subagent_specs(tmp_path: Path):
+    target = tmp_path / "p"
+    scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+    agents = target / ".claude" / "agents"
+    for name in ("code-reviewer", "explore"):
+        spec = agents / f"{name}.md"
+        assert spec.is_file(), f"{name}.md must be scaffolded"
+        fm = _frontmatter(spec.read_text())
+        assert fm.get("name") == name, f"{name}.md frontmatter name mismatch"
+        assert fm.get("description"), f"{name}.md needs a description"
+        # model-agnostic by default so the spec works on any session model
+        assert fm.get("model") == "inherit"
+        # body (system prompt) is non-empty after the frontmatter
+        assert spec.read_text().split("---\n", 2)[2].strip()

--- a/tests/contracts/test_subagent_specs.py
+++ b/tests/contracts/test_subagent_specs.py
@@ -8,15 +8,17 @@ from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
 
 
-def _frontmatter(text: str) -> dict[str, str]:
-    assert text.startswith("---\n"), "spec must open with YAML frontmatter"
-    block = text.split("---\n", 2)[1]
-    out: dict[str, str] = {}
-    for line in block.splitlines():
+def _split_spec(text: str) -> tuple[dict[str, str], str]:
+    """Return (frontmatter dict, body). Asserts the open+close `---` delimiters
+    exist so a malformed spec fails clearly rather than with an IndexError."""
+    parts = text.split("---\n", 2)
+    assert len(parts) == 3 and parts[0] == "", "spec needs YAML frontmatter + body"
+    fm: dict[str, str] = {}
+    for line in parts[1].splitlines():
         if ":" in line and not line.startswith((" ", "#")):
             key, _, value = line.partition(":")
-            out[key.strip()] = value.strip()
-    return out
+            fm[key.strip()] = value.strip()
+    return fm, parts[2].strip()
 
 
 def test_ships_reusable_subagent_specs(tmp_path: Path):
@@ -26,10 +28,9 @@ def test_ships_reusable_subagent_specs(tmp_path: Path):
     for name in ("code-reviewer", "explore"):
         spec = agents / f"{name}.md"
         assert spec.is_file(), f"{name}.md must be scaffolded"
-        fm = _frontmatter(spec.read_text())
+        fm, body = _split_spec(spec.read_text())
         assert fm.get("name") == name, f"{name}.md frontmatter name mismatch"
         assert fm.get("description"), f"{name}.md needs a description"
         # model-agnostic by default so the spec works on any session model
         assert fm.get("model") == "inherit"
-        # body (system prompt) is non-empty after the frontmatter
-        assert spec.read_text().split("---\n", 2)[2].strip()
+        assert body, f"{name}.md needs a system-prompt body"


### PR DESCRIPTION
Closes #395

## Problem (audit)
`.claude/agents/` shipped only a `README.md` — zero reusable subagent specs, and the README's frontmatter doc was ~10 fields behind the current schema.

## Changes
- **`code-reviewer.md`** — read-only diff review (tools: Read/Grep/Glob/Bash, `model: inherit`, color green).
- **`explore.md`** — read-only codebase research (tools: Read/Grep/Glob, `model: inherit`, color cyan).
- Both omit `permissionMode`/`mcpServers`/`hooks` so they render identically in plugin and non-plugin layouts (plugin subagents ignore those for security).
- **README** refreshed to the current frontmatter set (only `name`+`description` required; documents `disallowedTools`, `permissionMode`, `maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`, `effort`, `isolation`, `color`, `initialPrompt`), the plugin caveat, agent-team reuse, and the correct docs URL.
- Contract test (`test_subagent_specs.py`) scaffolds and asserts both specs parse with valid frontmatter + non-empty body.

## Verification
`ruff` clean; **1046 passed / 3 skipped**.