### PR TITLE
chore(PI-452): benchmark harness supports Claude subscription auth

### DIFF
--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -234,3 +234,46 @@ class TestRunTaskGuard:
         monkeypatch.setattr(harness.shutil, "which", lambda _: None)
         with pytest.raises(RuntimeError, match="claude.*CLI"):
             harness.run_task(tmp_path, {"prompt": "x"}, model="m", config_dir=tmp_path)
+
+
+class TestAuth:
+    """Subscription-or-API-key auth for the manual `run` path (no agent driven)."""
+
+    def test_default_config_dir_honors_env(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+        assert harness.default_config_dir() == tmp_path / "cfg"
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert harness.default_config_dir() == Path.home() / ".claude"
+
+    def test_seed_credentials_copies_subscription_token(self, tmp_path: Path):
+        source = tmp_path / "real"
+        source.mkdir()
+        (source / ".credentials.json").write_text('{"token": "x"}', encoding="utf-8")
+        config_dir = tmp_path / "iso"
+        assert harness.seed_credentials(config_dir, source=source) is True
+        dest = config_dir / ".credentials.json"
+        assert dest.read_text() == '{"token": "x"}'
+        assert dest.stat().st_mode & 0o777 == 0o600  # never widen token perms
+
+    def test_seed_credentials_absent_returns_false(self, tmp_path: Path):
+        assert harness.seed_credentials(tmp_path / "iso", source=tmp_path / "empty") is False
+
+    def test_auth_available_prefers_api_key(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        assert harness.auth_available(tmp_path) is True  # no creds file needed
+
+    def test_auth_available_via_seeded_creds(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert harness.auth_available(tmp_path) is False
+        (tmp_path / ".credentials.json").write_text("{}", encoding="utf-8")
+        assert harness.auth_available(tmp_path) is True
+
+    def test_run_aborts_clearly_when_unauthenticated(self, tmp_path: Path, monkeypatch, capsys):
+        """The silent per-task skip is replaced by an upfront precondition error."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(harness.shutil, "which", lambda _: "/usr/bin/claude")
+        # Point cred discovery at an empty dir so no subscription token is found.
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "empty"))
+        rc = harness.main(["run", "--task", "noop", "--repeats", "1"])
+        assert rc == 1
+        assert "not authenticated" in capsys.readouterr().err

--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -258,12 +258,30 @@ class TestAuth:
     def test_seed_credentials_absent_returns_false(self, tmp_path: Path):
         assert harness.seed_credentials(tmp_path / "iso", source=tmp_path / "empty") is False
 
+    def test_seed_credentials_does_not_widen_restrictive_mode(self, tmp_path: Path):
+        """A 0o400 source token must not be widened to 0o600 (Copilot review)."""
+        source = tmp_path / "real"
+        source.mkdir()
+        src = source / ".credentials.json"
+        src.write_text("{}", encoding="utf-8")
+        src.chmod(0o400)
+        config_dir = tmp_path / "iso"
+        assert harness.seed_credentials(config_dir, source=source) is True
+        assert (config_dir / ".credentials.json").stat().st_mode & 0o777 == 0o400
+
     def test_auth_available_prefers_api_key(self, tmp_path: Path, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         assert harness.auth_available(tmp_path) is True  # no creds file needed
 
+    def test_auth_available_honors_oauth_token(self, tmp_path: Path, monkeypatch):
+        """CLAUDE_CODE_OAUTH_TOKEN is valid non-interactive auth (Codex review)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok")
+        assert harness.auth_available(tmp_path) is True  # no API key / creds needed
+
     def test_auth_available_via_seeded_creds(self, tmp_path: Path, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         assert harness.auth_available(tmp_path) is False
         (tmp_path / ".credentials.json").write_text("{}", encoding="utf-8")
         assert harness.auth_available(tmp_path) is True
@@ -271,6 +289,7 @@ class TestAuth:
     def test_run_aborts_clearly_when_unauthenticated(self, tmp_path: Path, monkeypatch, capsys):
         """The silent per-task skip is replaced by an upfront precondition error."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr(harness.shutil, "which", lambda _: "/usr/bin/claude")
         # Point cred discovery at an empty dir so no subscription token is found.
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "empty"))

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -94,8 +94,8 @@ def seed_credentials(config_dir: Path, source: Path | None = None) -> bool:
     Lets ``run`` use a Pro/Max **subscription** (OAuth creds on disk) instead of
     requiring ``ANTHROPIC_API_KEY``, while keeping the run otherwise isolated so
     the fixed-overhead measurement stays clean. Returns True iff a credentials
-    file was found and copied. ``ANTHROPIC_API_KEY`` (if set) still wins in
-    ``run_task`` since the env is inherited.
+    file was found and copied. An API key / OAuth token in env (if set) still
+    wins in ``run_task`` since the env is inherited.
     """
     src = (source or default_config_dir()) / ".credentials.json"
     if not src.is_file():
@@ -103,13 +103,19 @@ def seed_credentials(config_dir: Path, source: Path | None = None) -> bool:
     config_dir.mkdir(parents=True, exist_ok=True)
     dest = config_dir / ".credentials.json"
     shutil.copyfile(src, dest)
-    dest.chmod(0o600)  # the source is 0600; never widen the token's perms.
+    # Match the source's mode but cap at 0o600 — never widen a stricter token.
+    dest.chmod(src.stat().st_mode & 0o600)
     return True
 
 
+# Env vars Claude Code honors for non-interactive auth — both take precedence
+# over stored credentials, so either is sufficient (https://code.claude.com/docs/en/env-vars).
+_AUTH_ENV_VARS = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+
+
 def auth_available(config_dir: Path) -> bool:
-    """True if the run can authenticate: an API key in env or seeded creds."""
-    return bool(os.environ.get("ANTHROPIC_API_KEY")) or (config_dir / ".credentials.json").is_file()
+    """True if the run can authenticate: an API key / OAuth token in env, or seeded creds."""
+    return any(os.environ.get(v) for v in _AUTH_ENV_VARS) or (config_dir / ".credentials.json").is_file()
 
 
 # --- target setup (testable — no agent) -----------------------------------

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -76,6 +76,42 @@ def transcript_path_for(config_dir: Path, target_dir: Path, session_id: str) -> 
     return config_dir / "projects" / slug / f"{session_id}.jsonl"
 
 
+# --- auth (subscription or API key) ---------------------------------------
+
+
+def default_config_dir() -> Path:
+    """The user's real Claude config dir — where OAuth/subscription creds live.
+
+    Honors ``CLAUDE_CONFIG_DIR`` (matching Claude Code), else ``~/.claude``.
+    """
+    env = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(env) if env else Path.home() / ".claude"
+
+
+def seed_credentials(config_dir: Path, source: Path | None = None) -> bool:
+    """Copy Claude's ``.credentials.json`` into the isolated run config dir.
+
+    Lets ``run`` use a Pro/Max **subscription** (OAuth creds on disk) instead of
+    requiring ``ANTHROPIC_API_KEY``, while keeping the run otherwise isolated so
+    the fixed-overhead measurement stays clean. Returns True iff a credentials
+    file was found and copied. ``ANTHROPIC_API_KEY`` (if set) still wins in
+    ``run_task`` since the env is inherited.
+    """
+    src = (source or default_config_dir()) / ".credentials.json"
+    if not src.is_file():
+        return False
+    config_dir.mkdir(parents=True, exist_ok=True)
+    dest = config_dir / ".credentials.json"
+    shutil.copyfile(src, dest)
+    dest.chmod(0o600)  # the source is 0600; never widen the token's perms.
+    return True
+
+
+def auth_available(config_dir: Path) -> bool:
+    """True if the run can authenticate: an API key in env or seeded creds."""
+    return bool(os.environ.get("ANTHROPIC_API_KEY")) or (config_dir / ".credentials.json").is_file()
+
+
 # --- target setup (testable — no agent) -----------------------------------
 
 
@@ -319,6 +355,18 @@ def _cmd_run(args: argparse.Namespace) -> int:
     with tempfile.TemporaryDirectory(prefix="pi-benchmark-") as tmp:
         tmp_root = Path(tmp)
         config_dir = tmp_root / "claude-config"
+        # Isolate the run from the user's history, but seed the subscription
+        # credentials so a Pro/Max login works without ANTHROPIC_API_KEY.
+        seeded = seed_credentials(config_dir)
+        if not auth_available(config_dir):
+            sys.stderr.write(
+                "benchmark: not authenticated — `claude -p` would fail. Set "
+                "ANTHROPIC_API_KEY, or log in once with `claude` so "
+                f"{default_config_dir() / '.credentials.json'} exists.\n"
+            )
+            return 1
+        if seeded and not os.environ.get("ANTHROPIC_API_KEY"):
+            sys.stdout.write("benchmark: using Claude subscription credentials (no API key set).\n")
         for target in targets:
             for task_id, task in tasks.items():
                 for run_index in range(args.repeats):


### PR DESCRIPTION
## Problem

`tools/benchmark/harness.py run` isolated `CLAUDE_CONFIG_DIR` to an empty temp dir, discarding the user's OAuth/subscription credentials (`~/.claude/.credentials.json`). So `claude -p` returned `"Not logged in"` unless `ANTHROPIC_API_KEY` was exported — then the run *silently skipped* every task (recorded the error's session_id, found no transcript → "skipping"). This blocked the whole study for the common case (Pro/Max subscription, no API key).

## Fix

- `seed_credentials()` copies `.credentials.json` from the real config dir into the isolated run dir before launching, so a **subscription works without an API key**. The run stays otherwise isolated (clean fixed-overhead). API key still wins when set (env is inherited).
- `auth_available()` + an upfront precondition error in `run` replaces the silent per-task skip.
- `default_config_dir()` honors `CLAUDE_CONFIG_DIR`, else `~/.claude`.
- Token file copied at `0600` (never widens perms).

## Verification

- `uv run ruff check` — clean
- `uv run pytest` — 1258 passed, 3 skipped (6 new auth tests)
- **Ran for real on a Max subscription** (no API key): `harness run` now authenticates and writes records end-to-end.

Closes #452