### PR TITLE
fix(PI-440): render full observability HTML report + robust token parsing

### DIFF
--- a/templates/observability/dot_claude/observability/usage_report.py
+++ b/templates/observability/dot_claude/observability/usage_report.py
@@ -150,6 +150,16 @@ def _count_lines(text: object) -> int:
     return text.count("\n") + 1
 
 
+def _safe_int(value: object) -> int:
+    """Best-effort int cast — a malformed (non-numeric) token field yields 0.
+
+    Keeps a single bad transcript line from aborting the whole report."""
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def parse_transcript(path: Path) -> dict:
     """Single pass over the transcript → raw aggregates (names/counts/numbers).
 
@@ -179,10 +189,10 @@ def parse_transcript(path: Path) -> dict:
                     model,
                     {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0, "messages": 0},
                 )
-                acc["input"] += int(usage.get("input_tokens") or 0)
-                acc["output"] += int(usage.get("output_tokens") or 0)
-                acc["cache_creation"] += int(usage.get("cache_creation_input_tokens") or 0)
-                acc["cache_read"] += int(usage.get("cache_read_input_tokens") or 0)
+                acc["input"] += _safe_int(usage.get("input_tokens"))
+                acc["output"] += _safe_int(usage.get("output_tokens"))
+                acc["cache_creation"] += _safe_int(usage.get("cache_creation_input_tokens"))
+                acc["cache_read"] += _safe_int(usage.get("cache_read_input_tokens"))
                 acc["messages"] += 1
             for block in msg.get("content") or []:
                 if not isinstance(block, dict) or block.get("type") != "tool_use":
@@ -464,8 +474,7 @@ def render_html(report: dict, transcript: Path) -> str:
 <p class="muted">{c['total_tokens']:,} tokens · {c['cache_read_ratio']:.0%} cache-read</p></div>
 <div class="card"><h2>Productivity</h2>
 <p class="kpi">{p['loc_added_approx']:,} LoC</p>
-<p class="muted">{p['edits']} edits · {p['writes']} writes · """
-    f"""{p['commits'] if p['commits'] is not None else 'n/a'} commits</p></div>
+<p class="muted">{p['edits']} edits · {p['writes']} writes · {p['commits'] if p['commits'] is not None else 'n/a'} commits</p></div>
 <div class="card"><h2>Reliability</h2>
 <p class="kpi">{r['error_rate']:.0%} errors</p>
 <p class="muted">{r['tool_calls']} calls · {r['errors']} errors</p></div>

--- a/tests/contracts/test_observability_report.py
+++ b/tests/contracts/test_observability_report.py
@@ -147,6 +147,32 @@ class TestBuckets:
         )
         assert found == tx
 
+    def test_non_numeric_token_field_does_not_crash(self, tmp_path: Path):
+        """#436: a malformed (non-numeric) token field is coerced to 0 instead
+        of aborting the whole report; sibling good values still count."""
+        mod = _load_report(_scaffold(tmp_path / "p"))
+        tx = tmp_path / "bad.jsonl"
+        entry = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-8",
+                "usage": {
+                    "input_tokens": "not-a-number",
+                    "output_tokens": None,
+                    "cache_creation_input_tokens": 2000,
+                    "cache_read_input_tokens": 8000,
+                },
+                "content": [],
+            },
+        }
+        tx.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+        report = mod.analyze(
+            mod.parse_transcript(tx), {}, {"commits": None, "merge_commits": None}
+        )
+        model = report["cost"]["models"][0]
+        assert model["input"] == 0  # bad value coerced, not raised
+        assert model["cache_read"] == 8000  # good siblings still counted
+
     def test_missing_transcript_errors_clearly(self, tmp_path: Path):
         import pytest
 
@@ -172,6 +198,32 @@ class TestHtmlReport:
         assert _LEAK_PROMPT not in html
         assert _LEAK_COMMAND not in html
         assert _LEAK_FILE not in html
+
+    def test_full_dashboard_renders_not_truncated(self, tmp_path: Path):
+        """#427: the whole document renders. Previously render_html closed its
+        f-string mid-``<p>`` and returned early, so every section below the
+        Productivity card (and the closing tags) was unreachable dead code."""
+        target = _scaffold(tmp_path / "p")
+        mod = _load_report(target)
+        tx = tmp_path / "t.jsonl"
+        _write_transcript(tx)
+        report = mod.analyze(
+            mod.parse_transcript(tx), {}, {"commits": 7, "merge_commits": 0}
+        )
+        html = mod.render_html(report, tx)
+        # Document is complete, not cut off mid-tag.
+        assert html.rstrip().endswith("</html>")
+        # Every section at/after the historical truncation boundary is present.
+        for section in (
+            "<h2>Reliability</h2>",
+            "<h2>Adoption — Skills</h2>",
+            "<h2>Adoption — Hooks (self-log)</h2>",
+            "<h2>Cost by model</h2>",
+            "<h2>Reliability — errors by tool</h2>",
+        ):
+            assert section in html, f"missing section: {section}"
+        # The commits span sat exactly on the broken f-string boundary.
+        assert "7 commits" in html
 
 
 class TestInvariants:


### PR DESCRIPTION
Fixes epic #440 (observability overlay defects), both sub-issues.

## #427 — truncated HTML report (HIGH)
`render_html()` closed its first triple-quoted f-string mid-`<p>` (right after the Productivity card's `… writes ·`) and started a **second** f-string on the next line. `return` only returned the first, so the commits span, the **Reliability** card, every **Adoption** bar-chart, the **Cost by model** table, and the closing `</body></html>` were unreachable dead code — the HTML ended mid-tag.

**Fix:** merge the two adjacent f-strings into one so `return` covers the whole document.

## #436 — crash on non-integer token field (LOW)
`parse_transcript()` used `int(usage.get(...) or 0)`, which raises `ValueError`/`TypeError` on a non-numeric token value and aborts the entire report despite the parser's documented robustness to malformed lines.

**Fix:** add a `_safe_int()` helper (`try/except → 0`) and use it for all four token casts.

## Tests
- `test_full_dashboard_renders_not_truncated` — asserts the output ends with `</html>` and contains every `<h2>` section below the old truncation point (the existing HTML test only checked for leaks/external refs, which is why this shipped).
- `test_non_numeric_token_field_does_not_crash` — a non-numeric `input_tokens` coerces to 0 while good siblings still count.

All observability tests pass (`11` report + `34` overlay/integration/self-log); ruff clean.

Closes #427
Closes #436
Closes #440

https://claude.ai/code/session_016fFwuenhrb7YtApYKxouU5