### PR TITLE
fix(PI-444): align README AGENTS/CLAUDE direction with output; gate GEMINI INDEX link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Inside any target project:
 
 ```
 <your-project>/
-├── CLAUDE.md          # canonical agent instructions; points into .claude/
-├── AGENTS.md          # thin redirect to CLAUDE.md for non-Claude agents
+├── AGENTS.md          # canonical agent instructions; points into .claude/
+├── CLAUDE.md          # thin redirect to AGENTS.md (+ Claude-only compact instructions)
 └── .claude/
     ├── project-init.md      # workflow + conventions
     ├── config.yaml          # record of options chosen at init
@@ -39,7 +39,7 @@ that is cheap, but it is not natively so — be explicit about what each agent g
 |---|---|---|
 | **Native** | Everything: deterministic hooks (lifecycle guard, pre-commit gate), skills invoked as `/commands`, settings wiring — read directly from `.claude/` | Claude Code (CLI + the Anthropic VS Code extension) |
 | **Generated per-surface config** | One canonical hook/MCP spec rendered to each surface's native files (ADR-017): Codex `.codex/`, Cursor `.cursor/`, Antigravity `.agents/` (experimental), VS Code `.vscode/mcp.json`, Amp `.amp/settings.json`, Junie `.junie/mcp/mcp.json`. Skills cross-read natively. Agent hooks (incl. the Codex CLI) are **best-effort/fail-open** | Codex (CLI+IDE), Cursor, Antigravity, VS Code Copilot, Amp, JetBrains Junie |
-| **Instructions + portable** | `AGENTS.md`/`GEMINI.md` redirect to `CLAUDE.md`; lifecycle scripts (plain bash), memory/vault (markdown), git hooks (`commit-msg`, `pre-push`) — agent-independent; git hooks bind once `.claude/scripts/install_hooks.sh` has run (server-side actions need branch protection) | Everything, including Ollama-based agents |
+| **Instructions + portable** | `AGENTS.md` is canonical; `CLAUDE.md`/`GEMINI.md` redirect to it; lifecycle scripts (plain bash), memory/vault (markdown), git hooks (`commit-msg`, `pre-push`) — agent-independent; git hooks bind once `.claude/scripts/install_hooks.sh` has run (server-side actions need branch protection) | Everything, including Ollama-based agents |
 
 ### Surface support matrix
 
@@ -343,9 +343,9 @@ adopters know what this tool owns and where it defers:
 - **`AGENTS.md` vs `CLAUDE.md`**: Claude Code still reads only `CLAUDE.md`
   ([anthropics/claude-code#34235](https://github.com/anthropics/claude-code/issues/34235)),
   while most other tools read the `AGENTS.md` standard — which is why this
-  repo and scaffolded projects keep both: today `AGENTS.md` (and `GEMINI.md`)
-  redirect readers to the canonical `CLAUDE.md`; inverting that so `AGENTS.md`
-  becomes canonical is planned in #136.
+  repo and scaffolded projects keep both: `AGENTS.md` is the canonical source of
+  truth and `CLAUDE.md` (and `GEMINI.md`) redirect to it — Claude Code still
+  reads `CLAUDE.md` only because of the issue above (the #136 inversion shipped).
 
 ## Further reading
 

--- a/templates/base/GEMINI.md.tmpl
+++ b/templates/base/GEMINI.md.tmpl
@@ -8,9 +8,8 @@ naming. Ignore its "Claude Code specifics" section — enforcement that
 applies to you (git hooks, CI checks) is listed under "Key rules for
 agents".
 
-Before any GitHub action (create issue, branch, push, PR, merge), check
-[`.claude/skills/INDEX.md`](.claude/skills/INDEX.md) and load the relevant
-skill file.
+Before any GitHub action (create issue, branch, push, PR, merge), load the
+relevant skill (plugin-provided in the default scaffold;{{#if no_plugin}} indexed in [`.claude/skills/INDEX.md`](.claude/skills/INDEX.md);{{/if no_plugin}} use your harness's skill listing to discover them).
 
 {{#if lint_command}}Discover project commands with `just --list` — the justfile is the canonical, agent-agnostic command surface (lint, format, test, docs, ci).
 {{/if}}

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from project_init.scaffold import load_preset, scaffold
+from project_init.scaffold import load_preset, overlay_layers, scaffold
 from tests.helpers import make_variables
 
 
@@ -71,6 +71,26 @@ class TestPortableReferencesResolve:
         assert referenced, "expected path references in AGENTS.md"
         for rel in referenced:
             assert (target / rel).exists(), f"AGENTS.md references missing path: {rel}"
+
+    def test_gemini_skills_index_link_gated_by_plugin_mode(self, tmp_path: Path):
+        """#437: GEMINI.md must not dangle a `.claude/skills/INDEX.md` link in
+        the default plugin scaffold — INDEX.md ships only via the fallback layer
+        (--no-plugin). In plugin mode the link must be absent; in --no-plugin
+        mode it must be present and resolve."""
+        # Plugin mode (default): no INDEX.md link, and no such file.
+        plug = tmp_path / "plug"
+        scaffold(plug, load_preset("obsidian-only"), make_variables())
+        gemini_plug = (plug / "GEMINI.md").read_text()
+        assert "skills/INDEX.md" not in gemini_plug
+        assert not (plug / ".claude" / "skills" / "INDEX.md").exists()
+        # --no-plugin mode: INDEX.md is linked and present.
+        np = tmp_path / "np"
+        preset = load_preset("obsidian-only")
+        preset = {**preset, "layers": list(preset["layers"]) + overlay_layers("claude", no_plugin=True)}
+        scaffold(np, preset, make_variables(no_plugin="true"), strict=True)
+        gemini_np = (np / "GEMINI.md").read_text()
+        assert "skills/INDEX.md" in gemini_np
+        assert (np / ".claude" / "skills" / "INDEX.md").exists()
 
     def test_no_unrendered_placeholders_in_instruction_files(self, target: Path):
         placeholder = re.compile(r"(?<!\$)\{\{[^}]+\}\}")

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -83,11 +83,13 @@ class TestPortableReferencesResolve:
         gemini_plug = (plug / "GEMINI.md").read_text()
         assert "skills/INDEX.md" not in gemini_plug
         assert not (plug / ".claude" / "skills" / "INDEX.md").exists()
-        # --no-plugin mode: INDEX.md is linked and present.
+        # --no-plugin mode: INDEX.md is linked and present. Clear plugin_mode as
+        # the real CLI does (plugin_mode and no_plugin are coupled: __main__.py
+        # sets `plugin_mode = "" if no_plugin`) so this is not an impossible mix.
         np = tmp_path / "np"
         preset = load_preset("obsidian-only")
         preset = {**preset, "layers": list(preset["layers"]) + overlay_layers("claude", no_plugin=True)}
-        scaffold(np, preset, make_variables(no_plugin="true"), strict=True)
+        scaffold(np, preset, make_variables(plugin_mode="", no_plugin="true"), strict=True)
         gemini_np = (np / "GEMINI.md").read_text()
         assert "skills/INDEX.md" in gemini_np
         assert (np / ".claude" / "skills" / "INDEX.md").exists()

--- a/tests/integration/test_readme_examples.py
+++ b/tests/integration/test_readme_examples.py
@@ -86,3 +86,18 @@ def test_readme_documents_env_model_flags():
     readme = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
     for flag in ("--delivery", "--deploy", "--iac", "--multi-model"):
         assert flag in readme, f"README.md missing {flag}"
+
+
+def test_readme_states_agents_md_canonical():
+    """#434: #136 shipped — AGENTS.md is canonical and CLAUDE.md/GEMINI.md
+    redirect to it. The README must not still describe the inverse (CLAUDE.md
+    canonical / AGENTS.md a redirect), which contradicts the generated output."""
+    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
+    # Stale inverse fragments must be gone.
+    assert "thin redirect to CLAUDE.md" not in readme
+    assert "redirect to `CLAUDE.md`" not in readme
+    assert "redirect readers to the canonical `CLAUDE.md`" not in readme
+    assert "planned in #136" not in readme  # the inversion shipped
+    # Canonical-AGENTS statements must be present.
+    assert "AGENTS.md` is the portability backbone" in readme
+    assert "`CLAUDE.md`/`GEMINI.md` redirect to it" in readme


### PR DESCRIPTION
Fixes epic #444 (docs ↔ generated-output consistency). Both clear bugs — no policy decision.

## #434 — README inverts the AGENTS.md/CLAUDE.md canonical direction (MED)
#136 (make AGENTS.md canonical) shipped, and the templates already emit AGENTS.md-canonical (CLAUDE.md/GEMINI.md redirect to it; `test_agents_canonical.py` enforces it). But the README still described the **inverse** in three spots:
- layout diagram: "CLAUDE.md # canonical / AGENTS.md # thin redirect to CLAUDE.md"
- agent-support-tiers row: "`AGENTS.md`/`GEMINI.md` redirect to `CLAUDE.md`"
- Positioning bullet: "redirect readers to the canonical `CLAUDE.md`; … planned in #136" (calls a *closed* issue "planned")

**Fix:** flip all three to shipped reality — AGENTS.md canonical; CLAUDE.md/GEMINI.md redirect to it (CLAUDE.md also carries Claude-only compact instructions); Claude Code reads CLAUDE.md only because of [anthropics/claude-code#34235](https://github.com/anthropics/claude-code/issues/34235). (The verification caught the tiers-row spot, which the issue itself missed.) Templates were already correct — README-only alignment.

## #437 — GEMINI.md links a plugin-mode-absent INDEX.md (LOW)
`GEMINI.md.tmpl` unconditionally linked `.claude/skills/INDEX.md`, but INDEX.md ships only via the fallback layer (`--no-plugin`); in the default plugin scaffold the link dangled. **Fix:** gate the INDEX.md clause behind `{{#if no_plugin}}`, mirroring `AGENTS.md.tmpl` — plugin-mode GEMINI points at the harness skill listing; only `--no-plugin` links the file.

## Tests
- `test_readme_states_agents_md_canonical` — stale inverse fragments absent ("thin redirect to CLAUDE.md", "redirect to `CLAUDE.md`", "planned in #136"); canonical statements present.
- `test_gemini_skills_index_link_gated_by_plugin_mode` — plugin mode: no INDEX link, no file; `--no-plugin`: link present and resolves. (Would have failed pre-fix — INDEX.md absent in plugin mode.)

Full suite: **1252 passed, 3 skipped**; ruff clean.

Closes #434
Closes #437
Closes #444

https://claude.ai/code/session_016fFwuenhrb7YtApYKxouU5