### PR TITLE
feat(PI-275): cost-benefit Pareto report (report.py)

### DIFF
--- a/tests/contracts/test_benchmark_report.py
+++ b/tests/contracts/test_benchmark_report.py
@@ -1,0 +1,129 @@
+"""#275: cost–benefit Pareto report over harness records.
+
+Compute layer (aggregate / pareto / verdict / diminishing returns / overhead) is
+pure and tested from fixture records; rendering is smoke-tested. No agent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.benchmark import report
+from tools.benchmark.record import RunRecord, write_records
+
+
+def _rec(target: str, **over) -> RunRecord:
+    """Build a RunRecord with sane defaults; `over` uses dataclass field names."""
+    base = dict(
+        task="feat", target=target, run_index=0, model="claude-opus-4-8",
+        claude_version="v", session_id="", transcript_path="/t",
+        input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+        total_tokens=0, tool_calls=0, turns=1, wall_clock_s=None, first_ts=None, last_ts=None,
+        cost_usd=None, success=None, first_try=None, rework_cycles=None,
+    )
+    base.update(over)
+    return RunRecord(**base)
+
+
+def _sample() -> list[RunRecord]:
+    return [
+        # bare: cheap, often wrong (1 of 2 passes, never first-try)
+        _rec("bare", run_index=0, cost_usd=0.10, total_tokens=1000, wall_clock_s=10.0,
+             success=False, first_try=False, rework_cycles=2),
+        _rec("bare", run_index=1, cost_usd=0.10, total_tokens=1000, wall_clock_s=12.0,
+             success=True, first_try=False, rework_cycles=1),
+        # obsidian-only: pricier, more accurate (both pass first-try)
+        _rec("obsidian-only", run_index=0, cost_usd=0.15, total_tokens=1500, wall_clock_s=11.0,
+             success=True, first_try=True, rework_cycles=0),
+        _rec("obsidian-only", run_index=1, cost_usd=0.15, total_tokens=1500, wall_clock_s=13.0,
+             success=True, first_try=True, rework_cycles=0),
+        # obsidian-graphify: priciest, no better accuracy → dominated
+        _rec("obsidian-graphify", run_index=0, cost_usd=0.20, total_tokens=2000, wall_clock_s=14.0,
+             success=True, first_try=True, rework_cycles=0),
+        _rec("obsidian-graphify", run_index=1, cost_usd=0.20, total_tokens=2000, wall_clock_s=15.0,
+             success=True, first_try=True, rework_cycles=0),
+    ]
+
+
+class TestAggregate:
+    def test_per_target_means_and_rates(self):
+        summ = report.aggregate(_sample())
+        bare = summ["bare"]
+        assert bare.n == 2
+        assert bare.mean_cost_usd == 0.10
+        assert bare.mean_total_tokens == 1000
+        assert bare.pass_rate == 0.5  # one of two succeeded
+        assert bare.first_try_rate == 0.0
+        assert bare.mean_rework == 1.5
+
+    def test_zero_rate_not_collapsed_to_none(self):
+        """A real 0.0 first-try rate must stay 0.0, not become None."""
+        summ = report.aggregate(_sample())
+        assert summ["bare"].first_try_rate == 0.0
+
+    def test_noop_success_none_excluded_from_pass_rate(self):
+        recs = [_rec("bare", cost_usd=0.1, total_tokens=1, wall_clock_s=1.0)]  # success defaults None
+        assert report.aggregate(recs)["bare"].pass_rate is None
+
+
+class TestPareto:
+    def test_frontier_flags_dominated_preset(self):
+        summ = report.aggregate(_sample())
+        eff = report.pareto_efficient(summ)
+        # bare (cheapest) and obsidian-only (more accurate) are efficient;
+        # graphify costs more for the same accuracy → dominated.
+        assert "bare" in eff
+        assert "obsidian-only" in eff
+        assert "obsidian-graphify" not in eff
+
+
+class TestVerdict:
+    def test_pairs_cost_with_what_it_bought(self):
+        summ = report.aggregate(_sample())
+        eff = report.pareto_efficient(summ)
+        line = report.verdict(summ["bare"], summ["obsidian-only"], eff)
+        assert "obsidian-only" in line
+        assert "% tokens" in line and "first-try" in line
+        assert "efficient" in line
+
+    def test_dominated_flag(self):
+        summ = report.aggregate(_sample())
+        eff = report.pareto_efficient(summ)
+        line = report.verdict(summ["bare"], summ["obsidian-graphify"], eff)
+        assert "dominated" in line
+
+
+class TestDiminishingReturns:
+    def test_flags_knee(self):
+        lines = report.diminishing_returns(report.aggregate(_sample()))
+        # The graphify step buys no accuracy → flagged past the knee.
+        assert any("past the knee" in line for line in lines)
+
+
+class TestFixedOverhead:
+    def test_attributes_per_artifact_descending(self, tmp_path: Path):
+        (tmp_path / "CLAUDE.md").write_text("x" * 400)  # ~100 tokens
+        skills = tmp_path / ".claude" / "skills" / "demo"
+        skills.mkdir(parents=True)
+        (skills / "SKILL.md").write_text("y" * 40)  # ~10 tokens
+        rows = report.fixed_overhead(tmp_path)
+        assert rows[0][0] == "CLAUDE.md" and rows[0][1] == 100
+        assert any(name.endswith("demo/SKILL.md") for name, _ in rows)
+        # Sorted descending by token estimate.
+        assert [t for _, t in rows] == sorted((t for _, t in rows), reverse=True)
+
+
+class TestRenderAndCli:
+    def test_render_smoke(self, capsys):
+        report.render(_sample())
+        out = capsys.readouterr().out
+        assert "Cost" in out and "bare" in out and "Verdict" in out
+
+    def test_cli_from_records_file(self, tmp_path: Path, capsys):
+        recs = tmp_path / "r.jsonl"
+        write_records(_sample(), recs)
+        assert report.main(["--records", str(recs)]) == 0
+        assert "bare" in capsys.readouterr().out
+
+    def test_cli_missing_records(self, tmp_path: Path):
+        assert report.main(["--records", str(tmp_path / "nope.jsonl")]) == 1

--- a/tests/contracts/test_benchmark_report.py
+++ b/tests/contracts/test_benchmark_report.py
@@ -77,6 +77,27 @@ class TestPareto:
         assert "obsidian-graphify" not in eff
 
 
+class TestParetoTiesAndIncomparable:
+    def test_equal_cost_and_accuracy_both_efficient(self):
+        """Tied points dominate neither — both are on the frontier (Codex review)."""
+        recs = [
+            _rec("a", cost_usd=0.10, total_tokens=100, success=True),
+            _rec("b", cost_usd=0.10, total_tokens=100, success=True),
+        ]
+        eff = report.pareto_efficient(report.aggregate(recs))
+        assert eff == {"a", "b"}
+
+    def test_unpriced_target_is_incomparable_not_dominated(self):
+        """A target missing a Pareto axis must not be labelled 'dominated' (Codex review)."""
+        summ = report.aggregate([
+            _rec("bare", cost_usd=0.10, total_tokens=100, success=True, first_try=True),
+            _rec("mystery", cost_usd=None, total_tokens=100, success=True, first_try=True),
+        ])
+        eff = report.pareto_efficient(summ)
+        line = report.verdict(summ["bare"], summ["mystery"], eff)
+        assert "incomparable" in line and "dominated" not in line
+
+
 class TestVerdict:
     def test_pairs_cost_with_what_it_bought(self):
         summ = report.aggregate(_sample())
@@ -111,6 +132,16 @@ class TestFixedOverhead:
         assert any(name.endswith("demo/SKILL.md") for name, _ in rows)
         # Sorted descending by token estimate.
         assert [t for _, t in rows] == sorted((t for _, t in rows), reverse=True)
+
+    def test_includes_start_here_files(self, tmp_path: Path):
+        """.claude/project-init.md is typically the heaviest always-loaded file
+        and must be attributed (Codex review)."""
+        pi = tmp_path / ".claude" / "project-init.md"
+        pi.parent.mkdir(parents=True)
+        pi.write_text("z" * 800)  # ~200 tokens — the heaviest
+        (tmp_path / "CLAUDE.md").write_text("x" * 400)  # ~100
+        rows = report.fixed_overhead(tmp_path)
+        assert rows[0][0] == ".claude/project-init.md" and rows[0][1] == 200
 
 
 class TestRenderAndCli:

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -26,6 +26,7 @@ the `rich` report is #275.
 | `prices.py` | `cost_for` / `apply_cost` — $ from tokens × the static table (#272) |
 | `latency.py` | per-step latency + P50/P99 aggregation over repeats (#272) |
 | `scoring.py` | `score` — deterministic success + first_try + rework_cycles from the `[check]` specs (#273) |
+| `report.py` | the `rich` cost–benefit verdict: bare-vs-scaffolded deltas, Pareto flag, diminishing returns, overhead (#275) |
 | `model_prices.json` | vendored, litellm-shaped price table for the $ axis (#272) |
 | `results/` | raw per-run JSONL (gitignored) |
 
@@ -94,6 +95,31 @@ deterministic signal from the task's authored `[check]` spec:
 No LLM judge (ADR-001): test exit codes, file existence, a regex. `record-from`
 fills `rework_cycles` from the transcript but leaves `success`/`first_try` null
 (it has no target to check); use `run` for the full score.
+
+## The cost–benefit report (#275)
+
+The headline deliverable — turns the records into a **verdict**, not raw numbers:
+
+```sh
+uv run python -m tools.benchmark.report --records tools/benchmark/results/records.jsonl
+# attribute fixed overhead per always-loaded file from a scaffolded project:
+uv run python -m tools.benchmark.report --overhead-from /path/to/scaffolded-project
+```
+
+It renders (all from the records — no scaffold runtime):
+
+- **bare vs scaffolded, side by side** — cost, tokens, P50 latency, pass%,
+  first-try%, rework, tool calls, with a ✓ on the Pareto-efficient configs.
+- a **plain-language verdict per target** — *"costs +X% tokens, +Y% \$, buys
+  +Zpp first-try … — (efficient|dominated)"* — every cost delta paired with what
+  it bought.
+- a **Pareto flag** (minimize cost, maximize pass-rate; the cheapest config and
+  any strictly-more-accurate one are efficient; the rest are dominated).
+- a **diminishing-returns** walk (cheapest → dearest) flagging the knee where a
+  pricier preset buys no more accuracy.
+- optional **fixed-overhead per-artifact attribution** (`--overhead-from`):
+  approximate always-loaded context tokens per file (chars/4), so the heaviest
+  CLAUDE.md / skill files can be trimmed.
 
 ## Caveats (from the methodology)
 

--- a/tools/benchmark/report.py
+++ b/tools/benchmark/report.py
@@ -1,0 +1,282 @@
+"""Cost–benefit presentation layer (#275) — the headline Track B deliverable.
+
+Turns the harness records (cost #272, latency #272, accuracy #273) into a
+readable terminal verdict: bare vs scaffolded, **every cost delta paired with
+the quality it bought**, a per-target plain-language verdict + Pareto flag
+(efficient vs dominated), a diminishing-returns view across presets, and a
+per-artifact fixed-overhead attribution.
+
+Reads harness artifacts only (the JSONL records + an optional scaffolded dir for
+overhead) — no scaffold runtime, no LLM, no network (CLAUDE.md / ADR-001). The
+compute layer is pure + tested; ``rich`` is used only for rendering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.benchmark.latency import summarize as summarize_latency
+from tools.benchmark.record import RunRecord, read_records
+
+# Files that contribute to a scaffolded project's always-loaded agent context.
+# Token cost is approximated (chars / 4) — labelled approximate; exact counts
+# need a tokenizer we won't add (no network, no tiktoken). This is the
+# "which files cost the most context" attribution, not a billing figure.
+_OVERHEAD_CANDIDATES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
+_CHARS_PER_TOKEN = 4
+
+
+@dataclass
+class Summary:
+    """Per-target aggregate over its runs (means; None when no data)."""
+
+    target: str
+    n: int
+    mean_cost_usd: float | None
+    mean_total_tokens: float | None
+    wall_clock_p50: float | None
+    wall_clock_p99: float | None
+    pass_rate: float | None  # mean success over *scored* runs (noop excluded)
+    first_try_rate: float | None
+    mean_rework: float | None
+    mean_tool_calls: float | None
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _rate(flags: list[bool]) -> float | None:
+    return sum(1 for f in flags if f) / len(flags) if flags else None
+
+
+def aggregate(records: list[RunRecord]) -> dict[str, Summary]:
+    """Fold records into one :class:`Summary` per target."""
+    by_target: dict[str, list[RunRecord]] = {}
+    for rec in records:
+        by_target.setdefault(rec.target, []).append(rec)
+
+    out: dict[str, Summary] = {}
+    for target, recs in by_target.items():
+        wall = [r.wall_clock_s for r in recs if r.wall_clock_s is not None]
+        lat = summarize_latency(wall)
+        scored = [r.success for r in recs if r.success is not None]
+        first_tries = [r.first_try for r in recs if r.first_try is not None]
+        out[target] = Summary(
+            target=target,
+            n=len(recs),
+            mean_cost_usd=_mean([r.cost_usd for r in recs if r.cost_usd is not None]),
+            mean_total_tokens=_mean([float(r.total_tokens) for r in recs]),
+            wall_clock_p50=lat["p50"],
+            wall_clock_p99=lat["p99"],
+            pass_rate=_rate(scored),  # _rate returns None on empty
+            first_try_rate=_rate(first_tries),
+            mean_rework=_mean([float(r.rework_cycles) for r in recs if r.rework_cycles is not None]),
+            mean_tool_calls=_mean([float(r.tool_calls) for r in recs]),
+        )
+    return out
+
+
+def pareto_efficient(summaries: dict[str, Summary]) -> set[str]:
+    """Targets on the cost–accuracy frontier (minimize cost, maximize pass_rate).
+
+    Classic skyline: sort ascending by cost, sweep once keeping the running-max
+    accuracy; a target is efficient if its accuracy strictly exceeds every
+    cheaper target (the cheapest is always efficient). Targets missing either
+    axis can't be placed and are omitted from the frontier.
+    """
+    placeable = [
+        s for s in summaries.values() if s.mean_cost_usd is not None and s.pass_rate is not None
+    ]
+    placeable.sort(key=lambda s: (s.mean_cost_usd, -s.pass_rate))
+    efficient: set[str] = set()
+    best_acc = float("-inf")
+    for s in placeable:
+        if s.pass_rate > best_acc:
+            efficient.add(s.target)
+            best_acc = s.pass_rate
+    return efficient
+
+
+def _pct_delta(base: float | None, other: float | None) -> float | None:
+    if base in (None, 0) or other is None:
+        return None
+    return (other - base) / base * 100
+
+
+def _pp_delta(base: float | None, other: float | None) -> float | None:
+    """Percentage-point delta between two rates."""
+    if base is None or other is None:
+        return None
+    return (other - base) * 100
+
+
+def verdict(bare: Summary, other: Summary, efficient: set[str]) -> str:
+    """One plain-language line: what the scaffold costs and what it buys."""
+    parts: list[str] = []
+    tok = _pct_delta(bare.mean_total_tokens, other.mean_total_tokens)
+    if tok is not None:
+        parts.append(f"costs {tok:+.0f}% tokens")
+    cost = _pct_delta(bare.mean_cost_usd, other.mean_cost_usd)
+    if cost is not None:
+        parts.append(f"{cost:+.0f}% $")
+    ft = _pp_delta(bare.first_try_rate, other.first_try_rate)
+    if ft is not None:
+        parts.append(f"buys {ft:+.0f}pp first-try")
+    pr = _pp_delta(bare.pass_rate, other.pass_rate)
+    if pr is not None:
+        parts.append(f"{pr:+.0f}pp pass")
+    rw = (
+        (other.mean_rework - bare.mean_rework)
+        if other.mean_rework is not None and bare.mean_rework is not None
+        else None
+    )
+    if rw is not None:
+        parts.append(f"{rw:+.1f} rework")
+    flag = "efficient" if other.target in efficient else "dominated"
+    body = ", ".join(parts) if parts else "no comparable metrics"
+    # Parens, not brackets — rich would parse "[efficient]" as a markup tag.
+    return f"{other.target}: {body} — ({flag})"
+
+
+def diminishing_returns(summaries: dict[str, Summary]) -> list[str]:
+    """Accuracy gained per extra dollar, walking presets cheapest→dearest."""
+    placeable = sorted(
+        (s for s in summaries.values() if s.mean_cost_usd is not None and s.pass_rate is not None),
+        key=lambda s: s.mean_cost_usd,
+    )
+    lines: list[str] = []
+    for prev, cur in zip(placeable, placeable[1:], strict=False):
+        dcost = cur.mean_cost_usd - prev.mean_cost_usd
+        dacc = (cur.pass_rate - prev.pass_rate) * 100
+        per = f"{dacc / dcost:+.1f}pp/$" if dcost > 0 else "n/a"
+        knee = " (past the knee — no accuracy gain)" if dacc <= 0 and dcost > 0 else ""
+        lines.append(f"{prev.target} → {cur.target}: {dacc:+.0f}pp for ${dcost:+.4f} ({per}){knee}")
+    return lines
+
+
+def fixed_overhead(target_dir: Path) -> list[tuple[str, int]]:
+    """Approx always-loaded context tokens per artifact (chars/4), descending.
+
+    Inspects a scaffolded project directory (an artifact, not the runtime):
+    top-level instruction files + every skill's SKILL.md. Approximate by design.
+    """
+    rows: list[tuple[str, int]] = []
+    for name in _OVERHEAD_CANDIDATES:
+        path = target_dir / name
+        if path.is_file():
+            rows.append((name, len(path.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN))
+    for skill in sorted((target_dir / ".claude" / "skills").glob("*/SKILL.md")):
+        rel = skill.relative_to(target_dir)
+        rows.append((str(rel), len(skill.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN))
+    rows.sort(key=lambda r: -r[1])
+    return rows
+
+
+# --- rendering (rich) -----------------------------------------------------
+
+
+def _fmt(value: float | None, spec: str = ".2f") -> str:
+    return format(value, spec) if value is not None else "-"
+
+
+def _render_comparison(console, order: list[Summary], efficient: set[str]) -> None:
+    from rich.table import Table
+
+    table = Table(title="Cost–benefit: bare vs scaffolded")
+    for col in ("Target", "n", "$", "Tokens", "P50 s", "Pass%", "First-try%", "Rework", "Tools", ""):
+        table.add_column(col)
+    for s in order:
+        table.add_row(
+            s.target,
+            str(s.n),
+            _fmt(s.mean_cost_usd, ".4f"),
+            _fmt(s.mean_total_tokens, ",.0f"),
+            _fmt(s.wall_clock_p50, ".1f"),
+            _fmt(None if s.pass_rate is None else s.pass_rate * 100, ".0f"),
+            _fmt(None if s.first_try_rate is None else s.first_try_rate * 100, ".0f"),
+            _fmt(s.mean_rework, ".1f"),
+            _fmt(s.mean_tool_calls, ".0f"),
+            "✓ efficient" if s.target in efficient else "",
+        )
+    console.print(table)
+
+
+def _render_overhead(console, overhead_from: Path) -> None:
+    from rich.table import Table
+
+    rows = fixed_overhead(overhead_from)
+    if not rows:
+        return
+    ot = Table(title="Fixed overhead per artifact (approx tokens, chars/4)")
+    ot.add_column("Artifact")
+    ot.add_column("~tokens", justify="right")
+    for name, toks in rows:
+        ot.add_row(name, f"{toks:,}")
+    console.print()
+    console.print(ot)
+
+
+def render(records: list[RunRecord], *, overhead_from: Path | None = None) -> None:
+    """Render the full cost–benefit report to the terminal via rich."""
+    from rich.console import Console
+
+    console = Console()
+    summaries = aggregate(records)
+    if not summaries:
+        console.print("[yellow]No records to report.[/yellow]")
+        return
+    efficient = pareto_efficient(summaries)
+    # Bare first (the baseline), then the rest by cost.
+    order = sorted(
+        summaries.values(),
+        key=lambda s: (s.target != "bare", s.mean_cost_usd if s.mean_cost_usd is not None else 0.0),
+    )
+    _render_comparison(console, order, efficient)
+
+    bare = summaries.get("bare")
+    if bare is not None:
+        console.print("\n[bold]Verdict[/bold] (vs bare):")
+        for s in order:
+            if s.target != "bare":
+                console.print(f"  {verdict(bare, s, efficient)}")
+
+    dr = diminishing_returns(summaries)
+    if dr:
+        console.print("\n[bold]Diminishing returns[/bold] (cheapest → dearest):")
+        for line in dr:
+            console.print(f"  {line}")
+
+    if overhead_from is not None:
+        _render_overhead(console, overhead_from)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: render the cost–benefit report from a records JSONL."""
+    parser = argparse.ArgumentParser(
+        prog="benchmark-report",
+        description="Cost–benefit Pareto report over harness records (#275).",
+    )
+    parser.add_argument(
+        "--records",
+        default=str(Path(__file__).resolve().parent / "results" / "records.jsonl"),
+        help="records JSONL from the harness (default: results/records.jsonl)",
+    )
+    parser.add_argument(
+        "--overhead-from",
+        help="a scaffolded project dir to attribute fixed overhead per artifact",
+    )
+    args = parser.parse_args(argv)
+    records = read_records(Path(args.records))
+    if not records:
+        sys.stderr.write(f"benchmark-report: no records at {args.records}\n")
+        return 1
+    render(records, overhead_from=Path(args.overhead_from) if args.overhead_from else None)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/benchmark/report.py
+++ b/tools/benchmark/report.py
@@ -25,7 +25,16 @@ from tools.benchmark.record import RunRecord, read_records
 # Token cost is approximated (chars / 4) — labelled approximate; exact counts
 # need a tokenizer we won't add (no network, no tiktoken). This is the
 # "which files cost the most context" attribution, not a billing figure.
-_OVERHEAD_CANDIDATES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
+# Includes the start-here files AGENTS.md points agents at — .claude/project-init.md
+# is typically the *largest* always-loaded artifact, so omitting it undercounts
+# the fixed context (Codex review).
+_OVERHEAD_CANDIDATES = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "GEMINI.md",
+    ".claude/project-init.md",
+    ".claude/memory/MEMORY.md",
+)
 _CHARS_PER_TOKEN = 4
 
 
@@ -83,21 +92,25 @@ def aggregate(records: list[RunRecord]) -> dict[str, Summary]:
 def pareto_efficient(summaries: dict[str, Summary]) -> set[str]:
     """Targets on the cost–accuracy frontier (minimize cost, maximize pass_rate).
 
-    Classic skyline: sort ascending by cost, sweep once keeping the running-max
-    accuracy; a target is efficient if its accuracy strictly exceeds every
-    cheaper target (the cheapest is always efficient). Targets missing either
-    axis can't be placed and are omitted from the frontier.
+    A target is efficient iff no other target *dominates* it — i.e. none is both
+    no costlier and no less accurate with at least one strictly better. Equal-
+    cost/equal-accuracy ties dominate neither, so all tied points are efficient
+    (Codex review). Targets missing either axis can't be placed and are omitted.
     """
     placeable = [
         s for s in summaries.values() if s.mean_cost_usd is not None and s.pass_rate is not None
     ]
-    placeable.sort(key=lambda s: (s.mean_cost_usd, -s.pass_rate))
     efficient: set[str] = set()
-    best_acc = float("-inf")
-    for s in placeable:
-        if s.pass_rate > best_acc:
-            efficient.add(s.target)
-            best_acc = s.pass_rate
+    for a in placeable:
+        dominated = any(
+            b is not a
+            and b.mean_cost_usd <= a.mean_cost_usd
+            and b.pass_rate >= a.pass_rate
+            and (b.mean_cost_usd < a.mean_cost_usd or b.pass_rate > a.pass_rate)
+            for b in placeable
+        )
+        if not dominated:
+            efficient.add(a.target)
     return efficient
 
 
@@ -112,6 +125,15 @@ def _pp_delta(base: float | None, other: float | None) -> float | None:
     if base is None or other is None:
         return None
     return (other - base) * 100
+
+
+def _frontier_flag(other: Summary, efficient: set[str]) -> str:
+    """Frontier label: efficient / dominated / incomparable (missing a Pareto axis)."""
+    if other.target in efficient:
+        return "efficient"
+    if other.mean_cost_usd is None or other.pass_rate is None:
+        return "incomparable"  # can't be placed on the frontier — not "dominated"
+    return "dominated"
 
 
 def verdict(bare: Summary, other: Summary, efficient: set[str]) -> str:
@@ -136,10 +158,9 @@ def verdict(bare: Summary, other: Summary, efficient: set[str]) -> str:
     )
     if rw is not None:
         parts.append(f"{rw:+.1f} rework")
-    flag = "efficient" if other.target in efficient else "dominated"
     body = ", ".join(parts) if parts else "no comparable metrics"
     # Parens, not brackets — rich would parse "[efficient]" as a markup tag.
-    return f"{other.target}: {body} — ({flag})"
+    return f"{other.target}: {body} — ({_frontier_flag(other, efficient)})"
 
 
 def diminishing_returns(summaries: dict[str, Summary]) -> list[str]:
@@ -230,10 +251,13 @@ def render(records: list[RunRecord], *, overhead_from: Path | None = None) -> No
         console.print("[yellow]No records to report.[/yellow]")
         return
     efficient = pareto_efficient(summaries)
-    # Bare first (the baseline), then the rest by cost.
+    # Bare first (the baseline), then by cost ascending; unknown-cost configs last.
     order = sorted(
         summaries.values(),
-        key=lambda s: (s.target != "bare", s.mean_cost_usd if s.mean_cost_usd is not None else 0.0),
+        key=lambda s: (
+            s.target != "bare",
+            s.mean_cost_usd if s.mean_cost_usd is not None else float("inf"),
+        ),
     )
     _render_comparison(console, order, efficient)
 


### PR DESCRIPTION
Closes #275. The **headline Track B deliverable** (epic #269) — turns the harness records (cost #272, latency #272, accuracy #273) into a readable cost–benefit **verdict**, not raw numbers. Reads harness artifacts only; no scaffold runtime, no LLM, no network.

## What

`report.py` — a pure compute layer + a `rich` renderer (`rich` is a core dep):

- **Bare vs scaffolded, side by side** — cost, tokens, P50 latency, pass%, first-try%, rework, tool calls, with the Pareto-efficient configs flagged ✓.
- **Plain-language verdict per target** — *"costs +X% tokens, +Y% $, buys +Zpp first-try, −W rework — (efficient|dominated)"*: **every cost delta paired with what it bought**, never shown in isolation.
- **Pareto flag** — minimize cost, maximize pass-rate (classic skyline: the cheapest config and any strictly-more-accurate one are efficient; the rest **dominated**).
- **Diminishing-returns** walk (cheapest → dearest) flagging **the knee** where a pricier preset buys no more accuracy.
- **Fixed-overhead per-artifact attribution** (`--overhead-from <dir>`) — approximate always-loaded context tokens per file (chars/4, labelled approximate), so the heaviest CLAUDE.md / skill files can be trimmed.
- CLI: `python -m tools.benchmark.report --records … [--overhead-from …]`.

## Acceptance (all green)
- Bare-vs-scaffolded deltas across all captured dimensions. ✓
- Every cost delta paired with the quality/efficiency delta it bought. ✓
- Per-target verdict line + Pareto flag (efficient/dominated). ✓
- Fixed-overhead per-artifact attribution. ✓
- Runs from harness artifacts with no scaffold-runtime involvement. ✓
- `rich` terminal report runnable + documented; **test renders from a fixture record set** (+ aggregate/Pareto/verdict/diminishing-returns/overhead unit tests, and a CLI smoke test).
- `just lint && just test` green (1219 passed, 3 skipped).

## This completes Track B
#271 harness → #272 cost+latency → #273 accuracy → **#275 report**. With this merged, epic **#269 can close** (both tracks done); the only remaining open issue is the governance epic **#276**, whose Buckets 2/3 are intentionally boundary-only ADRs.