### PR TITLE
docs(PI-407): observability guides + ADR-019 (Track A closeout)

### DIFF
--- a/docs/adr/adr-019-local-observability-overlay.md
+++ b/docs/adr/adr-019-local-observability-overlay.md
@@ -1,0 +1,152 @@
+# ADR-019: Local observability overlay — file-based usage report, no Docker, no OTEL
+
+- Status: Accepted
+- Date: 2026-06-23
+- Implements: epic #269 (Metrics & evaluation), Track A — subs #404 (flag
+  plumbing), #405 (analyzer + report), #406 (guarded hook self-log), #407 (this
+  ADR + docs)
+- Relates to: ADR-001 (deterministic scaffolder, no LLM calls), ADR-007
+  (enforcement layers — git/CI are the boundary), ADR-010 (plugin dual-ship),
+  ADR-012 (prod-safety guard — the cross-surface hook this self-log piggybacks
+  on), ADR-016 (model-agnostic switching — the AIBOM/CCR config the cost bucket
+  reads), ADR-018 (governance overlay — the opt-in overlay pattern mirrored here)
+
+> **ADR numbering:** ADR-018 is the governance overlay (#413). This observability
+> overlay takes **ADR-019** — both were drafted concurrently and originally
+> claimed 018; governance landed first.
+
+## Context
+
+A scaffolded project installs skills, hooks, sub-agents, and MCP servers, but
+gives the user no way to see whether any of it is *used* — adoption, cost,
+productivity, reliability. epic #269 asks for that visibility (Track A), and
+separately for a cost–benefit benchmark of the presets themselves (Track B).
+This ADR covers **Track A**.
+
+The hard constraints:
+
+1. **No LLM at runtime, deterministic only** (ADR-001) — the reporting tool
+   parses and counts; it never calls a model.
+2. **User constraint: no Docker, no daemon.** The user explicitly does not want
+   a telemetry server, a collector, or a background process to operate.
+3. **Stdlib-only in the scaffolded output.** Scaffolded Python runs via `_py.sh`
+   against whatever Python 3 the host has (PI-361) — no third-party imports, no
+   pinned interpreter.
+4. **Two facts about the available signals:**
+   - Claude Code already writes a per-session **transcript JSONL**
+     (`~/.claude/projects/<slug>/*.jsonl`) carrying model usage, tool calls, and
+     timings — always present, no setup. Its schema is **not officially stable**.
+   - The one thing the transcript does *not* record cleanly is **which hooks
+     fired**. Claude Code's OTEL export captures more (exact active-time,
+     accept/reject) but needs a collector — exactly what constraint 2 forbids.
+
+## Decision
+
+### 1. A file-based snapshot, not a telemetry stack
+
+The overlay ships a **deterministic, stdlib-only analyzer** (`usage_report.py`,
+run via `_py.sh`) that reads local files on demand and emits a **text summary +
+a self-contained `dashboard.html`** (inline CSS, no CDN, no JS). There is **no
+collector, no server, no daemon** — the report is computed when the user runs
+`observability.sh report`, from data already on disk. This is the whole point:
+visibility with zero standing infrastructure.
+
+### 2. Two local sources; the hook self-log is shipped-always-dormant
+
+- **Transcript JSONL** — the primary source (tokens, tool/skill/sub-agent/MCP
+  counts, errors, timings). Parsing is confined to one module and tolerates
+  missing fields, because the schema is unstable.
+- **Hook self-log** (`.claude/observability/usage.jsonl`) — the missing
+  hook-firing signal. A guarded helper (`_usage_log.sh`) is sourced by the
+  always-on shell hooks and folded into `prod_guard.py`; it is
+  **shipped-always-dormant** — present in every scaffold but a no-op unless the
+  overlay marker directory `.claude/observability/` exists. The plugin
+  `hooks.json` is static and non-gateable (ADR-010), so the gate lives in the
+  hook body, not in separate wiring. The helper **never reads stdin** (the hook
+  payload belongs to the real hook body) and is fully fail-open.
+
+### 3. Aggregate-only, zero-egress — by construction
+
+The analyzer extracts only **names, counts, and numbers** — never prompt text,
+tool-input bodies, command strings, or file contents (the one place it touches a
+body, Edit/Write, it derives a line *count* and discards the text). It reads the
+local transcript and runs local `git` only — **never `gh`, never the network**.
+The generated `dashboard.html` and `usage.jsonl` are gitignored.
+
+### 4. Honest about precision
+
+Exact signals (token/tool/skill/hook counts, error rate) are read straight from
+the transcript. **Cost is approximate** — a static embedded price table matched
+by model-id substring, labelled as such; it is not the user's invoice. **Lines
+added** is approximate (Edit/Write payload sizes, not a real diff).
+Accept/reject rates and exact active-time are **OTEL-only and excluded**, with a
+documented upgrade path rather than a half-measure.
+
+### 5. Claude-Code-only scope
+
+The report is built from the Claude Code transcript format. Other surfaces
+(Codex/Cursor/Antigravity) are out of scope for v1 — git+CI remains the
+cross-surface boundary (ADR-007).
+
+### 6. Opt-in overlay, off by default
+
+Shipped as the `--observability` overlay (mirroring `--multi-model` / governance:
+flag → recorded variable → re-derived on upgrade). Most projects are not
+instrumentation-hungry, so it is strictly opt-in and clean-by-default.
+
+### 7. A documented OTEL upgrade path — doc only
+
+For teams that outgrow the snapshot (live dashboards, cross-run aggregation,
+exact active-time), the upgrade guide documents Claude Code's native OTEL export
+→ a self-operated collector → Grafana/Phoenix. **Documentation only** —
+project-init scaffolds no collector. Leaving the overlay means leaving
+zero-egress; that is stated as a deliberate trade, not a default.
+
+### 8. Track A / Track B share the parsing, not the dependency tree
+
+The Track B benchmark harness (#271–#275, `tools/benchmark/`) parses the **same**
+transcript JSONL over the same local sources. They share the *method*
+(`docs/development/measurement-methodology.md`), not code: the repo harness may
+use `rich`; the **scaffolded** analyzer stays stdlib-only, because it ships into
+other people's projects.
+
+## Consequences
+
+**Positive**
+- Visibility into adoption/cost/productivity/reliability with **zero standing
+  infrastructure** and zero egress.
+- Stdlib-only + `_py.sh` → runs on any host a scaffolded project already runs on.
+- The hook-firing signal is captured without a new hook or non-gateable wiring,
+  and costs nothing until a project opts in.
+- A clean exit ramp (OTEL) for teams that genuinely need more.
+
+**Negative / accepted**
+- Cost and LoC are approximate; accept/reject and active-time are absent (OTEL
+  trade).
+- Tied to an **unstable** transcript schema — mitigated by single-module,
+  fail-tolerant parsing and recording the Claude Code version.
+- Claude-Code-only.
+- The self-log records hook *counts*, not arguments — by design (aggregate-only).
+
+## Alternatives considered
+
+- **OTEL → Grafana/Phoenix as the default** — rejected: needs a collector/daemon
+  (violates the no-Docker constraint) and egress. Kept as the documented upgrade.
+- **A small local server / TUI dashboard** — rejected: a standing process is the
+  thing the user asked to avoid; a regenerated static HTML file gives the same
+  view with no daemon.
+- **Adopt an eval/telemetry framework** (Langfuse, Phoenix, Inspect AI, …) —
+  rejected for the same reasons Track B rejected them
+  (`measurement-methodology.md`): server/SaaS/heavy-dependency, against the
+  stdlib-only rule.
+- **A new dedicated observability hook** — rejected: the plugin `hooks.json` is
+  static/non-gateable, so a new always-on hook couldn't be overlay-gated;
+  folding a dormant guarded helper into the existing hooks is gateable and
+  cheaper.
+
+## References
+
+- Methodology (shared with Track B): `docs/development/measurement-methodology.md`
+- Guides: `templates/observability/dot_claude/docs/guides/using-observability.md`,
+  `…/upgrading-observability.md`
+- epic #269 Track A; child issues #404–#407

--- a/docs/development/measurement-methodology.md
+++ b/docs/development/measurement-methodology.md
@@ -52,6 +52,26 @@ trees, from the actual standards:
 > data-source choice should be a formal ADR, promote it to **ADR-014** and bump
 > the self-improvement ADR (#278) to ADR-015.
 
+## Relationship to the observability overlay (Track A)
+
+Track A of this epic shipped a **scaffolded** observability overlay (ADR-019,
+#404–#407): `templates/observability/dot_claude/observability/usage_report.py`
+parses the **same** Claude Code transcript JSONL described below, over the same
+local sources, into the same cost/adoption/reliability signals. Track B reuses
+that **parsing method**, not the code:
+
+- The **scaffolded analyzer stays stdlib-only** — it ships into other people's
+  projects and runs via `_py.sh` against any Python 3.
+- The **repo benchmark harness** (`tools/benchmark/`, dev tooling) may use `rich`
+  and the vendored price table, and orchestrates *runs* (bare vs scaffolded) the
+  in-project analyzer never does.
+
+So the transcript-field contract in the next section is shared by both; keep the
+two parsers consistent (one transcript schema, both fail-tolerant) but separate
+(different dependency budgets). The overlay is the per-project "what did my
+agents do?" view; this harness is the one-shot "do the presets earn their keep?"
+study.
+
 ## Data sources
 
 Verified against Claude Code 2.1.181.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Model-agnostic switching (CCR): adr/adr-016-model-agnostic-switching.md
     - Per-surface config generator: adr/adr-017-per-surface-config-generator.md
     - AI-governance overlay: adr/adr-018-ai-governance-overlay.md
+    - Local observability overlay: adr/adr-019-local-observability-overlay.md
   - Development:
     - Template system: development/template-system.md
     - Non-CLI surface matrix: development/non-cli-surface-matrix.md

--- a/templates/observability/dot_claude/docs/guides/upgrading-observability.md
+++ b/templates/observability/dot_claude/docs/guides/upgrading-observability.md
@@ -3,9 +3,9 @@
 The built-in overlay ([using-observability.md](using-observability.md)) is a
 **local, on-demand snapshot**. That is a deliberate ceiling (ADR-019): no
 Docker, no daemon, no egress. This guide is the **documented exit path** for
-teams that outgrow it — it is **documentation only**. project-init scaffolds **no
-collector, no server, and no agent** for any of the options below; wiring one up
-is your decision and your operational burden.
+teams that outgrow it — it is **documentation only**.
+project-init scaffolds **no collector, no server, and no agent** for any of the
+options below; wiring one up is your decision and your operational burden.
 
 ## When to upgrade
 

--- a/templates/observability/dot_claude/docs/guides/upgrading-observability.md
+++ b/templates/observability/dot_claude/docs/guides/upgrading-observability.md
@@ -1,0 +1,62 @@
+# Upgrading observability — when the file-based report isn't enough
+
+The built-in overlay ([using-observability.md](using-observability.md)) is a
+**local, on-demand snapshot**. That is a deliberate ceiling (ADR-019): no
+Docker, no daemon, no egress. This guide is the **documented exit path** for
+teams that outgrow it — it is **documentation only**. project-init scaffolds **no
+collector, no server, and no agent** for any of the options below; wiring one up
+is your decision and your operational burden.
+
+## When to upgrade
+
+Reach for a real telemetry stack only when you actually need something the
+snapshot can't give you:
+
+| You need… | The snapshot can't… |
+|---|---|
+| Live dashboards / alerting | it's computed on demand, not streamed |
+| Cross-run / cross-developer aggregation | it reads one local transcript at a time |
+| Exact active-time, accept/reject rates | those are OTEL-only signals |
+| Long-term retention & trends | it keeps no history beyond the transcript files |
+| Multi-machine / CI fleet rollups | it is single-machine by design |
+
+If none of these apply, **stay on the file-based report** — it is faster, has no
+moving parts, and keeps your data on the box.
+
+## The upgrade path: Claude Code's native OTEL export
+
+Claude Code can emit OpenTelemetry metrics and logs directly — this is the
+supported way to get telemetry off-box, and it **replaces** the file-based
+overlay rather than extending it (you would typically turn the local overlay off
+once you have a real backend).
+
+1. **Enable OTEL in Claude Code.** Set the telemetry environment variables
+   Claude Code documents (an OTLP endpoint + headers). This is a Claude Code
+   setting — project-init does not manage it.
+2. **Run a collector you operate.** An OpenTelemetry Collector receives the OTLP
+   stream and fans it out to your backend(s).
+3. **Pick a backend** (you host / contract it — pick by license and ops appetite):
+
+   | Backend | Shape | Notes |
+   |---|---|---|
+   | **Grafana + Prometheus/Loki/Tempo** | self-hosted, OSS | The common metrics+logs+traces stack; you run it |
+   | **Arize Phoenix** | self-hosted, LLM-trace-focused | Elastic-2.0 license — check it fits your use; pulls a heavy dependency tree |
+   | **Honeycomb / Datadog / Grafana Cloud** | SaaS | Lowest ops, but data leaves your environment — the opposite of this overlay's premise |
+
+## What you lose by leaving the overlay
+
+- **Zero-egress.** Every option above sends data off the machine (even
+  self-hosted, it leaves the dev's box). That is the entire property the
+  file-based overlay was built to preserve — leave it on purpose, not by
+  accident.
+- **No moving parts.** A collector + backend is infrastructure to run, secure,
+  and keep up.
+
+## What stays the same
+
+The local snapshot and the OTEL path read the **same underlying activity** — the
+agent's tool calls, tokens, and timings. The methodology behind both (what's
+measured, what "cost" and "accuracy" mean) is recorded once in
+`docs/development/measurement-methodology.md` in the project-init repo. You can
+adopt OTEL for production telemetry and still
+use the file-based report for a quick local check — they don't conflict.

--- a/templates/observability/dot_claude/docs/guides/using-observability.md
+++ b/templates/observability/dot_claude/docs/guides/using-observability.md
@@ -1,0 +1,88 @@
+# Using the observability overlay
+
+A **file-based, zero-egress** usage report for your agent sessions — scaffolded
+when this project was created with `--observability` (ADR-019). It answers
+"what are my agents actually doing?" — adoption, cost, productivity, reliability
+— **without a backend**: no Docker, no OTEL collector, no daemon, no network
+calls. Everything stays on disk.
+
+## Run it
+
+```sh
+.claude/scripts/observability.sh report          # text summary + dashboard.html
+.claude/scripts/observability.sh report --open    # also open the HTML report
+```
+
+The report is a **snapshot**, computed on demand from local files — there is no
+always-on process. Re-run it whenever you want a fresh picture.
+
+By default it analyses the most recent transcript for this project. To target a
+specific one:
+
+```sh
+.claude/scripts/observability.sh report --session-id <id>
+.claude/scripts/observability.sh report --transcript /path/to/session.jsonl
+```
+
+If no transcript is found it tells you so and asks for `--transcript` — it never
+silently produces an empty report.
+
+## What it measures — the four buckets
+
+| Bucket | What it shows | Source |
+|---|---|---|
+| **Adoption** | Per-skill / tool / sub-agent / MCP-tool / hook firing counts | transcript + hook self-log |
+| **Cost** | USD per model + cache-read ratio | transcript token usage × a static price table |
+| **Productivity** | Lines added (approx), commits | Edit/Write sizes + **local git** |
+| **Reliability** | Tool error rate | transcript `tool_result.is_error` |
+
+Two data sources, both local:
+
+1. **The transcript JSONL** Claude Code already writes
+   (`~/.claude/projects/<slug>/*.jsonl`) — always present, no setup.
+2. **The hook self-log** (`.claude/observability/usage.jsonl`) — written by the
+   project's own hooks, but **only while this overlay is installed** (the
+   `.claude/observability/` directory is the activation marker). It is the one
+   signal the transcript doesn't record: which hooks fired.
+
+## Approximate vs exact
+
+Some numbers are exact; some are deliberately approximate. The report labels the
+approximate ones — don't read them as billing-grade.
+
+| Signal | Quality |
+|---|---|
+| Token counts, tool/skill/hook counts, error rate | **Exact** (read straight from the transcript) |
+| **Cost (USD)** | **Approximate** — derived from a *static* embedded price table matched by model-id substring; prices drift, and it is not your invoice |
+| **Lines added** | **Approximate** — counted from Edit/Write payload sizes, not a real diff |
+| Accept/reject rates, exact active "thinking" time | **Not available** — these are OTEL-only signals; see the upgrade guide |
+
+## Privacy & egress
+
+- **Aggregate-only by construction.** The analyzer extracts only names, counts,
+  and numbers — never prompt text, tool-input bodies, command strings, or file
+  contents. The generated `dashboard.html` is self-contained (inline CSS, no
+  CDN, no JS) and carries no raw transcript content.
+- **Zero-egress.** It reads the local transcript and runs local `git` only —
+  never `gh`, never the network.
+- The generated `dashboard.html` and the `usage.jsonl` self-log are **gitignored**
+  (they are local, transcript-derived artifacts) — don't commit them.
+
+## Scope
+
+**Claude Code only.** The report is built from the Claude Code transcript
+format; other surfaces (Codex, Cursor, Antigravity, …) are not covered here.
+
+## Turning it off
+
+Delete the `.claude/observability/` directory. The hook self-log goes dormant
+immediately (the marker is gone) and nothing else changes — the hooks keep
+working, they just stop recording. To remove the overlay entirely, re-run an
+upgrade without `--observability`.
+
+## Going further
+
+This overlay is deliberately minimal and local. If you outgrow it and want
+dashboards, alerting, or cross-run aggregation, see
+[upgrading-observability.md](upgrading-observability.md) for the OTEL →
+Grafana/Phoenix path (documentation only — project-init ships no collector).

--- a/tests/contracts/test_observability_overlay.py
+++ b/tests/contracts/test_observability_overlay.py
@@ -85,6 +85,21 @@ class TestObservabilityOn:
         assert "egress" in text.lower()
         assert "OTEL" in text
 
+    def test_guides_scaffold(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", observability=True)
+        guides = target / ".claude" / "docs" / "guides"
+        using = guides / "using-observability.md"
+        upgrading = guides / "upgrading-observability.md"
+        assert using.is_file() and upgrading.is_file()
+        # The using-guide must carry the load-bearing caveats.
+        utext = using.read_text(encoding="utf-8")
+        assert "Claude Code only" in utext  # scope
+        assert "Approximate" in utext  # cost honesty
+        # The upgrade guide is the OTEL path and must disclaim shipping a collector.
+        gtext = upgrading.read_text(encoding="utf-8")
+        assert "OTEL" in gtext or "OpenTelemetry" in gtext
+        assert "documentation only" in gtext.lower()
+
 
 class TestObservabilityOff:
     def test_no_layer_dir(self, tmp_path: Path):


### PR DESCRIPTION
Closes #407. Final increment of epic #269 Track A — documents the observability overlay and formally lands **ADR-019**, the ADR number #404–#406 all reference.

## What

- **`using-observability.md`** (scaffolded under the overlay) — Claude-Code-only scope, local/no-egress, the snapshot model, the four buckets, the approximate-vs-exact caveat table, privacy/egress guarantees, and how to turn it off.
- **`upgrading-observability.md`** (scaffolded) — the **optional** OTEL → self-hosted collector → Grafana/Phoenix upgrade path. **Documentation only**: project-init ships no collector; the guide is explicit that leaving the overlay means leaving zero-egress.
- **`docs/development/measurement-methodology.md`** — new Track A/B tie-in section: the Track B benchmark harness (`tools/benchmark/`) reuses the **same transcript parsing method** over the same local sources. Scaffolded analyzer stays stdlib-only (ships into other projects); repo harness may use `rich`. Same schema contract, separate dependency budgets.
- **`docs/adr/adr-019-local-observability-overlay.md`** — records the decisions: file-based snapshot (no Docker/daemon — the user constraint), two local sources, shipped-always-dormant stdin-safe self-log, aggregate-only/zero-egress by construction, approximate-cost honesty, Claude-Code-only scope, opt-in overlay, the documented OTEL exit ramp, and the Track A/B parsing split. Added to the mkdocs nav.

## Acceptance (all green)
- Guides scaffold under the overlay (new test asserts both files + their load-bearing caveats: Claude-Code-only, approximate-cost, OTEL doc-only).
- `mkdocs build --strict` exits 0; ADR-019 in the nav.
- `just lint && just test` green (1153 passed, 3 skipped).

## Track A is now complete
`--observability` (#404) → analyzer + report (#405) → guarded self-log (#406) → docs + ADR-019 (#407). The overlay is functional end-to-end and documented. Remaining on #269: only Track B (the #271–#275 cost–benefit benchmark).