### PR TITLE
feat(PI-271): benchmark collection harness (tools/benchmark/)

### DIFF
--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -128,6 +128,17 @@ class TestBuildRecord:
         assert rec.wall_clock_s == 12.3 and rec.claude_version == "2.1.181"
         assert rec.cost_usd is None and rec.success is None  # later issues
 
+    def test_empty_model_falls_back_to_transcript(self, tmp_path: Path):
+        """record-from defaults --model to '' so the transcript's own model wins
+        instead of being overwritten by a CLI default (Codex review)."""
+        tx = tmp_path / "t.jsonl"
+        _write_transcript(tx)
+        rec = harness.build_record(
+            harness.RunContext(task="qa", target="bare", run_index=0, model=""),
+            tx,
+        )
+        assert rec.model == "claude-opus-4-8"  # from the transcript, not a default
+
 
 class TestTaskSpecs:
     @pytest.mark.parametrize("task_id", ["feat", "fix", "qa", "noop"])
@@ -161,6 +172,12 @@ class TestTargetSetup:
         target = harness.setup_bare_target(tmp_path / "bare")
         assert (target / "pyproject.toml").is_file()
         assert not (target / ".claude").exists()
+
+    def test_bare_target_has_pytest_for_checks(self, tmp_path: Path):
+        """The deterministic check runner must be available on the bare arm too,
+        so the comparison isolates the scaffold's contribution (Codex review)."""
+        target = harness.setup_bare_target(tmp_path / "bare")
+        assert "pytest" in (target / "pyproject.toml").read_text()
 
     def test_scaffolded_has_claude(self, tmp_path: Path):
         target = harness.setup_scaffolded_target(tmp_path / "scaf", "obsidian-only")

--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -1,0 +1,176 @@
+"""#271: benchmark collection harness — the testable (no-agent) core.
+
+The agent-driving half (`claude -p`) is manual-only and not exercised here; the
+parsing, record schema, task specs, and target setup are pure/deterministic and
+fully covered. This is dev tooling under tools/ — imported, never scaffolded.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.benchmark import harness, transcript
+from tools.benchmark.record import RunRecord, read_records, write_records
+
+
+def _write_transcript(path: Path) -> None:
+    """A small but representative Claude Code transcript."""
+    entries = [
+        {"type": "user", "timestamp": "2026-06-23T10:00:00Z", "version": "2.1.181",
+         "message": {"content": "hi"}},
+        {
+            "type": "assistant",
+            "timestamp": "2026-06-23T10:00:05Z",
+            "version": "2.1.181",
+            "message": {
+                "model": "claude-opus-4-8",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 800,
+                    "cache_creation_input_tokens": 200,
+                },
+                "content": [
+                    {"type": "text", "text": "ok"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "tool_use", "id": "t2", "name": "Read", "input": {}},
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-06-23T10:00:09Z",
+            "version": "2.1.181",
+            "message": {
+                "model": "claude-opus-4-8",
+                "usage": {"input_tokens": 20, "output_tokens": 10,
+                          "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                "content": [{"type": "text", "text": "done"}],
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+class TestTranscriptParse:
+    def test_aggregates(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        _write_transcript(tx)
+        agg = transcript.parse(tx)
+        assert agg.input_tokens == 120
+        assert agg.output_tokens == 60
+        assert agg.cache_read_tokens == 800
+        assert agg.cache_creation_tokens == 200
+        assert agg.total_tokens == 1180
+        assert agg.tool_calls == 2
+        assert agg.turns == 2  # two assistant messages
+        assert agg.models == ["claude-opus-4-8"]
+        assert agg.claude_version == "2.1.181"
+        assert agg.first_ts == "2026-06-23T10:00:00Z"
+        assert agg.last_ts == "2026-06-23T10:00:09Z"
+
+    def test_tolerates_garbage_lines(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        tx.write_text('not json\n{"type":"assistant","message":{"model":"m","usage":{}}}\n\n')
+        agg = transcript.parse(tx)
+        assert agg.turns == 1  # the one valid assistant line counted; garbage skipped
+
+
+class TestRecord:
+    def test_jsonl_round_trip(self, tmp_path: Path):
+        rec = RunRecord(
+            task="feat", target="bare", run_index=0, model="claude-opus-4-8",
+            claude_version="2.1.181", session_id="s1", transcript_path="/t.jsonl",
+            input_tokens=120, output_tokens=60, cache_read_tokens=800,
+            cache_creation_tokens=200, total_tokens=1180, tool_calls=2, turns=2,
+            wall_clock_s=9.0, first_ts="a", last_ts="b",
+        )
+        out = tmp_path / "records.jsonl"
+        write_records([rec], out)
+        loaded = read_records(out)
+        assert len(loaded) == 1 and loaded[0] == rec
+        # Placeholder fields default to None — owned by #272/#273.
+        assert loaded[0].cost_usd is None
+        assert loaded[0].success is None
+
+    def test_from_dict_tolerant(self):
+        # Unknown keys ignored, missing optional keys default — forward/backward compat.
+        rec = RunRecord.from_dict({
+            "task": "qa", "target": "bare", "run_index": 1, "model": "m",
+            "claude_version": "v", "session_id": "", "transcript_path": "/t",
+            "input_tokens": 1, "output_tokens": 2, "cache_read_tokens": 3,
+            "cache_creation_tokens": 4, "total_tokens": 10, "tool_calls": 0, "turns": 1,
+            "wall_clock_s": None, "first_ts": None, "last_ts": None,
+            "future_field_from_a_later_issue": 123,  # ignored
+        })
+        assert rec.task == "qa" and rec.cost_usd is None
+
+    def test_read_missing_file_is_empty(self, tmp_path: Path):
+        assert read_records(tmp_path / "nope.jsonl") == []
+
+
+class TestBuildRecord:
+    def test_assembles_from_transcript(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        _write_transcript(tx)
+        rec = harness.build_record(
+            harness.RunContext(
+                task="feat", target="obsidian-only", run_index=2,
+                model="claude-opus-4-8", session_id="sess-1", wall_clock_s=12.3,
+            ),
+            tx,
+        )
+        assert rec.task == "feat" and rec.target == "obsidian-only" and rec.run_index == 2
+        assert rec.total_tokens == 1180 and rec.tool_calls == 2 and rec.turns == 2
+        assert rec.wall_clock_s == 12.3 and rec.claude_version == "2.1.181"
+        assert rec.cost_usd is None and rec.success is None  # later issues
+
+
+class TestTaskSpecs:
+    @pytest.mark.parametrize("task_id", ["feat", "fix", "qa", "noop"])
+    def test_all_tasks_load_with_prompt(self, task_id: str):
+        spec = harness.load_task(task_id)
+        assert spec["id"] == task_id
+        assert spec["prompt"].strip()
+        assert "check" in spec  # the #273 contract is authored
+
+    def test_load_all(self):
+        tasks = harness.load_all_tasks()
+        assert set(tasks) == {"feat", "fix", "qa", "noop"}
+
+    def test_unknown_task_raises(self):
+        with pytest.raises(FileNotFoundError):
+            harness.load_task("does-not-exist")
+
+
+class TestProjectSlug:
+    def test_slug_rule(self):
+        assert harness.project_slug("/home/u/p_x.y") == "-home-u-p-x-y"
+
+    def test_transcript_path_for(self, tmp_path: Path):
+        p = harness.transcript_path_for(tmp_path / "cfg", Path("/proj/x"), "sess-9")
+        assert p.name == "sess-9.jsonl"
+        assert "projects" in p.parts
+
+
+class TestTargetSetup:
+    def test_bare_has_no_claude(self, tmp_path: Path):
+        target = harness.setup_bare_target(tmp_path / "bare")
+        assert (target / "pyproject.toml").is_file()
+        assert not (target / ".claude").exists()
+
+    def test_scaffolded_has_claude(self, tmp_path: Path):
+        target = harness.setup_scaffolded_target(tmp_path / "scaf", "obsidian-only")
+        assert (target / ".claude").is_dir()
+        assert (target / ".claude" / "config.yaml").is_file()
+
+
+class TestRunTaskGuard:
+    def test_run_task_requires_claude_cli(self, tmp_path: Path, monkeypatch):
+        # Deterministic regardless of whether claude is installed locally.
+        monkeypatch.setattr(harness.shutil, "which", lambda _: None)
+        with pytest.raises(RuntimeError, match="claude.*CLI"):
+            harness.run_task(tmp_path, {"prompt": "x"}, model="m", config_dir=tmp_path)

--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -167,6 +167,34 @@ class TestTargetSetup:
         assert (target / ".claude").is_dir()
         assert (target / ".claude" / "config.yaml").is_file()
 
+    def test_fix_task_seeds_failing_fixture(self, tmp_path: Path):
+        """The fix task must arrive with a real failing+passing baseline, not an
+        empty project (Codex review P1)."""
+        target = harness.prepare_target(
+            tmp_path / "fix", "bare", harness.load_task("fix"), model="m"
+        )
+        calc = target / "calc.py"
+        test = target / "test_calc.py"
+        assert calc.is_file() and test.is_file()
+        # No stray leading blank line from the TOML triple-quote.
+        assert calc.read_text().startswith("def divide")
+        assert "test_divide_by_zero" in test.read_text()
+
+    def test_prepare_target_is_fresh_per_run(self, tmp_path: Path):
+        """A prior run's writes must not leak into the next (Codex review P1)."""
+        task = harness.load_task("feat")
+        first = harness.prepare_target(tmp_path / "r0", "bare", task, model="m")
+        (first / "leftover.py").write_text("# from a previous run\n")
+        # A different run dir is a clean baseline.
+        second = harness.prepare_target(tmp_path / "r1", "bare", task, model="m")
+        assert not (second / "leftover.py").exists()
+
+    def test_seed_task_noop_without_seed_files(self, tmp_path: Path):
+        target = tmp_path / "t"
+        target.mkdir()
+        harness.seed_task(target, harness.load_task("feat"))  # feat has no seeds
+        assert list(target.iterdir()) == []
+
 
 class TestRunTaskGuard:
     def test_run_task_requires_claude_cli(self, tmp_path: Path, monkeypatch):

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -1,0 +1,68 @@
+# Scaffold cost–benefit benchmark (`tools/benchmark/`)
+
+Dev tooling for epic #269 **Track B** — the one-shot study answering *"do the
+presets earn their keep?"* It runs the methodology's representative tasks against
+a **bare** target and one or more **scaffolded** targets and normalizes each run
+into a stable record other dimensions read.
+
+**Not part of the scaffold runtime.** This never runs during `project-init` and
+the scaffolder calls no LLM (CLAUDE.md / ADR-001). It is not collected by pytest
+(`testpaths = ["tests"]`); its *tests* live under `tests/` and exercise the pure
+parsing/record code without an agent.
+
+Read [`docs/development/measurement-methodology.md`](../../docs/development/measurement-methodology.md)
+first — it fixes *what* is measured, *on what tasks*, and what "cost"/"accuracy"
+mean. This harness is #271 (capture); latency+cost is #272, accuracy is #273,
+the `rich` report is #275.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `record.py` | `RunRecord` — the normalized per-run schema + JSONL read/write (the contract #272/#273/#275 consume) |
+| `transcript.py` | parse a Claude Code transcript JSONL → capture aggregates (tokens/tools/turns/span) |
+| `harness.py` | target setup + `claude -p` orchestration + `build_record` + the CLI |
+| `tasks/*.toml` | the task set: `feat`, `fix`, `qa`, `noop` (probe). `[check]` is for #273 |
+| `model_prices.json` | (added in #272) vendored MIT price table for the $ axis |
+| `results/` | raw per-run JSONL (gitignored) |
+
+## Running it
+
+**Collect (manual — needs the `claude` CLI + an API key + network):**
+
+```sh
+uv run python -m tools.benchmark.harness run \
+  --task all --preset obsidian-only --preset obsidian-graphify --repeats 5
+```
+
+This scaffolds throwaway bare + per-preset targets under a temp dir, runs each
+task with an isolated `CLAUDE_CONFIG_DIR`, and appends normalized records to
+`tools/benchmark/results/records.jsonl`. Real agent runs cost money and time —
+hence the manual, opt-in invocation.
+
+**Normalize a transcript you already have (no agent):**
+
+```sh
+uv run python -m tools.benchmark.harness record-from \
+  --task feat --target bare --transcript ~/.claude/projects/<slug>/<session>.jsonl
+```
+
+Useful for re-deriving records from past sessions, and the path the tests
+exercise.
+
+## The record schema
+
+One JSON object per `(task, target, run)`. #271 populates the **capture** fields
+(identity + token/tool/turn counts + wall-clock + transcript span). The
+later-owned fields are present but `None` until their issue lands:
+`cost_usd` (#272), `success` / `first_try` / `rework_cycles` (#273). Downstream
+code reads `RunRecord`, never raw transcripts.
+
+## Caveats (from the methodology)
+
+- The transcript JSONL schema is **not officially stable** — parsing is confined
+  to `transcript.py`, tolerant of missing fields, and records `claude --version`.
+- `total_cost_usd` from `claude -p` is a *client-side estimate*; #272 derives the
+  authoritative $ from token counts × the vendored price table.
+- Prompt caching makes repeats cheaper but not identical — `cache_read` is kept
+  as its own field, never folded into input tokens.

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -81,19 +81,27 @@ def _git_init(target: Path) -> None:
     subprocess.run(["git", "-C", str(target), "init", "-q"], check=False, timeout=30)
 
 
+# pytest is the deterministic check runner (#273) and must be available in BOTH
+# arms so the comparison isolates what the scaffold actually adds (conventions,
+# skills, CLAUDE.md) — not whether the test runner happens to be installed. uv
+# includes the `dev` dependency-group by default, so `uv run pytest` resolves.
 _MINIMAL_PYPROJECT = """\
 [project]
 name = "benchmark-target"
 version = "0.0.0"
 requires-python = ">=3.11"
+
+[dependency-groups]
+dev = ["pytest"]
 """
 
 
 def setup_bare_target(target: Path) -> Path:
     """Create the baseline target — a temp project with NO ``.claude/``.
 
-    Carries a minimal pyproject + git so pytest-based tasks have a project to
-    run in.
+    Carries a minimal pyproject (with pytest in its dev group) + git so the
+    deterministic checks run on the bare arm too, isolating the scaffold's real
+    contribution rather than test-runner availability.
     """
     _git_init(target)
     (target / "pyproject.toml").write_text(_MINIMAL_PYPROJECT, encoding="utf-8")
@@ -340,7 +348,9 @@ def main(argv: list[str] | None = None) -> int:
     rec.add_argument("--task", required=True)
     rec.add_argument("--target", required=True, help="'bare' or a preset name")
     rec.add_argument("--transcript", required=True)
-    rec.add_argument("--model", default=_DEFAULT_MODEL)
+    # Default empty so the transcript's own model wins (build_record falls back
+    # to it); pass --model only to override. The `run` subcommand pins the model.
+    rec.add_argument("--model", default="", help="override; default = transcript's model")
     rec.add_argument("--run-index", type=int, default=0, dest="run_index")
     rec.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
     rec.set_defaults(func=_cmd_record_from)

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -1,0 +1,329 @@
+"""Benchmark collection harness (#271) — the runner every dimension feeds.
+
+Two cleanly separable halves:
+
+- **Orchestration** (``setup_*_target`` / ``run_task`` / the ``run`` CLI) drives
+  ``claude -p`` against bare and scaffolded temp targets. It needs the Claude
+  CLI + an API key + network, so it is **run manually**, never in CI and never
+  from the scaffold runtime (CLAUDE.md / ADR-001).
+- **Parsing → normalized record** (``build_record`` + ``tools.benchmark.transcript``)
+  is pure and fully testable against fixture transcripts. This is the stable
+  contract #272/#273/#275 consume.
+
+Run: ``uv run python -m tools.benchmark.harness run --task all --preset obsidian-only``
+or, to normalize a transcript you already have:
+``uv run python -m tools.benchmark.harness record-from --task feat --target bare --transcript <path>``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.benchmark.record import RunRecord, write_records
+from tools.benchmark.transcript import parse as parse_transcript
+
+_HERE = Path(__file__).resolve().parent
+_TASKS_DIR = _HERE / "tasks"
+_RESULTS_DIR = _HERE / "results"
+_DEFAULT_MODEL = "claude-opus-4-8"
+_TASK_IDS = ("feat", "fix", "qa", "noop")
+
+
+# --- task specs -----------------------------------------------------------
+
+
+def load_task(task_id: str) -> dict:
+    """Load and minimally validate a task spec from tasks/<id>.toml."""
+    path = _TASKS_DIR / f"{task_id}.toml"
+    if not path.is_file():
+        raise FileNotFoundError(f"unknown task {task_id!r} (no {path})")
+    spec = tomllib.loads(path.read_text(encoding="utf-8"))
+    if not spec.get("prompt"):
+        raise ValueError(f"task {task_id!r} has no prompt")
+    spec.setdefault("id", task_id)
+    return spec
+
+
+def load_all_tasks() -> dict[str, dict]:
+    """Load every task spec in the methodology's set (feat/fix/qa/noop)."""
+    return {tid: load_task(tid) for tid in _TASK_IDS}
+
+
+# --- transcript discovery (mirrors Claude Code's slug rule) ---------------
+
+
+def project_slug(project_dir: str) -> str:
+    """Claude Code transcript-dir slug: non-alphanumeric/non-dash → ``-``."""
+    return "".join(c if (c.isalnum() or c == "-") else "-" for c in project_dir)
+
+
+def transcript_path_for(config_dir: Path, target_dir: Path, session_id: str) -> Path:
+    """Where Claude Code writes the transcript under an isolated CLAUDE_CONFIG_DIR."""
+    slug = project_slug(str(target_dir.resolve()))
+    return config_dir / "projects" / slug / f"{session_id}.jsonl"
+
+
+# --- target setup (testable — no agent) -----------------------------------
+
+
+def _git_init(target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(target), "init", "-q"], check=False, timeout=30)
+
+
+_MINIMAL_PYPROJECT = """\
+[project]
+name = "benchmark-target"
+version = "0.0.0"
+requires-python = ">=3.11"
+"""
+
+
+def setup_bare_target(target: Path) -> Path:
+    """Create the baseline target — a temp project with NO ``.claude/``.
+
+    Carries a minimal pyproject + git so pytest-based tasks have a project to
+    run in.
+    """
+    _git_init(target)
+    (target / "pyproject.toml").write_text(_MINIMAL_PYPROJECT, encoding="utf-8")
+    return target
+
+
+def setup_scaffolded_target(target: Path, preset: str, *, model: str = _DEFAULT_MODEL) -> Path:
+    """The same temp project + project-init output for one preset."""
+    from project_init.__main__ import main as project_init_main
+
+    _git_init(target)
+    (target / "pyproject.toml").write_text(_MINIMAL_PYPROJECT, encoding="utf-8")
+    rc = project_init_main(
+        [
+            str(target),
+            "--non-interactive",
+            "--preset",
+            preset,
+            "--name",
+            "benchmark-target",
+            "--description",
+            "benchmark scaffolded target",
+            "--language",
+            "python",
+        ]
+    )
+    if rc != 0:
+        raise RuntimeError(f"project-init failed (rc={rc}) for preset {preset!r}")
+    return target
+
+
+# --- agent run (manual only — needs claude + API key + network) -----------
+
+
+def run_task(
+    target_dir: Path,
+    task: dict,
+    *,
+    model: str,
+    config_dir: Path,
+) -> dict:
+    """Drive ``claude -p`` on one task; return {session_id, wall_clock_s, cost_estimate}.
+
+    Requires the Claude CLI. Wraps the subprocess for the authoritative
+    wall-clock (methodology). The throwaway ``config_dir`` isolates the run from
+    the user's history and keeps fixed-overhead clean.
+    """
+    if shutil.which("claude") is None:
+        raise RuntimeError("the `claude` CLI is not installed — run_task is manual-only")
+    cmd = [
+        "claude",
+        "-p",
+        task["prompt"],
+        "--output-format",
+        "json",
+        "--model",
+        model,
+        # Throwaway dir → safe to skip interactive permission prompts headlessly.
+        "--permission-mode",
+        "bypassPermissions",
+    ]
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "CLAUDE_CONFIG_DIR": str(config_dir),
+        "HOME": str(Path.home()),
+    }
+    start = time.monotonic()
+    proc = subprocess.run(
+        cmd, cwd=str(target_dir), capture_output=True, text=True, env=env, timeout=1800
+    )
+    wall_clock_s = time.monotonic() - start
+    session_id, cost = "", None
+    try:
+        out = json.loads(proc.stdout)
+        if isinstance(out, dict):
+            session_id = out.get("session_id") or ""
+            cost = out.get("total_cost_usd")
+    except (ValueError, TypeError):
+        pass
+    return {"session_id": session_id, "wall_clock_s": wall_clock_s, "cost_estimate": cost}
+
+
+# --- normalized record (pure — testable) ----------------------------------
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Identity + harness-measured metadata for one run (the ``(task,target,run)`` key)."""
+
+    task: str
+    target: str  # "bare" or a preset name
+    run_index: int
+    model: str
+    session_id: str = ""
+    wall_clock_s: float | None = None
+
+
+def build_record(ctx: RunContext, transcript_path: Path) -> RunRecord:
+    """Assemble a :class:`RunRecord` from a transcript. Pure: parse + pack."""
+    agg = parse_transcript(transcript_path)
+    return RunRecord(
+        task=ctx.task,
+        target=ctx.target,
+        run_index=ctx.run_index,
+        model=ctx.model or (agg.models[0] if agg.models else ""),
+        claude_version=agg.claude_version,
+        session_id=ctx.session_id,
+        transcript_path=str(transcript_path),
+        input_tokens=agg.input_tokens,
+        output_tokens=agg.output_tokens,
+        cache_read_tokens=agg.cache_read_tokens,
+        cache_creation_tokens=agg.cache_creation_tokens,
+        total_tokens=agg.total_tokens,
+        tool_calls=agg.tool_calls,
+        turns=agg.turns,
+        wall_clock_s=ctx.wall_clock_s,
+        first_ts=agg.first_ts,
+        last_ts=agg.last_ts,
+    )
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def _cmd_record_from(args: argparse.Namespace) -> int:
+    """Normalize an existing transcript into a record (no agent needed)."""
+    transcript = Path(args.transcript).expanduser()
+    if not transcript.is_file():
+        sys.stderr.write(f"benchmark: transcript not found: {transcript}\n")
+        return 1
+    record = build_record(
+        RunContext(
+            task=args.task,
+            target=args.target,
+            run_index=args.run_index,
+            model=args.model,
+        ),
+        transcript,
+    )
+    out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
+    write_records([record], out)
+    sys.stdout.write(json.dumps(record.to_dict(), indent=2) + "\n")
+    sys.stdout.write(f"\nappended to {out}\n")
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    """Orchestrate bare + scaffolded runs (manual; needs the claude CLI)."""
+    if shutil.which("claude") is None:
+        sys.stderr.write("benchmark: the `claude` CLI is not installed — `run` is manual-only.\n")
+        return 1
+    tasks = load_all_tasks() if args.task == "all" else {args.task: load_task(args.task)}
+    targets = ["bare", *args.preset]
+    out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
+    records: list[RunRecord] = []
+    with tempfile.TemporaryDirectory(prefix="pi-benchmark-") as tmp:
+        tmp_root = Path(tmp)
+        config_dir = tmp_root / "claude-config"
+        for target in targets:
+            tdir = tmp_root / f"target-{target}"
+            if target == "bare":
+                setup_bare_target(tdir)
+            else:
+                setup_scaffolded_target(tdir, target, model=args.model)
+            for task_id, task in tasks.items():
+                for run_index in range(args.repeats):
+                    result = run_task(tdir, task, model=args.model, config_dir=config_dir)
+                    transcript = transcript_path_for(config_dir, tdir, result["session_id"])
+                    if not transcript.is_file():
+                        sys.stderr.write(
+                            f"benchmark: no transcript for {target}/{task_id} run {run_index} "
+                            f"(session {result['session_id']!r}) — skipping\n"
+                        )
+                        continue
+                    record = build_record(
+                        RunContext(
+                            task=task_id,
+                            target=target,
+                            run_index=run_index,
+                            model=args.model,
+                            session_id=result["session_id"],
+                            wall_clock_s=result["wall_clock_s"],
+                        ),
+                        transcript,
+                    )
+                    records.append(record)
+                    sys.stdout.write(
+                        f"{target}/{task_id} run {run_index}: "
+                        f"{record.total_tokens} tok, {record.tool_calls} tool calls, "
+                        f"{record.wall_clock_s:.1f}s\n"
+                    )
+    if records:
+        write_records(records, out)
+        sys.stdout.write(f"\nwrote {len(records)} record(s) to {out}\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args and dispatch the ``run`` / ``record-from`` subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="benchmark",
+        description="Collection harness: run tasks in bare vs scaffolded targets (#271).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    run = sub.add_parser("run", help="orchestrate agent runs (manual; needs the claude CLI)")
+    run.add_argument("--task", default="all", help="task id or 'all' (default)")
+    run.add_argument(
+        "--preset",
+        action="append",
+        default=[],
+        help="scaffolded preset to compare against bare (repeatable)",
+    )
+    run.add_argument("--model", default=_DEFAULT_MODEL)
+    run.add_argument("--repeats", type=int, default=5, help="repeats per (task,target) for variance")
+    run.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
+    run.set_defaults(func=_cmd_run)
+
+    rec = sub.add_parser("record-from", help="normalize an existing transcript (no agent)")
+    rec.add_argument("--task", required=True)
+    rec.add_argument("--target", required=True, help="'bare' or a preset name")
+    rec.add_argument("--transcript", required=True)
+    rec.add_argument("--model", default=_DEFAULT_MODEL)
+    rec.add_argument("--run-index", type=int, default=0, dest="run_index")
+    rec.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
+    rec.set_defaults(func=_cmd_record_from)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -100,6 +100,34 @@ def setup_bare_target(target: Path) -> Path:
     return target
 
 
+def seed_task(target: Path, task: dict) -> None:
+    """Materialize a task's ``[[seed_files]]`` into the target before the run.
+
+    Some tasks (e.g. ``fix``) need a pre-existing fixture — a failing + passing
+    test to repair — rather than starting from an empty project. Tasks without
+    seed files are a no-op.
+    """
+    for spec in task.get("seed_files", []):
+        dest = target / spec["path"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # Strip the leading newline the TOML triple-quote literal carries.
+        dest.write_text(spec["content"].lstrip("\n"), encoding="utf-8")
+
+
+def prepare_target(target_dir: Path, target: str, task: dict, *, model: str) -> Path:
+    """Create a FRESH target for one run and seed the task fixture.
+
+    Recreated per ``(task, run_index)`` so each run measures an identical clean
+    baseline — a prior task's writes (or an earlier repeat) never leak in.
+    """
+    if target == "bare":
+        setup_bare_target(target_dir)
+    else:
+        setup_scaffolded_target(target_dir, target, model=model)
+    seed_task(target_dir, task)
+    return target_dir
+
+
 def setup_scaffolded_target(target: Path, preset: str, *, model: str = _DEFAULT_MODEL) -> Path:
     """The same temp project + project-init output for one preset."""
     from project_init.__main__ import main as project_init_main
@@ -155,11 +183,9 @@ def run_task(
         "--permission-mode",
         "bypassPermissions",
     ]
-    env = {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        "CLAUDE_CONFIG_DIR": str(config_dir),
-        "HOME": str(Path.home()),
-    }
+    # Inherit the caller's env (ANTHROPIC_API_KEY, proxy vars, …) and only
+    # override CLAUDE_CONFIG_DIR so the run is isolated from the user's history.
+    env = {**os.environ, "CLAUDE_CONFIG_DIR": str(config_dir)}
     start = time.monotonic()
     proc = subprocess.run(
         cmd, cwd=str(target_dir), capture_output=True, text=True, env=env, timeout=1800
@@ -253,13 +279,11 @@ def _cmd_run(args: argparse.Namespace) -> int:
         tmp_root = Path(tmp)
         config_dir = tmp_root / "claude-config"
         for target in targets:
-            tdir = tmp_root / f"target-{target}"
-            if target == "bare":
-                setup_bare_target(tdir)
-            else:
-                setup_scaffolded_target(tdir, target, model=args.model)
             for task_id, task in tasks.items():
                 for run_index in range(args.repeats):
+                    # Fresh target per run — clean baseline, no cross-run leakage.
+                    tdir = tmp_root / f"target-{target}-{task_id}-{run_index}"
+                    prepare_target(tdir, target, task, model=args.model)
                     result = run_task(tdir, task, model=args.model, config_dir=config_dir)
                     transcript = transcript_path_for(config_dir, tdir, result["session_id"])
                     if not transcript.is_file():

--- a/tools/benchmark/record.py
+++ b/tools/benchmark/record.py
@@ -59,10 +59,12 @@ class RunRecord:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RunRecord:
-        """Tolerant load — ignore unknown keys, default missing ones.
+        """Tolerant load — ignore unknown keys; fields with defaults fill in if absent.
 
         Keeps old result files readable as the schema grows (later issues add
-        fields); only the dataclass's known fields are consumed.
+        fields with defaults, so older records lacking them still load). Only the
+        dataclass's known fields are consumed; a record missing a *required*
+        capture field (no default) is malformed and raises ``TypeError``.
         """
         known = {f.name for f in fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in known})

--- a/tools/benchmark/record.py
+++ b/tools/benchmark/record.py
@@ -1,0 +1,94 @@
+"""Normalized benchmark record — the stable artifact contract (#271).
+
+One :class:`RunRecord` per ``(task, target, run)``. Every other Track B
+dimension reads this schema instead of re-parsing transcripts: latency + cost
+(#272) fill ``cost_usd``; accuracy (#273) fills ``success`` / ``first_try`` /
+``rework_cycles``; the presentation layer (#275) renders the lot. So #271 owns
+the schema and the *capture* fields and leaves the later-owned fields ``None``.
+
+Dev tooling under ``tools/benchmark/`` — never imported by the scaffold runtime
+(CLAUDE.md / ADR-001: the scaffolder calls no LLM). Stdlib-only here; ``rich``
+is reserved for the #275 report.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "benchmark/v1"
+
+
+@dataclass
+class RunRecord:
+    """A single benchmark run, normalized for downstream dimensions."""
+
+    # --- identity ---------------------------------------------------------
+    task: str  # task id (feat | fix | qa | noop)
+    target: str  # "bare" or a preset name (obsidian-only, obsidian-graphify)
+    run_index: int  # 0-based repeat index (variance comes from repeats)
+    model: str  # pinned model id used for the run
+    claude_version: str  # `claude --version`, recorded per methodology
+    session_id: str  # → transcript path; "" if unknown
+    transcript_path: str  # absolute path to the parsed transcript JSONL
+
+    # --- capture (#271) ---------------------------------------------------
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    total_tokens: int
+    tool_calls: int
+    turns: int  # assistant messages
+    wall_clock_s: float | None  # harness-measured (authoritative); None if parsed post-hoc
+    first_ts: str | None  # first transcript timestamp (per-step latency source, #272)
+    last_ts: str | None
+
+    # --- derived later — schema placeholders, populated by sibling issues -
+    cost_usd: float | None = None  # #272 (tokens × static price table)
+    success: bool | None = None  # #273 (deterministic task check)
+    first_try: bool | None = None  # #273
+    rework_cycles: int | None = None  # #273
+    schema: str = SCHEMA
+
+    def to_dict(self) -> dict[str, Any]:
+        """Plain-dict view for JSONL serialization."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunRecord:
+        """Tolerant load — ignore unknown keys, default missing ones.
+
+        Keeps old result files readable as the schema grows (later issues add
+        fields); only the dataclass's known fields are consumed.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def write_records(records: list[RunRecord], path: Path) -> None:
+    """Append-safe write of one JSON object per line (JSONL)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record.to_dict()) + "\n")
+
+
+def read_records(path: Path) -> list[RunRecord]:
+    """Read a JSONL result file into records (skips blank/garbage lines)."""
+    out: list[RunRecord] = []
+    if not path.is_file():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict):
+            out.append(RunRecord.from_dict(obj))
+    return out

--- a/tools/benchmark/tasks/feat.toml
+++ b/tools/benchmark/tasks/feat.toml
@@ -1,0 +1,17 @@
+# Benchmark task: small feature + test (methodology "feat").
+# Exercises the conventions/skills the scaffold injects.
+id = "feat"
+description = "Add a small function + a passing test"
+prompt = """
+Add a function `slugify(text: str) -> str` to a new module `slug.py` that
+lowercases the input and replaces every run of non-alphanumeric characters with
+a single hyphen, trimming leading/trailing hyphens. Add a pytest test in
+`test_slug.py` that covers a basic case and an edge case. Make the test pass.
+"""
+
+# Consumed by accuracy scoring (#273), ignored by the #271 collection harness.
+[check]
+type = "pytest"          # pytest | regex | none
+command = "uv run pytest -q test_slug.py"
+expect_exit = 0
+must_exist = ["slug.py", "test_slug.py"]

--- a/tools/benchmark/tasks/fix.toml
+++ b/tools/benchmark/tasks/fix.toml
@@ -1,0 +1,20 @@
+# Benchmark task: make a failing test pass without breaking others
+# (methodology "fix"). SWE-bench-style FAIL_TO_PASS / PASS_TO_PASS; isolates rework.
+id = "fix"
+description = "Make one failing test pass without breaking others"
+prompt = """
+The test `test_calc.py::test_divide_by_zero` is failing: `divide(a, b)` in
+`calc.py` raises `ZeroDivisionError` instead of returning `None` for a zero
+divisor. Fix `divide` so that test passes. Do not change any other behavior —
+the existing passing tests in `test_calc.py` must stay green.
+"""
+
+# Consumed by accuracy scoring (#273), ignored by the #271 collection harness.
+# The harness seeds calc.py + test_calc.py into the target before the run; #273
+# checks FAIL_TO_PASS flips green while PASS_TO_PASS stays green.
+[check]
+type = "pytest"
+command = "uv run pytest -q test_calc.py"
+expect_exit = 0
+fail_to_pass = ["test_calc.py::test_divide_by_zero"]
+pass_to_pass = ["test_calc.py::test_divide_basic"]

--- a/tools/benchmark/tasks/fix.toml
+++ b/tools/benchmark/tasks/fix.toml
@@ -9,9 +9,33 @@ divisor. Fix `divide` so that test passes. Do not change any other behavior —
 the existing passing tests in `test_calc.py` must stay green.
 """
 
+# Seed files the harness materializes into the target BEFORE the run, so the
+# agent has a real failing-vs-passing baseline to fix (not an empty project).
+# As written: test_divide_basic passes; test_divide_by_zero fails (divide raises
+# ZeroDivisionError instead of returning None) — the FAIL_TO_PASS the agent fixes.
+[[seed_files]]
+path = "calc.py"
+content = """
+def divide(a, b):
+    return a / b
+"""
+
+[[seed_files]]
+path = "test_calc.py"
+content = """
+from calc import divide
+
+
+def test_divide_basic():
+    assert divide(6, 2) == 3
+
+
+def test_divide_by_zero():
+    assert divide(1, 0) is None
+"""
+
 # Consumed by accuracy scoring (#273), ignored by the #271 collection harness.
-# The harness seeds calc.py + test_calc.py into the target before the run; #273
-# checks FAIL_TO_PASS flips green while PASS_TO_PASS stays green.
+# #273 checks FAIL_TO_PASS flips green while PASS_TO_PASS stays green.
 [check]
 type = "pytest"
 command = "uv run pytest -q test_calc.py"

--- a/tools/benchmark/tasks/noop.toml
+++ b/tools/benchmark/tasks/noop.toml
@@ -1,0 +1,10 @@
+# Benchmark probe: trivial prompt (methodology "noop").
+# Triggers context loading but no real work — measures the fixed, always-loaded
+# overhead a scaffold adds. task-dependent cost = total - noop.
+id = "noop"
+description = "Trivial probe — measures fixed always-loaded overhead"
+prompt = "Reply with the single word: ready"
+
+# No success check — this probe measures overhead, not correctness.
+[check]
+type = "none"

--- a/tools/benchmark/tasks/qa.toml
+++ b/tools/benchmark/tasks/qa.toml
@@ -9,7 +9,7 @@ in one sentence naming the tool.
 """
 
 # Consumed by accuracy scoring (#273), ignored by the #271 collection harness.
-# Substring match against the agent's final text output — the scaffolded target
+# Regex match against the agent's final text output — the scaffolded target
 # should know this from CLAUDE.md; a bare target likely won't.
 [check]
 type = "regex"

--- a/tools/benchmark/tasks/qa.toml
+++ b/tools/benchmark/tasks/qa.toml
@@ -1,0 +1,16 @@
+# Benchmark task: factual question about the repo (methodology "qa").
+# Where CLAUDE.md / memory / INDEX should help the scaffolded target most.
+id = "qa"
+description = "Answer a factual question about the repo"
+prompt = """
+What is the canonical command surface for this project — i.e. which tool's
+recipes are the canonical way to run setup, lint, format, test, and docs? Answer
+in one sentence naming the tool.
+"""
+
+# Consumed by accuracy scoring (#273), ignored by the #271 collection harness.
+# Substring match against the agent's final text output — the scaffolded target
+# should know this from CLAUDE.md; a bare target likely won't.
+[check]
+type = "regex"
+pattern = "(?i)\\bjust(file)?\\b"

--- a/tools/benchmark/transcript.py
+++ b/tools/benchmark/transcript.py
@@ -1,0 +1,100 @@
+"""Transcript aggregation for the benchmark harness (#271).
+
+Parses a Claude Code transcript JSONL into the capture aggregates a
+:class:`~tools.benchmark.record.RunRecord` needs. This reuses the **method**
+documented in ``docs/development/measurement-methodology.md`` (and shared with
+the scaffolded Track A analyzer), not its code — the two parsers are kept
+separate on purpose: the scaffolded one ships into other projects and stays
+stdlib-only; this one is dev tooling.
+
+The transcript schema is **not officially stable** (methodology caveat), so
+parsing is single-module, streams line-by-line, and tolerates missing fields.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class TranscriptAggregates:
+    """Capture aggregates folded from one transcript (tokens/tools/turns/span)."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    tool_calls: int = 0
+    turns: int = 0  # assistant messages
+    models: list[str] = field(default_factory=list)
+    claude_version: str = ""
+    first_ts: str | None = None
+    last_ts: str | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Sum of input, output, and both cache token classes."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+        )
+
+
+def _iter_entries(path: Path):
+    """Yield parsed JSON objects from a JSONL file; skip unparseable lines.
+
+    Streams line-by-line — transcripts can be large.
+    """
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(obj, dict):
+                yield obj
+
+
+def _fold_assistant(agg: TranscriptAggregates, msg: dict, seen_models: list[str]) -> None:
+    """Fold one assistant message's usage + tool calls into the aggregates."""
+    agg.turns += 1
+    model = msg.get("model")
+    if isinstance(model, str) and model not in seen_models:
+        seen_models.append(model)
+    usage = msg.get("usage")
+    if isinstance(usage, dict):
+        agg.input_tokens += int(usage.get("input_tokens") or 0)
+        agg.output_tokens += int(usage.get("output_tokens") or 0)
+        agg.cache_read_tokens += int(usage.get("cache_read_input_tokens") or 0)
+        agg.cache_creation_tokens += int(usage.get("cache_creation_input_tokens") or 0)
+    for block in msg.get("content") or []:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            agg.tool_calls += 1
+
+
+def parse(path: Path) -> TranscriptAggregates:
+    """Fold a transcript into capture aggregates (tokens, tools, turns, span)."""
+    agg = TranscriptAggregates()
+    seen_models: list[str] = []
+    for obj in _iter_entries(path):
+        ts = obj.get("timestamp")
+        if isinstance(ts, str):
+            if agg.first_ts is None:
+                agg.first_ts = ts
+            agg.last_ts = ts
+        if not agg.claude_version:
+            version = obj.get("version")
+            if isinstance(version, str):
+                agg.claude_version = version
+        msg = obj.get("message")
+        if obj.get("type") == "assistant" and isinstance(msg, dict):
+            _fold_assistant(agg, msg, seen_models)
+    agg.models = seen_models
+    return agg


### PR DESCRIPTION
Closes #271. First increment of epic #269 **Track B** (the cost–benefit benchmark) — the runner every other dimension feeds.

## What

Runs the methodology's representative tasks against a **bare** target and one or more **scaffolded** targets and normalizes each run into a stable record. Built in two cleanly separable halves:

- **Orchestration** (`setup_*_target` / `run_task` / the `run` CLI) drives `claude -p` against throwaway bare + per-preset temp targets under an isolated `CLAUDE_CONFIG_DIR`. Needs the Claude CLI + API key + network → **manual-only**, never CI, never the scaffold runtime (CLAUDE.md / ADR-001).
- **Parsing → normalized record** (`build_record` + `transcript.parse` + `RunRecord`) is **pure and fully tested** against fixtures. This is the stable contract #272/#273/#275 consume.

## Layout (dev tooling under `tools/benchmark/`)
`testpaths = ["tests"]`, so the harness is **not collected** as tests; its tests live in `tests/` and exercise the no-agent core.

- `record.py` — `RunRecord` schema: #271 populates the **capture** fields (identity + tokens + tool/turn counts + wall-clock + transcript span); `cost_usd` (#272) and `success`/`first_try`/`rework_cycles` (#273) are present but `None` until their issue lands. Tolerant JSONL read/write (ignores unknown keys, defaults missing — forward/backward compatible as the schema grows).
- `transcript.py` — Claude Code transcript JSONL → capture aggregates. Reuses the **method** in `measurement-methodology.md` (shared with Track A's analyzer), **separate code**: this harness may later use `rich`; the scaffolded analyzer stays stdlib-only.
- `harness.py` — target setup, `run_task`, `build_record(RunContext, path)`, CLI: `run` (orchestrate) + `record-from` (normalize an existing transcript — no agent).
- `tasks/{feat,fix,qa,noop}.toml` — the methodology task set; `[check]` authored for #273 to consume.
- `README.md` — how to run; `results/` already gitignored.

## Acceptance (all green)
- Sets up bare (no `.claude/`) and scaffolded targets for the task set (tested — scaffolding needs no agent).
- Per-run usage + timing + tool-call signals extracted into the normalized `RunRecord`.
- Output is a stable JSONL artifact downstream reads without re-parsing transcripts.
- No scaffold-runtime change; isolated under `tools/`, not pytest-collected.
- `just lint && just test` green (1170 passed, 3 skipped); `record-from` smoke-tested against a real transcript.

## Next on Track B
#272 fills `cost_usd` (tokens × a vendored static price table) + per-step latency/P50-P99; #273 fills the accuracy fields via the `[check]` specs; #275 renders the Pareto-aware `rich` verdict. The schema here is the contract they build on.