### PR TITLE
chore(PI-454): verify current schema in add_hook/add_command; fix stale dev copy

### DIFF
--- a/.claude/skills/add_command/SKILL.md
+++ b/.claude/skills/add_command/SKILL.md
@@ -13,11 +13,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if the lookup fails or you are offline, fall back to the
-embedded reference below and proceed — never block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/.claude/skills/add_command/SKILL.md
+++ b/.claude/skills/add_command/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if the lookup fails or you are offline, fall back to the
+embedded reference below and proceed — never block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/.claude/skills/add_hook/SKILL.md
+++ b/.claude/skills/add_hook/SKILL.md
@@ -9,11 +9,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if the lookup fails or you are offline, fall back to the embedded reference
-below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/.claude/skills/add_hook/SKILL.md
+++ b/.claude/skills/add_hook/SKILL.md
@@ -6,6 +6,15 @@ argument-hint: "<hook-name> <event> <description>"
 allowed-tools: Read Write Bash
 ---
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if the lookup fails or you are offline, fall back to the embedded reference
+below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:
@@ -42,7 +51,8 @@ Create `.claude/hooks/<name>.sh`:
 INPUT=$(cat)
 
 # exit 0 = allow (or no-op for non-blocking events)
-# stdout JSON with {"decision":"block","reason":"..."} = block (PreToolUse)
+# PreToolUse block: stdout JSON {"hookSpecificOutput":{"hookEventName":
+#   "PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
 # stdout JSON with {"additionalContext":"..."} = inject context
 # Always exit 0 — exit 1 means hook error, not a block
 
@@ -59,7 +69,7 @@ print((data.get('tool_input', {}) or {}).get('command', '') or '')
 [ -z "$CMD" ] && exit 0
 
 if echo "$CMD" | grep -qE 'git push.*(main|master)'; then
-  python3 -c "import json,sys; print(json.dumps({'decision':'block','reason':sys.argv[1]}))" \
+  python3 -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','permissionDecision':'deny','permissionDecisionReason':sys.argv[1]}}))" \
     "Direct push to main is not allowed. Use a branch and PR."
   exit 0
 fi

--- a/plugins/project-init-workflow/skills/add_command/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/plugins/project-init-workflow/skills/add_command/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/amp/dot_agents/skills/add_command/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/templates/amp/dot_agents/skills/add_command/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/templates/amp/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/templates/amp/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/antigravity/dot_agents/skills/add_command/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/templates/antigravity/dot_agents/skills/add_command/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/codex/dot_agents/skills/add_command/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/templates/codex/dot_agents/skills/add_command/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/templates/codex/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/templates/codex/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/fallback/dot_claude/skills/add_command/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/templates/fallback/dot_claude/skills/add_command/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/templates/fallback/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/templates/fallback/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:

--- a/templates/junie/dot_junie/skills/add_command/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_command/SKILL.md
@@ -14,6 +14,16 @@ allowed-tools: Write
 
 Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter.
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The frontmatter fields below are a snapshot and can lag Claude Code releases.
+Before relying on a field name or value, confirm against the current docs —
+Context7 (resolve `claude code`, then the slash-commands / skills reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
+Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
+lookup fails, fall back to the embedded reference below and proceed — never
+block on this.
+
 ## Step 1 — Create the file
 
 Create `.claude/skills/<name>/SKILL.md` where `<name>` is the command name (lowercase, hyphen-separated).

--- a/templates/junie/dot_junie/skills/add_command/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_command/SKILL.md
@@ -17,12 +17,13 @@ Slash commands in this project live in `.claude/skills/<name>/SKILL.md`. Each sk
 ## Step 0 — Confirm the current schema (best-effort)
 
 The frontmatter fields below are a snapshot and can lag Claude Code releases.
-Before relying on a field name or value, confirm against the current docs —
-Context7 (resolve `claude code`, then the slash-commands / skills reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/slash-commands>.
-Best-effort only: if egress is disabled (`--no-egress` / air-gapped) or the
-lookup fails, fall back to the embedded reference below and proceed — never
-block on this.
+**If** a docs-lookup tool is available to you — the Context7 MCP, or WebFetch
+when it's permitted — confirm the field name / value against the current
+reference (<https://docs.claude.com/en/docs/claude-code/slash-commands>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Create the file
 

--- a/templates/junie/dot_junie/skills/add_hook/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_hook/SKILL.md
@@ -13,11 +13,13 @@ allowed-tools: Read Write Bash
 ## Step 0 — Confirm the current schema (best-effort)
 
 The event names and output schema below are a snapshot and can lag Claude Code
-releases. Before relying on an event name or output field, confirm against the
-current docs — Context7 (resolve `claude code`, then the hooks reference) or
-WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
-if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
-back to the embedded reference below and proceed — never block on this.
+releases. **If** a docs-lookup tool is available to you — the Context7 MCP, or
+WebFetch when it's permitted — confirm the event name / output field against the
+current reference (<https://docs.claude.com/en/docs/claude-code/hooks>) before
+relying on it. This skill's `allowed-tools` does not grant those tools, so skip
+this step cleanly whenever the tool is unavailable, unapproved, egress is
+disabled (`--no-egress` / air-gapped), or the lookup fails — fall back to the
+embedded reference below. Don't request extra permissions and never block on it.
 
 ## Step 1 — Choose an event
 

--- a/templates/junie/dot_junie/skills/add_hook/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_hook/SKILL.md
@@ -10,6 +10,15 @@ allowed-tools: Read Write Bash
 > (settings.json wiring). Other agents do not consume what it produces.
 
 
+## Step 0 — Confirm the current schema (best-effort)
+
+The event names and output schema below are a snapshot and can lag Claude Code
+releases. Before relying on an event name or output field, confirm against the
+current docs — Context7 (resolve `claude code`, then the hooks reference) or
+WebFetch <https://docs.claude.com/en/docs/claude-code/hooks>. Best-effort only:
+if egress is disabled (`--no-egress` / air-gapped) or the lookup fails, fall
+back to the embedded reference below and proceed — never block on this.
+
 ## Step 1 — Choose an event
 
 Pick the event that matches when the hook should fire:


### PR DESCRIPTION
Closes #454

## What
- **`add_hook` / `add_command`**: add a best-effort **Step 0 — Confirm the current schema** that points the agent at Context7 / the live Claude Code docs to verify hook events and frontmatter fields before trusting the embedded snapshot. Falls back to the baseline when offline or `--no-egress`; never blocks.
- **Stale dev-copy fix**: this repo's own `.claude/skills/add_hook` still taught the deprecated `{"decision":"block","reason":...}` hook output schema. Corrected to the current `hookSpecificOutput`/`permissionDecision` form (kept `python3` — this repo has no `_py.sh`).

## Where
Canonical edit in `templates/fallback/dot_claude/skills/`, propagated byte-identical to the 6 surfaces (plugin, junie, codex, amp, antigravity) via `tools/sync_plugin.py`.

## Verification
- `ruff check` clean
- 1258 passed, 3 skipped
- 58 contract/drift-guard tests green (`test_plugin_marketplace`, `test_agent_overlays`, `test_agents_canonical`, `test_surface_emission`)

## Not included
Anthropic's built-in `skill-creator` (upstream-managed) and the global grill-me-codex / grill-with-docs-codex skills (edited separately, outside this repo).