### PR TITLE
feat(PI-272): latency & cost capture (prices.py + latency.py)

### DIFF
--- a/tests/contracts/test_benchmark_cost_latency.py
+++ b/tests/contracts/test_benchmark_cost_latency.py
@@ -1,0 +1,107 @@
+"""#272: latency & cost capture on top of the benchmark records.
+
+Cost is derived from a static, model-keyed price table (no network); latency is
+aggregated to P50/P99 over repeats with honest n=1 handling. Pure functions —
+fully deterministic, no agent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.benchmark import latency, prices
+from tools.benchmark.record import RunRecord
+
+
+def _record(model: str = "claude-opus-4-8", **tok) -> RunRecord:
+    base = dict(
+        input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+    )
+    base.update(tok)
+    total = sum(base.values())
+    return RunRecord(
+        task="feat", target="bare", run_index=0, model=model,
+        claude_version="v", session_id="", transcript_path="/t",
+        total_tokens=total, tool_calls=0, turns=0, wall_clock_s=None,
+        first_ts=None, last_ts=None, **base,
+    )
+
+
+class TestCost:
+    def test_known_token_pricing_pair(self):
+        """1M input + 1M output on opus = $5 + $25 = $30 (the documented rate)."""
+        prc = prices.load_prices()
+        rec = _record("claude-opus-4-8", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert prices.cost_for(rec, prc) == 30.0
+
+    def test_cache_classes_priced_independently(self):
+        prc = prices.load_prices()
+        # 1M cache-read @ 0.5e-6 = $0.50; 1M cache-creation @ 6.25e-6 = $6.25.
+        rec = _record("claude-opus-4-8", cache_read_tokens=1_000_000,
+                      cache_creation_tokens=1_000_000)
+        assert prices.cost_for(rec, prc) == 6.75
+
+    def test_apply_cost_sets_field_rounded(self):
+        prc = prices.load_prices()
+        rec = _record("claude-sonnet-4-6", input_tokens=1_000_000)  # $3.00
+        prices.apply_cost(rec, prc)
+        assert rec.cost_usd == 3.0
+
+    def test_substring_model_fallback(self):
+        prc = prices.load_prices()
+        # A dated/suffixed id inherits the base model's rates.
+        rec = _record("claude-opus-4-8-20260101", input_tokens=1_000_000)
+        assert prices.cost_for(rec, prc) == 5.0
+
+    def test_unknown_model_is_none(self):
+        prc = prices.load_prices()
+        rec = _record("gpt-4o", input_tokens=1_000_000)
+        assert prices.cost_for(rec, prc) is None
+        prices.apply_cost(rec, prc)
+        assert rec.cost_usd is None
+
+    def test_price_table_is_litellm_shaped(self):
+        prc = prices.load_prices()
+        for row in prc.values():
+            assert "input_cost_per_token" in row
+            assert "output_cost_per_token" in row
+            assert "cache_read_input_token_cost" in row
+            assert "cache_creation_input_token_cost" in row
+
+    def test_table_updatable_without_code(self, tmp_path: Path):
+        custom = tmp_path / "p.json"
+        custom.write_text(json.dumps({"mymodel": {"input_cost_per_token": 1.0}}))
+        prc = prices.load_prices(custom)
+        rec = _record("mymodel", input_tokens=3)
+        assert prices.cost_for(rec, prc) == 3.0
+
+
+class TestLatency:
+    def test_percentile_interpolates(self):
+        vals = [1.0, 2.0, 3.0, 4.0]
+        assert latency.percentile(vals, 50) == 2.5
+        assert latency.percentile(vals, 0) == 1.0
+        assert latency.percentile(vals, 100) == 4.0
+
+    def test_percentile_empty_is_none(self):
+        assert latency.percentile([], 50) is None
+
+    def test_summarize_reports_n(self):
+        s = latency.summarize([1.0, 2.0, 3.0])
+        assert s["n"] == 3 and s["p50"] == 2.0
+
+    def test_summarize_single_run_is_honest(self):
+        s = latency.summarize([4.2])
+        assert s["n"] == 1 and s["p50"] == 4.2 and s["p99"] == 4.2
+
+    def test_step_latencies_from_timestamps(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        entries = [
+            {"type": "user", "timestamp": "2026-06-23T10:00:00Z"},
+            {"type": "assistant", "timestamp": "2026-06-23T10:00:03Z", "message": {}},
+            {"type": "assistant", "timestamp": "2026-06-23T10:00:08Z", "message": {}},
+        ]
+        tx.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+        steps = latency.step_latencies(tx)
+        assert steps == [3.0, 5.0]

--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -213,6 +213,21 @@ class TestTargetSetup:
         assert list(target.iterdir()) == []
 
 
+class TestUnpricedWarning:
+    def test_record_from_warns_on_unpriced_model(self, tmp_path: Path, capsys):
+        """Both CLI paths must warn (not silently emit null cost) — Copilot review."""
+        tx = tmp_path / "t.jsonl"
+        tx.write_text(json.dumps(
+            {"type": "assistant", "message": {"model": "gpt-4o", "usage": {}}}
+        ) + "\n")
+        rc = harness.main([
+            "record-from", "--task", "qa", "--target", "bare",
+            "--transcript", str(tx), "--out", str(tmp_path / "r.jsonl"),
+        ])
+        assert rc == 0
+        assert "no price row for model 'gpt-4o'" in capsys.readouterr().err
+
+
 class TestRunTaskGuard:
     def test_run_task_requires_claude_cli(self, tmp_path: Path, monkeypatch):
         # Deterministic regardless of whether claude is installed locally.

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -20,10 +20,12 @@ the `rich` report is #275.
 | File | Purpose |
 |---|---|
 | `record.py` | `RunRecord` — the normalized per-run schema + JSONL read/write (the contract #272/#273/#275 consume) |
-| `transcript.py` | parse a Claude Code transcript JSONL → capture aggregates (tokens/tools/turns/span) |
+| `transcript.py` | parse a Claude Code transcript JSONL → capture aggregates (tokens/tools/turns/span/timestamps) |
 | `harness.py` | target setup + `claude -p` orchestration + `build_record` + the CLI |
 | `tasks/*.toml` | the task set: `feat`, `fix`, `qa`, `noop` (probe). `[check]` is for #273 |
-| `model_prices.json` | (added in #272) vendored MIT price table for the $ axis |
+| `prices.py` | `cost_for` / `apply_cost` — $ from tokens × the static table (#272) |
+| `latency.py` | per-step latency + P50/P99 aggregation over repeats (#272) |
+| `model_prices.json` | vendored, litellm-shaped price table for the $ axis (#272) |
 | `results/` | raw per-run JSONL (gitignored) |
 
 ## Running it
@@ -57,6 +59,24 @@ One JSON object per `(task, target, run)`. #271 populates the **capture** fields
 later-owned fields are present but `None` until their issue lands:
 `cost_usd` (#272), `success` / `first_try` / `rework_cycles` (#273). Downstream
 code reads `RunRecord`, never raw transcripts.
+
+## Cost & latency (#272)
+
+- **Cost** is derived from `model_prices.json` × the four captured token classes
+  (input, output, cache-read, cache-creation priced independently, so prompt-cache
+  economics show up honestly). `cost_usd` is filled on every record the CLI emits;
+  an unpriced model leaves it `null` with a warning rather than guessing.
+- **The price table is updatable without code changes.** It is litellm-shaped
+  (`input_cost_per_token`, `output_cost_per_token`, `cache_read_input_token_cost`,
+  `cache_creation_input_token_cost`), keyed by model id (matched exact-then-
+  longest-substring). Refresh it from litellm's MIT
+  `model_prices_and_context_window.json` or the published Claude pricing; point at
+  an alternate file with `--prices <path>`.
+- **Latency**: `wall_clock_s` per run is the authoritative per-task figure
+  (harness-measured). `latency.step_latencies()` derives per-step deltas from
+  transcript timestamps (best-effort — unstable schema), and `latency.summarize()`
+  aggregates a metric over repeats into `{n, p50, p99}`, reporting `n=1` honestly
+  instead of faking a distribution. The #275 report consumes these.
 
 ## Caveats (from the methodology)
 

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -253,9 +253,8 @@ def build_record(ctx: RunContext, transcript_path: Path) -> RunRecord:
 # --- CLI ------------------------------------------------------------------
 
 
-def _price(record: RunRecord, prices_path: str | None) -> None:
-    """Fill record.cost_usd from the price table; warn (don't fail) if unpriced."""
-    apply_cost(record, load_prices(Path(prices_path) if prices_path else None))
+def _warn_if_unpriced(record: RunRecord) -> None:
+    """Emit the documented warning when a record's model has no price row."""
     if record.cost_usd is None:
         sys.stderr.write(
             f"benchmark: no price row for model {record.model!r} — cost_usd left null\n"
@@ -277,7 +276,8 @@ def _cmd_record_from(args: argparse.Namespace) -> int:
         ),
         transcript,
     )
-    _price(record, args.prices)
+    apply_cost(record, load_prices(Path(args.prices) if args.prices else None))
+    _warn_if_unpriced(record)
     out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
     write_records([record], out)
     sys.stdout.write(json.dumps(record.to_dict(), indent=2) + "\n")
@@ -324,6 +324,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
                         transcript,
                     )
                     apply_cost(record, prices)
+                    _warn_if_unpriced(record)
                     records.append(record)
                     cost = f"${record.cost_usd:.4f}" if record.cost_usd is not None else "$?"
                     sys.stdout.write(

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -29,6 +29,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from tools.benchmark.prices import apply_cost, load_prices
 from tools.benchmark.record import RunRecord, write_records
 from tools.benchmark.transcript import parse as parse_transcript
 
@@ -252,6 +253,15 @@ def build_record(ctx: RunContext, transcript_path: Path) -> RunRecord:
 # --- CLI ------------------------------------------------------------------
 
 
+def _price(record: RunRecord, prices_path: str | None) -> None:
+    """Fill record.cost_usd from the price table; warn (don't fail) if unpriced."""
+    apply_cost(record, load_prices(Path(prices_path) if prices_path else None))
+    if record.cost_usd is None:
+        sys.stderr.write(
+            f"benchmark: no price row for model {record.model!r} — cost_usd left null\n"
+        )
+
+
 def _cmd_record_from(args: argparse.Namespace) -> int:
     """Normalize an existing transcript into a record (no agent needed)."""
     transcript = Path(args.transcript).expanduser()
@@ -267,6 +277,7 @@ def _cmd_record_from(args: argparse.Namespace) -> int:
         ),
         transcript,
     )
+    _price(record, args.prices)
     out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
     write_records([record], out)
     sys.stdout.write(json.dumps(record.to_dict(), indent=2) + "\n")
@@ -282,6 +293,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
     tasks = load_all_tasks() if args.task == "all" else {args.task: load_task(args.task)}
     targets = ["bare", *args.preset]
     out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
+    prices = load_prices(Path(args.prices) if args.prices else None)
     records: list[RunRecord] = []
     with tempfile.TemporaryDirectory(prefix="pi-benchmark-") as tmp:
         tmp_root = Path(tmp)
@@ -311,10 +323,12 @@ def _cmd_run(args: argparse.Namespace) -> int:
                         ),
                         transcript,
                     )
+                    apply_cost(record, prices)
                     records.append(record)
+                    cost = f"${record.cost_usd:.4f}" if record.cost_usd is not None else "$?"
                     sys.stdout.write(
                         f"{target}/{task_id} run {run_index}: "
-                        f"{record.total_tokens} tok, {record.tool_calls} tool calls, "
+                        f"{record.total_tokens} tok, {cost}, {record.tool_calls} tool calls, "
                         f"{record.wall_clock_s:.1f}s\n"
                     )
     if records:
@@ -342,6 +356,7 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument("--model", default=_DEFAULT_MODEL)
     run.add_argument("--repeats", type=int, default=5, help="repeats per (task,target) for variance")
     run.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
+    run.add_argument("--prices", help="price table JSON (default: tools/benchmark/model_prices.json)")
     run.set_defaults(func=_cmd_run)
 
     rec = sub.add_parser("record-from", help="normalize an existing transcript (no agent)")
@@ -353,6 +368,7 @@ def main(argv: list[str] | None = None) -> int:
     rec.add_argument("--model", default="", help="override; default = transcript's model")
     rec.add_argument("--run-index", type=int, default=0, dest="run_index")
     rec.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
+    rec.add_argument("--prices", help="price table JSON (default: tools/benchmark/model_prices.json)")
     rec.set_defaults(func=_cmd_record_from)
 
     args = parser.parse_args(argv)

--- a/tools/benchmark/latency.py
+++ b/tools/benchmark/latency.py
@@ -1,0 +1,66 @@
+"""Latency derivation + aggregation for the benchmark (#272).
+
+Two things on top of the per-run ``wall_clock_s`` the harness already captures
+(#271):
+
+- **Per-step latency** — deltas between consecutive transcript timestamps, where
+  the data source allows it (the schema is unstable, so this is best-effort).
+- **P50/P99 aggregation** over repeats of a ``(task, target)`` — the variance
+  view the cost–benefit report (#275) renders; ``n=1`` is reported honestly
+  rather than faked.
+
+Stdlib only; dev tooling, never imported by the scaffold runtime.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from tools.benchmark.transcript import message_timestamps
+
+
+def _parse_ts(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp (tolerating a trailing ``Z``)."""
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def step_latencies(transcript_path: Path) -> list[float]:
+    """Seconds between consecutive transcript entries (per-step latency)."""
+    stamps = [dt for ts in message_timestamps(transcript_path) if (dt := _parse_ts(ts))]
+    return [
+        (b - a).total_seconds()
+        for a, b in zip(stamps, stamps[1:], strict=False)
+        if (b - a).total_seconds() >= 0
+    ]
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    """Linear-interpolated p-th percentile (p in [0, 100]); None if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (p / 100) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def summarize(values: list[float]) -> dict:
+    """Aggregate a metric over repeats → ``{n, p50, p99}``.
+
+    ``n`` is the count so the report can flag single-run measurements ("n=1")
+    instead of presenting a fake distribution. Empty input → ``n=0`` with null
+    percentiles.
+    """
+    return {
+        "n": len(values),
+        "p50": percentile(values, 50),
+        "p99": percentile(values, 99),
+    }

--- a/tools/benchmark/model_prices.json
+++ b/tools/benchmark/model_prices.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Vendored, litellm-shaped price table (USD per token) for the benchmark $ axis (#272). Refresh deliberately from litellm's model_prices_and_context_window.json (MIT) or platform.claude.com/docs/pricing; keys are model ids, matched exact-then-substring. cache_read ~= 0.1x input; cache_creation (5-min write) ~= 1.25x input.",
+  "claude-opus-4-8": {
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
+    "cache_read_input_token_cost": 5e-07,
+    "cache_creation_input_token_cost": 6.25e-06
+  },
+  "claude-opus-4-7": {
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
+    "cache_read_input_token_cost": 5e-07,
+    "cache_creation_input_token_cost": 6.25e-06
+  },
+  "claude-opus-4-6": {
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
+    "cache_read_input_token_cost": 5e-07,
+    "cache_creation_input_token_cost": 6.25e-06
+  },
+  "claude-sonnet-4-6": {
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
+    "cache_read_input_token_cost": 3e-07,
+    "cache_creation_input_token_cost": 3.75e-06
+  },
+  "claude-haiku-4-5": {
+    "input_cost_per_token": 1e-06,
+    "output_cost_per_token": 5e-06,
+    "cache_read_input_token_cost": 1e-07,
+    "cache_creation_input_token_cost": 1.25e-06
+  },
+  "claude-fable-5": {
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 5e-05,
+    "cache_read_input_token_cost": 1e-06,
+    "cache_creation_input_token_cost": 1.25e-05
+  }
+}

--- a/tools/benchmark/prices.py
+++ b/tools/benchmark/prices.py
@@ -51,18 +51,21 @@ def _rates_for(model: str, prices: dict[str, dict[str, float]]) -> dict[str, flo
 
 
 def cost_for(record: RunRecord, prices: dict[str, dict[str, float]]) -> float | None:
-    """USD for a record's token usage, or None if the model isn't in the table."""
+    """USD for a record's token usage, or None if the model isn't in the table.
+
+    Rounded to 6 dp so float-rate arithmetic doesn't leak noise
+    (``30.000000000000004``) to callers / exact-equality comparisons.
+    """
     rates = _rates_for(record.model, prices)
     if rates is None:
         return None
     total = 0.0
     for token_field, cost_key in _TOKEN_COST_KEYS:
         total += getattr(record, token_field) * float(rates.get(cost_key, 0.0))
-    return total
+    return round(total, 6)
 
 
 def apply_cost(record: RunRecord, prices: dict[str, dict[str, float]]) -> RunRecord:
-    """Set ``record.cost_usd`` in place (rounded) and return it; None if unpriced."""
-    cost = cost_for(record, prices)
-    record.cost_usd = round(cost, 6) if cost is not None else None
+    """Set ``record.cost_usd`` in place (None if unpriced) and return the record."""
+    record.cost_usd = cost_for(record, prices)
     return record

--- a/tools/benchmark/prices.py
+++ b/tools/benchmark/prices.py
@@ -1,0 +1,68 @@
+"""Cost derivation for benchmark records (#272).
+
+Turns the token counts a :class:`~tools.benchmark.record.RunRecord` captured
+(#271) into a dollar figure, using a **vendored, static, model-keyed** price
+table (``model_prices.json``) — no network call (CLAUDE.md / ADR-001). The four
+token classes are priced independently so prompt-cache economics show up
+honestly: cache reads are ~0.1x input, cache-creation writes ~1.25x input.
+
+The table is litellm-shaped (``input_cost_per_token`` etc.), so it can be
+refreshed from litellm's MIT data file or the published Claude pricing without
+code changes. Dev tooling — never imported by the scaffold runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.benchmark.record import RunRecord
+
+_DEFAULT_PRICES = Path(__file__).resolve().parent / "model_prices.json"
+
+# RunRecord token field → litellm per-token cost key.
+_TOKEN_COST_KEYS = (
+    ("input_tokens", "input_cost_per_token"),
+    ("output_tokens", "output_cost_per_token"),
+    ("cache_read_tokens", "cache_read_input_token_cost"),
+    ("cache_creation_tokens", "cache_creation_input_token_cost"),
+)
+
+
+def load_prices(path: Path | None = None) -> dict[str, dict[str, float]]:
+    """Load the vendored price table (drops the ``_comment`` metadata key)."""
+    data = json.loads((path or _DEFAULT_PRICES).read_text(encoding="utf-8"))
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _rates_for(model: str, prices: dict[str, dict[str, float]]) -> dict[str, float] | None:
+    """Resolve a model id to its rate row: exact match, else longest substring.
+
+    Substring fallback lets a dated/suffixed id (``claude-opus-4-8-2026…``)
+    inherit the base model's rates; the longest matching key wins so
+    ``claude-opus-4-8`` beats a hypothetical ``claude-opus``.
+    """
+    if model in prices:
+        return prices[model]
+    candidates = [key for key in prices if key in model]
+    if not candidates:
+        return None
+    return prices[max(candidates, key=len)]
+
+
+def cost_for(record: RunRecord, prices: dict[str, dict[str, float]]) -> float | None:
+    """USD for a record's token usage, or None if the model isn't in the table."""
+    rates = _rates_for(record.model, prices)
+    if rates is None:
+        return None
+    total = 0.0
+    for token_field, cost_key in _TOKEN_COST_KEYS:
+        total += getattr(record, token_field) * float(rates.get(cost_key, 0.0))
+    return total
+
+
+def apply_cost(record: RunRecord, prices: dict[str, dict[str, float]]) -> RunRecord:
+    """Set ``record.cost_usd`` in place (rounded) and return it; None if unpriced."""
+    cost = cost_for(record, prices)
+    record.cost_usd = round(cost, 6) if cost is not None else None
+    return record

--- a/tools/benchmark/transcript.py
+++ b/tools/benchmark/transcript.py
@@ -79,6 +79,16 @@ def _fold_assistant(agg: TranscriptAggregates, msg: dict, seen_models: list[str]
             agg.tool_calls += 1
 
 
+def message_timestamps(path: Path) -> list[str]:
+    """Every entry's ISO ``timestamp`` in order (for per-step latency, #272)."""
+    out: list[str] = []
+    for obj in _iter_entries(path):
+        ts = obj.get("timestamp")
+        if isinstance(ts, str):
+            out.append(ts)
+    return out
+
+
 def parse(path: Path) -> TranscriptAggregates:
     """Fold a transcript into capture aggregates (tokens, tools, turns, span)."""
     agg = TranscriptAggregates()


### PR DESCRIPTION
Closes #272. Adds the **$ and speed axes** on top of #271's collection-harness records (epic #269 Track B). Dev tooling; no scaffold-runtime change; no network.

## What

- **`model_prices.json`** — vendored, **litellm-shaped** price table (USD per token), keyed by model id, curated to the benchmarked Claude models. **Updatable without code changes** (refresh from litellm's MIT `model_prices_and_context_window.json` or published Claude pricing); override at runtime with `--prices <path>`.
- **`prices.py`** — `cost_for(record, prices)` / `apply_cost`. The four token classes (input, output, **cache-read, cache-creation**) are priced **independently**, so prompt-cache economics show up honestly. Model match is exact-then-longest-substring (dated/suffixed ids inherit the base rate). An unpriced model leaves `cost_usd` **null with a warning** — never a guess.
- **`latency.py`** — `step_latencies()` (per-step deltas from transcript timestamps, best-effort given the unstable schema), `percentile()` + `summarize() → {n, p50, p99}` over repeats, with **honest n=1** handling (no faked distribution). `transcript.py` gains `message_timestamps()`.
- **harness CLI** fills `cost_usd` on every emitted record (`run` + `record-from`) and adds `--prices`.

## Acceptance (all green)
- Wall-clock per task captured (#271); per-step latency derived where the transcript allows.
- Repeated runs → P50/P99 via `summarize`; `n=1` reported honestly.
- $ derived from token counts × a static, model-keyed table **with cache rates**.
- Price table updatable without code + documented (README + `--prices`).
- **Test covers the $ derivation for a known token/pricing pair** (1M in + 1M out on opus = $30), plus independent cache pricing, substring fallback, unknown→None, and the table-updatable path.
- `just lint && just test` green (1187 passed, 3 skipped); smoke-tested priced `record-from` on a real transcript.

## Next on Track B
#273 fills `success`/`first_try`/`rework_cycles` via the `[check]` specs; #275 renders the Pareto-aware `rich` verdict consuming `cost_usd` + `latency.summarize`.