### PR TITLE
chore(PI-399): post-PI-386 hygiene — reconcile stale Gemini doc bodies

### DIFF
--- a/docs/adr/adr-017-per-surface-config-generator.md
+++ b/docs/adr/adr-017-per-surface-config-generator.md
@@ -23,9 +23,9 @@ CLI (and, per the #365 spike, the Anthropic Claude Code VS Code extension, which
 shares the CLI's config). The other agent surfaces our users run — Cursor, the
 OpenAI Codex IDE, Google Antigravity, GitHub Copilot agent mode — read different
 files, with different schemas. Today project-init reaches them only incidentally:
-it emits `.codex/hooks.json` + `.agents/skills/` (Codex) and a `.gemini-extension/`
-overlay (Gemini), but nothing for Cursor or Antigravity, and no MCP config in any
-runnable form. The user's principle for this epic is **agnostic = visible to all
+it emits `.codex/hooks.json` + `.agents/skills/` (Codex) and (until PI-386) a
+`.gemini-extension/` overlay for the now-removed Gemini CLI, but nothing for Cursor
+or Antigravity, and no MCP config in any runnable form. The user's principle for this epic is **agnostic = visible to all
 surfaces**: one canonical definition should reach every surface, and adding a
 surface should be a one-line change.
 

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -68,7 +68,7 @@ Start with `obsidian-only` when in doubt. Upgrade later by re-running with `--pr
 your-project/
 ├── CLAUDE.md                    # Agent entry point — read first
 ├── AGENTS.md                    # Redirect for non-Claude agents
-├── GEMINI.md                    # Redirect for Gemini agents
+├── GEMINI.md                    # Redirect for Google agents (Antigravity / Gemini)
 └── .claude/
     ├── project-init.md          # Workflow and conventions
     ├── config.yaml              # Record of wizard answers

--- a/docs/research/model-agnostic-switching.md
+++ b/docs/research/model-agnostic-switching.md
@@ -7,11 +7,14 @@
 > Status: **design agreed, not yet implemented.** Date: 2026-06.
 >
 > **Update (PI-386/399, 2026-06-22):** this report predates the Gemini-CLI
-> retirement. Google sunset Gemini CLI's free/Pro/Ultra tiers on 2026-06-18, so
-> `--agents gemini` was removed — read every `--agents gemini` below as
-> **`--agents antigravity`** (`agy`, Google's successor harness). Gemini-the-model
-> is still routable via CCR (it's a seeded provider; PI-396), separate from the
-> harness.
+> retirement and is kept as a point-in-time record. Google sunset Gemini CLI's
+> free/Pro/Ultra tiers on 2026-06-18, so **every Gemini-CLI artifact mentioned
+> below is historical** — `--agents gemini`, `templates/gemini/`,
+> `.gemini-extension/`, `setup_gemini.sh`, and "Gemini CLI" as a native harness.
+> The successor is **Antigravity** (`agy`, `--agents antigravity`,
+> `templates/antigravity/`), which reads the same `.agents/` tree. Gemini-the-model
+> remains routable via CCR (a seeded provider; PI-396) — that's separate from the
+> retired harness.
 
 ---
 

--- a/docs/research/model-agnostic-switching.md
+++ b/docs/research/model-agnostic-switching.md
@@ -5,6 +5,13 @@
 > we landed on. Source for the eventual ADR-016 and the #315 child issues.
 >
 > Status: **design agreed, not yet implemented.** Date: 2026-06.
+>
+> **Update (PI-386/399, 2026-06-22):** this report predates the Gemini-CLI
+> retirement. Google sunset Gemini CLI's free/Pro/Ultra tiers on 2026-06-18, so
+> `--agents gemini` was removed — read every `--agents gemini` below as
+> **`--agents antigravity`** (`agy`, Google's successor harness). Gemini-the-model
+> is still routable via CCR (it's a seeded provider; PI-396), separate from the
+> harness.
 
 ---
 

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -7,10 +7,11 @@ scripts. Derived copies:
 
 - plugins/project-init-workflow/ (PI-129): the plugin payload — what
   default (plugin-mode) scaffolds actually run
-- templates/codex/dot_agents/skills/ and templates/antigravity/dot_agents/skills/
-  (PI-137, PI-386): Codex/Antigravity read .agents/skills — byte-identical
-  copies so those surfaces work even in plugin-mode scaffolds with no
-  .claude/skills (Antigravity discovers them natively — no command pointers)
+- templates/{codex,antigravity,amp}/dot_agents/skills/ and
+  templates/junie/dot_junie/skills/ (PI-137, PI-386, PI-397): Codex/Antigravity/Amp
+  read .agents/skills, Junie reads .junie/skills — byte-identical copies so each
+  surface works standalone (all discover <dir>/<name>/SKILL.md natively, no
+  command pointers)
 
 Templated files (e.g. plan/SKILL.md.tmpl) are project-specific and stay
 scaffold-only.


### PR DESCRIPTION
Closes #399

Final cleanup from the agnosticism audit — docs only.

## Done (acceptance criteria)
- **Stale doc bodies reconciled:** `model-agnostic-switching.md` gets a top Update note (read `--agents gemini` as `--agents antigravity`; Gemini-the-model still routable via CCR); `adr-017` Context notes the `.gemini-extension/` overlay was removed in PI-386; `using-project-init` GEMINI.md tree label → "Google agents (Antigravity / Gemini)".
- **No live refs to removed Gemini-CLI artifacts** (the remaining `--agents gemini` lines in the research doc are covered by its Update banner — it's a point-in-time design report).
- **Roo Code:** no references existed anywhere (nothing to drop).
- **MCP spec refs:** no `2025-06-18` pins existed.
- `sync_plugin` docstring updated for the 4 skill layers (codex/antigravity/amp + junie).

## Evaluated and deferred (behavior changes, outside hygiene/acceptance)
- **Gate GEMINI.md on antigravity** — kept unconditional: it's a harmless redirect that serves all Google agents (Antigravity *and* Gemini Code Assist), and gating it churns the template/`test_agents_canonical` GEMINI.md asserts. Reframed its label instead.
- **Add `.cursor/rules` / more Cursor hook events** — that's a feature; Cursor already gets AGENTS.md + the shell guard, and git/CI is the boundary (ADR-007).
- **Make Copilot a selectable surface** — `.github/copilot-instructions.md` is always emitted and Copilot is well-served; making it a `_VALID_AGENTS` entry is a behavior change with test churn for marginal gain.

`ruff` clean; **1052 passed / 3 skipped** (docs-only).