### PR TITLE
fix(PI-441): harden CI-gate + start_issue key/draft-PR in lifecycle scripts

### DIFF
--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -63,7 +63,11 @@ import json, sys
 data = json.load(sys.stdin)
 # Exclude review/decision; it is a derived commit status that only appears
 # after a review event. We detect review state directly via reviewDecision.
-print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('state') in ('PENDING', 'IN_PROGRESS', 'EXPECTED')))
+# Gate on gh's authoritative 'bucket' rollup (pass/fail/pending/skipping/
+# cancel), not a hand-rolled state allowlist: just-queued Actions report
+# state=QUEUED (and WAITING/REQUESTED for env-gated jobs), all bucket=pending.
+# An allowlist that omitted those let the CI-wait break before CI ran (#428).
+print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('bucket') == 'pending'))
 "
 }
 
@@ -161,7 +165,7 @@ while true; do
     echo "PR #$PR_NUMBER: CI did not settle within ${CI_TIMEOUT}s. Still pending:"
     echo "$CHECKS" | python3 -c "import json,sys
 for c in json.load(sys.stdin):
-    if c.get('name') != 'review/decision' and c.get('state') in ('PENDING','IN_PROGRESS','EXPECTED'):
+    if c.get('name') != 'review/decision' and c.get('bucket') == 'pending':
         print('  -', c.get('name'))" 2>/dev/null || true
     echo "Re-run once the check registers, or investigate why it never started."
     exit 1

--- a/templates/base/dot_claude/scripts/monitor_pr.sh
+++ b/templates/base/dot_claude/scripts/monitor_pr.sh
@@ -73,7 +73,11 @@ import json, sys
 data = json.load(sys.stdin)
 # Exclude review/decision; it is a derived commit status that only appears
 # after a review event. We detect review state directly via reviewDecision.
-print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('state') in ('PENDING', 'IN_PROGRESS', 'EXPECTED')))
+# Gate on gh's authoritative 'bucket' rollup (pass/fail/pending/skipping/
+# cancel), not a hand-rolled state allowlist: just-queued Actions report
+# state=QUEUED (and WAITING/REQUESTED for env-gated jobs), all bucket=pending.
+# An allowlist that omitted those let the CI-wait break before CI ran (#428).
+print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('bucket') == 'pending'))
 "
 }
 
@@ -181,7 +185,7 @@ while true; do
     echo "PR #$PR_NUMBER: CI did not settle within ${CI_TIMEOUT}s. Still pending:"
     echo "$CHECKS" | "$PY" -c "import json,sys
 for c in json.load(sys.stdin):
-    if c.get('name') != 'review/decision' and c.get('state') in ('PENDING','IN_PROGRESS','EXPECTED'):
+    if c.get('name') != 'review/decision' and c.get('bucket') == 'pending':
         print('  -', c.get('name'))" 2>/dev/null || true
     echo "Re-run once the check registers, or investigate why it never started."
     exit 1

--- a/templates/base/dot_claude/scripts/start_issue.sh
+++ b/templates/base/dot_claude/scripts/start_issue.sh
@@ -80,7 +80,17 @@ derive_project_key() {
 
 PROJECT_KEY=$(derive_project_key)
 PROJECT_KEY=$(echo "$PROJECT_KEY" | tr '[:lower:]' '[:upper:]' | tr -cd 'A-Z0-9')
-if [ -z "$PROJECT_KEY" ]; then
+# A single-word repo name yields a 1-char initials key (e.g. "widget" -> "W").
+# That passes the branch-name regex but the commit-msg hook then rejects every
+# commit — its scope regex requires >=2 chars: [A-Z][A-Z0-9]{1,9}- (#432).
+# Widen a too-short key to the repo name's leading alphanumerics first.
+if [ "${#PROJECT_KEY}" -lt 2 ]; then
+  PROJECT_KEY=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" \
+    | tr '[:lower:]' '[:upper:]' | tr -cd 'A-Z0-9' | cut -c1-4)
+fi
+# Final guard: the key must satisfy the shared key regex (>=2 chars, leading
+# letter). Empty, still-too-short, or digit-leading -> stable PROJ fallback.
+if ! echo "$PROJECT_KEY" | grep -qE '^[A-Z][A-Z0-9]{1,9}$'; then
   PROJECT_KEY="PROJ"
 fi
 
@@ -128,6 +138,17 @@ else
   git checkout -b "$BRANCH"
 fi
 
+# --- Seed an empty commit so the draft PR has a diff base ---
+# GitHub refuses a PR with no commits between base and head ("No commits between
+# main and <branch>"), so a freshly-created branch cannot open the draft PR this
+# script promises until it has >=1 commit. Seed one when the branch is level
+# with the base; real work simply adds commits on top (#433).
+BASE_BRANCH=$(base_branch)
+if [ -z "$(git rev-list "${BASE_BRANCH}..HEAD" 2>/dev/null || true)" ]; then
+  git commit --allow-empty -q \
+    -m "chore(${ISSUE_REF}): start #${ISSUE_NUMBER} — ${CLEAN_TITLE}"
+fi
+
 # --- Push and set upstream (retry + remote-SHA verification) ---
 .claude/scripts/push_branch.sh "$BRANCH"
 
@@ -136,7 +157,6 @@ fi
 PR_TITLE="${TYPE}(${ISSUE_REF}): ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
-BASE_BRANCH=$(base_branch)
 PR_URL=$(gh pr create \
   --draft \
   --base "$BASE_BRANCH" \

--- a/templates/base/dot_claude/scripts/start_issue.sh
+++ b/templates/base/dot_claude/scripts/start_issue.sh
@@ -143,10 +143,16 @@ fi
 # main and <branch>"), so a freshly-created branch cannot open the draft PR this
 # script promises until it has >=1 commit. Seed one when the branch is level
 # with the base; real work simply adds commits on top (#433).
+#
+# Build the seed from HEAD's own tree with commit-tree so it is empty by
+# construction and cannot capture the user's staged index — a plain
+# `git commit --allow-empty` still commits whatever is currently staged, which
+# would silently fold unrelated work into the generated seed commit (#446).
 BASE_BRANCH=$(base_branch)
 if [ -z "$(git rev-list "${BASE_BRANCH}..HEAD" 2>/dev/null || true)" ]; then
-  git commit --allow-empty -q \
-    -m "chore(${ISSUE_REF}): start #${ISSUE_NUMBER} — ${CLEAN_TITLE}"
+  SEED_COMMIT=$(git commit-tree "HEAD^{tree}" -p HEAD \
+    -m "chore(${ISSUE_REF}): start #${ISSUE_NUMBER} — ${CLEAN_TITLE}")
+  git reset --soft "$SEED_COMMIT"
 fi
 
 # --- Push and set upstream (retry + remote-SHA verification) ---

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -188,6 +188,28 @@ class TestScaffoldObsidianOnly:
         assert guard_idx != -1, "empty-slug fallback missing"
         assert guard_idx < branch_idx, "empty-slug fallback must precede the branch name"
 
+    def test_start_issue_sh_widens_short_project_key(self):
+        """#432: a single-word repo name yields a 1-char initials key that the
+        branch regex accepts but the commit-msg hook (>=2 chars) then rejects on
+        every commit. The script must widen/guard the key to a valid shape
+        before it becomes part of ISSUE_REF."""
+        content = (self.target / ".claude" / "scripts" / "start_issue.sh").read_text()
+        assert '"${#PROJECT_KEY}" -lt 2' in content, "short-key widening missing"
+        guard_idx = content.find("^[A-Z][A-Z0-9]{1,9}$")
+        ref_idx = content.find('ISSUE_REF="${PROJECT_KEY}-${ISSUE_NUMBER}"')
+        assert guard_idx != -1, "shared key-shape guard missing"
+        assert guard_idx < ref_idx, "key guard must precede ISSUE_REF"
+
+    def test_start_issue_sh_seeds_empty_commit_before_pr(self):
+        """#433: a freshly-created branch has no commits, so `gh pr create`
+        fails with 'No commits between main and <branch>'. The script must seed
+        a commit before opening the draft PR it promises."""
+        content = (self.target / ".claude" / "scripts" / "start_issue.sh").read_text()
+        seed_idx = content.find("git commit --allow-empty")
+        pr_idx = content.find("gh pr create")
+        assert seed_idx != -1, "empty-commit seed missing"
+        assert seed_idx < pr_idx, "seed must precede gh pr create"
+
     def test_project_init_md_has_script_commands(self):
         content = (self.target / ".claude" / "project-init.md").read_text()
         assert "create_issue.sh" in content

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -203,12 +203,24 @@ class TestScaffoldObsidianOnly:
     def test_start_issue_sh_seeds_empty_commit_before_pr(self):
         """#433: a freshly-created branch has no commits, so `gh pr create`
         fails with 'No commits between main and <branch>'. The script must seed
-        a commit before opening the draft PR it promises."""
+        a commit before opening the draft PR it promises.
+
+        #446: the seed must be index-isolated (built via commit-tree from HEAD's
+        own tree), never a plain `git commit --allow-empty`, which would also
+        commit whatever the user happens to have staged."""
         content = (self.target / ".claude" / "scripts" / "start_issue.sh").read_text()
-        seed_idx = content.find("git commit --allow-empty")
+        seed_idx = content.find("git commit-tree")
         pr_idx = content.find("gh pr create")
-        assert seed_idx != -1, "empty-commit seed missing"
+        assert seed_idx != -1, "index-isolated commit-tree seed missing"
         assert seed_idx < pr_idx, "seed must precede gh pr create"
+        # A plain --allow-empty would capture staged work — it must not be
+        # invoked (a comment may still reference it to explain the choice).
+        command_lines = [
+            ln for ln in content.splitlines() if not ln.lstrip().startswith("#")
+        ]
+        assert not any("git commit --allow-empty" in ln for ln in command_lines), (
+            "seed must not use `git commit --allow-empty` (captures staged work)"
+        )
 
     def test_project_init_md_has_script_commands(self):
         content = (self.target / ".claude" / "project-init.md").read_text()

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -401,6 +401,46 @@ exit 2
         assert "--no-review" in result.stdout or "skipping review gate" in result.stdout
         assert "Merged PR #42" in result.stdout
 
+    def test_monitor_pr_does_not_merge_while_checks_queued(self, tmp_path: Path):
+        """#428: a just-queued GitHub Actions check reports state=QUEUED /
+        bucket=pending. The CI-wait must keep polling — not break and merge
+        before CI runs. With the only check perpetually QUEUED the fixed script
+        stays in the wait loop (so it times out here); the old state-allowlist
+        version counted QUEUED as settled, broke on the first poll, and merged
+        within ~1s (returning before the timeout)."""
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            """#!/usr/bin/env bash
+if [ "$1 $2" = "pr checks" ]; then
+  echo '[{"name":"ci","state":"QUEUED","bucket":"pending"}]'
+  exit 0
+fi
+if [ "$1 $2" = "pr merge" ]; then
+  echo "MERGED PR #42"
+  exit 0
+fi
+exit 2
+""",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+
+        script = self.target / ".claude" / "scripts" / "monitor_pr.sh"
+        env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+        with pytest.raises(subprocess.TimeoutExpired) as exc:
+            subprocess.run(
+                [str(script), "42", "--merge", "--no-review"],
+                capture_output=True,
+                text=True,
+                cwd=self.target,
+                env=env,
+                timeout=4,
+            )
+        # It must not have reached the merge while the check was still queued.
+        assert "MERGED" not in (exc.value.stdout or "")
+
     def test_workflow_state_reminder_reads_prompt_stdin(self):
         hook = self.target / ".claude" / "hooks" / "workflow_state_reminder.sh"
         payload = json.dumps({"prompt": "please finish this PR"})
@@ -444,6 +484,8 @@ class TestCommitMsgHookFormats:
             "fix(APP-99): Handle null pointer in auth",
             "chore: Bump dev dependency",
             "feat(PI-9)!: Drop python 3.10",
+            "chore(WIDG-1): start work",  # #432: widened single-word repo key
+            "chore(PROJ-1): start work",  # #432: PROJ fallback key
             "[PI-42][feat] Add OAuth login",  # legacy, accepted in transition
             "[nojira][fix] Fix typo",  # legacy, accepted in transition
             "Merge branch 'main' into feat/PI-1-x",
@@ -460,6 +502,7 @@ class TestCommitMsgHookFormats:
             "feat(pi-42): lowercase key",
             "feat(PI-42) Missing colon",
             "feat(PI-42):",  # no description
+            "feat(W-1): one-char key",  # #432: 1-char key the fix prevents
         ],
     )
     def test_rejects_invalid_formats(self, message):


### PR DESCRIPTION
Fixes epic #441 (GitHub lifecycle script bugs), all three sub-issues.

## #428 — CI gate can pass before CI runs (HIGH)
`monitor_pr.sh`'s `_count_pending` counted only `state in (PENDING, IN_PROGRESS, EXPECTED)`. A just-queued GitHub Actions job reports `state=QUEUED` (and `WAITING`/`REQUESTED` for environment-gated jobs), all in `bucket=pending`. So immediately after a push every check is `QUEUED` → `_count_pending==0` → the CI-wait loop breaks → `_print_failures` finds nothing (jobs haven't run) → the documented `monitor_pr.sh <n> --merge` flow **merges before CI executed**.

**Fix:** gate on gh's authoritative `bucket == 'pending'` rollup (the same source `_print_failures` already trusts), in both the pending-count and the timeout "still pending" printer. The `CHECK_COUNT == 0` guard was already present.

Applied to **both** `templates/base/dot_claude/scripts/monitor_pr.sh` (the issue) **and this repo's own `.claude/scripts/monitor_pr.sh`**, which carried the identical bug and gates our own merges (dogfooding).

## #432 — single-word repo → 1-char key rejected by commit-msg (MED)
`start_issue.sh` derived the project key from the repo name's word-initials, so a single-word repo (`widget`, `api`, `core`) yielded a **1-char** key. The branch `feat/W-1-…` passes the branch regex, but the matching commit `feat(W-1): …` is rejected by the commit-msg hook (scope regex requires ≥2 chars: `[A-Z][A-Z0-9]{1,9}-`).

**Fix:** widen a too-short key to the repo name's leading alphanumerics, then a final regex guard enforces the shared key shape (else fall back to `PROJ`).

## #433 — draft PR fails on a fresh branch (MED)
`start_issue.sh` pushed a commit-less branch then `gh pr create` failed with `No commits between main and feat/…`.

**Fix:** seed an empty commit (valid Conventional-Commits message) before the push/PR so the draft PR opens.

## Tests
- `test_monitor_pr_does_not_merge_while_checks_queued` — behavioral: a perpetually-`QUEUED` check (bucket=pending) keeps the CI-wait looping (times out) instead of merging; the old allowlist would have merged in ~1s.
- commit-msg cases: widened (`WIDG-1`) and `PROJ-1` keys accepted; 1-char `W-1` key rejected.
- content guards (matching the PI-206 precedent): `start_issue.sh` widens short keys before `ISSUE_REF` and seeds a commit before `gh pr create`.

Full suite: 1228 passed, 3 skipped; ruff clean.

Closes #428
Closes #432
Closes #433
Closes #441

https://claude.ai/code/session_016fFwuenhrb7YtApYKxouU5