### PR TITLE
feat(PI-406): guarded hook self-log (_usage_log.sh + prod_guard.py)

### DIFF
--- a/plugins/project-init-workflow/hooks/_usage_log.sh
+++ b/plugins/project-init-workflow/hooks/_usage_log.sh
@@ -20,11 +20,19 @@
 # is emitted only when $CLAUDE_SESSION_ID is set; the analyzer otherwise joins
 # by timestamp + project. Fully fail-open: any error is swallowed.
 
-# _usage_log_json_escape <string> — minimal JSON string escaping (\\ and ").
+# _usage_log_json_escape <string> — JSON string escaping. Backslash and quote
+# first, then the control chars that would otherwise split the line or produce
+# invalid JSONL (a tab/newline in a path or $CLAUDE_SESSION_ID). $'...' is
+# ANSI-C quoting, available on bash 3.2.
 _usage_log_json_escape() {
   local s=$1
   s=${s//\\/\\\\}
   s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  s=${s//$'\b'/\\b}
+  s=${s//$'\f'/\\f}
   printf '%s' "$s"
 }
 

--- a/plugins/project-init-workflow/hooks/_usage_log.sh
+++ b/plugins/project-init-workflow/hooks/_usage_log.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
+# #406). Sourced by the always-on shell hooks; defines usage_log().
+#
+# SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
+# unless the observability overlay's marker directory (.claude/observability/)
+# exists — so it costs nothing until a project opts in by scaffolding the
+# overlay. The plugin hooks.json is static / non-gateable, hence this in-hook
+# guard rather than separate wiring.
+#
+# CRITICAL — never reads stdin. The hook payload JSON on stdin belongs to the
+# real hook body (dag_workflow.py, pre_commit_gate, …); consuming it here would
+# starve them. Inputs come from args + env only:
+#   usage_log <hook> <event> [cwd]
+# Project root is resolved from $CLAUDE_PROJECT_DIR, else `git rev-parse`, else
+# the optional [cwd] arg, else $PWD — git/network are never required.
+#
+# Appends one JSON line {ts,hook,event,project[,session]} to
+# .claude/observability/usage.jsonl (the file usage_report.py reads). Session id
+# is emitted only when $CLAUDE_SESSION_ID is set; the analyzer otherwise joins
+# by timestamp + project. Fully fail-open: any error is swallowed.
+
+# _usage_log_json_escape <string> — minimal JSON string escaping (\\ and ").
+_usage_log_json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+usage_log() {
+  # Never let logging break a hook.
+  {
+    local hook=${1:-unknown}
+    local event=${2:-}
+    local cwd_arg=${3:-}
+
+    local root
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+      root="$CLAUDE_PROJECT_DIR"
+    else
+      root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+      [ -z "$root" ] && root="${cwd_arg:-$PWD}"
+    fi
+
+    local obs="$root/.claude/observability"
+    # Marker gate: dormant unless the overlay is installed.
+    [ -d "$obs" ] || return 0
+
+    mkdir -p "$obs" 2>/dev/null || return 0
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+
+    local line
+    line="{\"ts\":\"$(_usage_log_json_escape "$ts")\""
+    line="$line,\"hook\":\"$(_usage_log_json_escape "$hook")\""
+    line="$line,\"event\":\"$(_usage_log_json_escape "$event")\""
+    line="$line,\"project\":\"$(_usage_log_json_escape "$root")\""
+    if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+      line="$line,\"session\":\"$(_usage_log_json_escape "$CLAUDE_SESSION_ID")\""
+    fi
+    line="$line}"
+
+    printf '%s\n' "$line" >>"$obs/usage.jsonl" 2>/dev/null || return 0
+  } 2>/dev/null || return 0
+}

--- a/plugins/project-init-workflow/hooks/github_command_guard.sh
+++ b/plugins/project-init-workflow/hooks/github_command_guard.sh
@@ -8,4 +8,11 @@
 
 set -euo pipefail
 
+# Self-log this firing (dormant unless the observability overlay is installed).
+# Reads no stdin (</dev/null), so the payload still reaches dag_workflow.py via
+# the exec below; runs before exec because exec replaces this process.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log github_command_guard PreToolUse </dev/null || true
+
 exec "$(dirname "$0")/_py.sh" "$(dirname "$0")/dag_workflow.py" guard

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -9,6 +9,13 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 # Resolve the Python interpreter through the canonical helper (PI-361).
 PY="$(dirname "$0")/_py.sh"
+
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
+
 INPUT=$(cat)
 
 FILE=$(printf '%s' "$INPUT" | "$PY" -c "

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 # Resolve the Python interpreter through the canonical helper (PI-361).
 PY="$(dirname "$0")/_py.sh"
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log pre_commit_gate PreToolUse </dev/null || true
+
 INPUT=$(cat)
 
 CMD=$(printf '%s' "$INPUT" | "$PY" -c "

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -23,8 +23,10 @@ Fail-open by design: any internal error lets the command proceed.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+import time
 from pathlib import Path
 
 # (pattern, label) — matched against the full command string. ``_SEG``
@@ -122,6 +124,51 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
         return []
 
 
+def _find_obs_dir(start: Path) -> Path | None:
+    """Locate the overlay marker dir (.claude/observability/), or None.
+
+    Prefers ``$CLAUDE_PROJECT_DIR``; otherwise walks up from *start* (the Bash
+    cwd, which may be a subdirectory after ``cd``), mirroring ``_find_config``.
+    """
+    env = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env:
+        obs = Path(env) / ".claude" / "observability"
+        return obs if obs.is_dir() else None
+    for candidate in (start, *start.parents):
+        obs = candidate / ".claude" / "observability"
+        if obs.is_dir():
+            return obs
+    return None
+
+
+def usage_log(payload: dict, root: Path) -> None:
+    """Append a self-log line iff the observability overlay is installed (#406).
+
+    Shipped-always-dormant: no-ops unless ``.claude/observability/`` exists.
+    Uses the *already-parsed* ``payload`` (no second stdin read) and is fully
+    fail-open — it must never raise or block the guard.
+    """
+    try:
+        obs = _find_obs_dir(root)
+        if obs is None:
+            return
+        line = {
+            # time.gmtime keeps this portable across every Python 3 (no
+            # datetime.UTC, which is 3.11+) — scaffolded projects may run older.
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "hook": "prod_guard",
+            "event": "PreToolUse",
+            "project": str(obs.parent.parent),
+        }
+        session = payload.get("session_id") or os.environ.get("CLAUDE_SESSION_ID")
+        if session:
+            line["session"] = session
+        with (obs / "usage.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line) + "\n")
+    except Exception:  # noqa: BLE001 — logging must never break the guard
+        return
+
+
 def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:
     """Return the hook verdict for *command*, or None to let it through."""
     if any(p.search(command) for p in allow):
@@ -162,6 +209,9 @@ def main() -> int:
         return 0
     mode = payload.get("permission_mode") or payload.get("permissionMode") or ""
     root = Path(payload.get("cwd") or ".")
+    # Self-log this firing from the same parsed payload (no second stdin read,
+    # #406). Dormant unless the observability overlay is installed; fail-open.
+    usage_log(payload, root)
     try:
         verdict = evaluate(command, mode, _allow_patterns(root))
     except Exception:  # noqa: BLE001 — guardrail must never break the session

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -11,6 +11,12 @@ STAMP=".claude/.session_setup_stamp"
 LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the SessionStart payload is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log session_setup SessionStart "$ROOT" </dev/null || true
+
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
 # host provides; fall back to POSIX `cksum` so the fingerprint is always defined
 # even on a minimal host with neither hasher (an empty fingerprint would force a

--- a/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+
 INPUT=$(cat)
 
 # Resolve the Python interpreter through the canonical helper (PI-361).

--- a/templates/base/dot_claude/hooks/prod_guard.py
+++ b/templates/base/dot_claude/hooks/prod_guard.py
@@ -23,8 +23,10 @@ Fail-open by design: any internal error lets the command proceed.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+import time
 from pathlib import Path
 
 # (pattern, label) — matched against the full command string. ``_SEG``
@@ -122,6 +124,51 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
         return []
 
 
+def _find_obs_dir(start: Path) -> Path | None:
+    """Locate the overlay marker dir (.claude/observability/), or None.
+
+    Prefers ``$CLAUDE_PROJECT_DIR``; otherwise walks up from *start* (the Bash
+    cwd, which may be a subdirectory after ``cd``), mirroring ``_find_config``.
+    """
+    env = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env:
+        obs = Path(env) / ".claude" / "observability"
+        return obs if obs.is_dir() else None
+    for candidate in (start, *start.parents):
+        obs = candidate / ".claude" / "observability"
+        if obs.is_dir():
+            return obs
+    return None
+
+
+def usage_log(payload: dict, root: Path) -> None:
+    """Append a self-log line iff the observability overlay is installed (#406).
+
+    Shipped-always-dormant: no-ops unless ``.claude/observability/`` exists.
+    Uses the *already-parsed* ``payload`` (no second stdin read) and is fully
+    fail-open — it must never raise or block the guard.
+    """
+    try:
+        obs = _find_obs_dir(root)
+        if obs is None:
+            return
+        line = {
+            # time.gmtime keeps this portable across every Python 3 (no
+            # datetime.UTC, which is 3.11+) — scaffolded projects may run older.
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "hook": "prod_guard",
+            "event": "PreToolUse",
+            "project": str(obs.parent.parent),
+        }
+        session = payload.get("session_id") or os.environ.get("CLAUDE_SESSION_ID")
+        if session:
+            line["session"] = session
+        with (obs / "usage.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line) + "\n")
+    except Exception:  # noqa: BLE001 — logging must never break the guard
+        return
+
+
 def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:
     """Return the hook verdict for *command*, or None to let it through."""
     if any(p.search(command) for p in allow):
@@ -162,6 +209,9 @@ def main() -> int:
         return 0
     mode = payload.get("permission_mode") or payload.get("permissionMode") or ""
     root = Path(payload.get("cwd") or ".")
+    # Self-log this firing from the same parsed payload (no second stdin read,
+    # #406). Dormant unless the observability overlay is installed; fail-open.
+    usage_log(payload, root)
     try:
         verdict = evaluate(command, mode, _allow_patterns(root))
     except Exception:  # noqa: BLE001 — guardrail must never break the session

--- a/templates/fallback/dot_claude/hooks/_usage_log.sh
+++ b/templates/fallback/dot_claude/hooks/_usage_log.sh
@@ -20,11 +20,19 @@
 # is emitted only when $CLAUDE_SESSION_ID is set; the analyzer otherwise joins
 # by timestamp + project. Fully fail-open: any error is swallowed.
 
-# _usage_log_json_escape <string> — minimal JSON string escaping (\\ and ").
+# _usage_log_json_escape <string> — JSON string escaping. Backslash and quote
+# first, then the control chars that would otherwise split the line or produce
+# invalid JSONL (a tab/newline in a path or $CLAUDE_SESSION_ID). $'...' is
+# ANSI-C quoting, available on bash 3.2.
 _usage_log_json_escape() {
   local s=$1
   s=${s//\\/\\\\}
   s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  s=${s//$'\b'/\\b}
+  s=${s//$'\f'/\\f}
   printf '%s' "$s"
 }
 

--- a/templates/fallback/dot_claude/hooks/_usage_log.sh
+++ b/templates/fallback/dot_claude/hooks/_usage_log.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
+# #406). Sourced by the always-on shell hooks; defines usage_log().
+#
+# SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
+# unless the observability overlay's marker directory (.claude/observability/)
+# exists — so it costs nothing until a project opts in by scaffolding the
+# overlay. The plugin hooks.json is static / non-gateable, hence this in-hook
+# guard rather than separate wiring.
+#
+# CRITICAL — never reads stdin. The hook payload JSON on stdin belongs to the
+# real hook body (dag_workflow.py, pre_commit_gate, …); consuming it here would
+# starve them. Inputs come from args + env only:
+#   usage_log <hook> <event> [cwd]
+# Project root is resolved from $CLAUDE_PROJECT_DIR, else `git rev-parse`, else
+# the optional [cwd] arg, else $PWD — git/network are never required.
+#
+# Appends one JSON line {ts,hook,event,project[,session]} to
+# .claude/observability/usage.jsonl (the file usage_report.py reads). Session id
+# is emitted only when $CLAUDE_SESSION_ID is set; the analyzer otherwise joins
+# by timestamp + project. Fully fail-open: any error is swallowed.
+
+# _usage_log_json_escape <string> — minimal JSON string escaping (\\ and ").
+_usage_log_json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+usage_log() {
+  # Never let logging break a hook.
+  {
+    local hook=${1:-unknown}
+    local event=${2:-}
+    local cwd_arg=${3:-}
+
+    local root
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+      root="$CLAUDE_PROJECT_DIR"
+    else
+      root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+      [ -z "$root" ] && root="${cwd_arg:-$PWD}"
+    fi
+
+    local obs="$root/.claude/observability"
+    # Marker gate: dormant unless the overlay is installed.
+    [ -d "$obs" ] || return 0
+
+    mkdir -p "$obs" 2>/dev/null || return 0
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+
+    local line
+    line="{\"ts\":\"$(_usage_log_json_escape "$ts")\""
+    line="$line,\"hook\":\"$(_usage_log_json_escape "$hook")\""
+    line="$line,\"event\":\"$(_usage_log_json_escape "$event")\""
+    line="$line,\"project\":\"$(_usage_log_json_escape "$root")\""
+    if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+      line="$line,\"session\":\"$(_usage_log_json_escape "$CLAUDE_SESSION_ID")\""
+    fi
+    line="$line}"
+
+    printf '%s\n' "$line" >>"$obs/usage.jsonl" 2>/dev/null || return 0
+  } 2>/dev/null || return 0
+}

--- a/templates/fallback/dot_claude/hooks/github_command_guard.sh
+++ b/templates/fallback/dot_claude/hooks/github_command_guard.sh
@@ -8,4 +8,11 @@
 
 set -euo pipefail
 
+# Self-log this firing (dormant unless the observability overlay is installed).
+# Reads no stdin (</dev/null), so the payload still reaches dag_workflow.py via
+# the exec below; runs before exec because exec replaces this process.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log github_command_guard PreToolUse </dev/null || true
+
 exec "$(dirname "$0")/_py.sh" "$(dirname "$0")/dag_workflow.py" guard

--- a/templates/fallback/dot_claude/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_claude/hooks/post_edit_lint.sh
@@ -9,6 +9,13 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 # Resolve the Python interpreter through the canonical helper (PI-361).
 PY="$(dirname "$0")/_py.sh"
+
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
+
 INPUT=$(cat)
 
 FILE=$(printf '%s' "$INPUT" | "$PY" -c "

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 # Resolve the Python interpreter through the canonical helper (PI-361).
 PY="$(dirname "$0")/_py.sh"
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log pre_commit_gate PreToolUse </dev/null || true
+
 INPUT=$(cat)
 
 CMD=$(printf '%s' "$INPUT" | "$PY" -c "

--- a/templates/fallback/dot_claude/hooks/session_setup.sh
+++ b/templates/fallback/dot_claude/hooks/session_setup.sh
@@ -11,6 +11,12 @@ STAMP=".claude/.session_setup_stamp"
 LOG=".claude/logs/session_setup.log"
 mkdir -p .claude/logs
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the SessionStart payload is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log session_setup SessionStart "$ROOT" </dev/null || true
+
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
 # host provides; fall back to POSIX `cksum` so the fingerprint is always defined
 # even on a minimal host with neither hasher (an empty fingerprint would force a

--- a/templates/fallback/dot_claude/hooks/workflow_state_reminder.sh
+++ b/templates/fallback/dot_claude/hooks/workflow_state_reminder.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# Self-log this firing (dormant unless the observability overlay is installed;
+# reads no stdin, so the payload below is untouched).
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_usage_log.sh" 2>/dev/null && \
+  usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+
 INPUT=$(cat)
 
 # Resolve the Python interpreter through the canonical helper (PI-361).

--- a/tests/contracts/test_observability_self_log.py
+++ b/tests/contracts/test_observability_self_log.py
@@ -10,6 +10,7 @@ that prod_guard logs while STILL blocking a destructive command (regression).
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -34,7 +35,8 @@ _WIRED_HOOKS = {
 
 def _call_helper(root: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
     """Source the helper and invoke usage_log with CLAUDE_PROJECT_DIR=root."""
-    script = f'. "{_HELPER}"\nusage_log {" ".join(args)}\n'
+    quoted = " ".join(shlex.quote(a) for a in args)
+    script = f". {shlex.quote(str(_HELPER))}\nusage_log {quoted}\n"
     return subprocess.run(
         ["bash", "-c", script],
         input=stdin,
@@ -84,6 +86,29 @@ class TestHelperGating:
         log = tmp_path / ".claude" / "observability" / "usage.jsonl"
         row = json.loads(log.read_text().splitlines()[0])
         assert row["session"] == "sess-42"
+
+    def test_control_chars_stay_single_valid_json_line(self, tmp_path: Path):
+        """A tab/newline in a field must be escaped, not split the JSONL line
+        or produce invalid JSON (Copilot review)."""
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        script = f". {shlex.quote(str(_HELPER))}\nusage_log pre_commit_gate PreToolUse\n"
+        subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": "/usr/bin:/bin",
+                "CLAUDE_PROJECT_DIR": str(tmp_path),
+                "CLAUDE_SESSION_ID": "ab\tcd\nef",
+            },
+            cwd=str(tmp_path),
+            timeout=30,
+        )
+        raw = (tmp_path / ".claude" / "observability" / "usage.jsonl").read_text()
+        # Exactly one physical line — the embedded newline did not split it.
+        assert len([line for line in raw.splitlines() if line.strip()]) == 1
+        row = json.loads(raw)  # valid JSON despite the control chars
+        assert row["session"] == "ab\tcd\nef"  # round-trips intact
 
     def test_never_consumes_stdin(self, tmp_path: Path):
         """usage_log must not read stdin — the payload belongs to the real hook

--- a/tests/contracts/test_observability_self_log.py
+++ b/tests/contracts/test_observability_self_log.py
@@ -1,0 +1,179 @@
+"""ADR-019 / #406: guarded hook self-log (_usage_log.sh + prod_guard.py).
+
+Shipped-always-dormant: the helper and the five always-on shell hooks carry the
+self-log, but it no-ops unless the overlay marker (.claude/observability/)
+exists. Asserts: marker gating in both directions, JSON validity, the
+never-reads-stdin invariant, every hook wiring (fallback + plugin copies), and
+that prod_guard logs while STILL blocking a destructive command (regression).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FALLBACK_HOOKS = _REPO_ROOT / "templates" / "fallback" / "dot_claude" / "hooks"
+_PLUGIN_HOOKS = _REPO_ROOT / "plugins" / "project-init-workflow" / "hooks"
+_HELPER = _FALLBACK_HOOKS / "_usage_log.sh"
+_PROD_GUARD = _REPO_ROOT / "templates" / "base" / "dot_claude" / "hooks" / "prod_guard.py"
+
+# The five always-on shell hooks that must self-log, with the (hook, event) each
+# should record.
+_WIRED_HOOKS = {
+    "session_setup.sh": ("session_setup", "SessionStart"),
+    "pre_commit_gate.sh": ("pre_commit_gate", "PreToolUse"),
+    "github_command_guard.sh": ("github_command_guard", "PreToolUse"),
+    "post_edit_lint.sh": ("post_edit_lint", "PostToolUse"),
+    "workflow_state_reminder.sh": ("workflow_state_reminder", "UserPromptSubmit"),
+}
+
+
+def _call_helper(root: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+    """Source the helper and invoke usage_log with CLAUDE_PROJECT_DIR=root."""
+    script = f'. "{_HELPER}"\nusage_log {" ".join(args)}\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "CLAUDE_PROJECT_DIR": str(root)},
+        cwd=str(root),
+        timeout=30,
+    )
+
+
+class TestHelperGating:
+    def test_dormant_without_marker(self, tmp_path: Path):
+        _call_helper(tmp_path, "session_setup", "SessionStart")
+        assert not (tmp_path / ".claude" / "observability" / "usage.jsonl").exists()
+
+    def test_writes_valid_json_with_marker(self, tmp_path: Path):
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        _call_helper(tmp_path, "github_command_guard", "PreToolUse")
+        log = tmp_path / ".claude" / "observability" / "usage.jsonl"
+        assert log.is_file()
+        rows = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["hook"] == "github_command_guard"
+        assert row["event"] == "PreToolUse"
+        assert row["project"] == str(tmp_path)
+        assert "ts" in row
+        # No session env set → the optional field is omitted.
+        assert "session" not in row
+
+    def test_session_emitted_when_env_present(self, tmp_path: Path):
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        script = f'. "{_HELPER}"\nusage_log pre_commit_gate PreToolUse\n'
+        subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": "/usr/bin:/bin",
+                "CLAUDE_PROJECT_DIR": str(tmp_path),
+                "CLAUDE_SESSION_ID": "sess-42",
+            },
+            cwd=str(tmp_path),
+            timeout=30,
+        )
+        log = tmp_path / ".claude" / "observability" / "usage.jsonl"
+        row = json.loads(log.read_text().splitlines()[0])
+        assert row["session"] == "sess-42"
+
+    def test_never_consumes_stdin(self, tmp_path: Path):
+        """usage_log must not read stdin — the payload belongs to the real hook
+        body. Source it, call it, then `cat`: stdin must still be intact."""
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        script = (
+            f'. "{_HELPER}"\n'
+            "usage_log github_command_guard PreToolUse </dev/null\n"
+            "cat\n"  # whatever usage_log left on stdin
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            input="PAYLOAD_STILL_HERE",
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", "CLAUDE_PROJECT_DIR": str(tmp_path)},
+            cwd=str(tmp_path),
+            timeout=30,
+        )
+        assert result.stdout == "PAYLOAD_STILL_HERE"
+
+
+class TestHookWiring:
+    @pytest.mark.parametrize("hook,expected", _WIRED_HOOKS.items())
+    def test_fallback_hook_sources_and_calls(self, hook: str, expected: tuple[str, str]):
+        text = (_FALLBACK_HOOKS / hook).read_text(encoding="utf-8")
+        assert "_usage_log.sh" in text, f"{hook} does not source the helper"
+        name, event = expected
+        assert f"usage_log {name} {event}" in text, f"{hook} missing usage_log call"
+
+    @pytest.mark.parametrize("hook", _WIRED_HOOKS)
+    def test_plugin_copy_in_sync(self, hook: str):
+        """Plugin-mode hooks self-log too — the synced copy must carry the call."""
+        plugin = _PLUGIN_HOOKS / hook
+        assert plugin.is_file(), f"{hook} missing from plugin (run just sync-plugin)"
+        assert "_usage_log.sh" in plugin.read_text(encoding="utf-8")
+
+    def test_helper_synced_to_plugin(self):
+        assert (_PLUGIN_HOOKS / "_usage_log.sh").is_file()
+        assert (_PLUGIN_HOOKS / "_usage_log.sh").read_bytes() == _HELPER.read_bytes()
+
+    def test_helper_never_reads_stdin_source(self):
+        """No stdin-consuming construct in the helper (cat/read/$(<)/</dev/stdin)."""
+        src = _HELPER.read_text(encoding="utf-8")
+        for bad in ("$(cat", "read ", "</dev/stdin", "$(<"):
+            assert bad not in src, f"helper appears to read stdin: {bad!r}"
+
+
+def _run_prod_guard(payload: dict, root: Path) -> tuple[dict | None, Path]:
+    result = subprocess.run(
+        ["python3", str(_PROD_GUARD)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "CLAUDE_PROJECT_DIR": str(root)},
+        cwd=str(root),
+        timeout=30,
+    )
+    assert result.returncode == 0, "guard must always exit 0 (fail-open)"
+    verdict = json.loads(result.stdout) if result.stdout.strip() else None
+    return verdict, root / ".claude" / "observability" / "usage.jsonl"
+
+
+class TestProdGuardSelfLog:
+    def test_blocks_destructive_and_logs_with_observability_on(self, tmp_path: Path):
+        """Regression: enabling observability must not weaken the guard."""
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        payload = {
+            "tool_input": {"command": "terraform destroy"},
+            "permission_mode": "bypassPermissions",
+            "cwd": str(tmp_path),
+            "session_id": "sess-xyz",
+        }
+        verdict, log = _run_prod_guard(payload, tmp_path)
+        # Still blocks.
+        assert verdict["hookSpecificOutput"]["permissionDecision"] == "deny"
+        # And logged exactly one prod_guard line carrying the session.
+        rows = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+        assert len(rows) == 1
+        assert rows[0]["hook"] == "prod_guard"
+        assert rows[0]["session"] == "sess-xyz"
+
+    def test_dormant_without_marker(self, tmp_path: Path):
+        payload = {"tool_input": {"command": "ls"}, "cwd": str(tmp_path)}
+        _, log = _run_prod_guard(payload, tmp_path)
+        assert not log.exists()
+
+    def test_logs_even_when_command_is_safe(self, tmp_path: Path):
+        (tmp_path / ".claude" / "observability").mkdir(parents=True)
+        payload = {"tool_input": {"command": "ls -la"}, "cwd": str(tmp_path)}
+        verdict, log = _run_prod_guard(payload, tmp_path)
+        assert verdict is None  # safe command → no verdict
+        assert log.is_file()  # but the firing is still recorded


### PR DESCRIPTION
Closes #406. Third increment of epic #269 Track A (observability overlay); the writer side of the `usage.jsonl` that #405's analyzer already reads.

## What

Captures the one signal neither the transcript nor OTEL records cleanly — **hook firings** — **shipped-always-dormant**: the helper and wiring ship in every scaffold but no-op unless the overlay marker `.claude/observability/` exists. The plugin `hooks.json` is static / non-gateable, so the gate lives in the hook body rather than in separate wiring.

- **`_usage_log.sh`** (fallback hooks) — defines `usage_log <hook> <event> [cwd]`:
  - **NEVER reads stdin** — the hook payload JSON belongs to the real hook body (`dag_workflow.py`, `pre_commit_gate`, …); consuming it would starve them. Inputs come from args + env only; root resolves `$CLAUDE_PROJECT_DIR` → `git rev-parse` → `[cwd]` → `$PWD`.
  - **marker-gated** (dormant unless `.claude/observability/` exists), **fail-open**, appends one JSON line `{ts,hook,event,project[,session]}`. `session` only when `$CLAUDE_SESSION_ID` is set.
- **The five always-on shell hooks** (`session_setup`, `pre_commit_gate`, `github_command_guard`, `post_edit_lint`, `workflow_state_reminder`) source it and call `usage_log` once — before any stdin read / `exec`, with `</dev/null` so the payload reaches the real body intact.
- **`prod_guard.py`** — new `usage_log()` folds off the **already-parsed** payload (no second stdin read), marker-gated, fail-open; called in `main()` before `evaluate()`. Uses portable `time.gmtime()` (no `datetime.UTC`, which is 3.11+ — scaffolded projects may run older Python).
- **Sync:** `sync_plugin.py` auto-discovers the new helper; plugin copies re-synced. No drift.

## Acceptance (all green)
- Self-log fires in **default plugin mode** AND **`--no-plugin`** mode when the marker is present; **silent when absent** (verified by scaffolding both ways).
- **Stdin passthrough preserved** — `usage_log` reads `</dev/null`; a subprocess test confirms stdin survives the call. `prod_guard.py` **still blocks** `terraform destroy` with observability ON (regression test).
- `sync_plugin.py` reports no drift; the existing `test_hook_scripts_in_sync` covers the new helper.
- `just lint && just test` green (1151 passed, 3 skipped); smoke-tested end-to-end.

## Note for reviewers
Writes to **`.claude/observability/usage.jsonl`** (next to the marker, where #405's analyzer + the layer `.gitignore` already point) — **not** the issue's pre-#405 `.claude/logs/` path. The issue text was written before #405 fixed the placement; this keeps writer and reader consistent.

Follow-up: #407 (using/upgrading docs + ADR-019) closes out Track A.