### PR TITLE
fix(PI-443): Antigravity serverUrl MCP, upgrade LF newlines, advisory IaC gate

### DIFF
--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -58,6 +58,24 @@ def render_mcp_json(servers: dict[str, dict], *, key: str, drop_type: bool = Fal
     return json.dumps({key: servers}, indent=2, sort_keys=True) + "\n"
 
 
+def render_antigravity_mcp(servers: dict[str, dict]) -> str:
+    """MCP config for Antigravity's ``.agents/mcp_config.json``.
+
+    Antigravity (Windsurf/Codeium + Gemini lineage) keys HTTP/streamable servers
+    by ``serverUrl`` — no ``type``, not ``url`` — unlike Cursor/Claude which use
+    ``type``+``url`` (an HTTP entry written as ``{"type":"http","url":...}`` fails
+    to load). Stdio servers (``command``/``args``) are emitted unchanged (#431).
+    """
+    mapped: dict[str, dict] = {}
+    for name, spec in servers.items():
+        if "url" in spec:
+            rest = {k: v for k, v in spec.items() if k not in ("type", "url")}
+            mapped[name] = {"serverUrl": spec["url"], **rest}
+        else:
+            mapped[name] = dict(spec)
+    return json.dumps({"mcpServers": mapped}, indent=2, sort_keys=True) + "\n"
+
+
 def render_mcp_toml(servers: dict[str, dict]) -> str:
     """MCP config as Codex ``config.toml`` ``[mcp_servers.<name>]`` tables.
 
@@ -159,8 +177,9 @@ SURFACES: dict[str, dict] = {
         "hooks_render": render_antigravity_hooks,
         # Antigravity reads project-scoped MCP from .agents/mcp_config.json (PI-386);
         # skills come from the antigravity template layer's .agents/skills.
+        # HTTP servers need the serverUrl key (not type+url) — dedicated renderer (#431).
         "mcp_file": ".agents/mcp_config.json",
-        "mcp_render": ("json", "mcpServers"),
+        "mcp_render": ("antigravity", "mcpServers"),
     },
     "amp": {
         "label": "Amp",
@@ -203,6 +222,8 @@ def render_mcp_for(kind_key: tuple, servers: dict[str, dict]) -> str:
         return render_mcp_json(servers, key=key, drop_type=bool(rest and rest[0]))
     if fmt == "toml":
         return render_mcp_toml(servers)
+    if fmt == "antigravity":
+        return render_antigravity_mcp(servers)
     raise ValueError(f"unknown MCP format: {fmt}")
 
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -783,14 +783,14 @@ def apply_drift(
         # Clean 3-way merge: write the combined content in place.
         dest = target / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(report.merge_results[rel], encoding="utf-8")
+        dest.write_text(report.merge_results[rel], encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)
     for rel in report.conflicts:
         # Prefer the conflict-marked merge (shows the overlap) when one exists,
         # else the raw new render. Either way the user's file is left intact.
         if rel in report.merge_results:
             sibling = _new_sibling(target / rel, report.merge_results[rel].encode("utf-8"))
             sibling.parent.mkdir(parents=True, exist_ok=True)
-            sibling.write_text(report.merge_results[rel], encoding="utf-8")
+            sibling.write_text(report.merge_results[rel], encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)
             _mirror_mode(staging / rel, sibling)
         else:
             _copy_rendered(staging / rel, _new_sibling(target / rel, (staging / rel).read_bytes()))
@@ -802,7 +802,7 @@ def apply_drift(
         text = config_path.read_text(encoding="utf-8")
         text = _VERSION_LINE_RE.sub(rf"\g<1>{variables['project_init_version']}", text, count=1)
         text = _ensure_observability_fields(text, variables)
-        config_path.write_text(text, encoding="utf-8")
+        config_path.write_text(text, encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)
 
     # Only files whose on-disk content now equals the render are recorded —
     # conflicted/merged files stay user-owned, so the next upgrade flags them

--- a/templates/base/dot_github/workflows/infra.yml.tmpl
+++ b/templates/base/dot_github/workflows/infra.yml.tmpl
@@ -46,8 +46,13 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: plan
     runs-on: ubuntu-24.04
-    # The infra-apply GitHub Environment is the human gate (required reviewers /
-    # wait timer). An agent cannot apply to prod infra without clearing it.
+    # Apply runs under the infra-apply GitHub Environment — the recommended human
+    # gate. Arm it (required reviewers / wait timer) via repo Settings →
+    # Environments to actually gate this job. NOTE: GitHub auto-creates a
+    # referenced-but-missing environment with NO protection rules, so until it is
+    # configured this does not block apply; on individual/standalone accounts only
+    # an advisory wait timer is available, not required reviewers (ADR-007: git +
+    # CI are the enforcement that always binds).
     environment: infra-apply
     permissions:
       contents: read

--- a/templates/base/infra/README.md.tmpl
+++ b/templates/base/infra/README.md.tmpl
@@ -13,5 +13,9 @@ tofu apply     # apply (manual / environment-gated in CI — never on merge)
 - **Commit `.terraform.lock.hcl`** (provider checksums). Never commit `*.tfstate`,
   `*.tfvars`, or credentials.
 - CI (`.github/workflows/infra.yml`) runs `fmt`/`validate`/`plan` on PRs; apply is
-  manual and gated by the `infra-apply` environment.
+  manual (`workflow_dispatch`). To gate it, **arm** the `infra-apply` environment
+  (required reviewers / wait timer) in repo Settings → Environments — GitHub
+  auto-creates a referenced-but-missing environment **unprotected**, so until you
+  configure it the apply is not blocked. (On individual/standalone accounts only
+  an advisory wait timer is available, not required reviewers.)
 {{/if iac_enabled}}

--- a/tests/contracts/test_iac_overlay.py
+++ b/tests/contracts/test_iac_overlay.py
@@ -50,6 +50,21 @@ class TestIacOverlayPresent:
         assert "workflow_dispatch" in wf                  # manual, not on merge
         assert "id-token: write" in wf                    # OIDC
 
+    def test_infra_apply_gate_documented_as_advisory(self, tmp_path: Path):
+        """#439: the infra-apply environment is referenced but no scaffolded
+        tooling arms it, and GitHub creates a referenced-but-missing environment
+        unprotected. The docs must not claim it is an unconditional gate; they
+        must say it has to be armed and is unprotected by default."""
+        target = _iac(tmp_path / "p")
+        wf = (target / ".github" / "workflows" / "infra.yml").read_text()
+        readme = (target / "infra" / "README.md").read_text()
+        # The old absolute over-promise must be gone.
+        assert "An agent cannot apply to prod infra without clearing it" not in wf
+        # ...replaced by the honest "arm it / does not block by default" framing.
+        assert "arm it" in wf.lower()
+        assert "does not block apply" in wf.lower()
+        assert "unprotected" in readme.lower()
+
     def test_precommit_targets_tofu(self, tmp_path: Path):
         pc = (_iac(tmp_path / "p") / "infra" / ".pre-commit-config.yaml").read_text()
         assert "pre-commit-terraform" in pc

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -794,6 +794,42 @@ class TestThreeWayMergeApply:
         # Base advances to the new render so the next upgrade re-merges cleanly.
         assert read_base(target)["justfile"] == live
 
+    def test_apply_writes_lf_on_merged_sibling_and_config(self, tmp_path: Path, monkeypatch):
+        """#435: apply_drift must write merged files, .new siblings, and
+        config.yaml with newline="\\n" so native-Windows Python doesn't emit
+        CRLF (PI-362) — CRLF in a merged shell hook breaks `/usr/bin/env bash`.
+        CPython gates the '\\n'->'\\r\\n' write translation behind #ifdef
+        MS_WINDOWS, so a raw byte check can't reproduce it on Linux/CI; spy on
+        Path.write_text and assert the newline kwarg on each delivered write."""
+        target = tmp_path / "p"
+        _scaffold(target)
+
+        # Clean 3-way merge on justfile -> report.merged -> in-place write.
+        justfile = target / "justfile"
+        live = justfile.read_text()
+        older = "".join(live.splitlines(keepends=True)[:-1])
+        _set_base(target, "justfile", older)
+        justfile.write_text("# USER-ADDED-LINE\n" + older)
+
+        # Overlapping edit on .gitignore -> report.conflicts -> .new sibling.
+        gitignore = target / ".gitignore"
+        _set_base(target, ".gitignore", "# pristine base shared by neither side\n")
+        gitignore.write_text("# my local ignores\n")
+
+        recorded: dict[str, object] = {}
+        real_write_text = Path.write_text
+
+        def spy(self, data, *args, **kwargs):
+            recorded[self.name] = kwargs.get("newline", "MISSING")
+            return real_write_text(self, data, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", spy)
+        assert main(["upgrade", str(target), "--apply"]) == 0
+
+        assert recorded.get("justfile") == "\n", "merged in-place write must be LF"
+        assert recorded.get(".gitignore.new") == "\n", ".new sibling write must be LF"
+        assert recorded.get("config.yaml") == "\n", "config.yaml rewrite must be LF"
+
     def test_apply_backfills_base_for_unchanged_files(self, tmp_path: Path):
         """A project that predates the sidecar (or had it deleted) must gain a
         full merge base after one --apply — not just for drifted files — so a

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -101,6 +101,29 @@ def test_amp_and_junie_mcp_files_drop_type_http():
     assert claude["mcpServers"]["context7-http"]["type"] == "http"
 
 
+def test_antigravity_http_mcp_uses_serverurl():
+    """#431: Antigravity keys HTTP/streamable servers by `serverUrl` (no `type`,
+    not `url`); an entry written as {type:http,url:...} fails to load. Stdio
+    (command/args) entries are emitted unchanged, and Claude's .mcp.json keeps
+    the type+url form (contrast)."""
+    servers = {
+        "context7-http": {"type": "http", "url": "https://mcp.context7.com/mcp"},
+        "context7": {"command": "bunx", "args": ["@upstash/context7-mcp"]},
+    }
+    files = surfaces.planned_files(["claude", "antigravity"], servers)
+
+    agy = json.loads(files[".agents/mcp_config.json"])
+    assert agy["mcpServers"]["context7-http"] == {"serverUrl": "https://mcp.context7.com/mcp"}
+    assert "type" not in agy["mcpServers"]["context7-http"]
+    assert "url" not in agy["mcpServers"]["context7-http"]
+    # stdio entries pass through untouched
+    assert agy["mcpServers"]["context7"] == {"command": "bunx", "args": ["@upstash/context7-mcp"]}
+    # Claude still uses type+url — the Antigravity mapping is surface-specific.
+    claude = json.loads(files[".mcp.json"])
+    assert claude["mcpServers"]["context7-http"]["type"] == "http"
+    assert claude["mcpServers"]["context7-http"]["url"] == "https://mcp.context7.com/mcp"
+
+
 def test_amp_junie_not_experimental():
     assert surfaces.SURFACES["amp"]["experimental"] is False
     assert surfaces.SURFACES["junie"]["experimental"] is False


### PR DESCRIPTION
Fixes epic #443 (generated config/artifact correctness). Two clear bugs (#431, #435) and the agreed advisory softening for #439.

## #431 — Antigravity HTTP-MCP key (MED)
`.agents/mcp_config.json` emitted HTTP servers as `{type:http,url:...}`, but Antigravity (Windsurf/Codeium + Gemini lineage) keys streamable servers by **`serverUrl`** (no `type`, not `url`), so the server failed to load. **Fix:** dedicated `render_antigravity_mcp` renderer (`{url}`→`{serverUrl}`, drop `type`; stdio `command`/`args` entries pass through unchanged) + a new `antigravity` `mcp_render` token. Claude's `.mcp.json` still uses `type`+`url` (surface-specific).

## #435 — upgrade `--apply` writes CRLF on Windows (MED)
`apply_drift` wrote the clean-merge result (`:786`), the conflict `.new` sibling (`:793`), and the `config.yaml` rewrite (`:805`) without `newline="\n"`, so native-Windows Python translated `\n`→`\r\n`, corrupting merged shell hooks (`/usr/bin/env: 'bash\r'`). **Fix:** `newline="\n"` on all three — the issue named only the first two; verification found the third. Matches every other write site (PI-362).

## #439 — IaC `infra-apply` gate never armed (LOW) → softened to advisory
`infra.yml` claimed the `infra-apply` environment was an unconditional human gate ("an agent cannot apply without clearing it"), but no scaffolded tooling arms it and GitHub auto-creates a referenced-but-missing environment **unprotected**. Per the agreed decision: soften to advisory (`infra.yml.tmpl` + `infra/README.md.tmpl`) — arm it to gate; unprotected until configured; only an advisory wait-timer on solo accounts (ADR-007). No arming code added.

## Tests
- `test_antigravity_http_mcp_uses_serverurl` — http→`serverUrl`, stdio passthrough, Claude contrast.
- `test_apply_writes_lf_on_merged_sibling_and_config` — cross-platform `Path.write_text` spy asserting `newline="\n"` on all three paths (CRLF can't be byte-reproduced on Linux — CPython gates the translation behind `#ifdef MS_WINDOWS`).
- `test_infra_apply_gate_documented_as_advisory` — over-promise gone; "arm it / does not block by default / unprotected" present.

Full suite: **1250 passed, 3 skipped**; ruff clean.

Closes #431
Closes #435
Closes #439
Closes #443

https://claude.ai/code/session_016fFwuenhrb7YtApYKxouU5