### PR TITLE
feat(PI-273): accuracy/task-success scoring (scoring.py)

### DIFF
--- a/tests/contracts/test_benchmark_scoring.py
+++ b/tests/contracts/test_benchmark_scoring.py
@@ -1,0 +1,111 @@
+"""#273: accuracy / task-success scoring against the authored [check] specs.
+
+Deterministic — pytest exit codes, file existence, a regex, and an
+error-tool_result count. No agent, no LLM judge.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.benchmark import scoring
+from tools.benchmark.harness import load_task
+
+
+def _seed_passing_pytest(target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "pyproject.toml").write_text(
+        '[project]\nname = "t"\nversion = "0"\nrequires-python = ">=3.11"\n'
+        '[dependency-groups]\ndev = ["pytest"]\n'
+    )
+
+
+class TestPytestCheck:
+    def test_passes_when_tests_green_and_files_exist(self, tmp_path: Path):
+        _seed_passing_pytest(tmp_path)
+        (tmp_path / "slug.py").write_text("def slugify(s):\n    return s.lower()\n")
+        (tmp_path / "test_slug.py").write_text(
+            "from slug import slugify\n\ndef test_basic():\n    assert slugify('AB') == 'ab'\n"
+        )
+        assert scoring.score_check(load_task("feat"), tmp_path) is True
+
+    def test_fails_when_test_fails(self, tmp_path: Path):
+        _seed_passing_pytest(tmp_path)
+        (tmp_path / "slug.py").write_text("def slugify(s):\n    return s\n")  # wrong
+        (tmp_path / "test_slug.py").write_text(
+            "from slug import slugify\n\ndef test_basic():\n    assert slugify('AB') == 'ab'\n"
+        )
+        assert scoring.score_check(load_task("feat"), tmp_path) is False
+
+    def test_fails_when_required_file_missing(self, tmp_path: Path):
+        _seed_passing_pytest(tmp_path)
+        # must_exist names slug.py + test_slug.py; neither created → fail without
+        # even running pytest.
+        assert scoring.score_check(load_task("feat"), tmp_path) is False
+
+
+class TestRegexCheck:
+    def test_matches_agent_output(self):
+        assert scoring.score_check(load_task("qa"), Path("."), "Use the justfile recipes.") is True
+
+    def test_no_match(self):
+        assert scoring.score_check(load_task("qa"), Path("."), "Use make targets.") is False
+
+
+class TestNoneCheck:
+    def test_noop_is_not_scored(self):
+        assert scoring.score_check(load_task("noop"), Path(".")) is None
+
+
+class TestRework:
+    def _transcript(self, path: Path, n_errors: int) -> None:
+        entries = [{"type": "assistant", "message": {"model": "m", "usage": {},
+                    "content": [{"type": "tool_use", "id": f"t{i}", "name": "Bash", "input": {}}]}}
+                   for i in range(n_errors)]
+        entries += [{"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": f"t{i}", "is_error": True}]}}
+            for i in range(n_errors)]
+        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+    def test_counts_error_tool_results(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        self._transcript(tx, 2)
+        assert scoring.rework_cycles(tx) == 2
+
+    def test_zero_errors(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        self._transcript(tx, 0)
+        assert scoring.rework_cycles(tx) == 0
+
+    def test_missing_transcript_is_none(self, tmp_path: Path):
+        assert scoring.rework_cycles(tmp_path / "nope.jsonl") is None
+        assert scoring.rework_cycles(None) is None
+
+
+class TestScoreOrchestrator:
+    def test_first_try_when_success_and_no_rework(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        tx.write_text(json.dumps({"type": "assistant", "message": {"model": "m"}}) + "\n")
+        s = scoring.score(load_task("qa"), target_dir=Path("."),
+                          transcript_path=tx, agent_output="see the justfile")
+        assert s.success is True and s.rework_cycles == 0 and s.first_try is True
+
+    def test_not_first_try_when_rework(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        entries = [
+            {"type": "assistant", "message": {"model": "m", "content": [
+                {"type": "tool_use", "id": "t0", "name": "Bash", "input": {}}]}},
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "t0", "is_error": True}]}},
+        ]
+        tx.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+        s = scoring.score(load_task("qa"), target_dir=Path("."),
+                          transcript_path=tx, agent_output="see the justfile")
+        assert s.success is True and s.rework_cycles == 1 and s.first_try is False
+
+    def test_no_target_leaves_success_none(self, tmp_path: Path):
+        tx = tmp_path / "t.jsonl"
+        tx.write_text(json.dumps({"type": "assistant", "message": {"model": "m"}}) + "\n")
+        s = scoring.score(load_task("feat"), target_dir=None, transcript_path=tx)
+        assert s.success is None and s.first_try is None and s.rework_cycles == 0

--- a/tests/contracts/test_benchmark_scoring.py
+++ b/tests/contracts/test_benchmark_scoring.py
@@ -45,6 +45,55 @@ class TestPytestCheck:
         assert scoring.score_check(load_task("feat"), tmp_path) is False
 
 
+class TestFixNodeLevel:
+    """SWE-bench-style fix task must validate the named nodes, not just exit 0
+    (Codex review P1 — deleting the failing test must not score a pass)."""
+
+    def _seeded_fix_target(self, tmp_path: Path):
+        from tools.benchmark.harness import prepare_target
+
+        return prepare_target(tmp_path / "fix", "bare", load_task("fix"), model="m")
+
+    def test_unfixed_fails(self, tmp_path: Path):
+        target = self._seeded_fix_target(tmp_path)
+        assert scoring.score_check(load_task("fix"), target) is False
+
+    def test_correct_fix_passes(self, tmp_path: Path):
+        target = self._seeded_fix_target(tmp_path)
+        (target / "calc.py").write_text("def divide(a, b):\n    return None if b == 0 else a / b\n")
+        assert scoring.score_check(load_task("fix"), target) is True
+
+    def test_deleting_failing_test_does_not_pass(self, tmp_path: Path):
+        """Agent removes test_divide_by_zero entirely — aggregate pytest would
+        exit 0, but the node-level check must catch the missing fail_to_pass node."""
+        target = self._seeded_fix_target(tmp_path)
+        (target / "calc.py").write_text("def divide(a, b):\n    return None if b == 0 else a / b\n")
+        (target / "test_calc.py").write_text(
+            "from calc import divide\n\ndef test_divide_basic():\n    assert divide(6, 2) == 3\n"
+        )
+        assert scoring.score_check(load_task("fix"), target) is False
+
+    def test_breaking_pass_to_pass_fails(self, tmp_path: Path):
+        target = self._seeded_fix_target(tmp_path)
+        # Fix the zero case but regress the basic one.
+        (target / "calc.py").write_text("def divide(a, b):\n    return None\n")
+        assert scoring.score_check(load_task("fix"), target) is False
+
+
+class TestPytestArgv:
+    def test_targets_node_ids_dropping_bare_file(self):
+        argv = scoring._pytest_argv(
+            "uv run pytest -q test_calc.py",
+            ["test_calc.py::test_a", "test_calc.py::test_b"],
+        )
+        assert argv == ["uv", "run", "pytest", "-q",
+                        "test_calc.py::test_a", "test_calc.py::test_b"]
+
+    def test_no_nodes_runs_command_as_authored(self):
+        argv = scoring._pytest_argv("uv run pytest -q test_slug.py", [])
+        assert argv == ["uv", "run", "pytest", "-q", "test_slug.py"]
+
+
 class TestRegexCheck:
     def test_matches_agent_output(self):
         assert scoring.score_check(load_task("qa"), Path("."), "Use the justfile recipes.") is True

--- a/tests/contracts/test_benchmark_scoring.py
+++ b/tests/contracts/test_benchmark_scoring.py
@@ -94,6 +94,20 @@ class TestPytestArgv:
         assert argv == ["uv", "run", "pytest", "-q", "test_slug.py"]
 
 
+class TestResolveUv:
+    def test_resolves_leading_uv_to_abs_path(self):
+        """uv run strips uv from PATH, so the scorer must resolve it (Copilot review)."""
+        argv = scoring._resolve_uv(["uv", "run", "pytest"])
+        # uv is available in the dev env → first token becomes an absolute path.
+        assert argv[0] != "uv"
+        assert Path(argv[0]).is_absolute()
+        assert argv[1:] == ["run", "pytest"]
+
+    def test_non_uv_argv_untouched(self):
+        assert scoring._resolve_uv(["pytest", "-q"]) == ["pytest", "-q"]
+        assert scoring._resolve_uv([]) == []
+
+
 class TestRegexCheck:
     def test_matches_agent_output(self):
         assert scoring.score_check(load_task("qa"), Path("."), "Use the justfile recipes.") is True

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -25,6 +25,7 @@ the `rich` report is #275.
 | `tasks/*.toml` | the task set: `feat`, `fix`, `qa`, `noop` (probe). `[check]` is for #273 |
 | `prices.py` | `cost_for` / `apply_cost` — $ from tokens × the static table (#272) |
 | `latency.py` | per-step latency + P50/P99 aggregation over repeats (#272) |
+| `scoring.py` | `score` — deterministic success + first_try + rework_cycles from the `[check]` specs (#273) |
 | `model_prices.json` | vendored, litellm-shaped price table for the $ axis (#272) |
 | `results/` | raw per-run JSONL (gitignored) |
 
@@ -77,6 +78,22 @@ code reads `RunRecord`, never raw transcripts.
   transcript timestamps (best-effort — unstable schema), and `latency.summarize()`
   aggregates a metric over repeats into `{n, p50, p99}`, reporting `n=1` honestly
   instead of faking a distribution. The #275 report consumes these.
+
+## Accuracy / success (#273)
+
+The **benefit** axis — cheap-but-wrong is not a win. Each `run` record gets a
+deterministic signal from the task's authored `[check]` spec:
+
+- **`success`** — `pytest` exits as expected and required files exist (`pytest`
+  checks like `feat`/`fix`); the agent's final text matches a pattern (`regex`,
+  e.g. `qa`); or `None` when no check applies (`none`, e.g. the `noop` probe).
+- **`rework_cycles`** — count of error `tool_result` blocks in the transcript: a
+  deterministic, artifact-reproducible *proxy* for correction rounds.
+- **`first_try`** — succeeded with zero rework.
+
+No LLM judge (ADR-001): test exit codes, file existence, a regex. `record-from`
+fills `rework_cycles` from the transcript but leaves `success`/`first_try` null
+(it has no target to check); use `run` for the full score.
 
 ## Caveats (from the methodology)
 

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -208,7 +208,10 @@ def run_task(
         if isinstance(out, dict):
             session_id = out.get("session_id") or ""
             cost = out.get("total_cost_usd")
-            result_text = out.get("result") or ""  # final agent text (for the regex check)
+            # Final agent text for the regex check; guard non-string payloads so
+            # re.search never gets a dict/list.
+            result_obj = out.get("result")
+            result_text = result_obj if isinstance(result_obj, str) else ""
     except (ValueError, TypeError):
         pass
     return {

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 from tools.benchmark.prices import apply_cost, load_prices
 from tools.benchmark.record import RunRecord, write_records
+from tools.benchmark.scoring import Score, rework_cycles
+from tools.benchmark.scoring import score as score_run
 from tools.benchmark.transcript import parse as parse_transcript
 
 _HERE = Path(__file__).resolve().parent
@@ -200,15 +202,21 @@ def run_task(
         cmd, cwd=str(target_dir), capture_output=True, text=True, env=env, timeout=1800
     )
     wall_clock_s = time.monotonic() - start
-    session_id, cost = "", None
+    session_id, cost, result_text = "", None, ""
     try:
         out = json.loads(proc.stdout)
         if isinstance(out, dict):
             session_id = out.get("session_id") or ""
             cost = out.get("total_cost_usd")
+            result_text = out.get("result") or ""  # final agent text (for the regex check)
     except (ValueError, TypeError):
         pass
-    return {"session_id": session_id, "wall_clock_s": wall_clock_s, "cost_estimate": cost}
+    return {
+        "session_id": session_id,
+        "wall_clock_s": wall_clock_s,
+        "cost_estimate": cost,
+        "result": result_text,
+    }
 
 
 # --- normalized record (pure — testable) ----------------------------------
@@ -253,6 +261,13 @@ def build_record(ctx: RunContext, transcript_path: Path) -> RunRecord:
 # --- CLI ------------------------------------------------------------------
 
 
+def _apply_score(record: RunRecord, result: Score) -> None:
+    """Copy a :class:`Score` onto the record's accuracy fields (#273)."""
+    record.success = result.success
+    record.first_try = result.first_try
+    record.rework_cycles = result.rework_cycles
+
+
 def _warn_if_unpriced(record: RunRecord) -> None:
     """Emit the documented warning when a record's model has no price row."""
     if record.cost_usd is None:
@@ -278,6 +293,9 @@ def _cmd_record_from(args: argparse.Namespace) -> int:
     )
     apply_cost(record, load_prices(Path(args.prices) if args.prices else None))
     _warn_if_unpriced(record)
+    # No target dir to check against here — record the rework proxy from the
+    # transcript; success/first_try stay null (use `run` for the full check).
+    record.rework_cycles = rework_cycles(transcript)
     out = Path(args.out) if args.out else _RESULTS_DIR / "records.jsonl"
     write_records([record], out)
     sys.stdout.write(json.dumps(record.to_dict(), indent=2) + "\n")
@@ -325,10 +343,20 @@ def _cmd_run(args: argparse.Namespace) -> int:
                     )
                     apply_cost(record, prices)
                     _warn_if_unpriced(record)
+                    _apply_score(
+                        record,
+                        score_run(
+                            task,
+                            target_dir=tdir,
+                            transcript_path=transcript,
+                            agent_output=result.get("result", ""),
+                        ),
+                    )
                     records.append(record)
                     cost = f"${record.cost_usd:.4f}" if record.cost_usd is not None else "$?"
+                    ok = {True: "ok", False: "FAIL", None: "n/a"}[record.success]
                     sys.stdout.write(
-                        f"{target}/{task_id} run {run_index}: "
+                        f"{target}/{task_id} run {run_index}: {ok}, "
                         f"{record.total_tokens} tok, {cost}, {record.tool_calls} tool calls, "
                         f"{record.wall_clock_s:.1f}s\n"
                     )

--- a/tools/benchmark/scoring.py
+++ b/tools/benchmark/scoring.py
@@ -36,18 +36,41 @@ class Score:
     rework_cycles: int | None
 
 
+def _pytest_argv(command: str, nodes: list[str]) -> list[str]:
+    """Build the pytest argv, targeting explicit node ids when given.
+
+    For SWE-bench-style tasks the check names ``fail_to_pass`` / ``pass_to_pass``
+    node ids: we run *those exact nodes* (keeping the runner + flags, dropping the
+    bare file arg) so an agent that deletes or rewrites the failing test can't
+    score a pass via the aggregate command — a missing node id makes pytest exit
+    non-zero. Without node lists, the command runs as authored.
+    """
+    tokens = shlex.split(command)
+    if not nodes:
+        return tokens
+    keep = [t for t in tokens if not (t.endswith(".py") and "::" not in t)]
+    return [*keep, *nodes]
+
+
 def _run_pytest_check(check: dict, target_dir: Path) -> bool:
-    """True iff all ``must_exist`` files are present AND the command exits as expected."""
+    """True iff ``must_exist`` files are present AND the pytest invocation exits as expected.
+
+    When ``fail_to_pass``/``pass_to_pass`` are listed, the invocation targets
+    those node ids explicitly (see :func:`_pytest_argv`): exit 0 then means the
+    previously-failing node now passes *and* every named passing node stayed
+    green — a missing/renamed node fails the run.
+    """
     for rel in check.get("must_exist", []):
         if not (target_dir / rel).exists():
             return False
     command = check.get("command")
     if not command:
         return False
+    nodes = [*check.get("fail_to_pass", []), *check.get("pass_to_pass", [])]
     expect_exit = int(check.get("expect_exit", 0))
     try:
         proc = subprocess.run(
-            shlex.split(command), cwd=str(target_dir), capture_output=True, timeout=600
+            _pytest_argv(command, nodes), cwd=str(target_dir), capture_output=True, timeout=600
         )
     except (OSError, subprocess.SubprocessError):
         return False

--- a/tools/benchmark/scoring.py
+++ b/tools/benchmark/scoring.py
@@ -20,11 +20,31 @@ from __future__ import annotations
 
 import re
 import shlex
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from tools.benchmark.transcript import parse as parse_transcript
+
+
+def _resolve_uv(argv: list[str]) -> list[str]:
+    """Replace a leading ``uv`` with its absolute path.
+
+    ``uv run`` strips ``uv`` from the child's PATH, so a scorer subprocess that
+    invokes ``uv run pytest`` can hit ``FileNotFoundError`` — a false-negative
+    ``success``. Resolve via PATH, then the common install locations (mirrors
+    ``tests/helpers.find_uv``).
+    """
+    if not argv or argv[0] != "uv":
+        return argv
+    uv = shutil.which("uv")
+    if not uv:
+        for candidate in (Path.home() / ".local" / "bin" / "uv", Path("/usr/local/bin/uv")):
+            if candidate.exists():
+                uv = str(candidate)
+                break
+    return [uv, *argv[1:]] if uv else argv
 
 
 @dataclass
@@ -70,7 +90,10 @@ def _run_pytest_check(check: dict, target_dir: Path) -> bool:
     expect_exit = int(check.get("expect_exit", 0))
     try:
         proc = subprocess.run(
-            _pytest_argv(command, nodes), cwd=str(target_dir), capture_output=True, timeout=600
+            _resolve_uv(_pytest_argv(command, nodes)),
+            cwd=str(target_dir),
+            capture_output=True,
+            timeout=600,
         )
     except (OSError, subprocess.SubprocessError):
         return False

--- a/tools/benchmark/scoring.py
+++ b/tools/benchmark/scoring.py
@@ -1,0 +1,89 @@
+"""Accuracy / task-success scoring for the benchmark (#273).
+
+The **benefit** axis — without it the cost numbers are meaningless (cheap-but-
+wrong is not a win). Each run gets a deterministic success signal from the
+task's authored ``[check]`` spec, plus a first-try flag and a rework-cycle count:
+
+- **success** — the deterministic check passed: ``pytest`` exits as expected and
+  required files exist (``pytest``); the agent's final text matches a pattern
+  (``regex``); or no check applies (``none`` → ``None``, e.g. the noop probe).
+- **rework_cycles** — count of error ``tool_result`` blocks in the transcript: a
+  deterministic, artifact-reproducible *proxy* for correction rounds the agent
+  had to recover from.
+- **first_try** — succeeded with zero rework.
+
+No LLM judge (CLAUDE.md / ADR-001): scoring is test exit codes, file existence,
+and a regex. Dev tooling; never imported by the scaffold runtime.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.benchmark.transcript import parse as parse_transcript
+
+
+@dataclass
+class Score:
+    """A run's accuracy signals — the benefit axis paired against cost."""
+
+    success: bool | None
+    first_try: bool | None
+    rework_cycles: int | None
+
+
+def _run_pytest_check(check: dict, target_dir: Path) -> bool:
+    """True iff all ``must_exist`` files are present AND the command exits as expected."""
+    for rel in check.get("must_exist", []):
+        if not (target_dir / rel).exists():
+            return False
+    command = check.get("command")
+    if not command:
+        return False
+    expect_exit = int(check.get("expect_exit", 0))
+    try:
+        proc = subprocess.run(
+            shlex.split(command), cwd=str(target_dir), capture_output=True, timeout=600
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == expect_exit
+
+
+def score_check(task: dict, target_dir: Path, agent_output: str = "") -> bool | None:
+    """Run the task's ``[check]`` and return pass/fail, or None when not applicable."""
+    check = task.get("check") or {}
+    check_type = check.get("type", "none")
+    if check_type == "none":
+        return None
+    if check_type == "regex":
+        pattern = check.get("pattern")
+        return bool(pattern) and re.search(pattern, agent_output) is not None
+    if check_type == "pytest":
+        return _run_pytest_check(check, target_dir)
+    return None  # unknown check type → not scored
+
+
+def rework_cycles(transcript_path: Path | None) -> int | None:
+    """Error-tool_result count from the transcript — the rework proxy."""
+    if transcript_path is None or not Path(transcript_path).is_file():
+        return None
+    return parse_transcript(Path(transcript_path)).tool_errors
+
+
+def score(
+    task: dict,
+    *,
+    target_dir: Path | None,
+    transcript_path: Path | None,
+    agent_output: str = "",
+) -> Score:
+    """Full per-run score: success (if a target is available) + rework + first_try."""
+    success = score_check(task, target_dir, agent_output) if target_dir is not None else None
+    rework = rework_cycles(transcript_path)
+    first_try = (success and rework == 0) if (success is not None and rework is not None) else None
+    return Score(success=success, first_try=first_try, rework_cycles=rework)

--- a/tools/benchmark/transcript.py
+++ b/tools/benchmark/transcript.py
@@ -27,6 +27,7 @@ class TranscriptAggregates:
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
     tool_calls: int = 0
+    tool_errors: int = 0  # tool_result blocks flagged is_error (rework proxy, #273)
     turns: int = 0  # assistant messages
     models: list[str] = field(default_factory=list)
     claude_version: str = ""
@@ -89,6 +90,16 @@ def message_timestamps(path: Path) -> list[str]:
     return out
 
 
+def _fold_user_errors(agg: TranscriptAggregates, msg: dict) -> None:
+    """Count error tool_result blocks (the agent hit a failure it had to recover from)."""
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_result" and block.get("is_error"):
+            agg.tool_errors += 1
+
+
 def parse(path: Path) -> TranscriptAggregates:
     """Fold a transcript into capture aggregates (tokens, tools, turns, span)."""
     agg = TranscriptAggregates()
@@ -104,7 +115,10 @@ def parse(path: Path) -> TranscriptAggregates:
             if isinstance(version, str):
                 agg.claude_version = version
         msg = obj.get("message")
-        if obj.get("type") == "assistant" and isinstance(msg, dict):
+        etype = obj.get("type")
+        if etype == "assistant" and isinstance(msg, dict):
             _fold_assistant(agg, msg, seen_models)
+        elif etype == "user" and isinstance(msg, dict):
+            _fold_user_errors(agg, msg)
     agg.models = seen_models
     return agg


### PR DESCRIPTION
Closes #273. The **benefit axis** for epic #269 Track B — without it the cost numbers are meaningless (cheap-but-wrong is not a win). Fills `success`/`first_try`/`rework_cycles` on the harness records via the `[check]` specs authored in #271. No LLM judge (CLAUDE.md / ADR-001).

## What

- **`scoring.py`** — `score(task, *, target_dir, transcript_path, agent_output) -> Score`:
  - **`success`** — deterministic per the task's `[check]`: `pytest` exits as expected **and** required files exist (`pytest` — `feat`/`fix`); the agent's final text matches a pattern (`regex` — `qa`); or `None` when no check applies (`none` — the `noop` probe).
  - **`rework_cycles`** — count of error `tool_result` blocks in the transcript: a deterministic, artifact-reproducible **proxy** for correction rounds.
  - **`first_try`** — succeeded with zero rework.
- **`transcript.py`** — `parse` now also counts error `tool_result`s (`tool_errors`) by folding user tool-result blocks.
- **harness** — `run_task` returns the agent's final text (for the regex check); `run` fills all three accuracy fields on every record; `record-from` fills `rework_cycles` from the transcript (no target → `success`/`first_try` stay null; use `run` for the full score).

## Acceptance (all green)
- Each run records a **deterministic task-success boolean** per its defined check.
- **First-try vs retried + rework-cycle count** captured.
- **Scoring is reproducible from the run artifact** — no manual judgement for the core signal.
- **Test asserts scoring on a known pass/fail fixture**: pytest passes/fails/missing-file, regex match/no-match, none→None, rework count, first_try logic. Verified the `fix` task end-to-end — the score flips **False→True** when `calc.py` is repaired.
- `just lint && just test` green (1200 passed, 3 skipped).

## Last on Track B
The record now carries all three axes (cost, latency, accuracy). **#275** renders the Pareto-aware `rich` "is it worth it?" verdict — bare vs scaffolded, each cost delta paired with the quality it bought — consuming `cost_usd` + `latency.summarize` + these accuracy fields.