### PR TITLE
chore(PI-456): fix skill/command/hook audit findings (fabricated APIs, deprecated schema, legacy drift)

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -362,7 +362,7 @@ def cmd_check(node: str) -> int:
         own_ok, own_reason = CHECKS[node]()
         marker = "OK" if own_ok else "REACHABLE (state not yet satisfied)"
         sys.stdout.write(f"{marker}: {node} — {own_reason}\n")
-        return 0 if own_ok else 0  # prereqs satisfied = transition allowed
+        return 0  # prereqs satisfied = transition allowed (own check is advisory)
     sys.stdout.write(f"BLOCKED: cannot reach {node}: {reason}\n")
     return 2
 

--- a/.claude/hooks/workflow_state_reminder.sh
+++ b/.claude/hooks/workflow_state_reminder.sh
@@ -68,5 +68,5 @@ context = (
     f"{state_block}"
 )
 
-print(json.dumps({"additionalContext": context}))
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,6 +6,8 @@ Project-local Claude Code skills. Each skill is a directory `.claude/skills/<nam
 |---|---|
 | `session_summary` | End of session — summarize work and save to vault |
 | `start_task` | Before any non-trivial task — create a GitHub Issue |
+| `github_workflow` | Any push, PR, review-response, or merge action |
+| `wiki` | Publish or update GitHub Wiki pages |
 | `add_hook` | When you need a new deterministic hook (safety, lint, logging) |
 | `add_command` | When you need a new slash command for a recurring workflow |
 

--- a/.claude/skills/add_hook/SKILL.md
+++ b/.claude/skills/add_hook/SKILL.md
@@ -38,9 +38,11 @@ Pick the event that matches when the hook should fire:
 
 **User input:**
 - `UserPromptSubmit` — when the user submits a prompt
+- `UserPromptExpansion` — when a typed command expands into a prompt (can block)
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/.claude/skills/add_hook/SKILL.md
+++ b/.claude/skills/add_hook/SKILL.md
@@ -25,20 +25,22 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
 **User input:**
 - `UserPromptSubmit` — when the user submits a prompt
-- `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -1,84 +1,68 @@
 ---
 name: wiki
-description: Creates and manages GitHub Wiki pages using gh CLI. Use when the user wants to create documentation pages, architecture guides, or populate wiki content.
-when_to_use: Use when the user says "create a wiki page", "add documentation to wiki", "create an architecture page", or "update the wiki".
+description: Creates and manages GitHub Wiki pages via the wiki's git repo and the guard-allowlisted push_wiki.sh helper. Use when the user wants to publish documentation pages, architecture guides, or populate wiki content.
+when_to_use: Use when the user says "create a wiki page", "add documentation to wiki", "create an architecture page", "publish to the wiki", or "update the wiki".
 argument-hint: "<action> [page-name]"
-allowed-tools: Bash Read Write
+allowed-tools: Bash(git *) Bash(.claude/scripts/*) Read Write
 effort: low
 ---
 
-Manage GitHub Wiki pages using `gh` CLI commands. Keep operations simple and deterministic.
+Manage the GitHub Wiki. A wiki is a **plain git repository** at
+`https://github.com/<owner>/<repo>.wiki.git` — there is **no `gh wiki`
+subcommand**. Each page is a markdown file named after its title with spaces
+replaced by hyphens (e.g. "Getting Started" → `Getting-Started.md`); `Home.md`
+is the landing page. Pushes go through `push_wiki.sh`, which the command guard
+allowlists (a raw `git push` to the wiki is otherwise blocked).
+
+> The wiki must be enabled and initialized once in the repo's GitHub UI
+> (create any first page) before `<repo>.wiki.git` exists to clone or push.
 
 ## Actions
 
-### 1. Create a new wiki page
+### 1. Update the Home page (supported write path)
 
 ```bash
-gh wiki create --title "<Page Title>" --body "$(cat <<'EOF'
-# Page Title
-
-## Overview
-
-Add your content here.
-
-## Section
-
-More details.
-EOF
-)"
+.claude/scripts/push_wiki.sh <owner>/<repo> <source-file.md> [--prune <stale-page.md> ...]
 ```
 
-Or using the template system:
+Writes `<source-file.md>` as `Home.md`, optionally removes stale pages, commits,
+and pushes — all in one guard-allowlisted step. Use a template as the source:
 
 ```bash
-gh wiki create --title "Architecture" --body "$(cat .claude/skills/wiki/templates/architecture.md)"
+.claude/scripts/push_wiki.sh <owner>/<repo> .claude/skills/wiki/templates/architecture.md
 ```
 
-**Available templates:**
+**Available templates** (`.claude/skills/wiki/templates/`):
 - `architecture.md` — System architecture and design
 - `scaffolder-logic.md` — Scaffolder workflow and implementation
 - `preset-guide.md` — Preset configuration guide
 - `implementation-guide.md` — Implementation guidance
 
-### 2. List wiki pages
+### 2. List / read existing pages
 
 ```bash
-gh wiki list
+git clone "https://github.com/<owner>/<repo>.wiki.git" /tmp/wiki && ls /tmp/wiki/*.md
 ```
 
-Shows all pages with their last update time.
+Each `*.md` file is a page; read them directly for current content.
 
-### 3. Update an existing page
+### 3. Create or edit additional named pages
 
-```bash
-# Edit locally first
-vim ~/tmp/wiki-page.md
-
-# Push the updated version
-gh wiki edit "<Page Title>" --body "$(cat ~/tmp/wiki-page.md)"
-```
-
-### 4. Clone the wiki for local editing
-
-```bash
-gh repo clone <repo>.wiki.git
-cd <repo>.wiki
-# Edit pages as markdown files
-git add .
-git commit -m "Update wiki"
-git push
-```
+`push_wiki.sh` manages `Home.md` only. To publish other pages, add the named
+markdown file(s) to the source flow — extend `push_wiki.sh` (it already clones,
+commits, and pushes the wiki repo) rather than running a raw `git push`, which
+the guard blocks. Name each file `<Page-Title>.md` with spaces as hyphens.
 
 ## Rules
 
-- Page titles are descriptive and match the markdown H1 heading
-- Templates are stored in `.claude/skills/wiki/templates/`
-- All wiki operations use `gh` CLI — no direct git operations in the skill
-- Test that wiki configuration exists before attempting operations
+- The wiki is a git repo, not a `gh` resource — never use `gh wiki ...` (it does not exist).
+- All wiki pushes go through `push_wiki.sh` so the command guard allows them.
+- Page file names mirror the title with spaces → hyphens; `Home.md` is the landing page.
+- Confirm the wiki is initialized before cloning/pushing.
 
 ## Testing
 
 The test suite validates:
-- `gh` CLI is available and authenticated
-- Wiki is enabled for the repository
-- Standard wiki operations work (create, list, clone)
+- The wiki git repo (`<repo>.wiki.git`) is reachable / wiki is enabled.
+- `push_wiki.sh` writes `Home.md` and pushes successfully.
+- Cloning and listing pages works for read operations.

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -2,7 +2,7 @@
 name: wiki
 description: Creates and manages GitHub Wiki pages via the wiki's git repo and the guard-allowlisted push_wiki.sh helper. Use when the user wants to publish documentation pages, architecture guides, or populate wiki content.
 when_to_use: Use when the user says "create a wiki page", "add documentation to wiki", "create an architecture page", "publish to the wiki", or "update the wiki".
-argument-hint: "<action> [page-name]"
+argument-hint: "<update|list> [owner/repo] [source-file.md]"
 allowed-tools: Bash(git *) Bash(.claude/scripts/*) Read Write
 effort: low
 ---
@@ -41,7 +41,8 @@ and pushes — all in one guard-allowlisted step. Use a template as the source:
 ### 2. List / read existing pages
 
 ```bash
-git clone "https://github.com/<owner>/<repo>.wiki.git" /tmp/wiki && ls /tmp/wiki/*.md
+WIKI=$(mktemp -d)
+git clone "https://github.com/<owner>/<repo>.wiki.git" "$WIKI" && ls "$WIKI"/*.md
 ```
 
 Each `*.md` file is a page; read them directly for current content.

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -362,7 +362,7 @@ def cmd_check(node: str) -> int:
         own_ok, own_reason = CHECKS[node]()
         marker = "OK" if own_ok else "REACHABLE (state not yet satisfied)"
         sys.stdout.write(f"{marker}: {node} — {own_reason}\n")
-        return 0 if own_ok else 0  # prereqs satisfied = transition allowed
+        return 0  # prereqs satisfied = transition allowed (own check is advisory)
     sys.stdout.write(f"BLOCKED: cannot reach {node}: {reason}\n")
     return 2
 

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -60,7 +60,8 @@ if [ -n "$ERRORS" ]; then
     "$PY" -c "
 import json, sys
 file, errors = sys.argv[1], sys.argv[2]
-print(json.dumps({'additionalContext': f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'}))
+ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
 " "$FILE" "$ERRORS"
 fi
 

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -89,7 +89,7 @@ if [ -n "$ERRORS" ]; then
 import json, sys
 errors = sys.argv[1].replace('\\\\n', '\n')
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
-print(json.dumps({'decision': 'block', 'reason': msg}))
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
 " "$ERRORS"
 fi
 

--- a/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-workflow/hooks/workflow_state_reminder.sh
@@ -77,5 +77,5 @@ context = (
     f"{state_block}"
 )
 
-print(json.dumps({"additionalContext": context}))
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/plugins/project-init-workflow/skills/add_hook/SKILL.md
+++ b/plugins/project-init-workflow/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/plugins/project-init-workflow/skills/audit/SKILL.md
+++ b/plugins/project-init-workflow/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/plugins/project-init-workflow/skills/github_workflow/SKILL.md
+++ b/plugins/project-init-workflow/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/plugins/project-init-workflow/skills/request_review/SKILL.md
+++ b/plugins/project-init-workflow/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/plugins/project-init-workflow/skills/review/SKILL.md
+++ b/plugins/project-init-workflow/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/plugins/project-init-workflow/skills/start_task/SKILL.md
+++ b/plugins/project-init-workflow/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/plugins/project-init-workflow/skills/status/SKILL.md
+++ b/plugins/project-init-workflow/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/templates/amp/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/amp/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/amp/dot_agents/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/amp/dot_agents/skills/audit/SKILL.md
+++ b/templates/amp/dot_agents/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/amp/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/amp/dot_agents/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/amp/dot_agents/skills/request_review/SKILL.md
+++ b/templates/amp/dot_agents/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/templates/amp/dot_agents/skills/review/SKILL.md
+++ b/templates/amp/dot_agents/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/templates/amp/dot_agents/skills/start_task/SKILL.md
+++ b/templates/amp/dot_agents/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/templates/amp/dot_agents/skills/status/SKILL.md
+++ b/templates/amp/dot_agents/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/antigravity/dot_agents/skills/audit/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/antigravity/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/antigravity/dot_agents/skills/request_review/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/templates/antigravity/dot_agents/skills/review/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/templates/antigravity/dot_agents/skills/start_task/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/templates/antigravity/dot_agents/skills/status/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -362,7 +362,7 @@ def cmd_check(node: str) -> int:
         own_ok, own_reason = CHECKS[node]()
         marker = "OK" if own_ok else "REACHABLE (state not yet satisfied)"
         sys.stdout.write(f"{marker}: {node} — {own_reason}\n")
-        return 0 if own_ok else 0  # prereqs satisfied = transition allowed
+        return 0  # prereqs satisfied = transition allowed (own check is advisory)
     sys.stdout.write(f"BLOCKED: cannot reach {node}: {reason}\n")
     return 2
 

--- a/templates/base/dot_claude/skills/plan/SKILL.md.tmpl
+++ b/templates/base/dot_claude/skills/plan/SKILL.md.tmpl
@@ -2,7 +2,7 @@
 name: plan
 description: TDD-style planning — understand requirements, write tests first, then implement with numbered steps
 when_to_use: Use for non-trivial features or bug fixes. Plan before code to reduce rework and improve test coverage.
-allowed-tools: Read Grep Glob Bash
+allowed-tools: Read Grep Glob Bash(git *)
 ---
 
 Plan this work in 5 phases. Format output clearly so it's actionable.

--- a/templates/codex/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/codex/dot_agents/skills/add_hook/SKILL.md
+++ b/templates/codex/dot_agents/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/codex/dot_agents/skills/audit/SKILL.md
+++ b/templates/codex/dot_agents/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/codex/dot_agents/skills/github_workflow/SKILL.md
+++ b/templates/codex/dot_agents/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/codex/dot_agents/skills/request_review/SKILL.md
+++ b/templates/codex/dot_agents/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/templates/codex/dot_agents/skills/review/SKILL.md
+++ b/templates/codex/dot_agents/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/templates/codex/dot_agents/skills/start_task/SKILL.md
+++ b/templates/codex/dot_agents/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/templates/codex/dot_agents/skills/status/SKILL.md
+++ b/templates/codex/dot_agents/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/templates/fallback/dot_claude/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_claude/hooks/post_edit_lint.sh
@@ -60,7 +60,8 @@ if [ -n "$ERRORS" ]; then
     "$PY" -c "
 import json, sys
 file, errors = sys.argv[1], sys.argv[2]
-print(json.dumps({'additionalContext': f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'}))
+ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
 " "$FILE" "$ERRORS"
 fi
 

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -89,7 +89,7 @@ if [ -n "$ERRORS" ]; then
 import json, sys
 errors = sys.argv[1].replace('\\\\n', '\n')
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
-print(json.dumps({'decision': 'block', 'reason': msg}))
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
 " "$ERRORS"
 fi
 

--- a/templates/fallback/dot_claude/hooks/workflow_state_reminder.sh
+++ b/templates/fallback/dot_claude/hooks/workflow_state_reminder.sh
@@ -77,5 +77,5 @@ context = (
     f"{state_block}"
 )
 
-print(json.dumps({"additionalContext": context}))
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/templates/fallback/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/fallback/dot_claude/skills/add_hook/SKILL.md
+++ b/templates/fallback/dot_claude/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/fallback/dot_claude/skills/audit/SKILL.md
+++ b/templates/fallback/dot_claude/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
+++ b/templates/fallback/dot_claude/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/fallback/dot_claude/skills/request_review/SKILL.md
+++ b/templates/fallback/dot_claude/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/templates/fallback/dot_claude/skills/review/SKILL.md
+++ b/templates/fallback/dot_claude/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/templates/fallback/dot_claude/skills/start_task/SKILL.md
+++ b/templates/fallback/dot_claude/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/templates/fallback/dot_claude/skills/status/SKILL.md
+++ b/templates/fallback/dot_claude/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/templates/junie/dot_junie/skills/add_hook/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_hook/SKILL.md
@@ -29,10 +29,14 @@ Pick the event that matches when the hook should fire:
 - `PreToolUse` — before a tool runs; output block JSON to block it
 - `PostToolUse` — after a tool runs; cannot block, can log or validate
 - `PostToolBatch` — after a batch of parallel tool calls completes
+- `PostToolUseFailure` — after a tool fails
 - `PermissionRequest` — when Claude asks for permission; can auto-approve
+- `PermissionDenied` — when permission is denied; can request a retry
 
 **Session lifecycle:**
 - `SessionStart` — when a session begins
+- `SessionEnd` — when a session closes
+- `PreCompact` — before context compaction (can block)
 - `Stop` — when Claude stops generating (end of turn)
 - `StopFailure` — when a turn fails
 
@@ -40,9 +44,8 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/task events:**
+**Agent/subagent events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
-- `TaskCreated` / `TaskCompleted` — task tracking events
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/junie/dot_junie/skills/add_hook/SKILL.md
+++ b/templates/junie/dot_junie/skills/add_hook/SKILL.md
@@ -44,8 +44,9 @@ Pick the event that matches when the hook should fire:
 - `UserPromptSubmit` — when the user submits a prompt
 - `UserPromptExpansion` — when slash commands expand
 
-**Agent/subagent events:**
+**Agent / task events:**
 - `SubagentStart` / `SubagentStop` — subagent lifecycle
+- `TaskCreated` / `TaskCompleted` — task lifecycle (via `TaskCreate` / completion)
 
 **File/config events:**
 - `FileChanged`, `CwdChanged`, `ConfigChange`

--- a/templates/junie/dot_junie/skills/audit/SKILL.md
+++ b/templates/junie/dot_junie/skills/audit/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--fix]"
 allowed-tools: Bash(git *) Bash(gh *) Bash(stat *) Bash(file *) Bash(head *) Read Write Edit Glob Grep
 effort: high
 context: fork
+agent: general-purpose
 ---
 
 Run a comprehensive project health audit. Create a GitHub issue with all findings. If `$ARGUMENTS` contains `--fix`, also fix the issues and open a PR.

--- a/templates/junie/dot_junie/skills/github_workflow/SKILL.md
+++ b/templates/junie/dot_junie/skills/github_workflow/SKILL.md
@@ -85,5 +85,5 @@ blindly apply a suggestion — post reasoning even when rejecting.
 ## Issue titles vs PR titles
 
 - **Issue titles**: plain description only — type is carried by the label.
-- **PR titles**: must include `[type]` — PR titles become merge commit messages in `git log`.
+- **PR titles**: use `type(PROJECT-123): description` (Conventional Commits, ADR-006); drop the scope for no-issue PRs (`type: description`). PR titles become merge commit messages in `git log`.
 - **nojira**: for minor fixes without a tracking issue; no `Closes #N` needed.

--- a/templates/junie/dot_junie/skills/request_review/SKILL.md
+++ b/templates/junie/dot_junie/skills/request_review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request_review
-description: Mark the current draft PR ready for review
-when_to_use: Use when a draft PR is ready to move from Draft to In Review status. Marks the PR ready and triggers board automation.
+description: Marks a draft PR ready for review, moving it Draft → In Review and triggering board automation. Use when a draft PR is finished and ready for reviewers.
+when_to_use: Use when the user says "request review", "mark the PR ready", "this PR is ready", or a draft PR is ready to move from Draft to In Review.
 argument-hint: "[pr-number]"
-allowed-tools: Bash Read
+allowed-tools: Bash(.claude/scripts/*) Read
 ---
 
 Mark PR $ARGUMENTS (or current branch's PR if omitted) ready for review.

--- a/templates/junie/dot_junie/skills/review/SKILL.md
+++ b/templates/junie/dot_junie/skills/review/SKILL.md
@@ -3,7 +3,7 @@ name: review
 description: Review staged or recent changes for bugs, style issues, and missed edge cases
 when_to_use: Use when you want a code review of work — staged changes, a specific commit, or a commit range.
 argument-hint: "[commit-range or file]"
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Review the code changes specified by: $ARGUMENTS

--- a/templates/junie/dot_junie/skills/start_task/SKILL.md
+++ b/templates/junie/dot_junie/skills/start_task/SKILL.md
@@ -34,7 +34,7 @@ Before starting any non-trivial task, create a GitHub Issue, a dedicated branch,
    ```bash
    .claude/scripts/start_issue.sh <issue-number> <type>
    ```
-   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `[PROJECT-123][type]` title and `Closes #n` body.
+   This derives the branch name (`<issue_type>/<project_abbr>-<issue_number>-<slug>`) from the issue title, pushes it, and opens a draft PR with the correct `type(PROJECT-123): description` title (Conventional Commits, ADR-006) and `Closes #n` body.
 
 5. **Proceed** — only begin implementation after the scripts have run successfully.
 

--- a/templates/junie/dot_junie/skills/status/SKILL.md
+++ b/templates/junie/dot_junie/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Show project status — git state, recent commits, open tasks, and memory summary
 when_to_use: Use when you want a quick snapshot of the project — current branch, uncommitted changes, recent work, active memory, and open TODOs.
-allowed-tools: Bash Read Grep Glob
+allowed-tools: Bash(git *) Read Grep Glob
 ---
 
 Give me a concise project status report:

--- a/tests/contracts/test_wiki_skill.py
+++ b/tests/contracts/test_wiki_skill.py
@@ -46,15 +46,23 @@ class TestWikiSkillStructure:
         assert "Bash" in content, "Skill should allow Bash tool"
         assert "Read" in content or "Write" in content, "Skill should allow file tools"
 
-    def test_skill_documents_cli_actions(self, skill_file: Path):
-        """Verify skill documents gh CLI actions."""
+    def test_skill_documents_real_actions(self, skill_file: Path):
+        """Verify skill documents the real git-based wiki mechanism, not a
+        fabricated ``gh wiki`` subcommand (which does not exist)."""
         content = skill_file.read_text()
-        cli_actions = [
-            "gh wiki create",
-            "gh wiki list",
+        required = [
+            "push_wiki.sh",  # guard-allowlisted write path
+            ".wiki.git",  # the wiki is a plain git repo
         ]
-        for action in cli_actions:
+        for action in required:
             assert action in content, f"Skill should document {action}"
+        # Regression guard: gh has no `wiki` subcommand. The only acceptable
+        # mentions are the negative instructions telling authors not to use it.
+        for line in content.splitlines():
+            if "gh wiki" in line:
+                assert ("no `gh wiki`" in line) or ("never use `gh wiki" in line), (
+                    f"Skill must not instruct using the nonexistent gh wiki CLI: {line!r}"
+                )
 
     def test_skill_documents_templates(self, skill_file: Path):
         """Verify skill mentions template directory."""

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -453,7 +453,10 @@ exit 2
             cwd=self.target,
         )
         out = json.loads(result.stdout)
-        assert "additionalContext" in out
+        # Canonical UserPromptSubmit shape: context nested under hookSpecificOutput.
+        hso = out.get("hookSpecificOutput", {})
+        assert hso.get("hookEventName") == "UserPromptSubmit"
+        assert "additionalContext" in hso
 
 
 class TestCommitMsgHookFormats:


### PR DESCRIPTION
Closes #456

Full quality audit of all skills, slash commands, and hooks against **current** Claude Code standards (freshly fetched skills + hooks docs). Audited the deduplicated surface (13 unique skills + 9 unique hook scripts; the 5 surface copies are byte-identical to canonical).

## Verdict
Suite is strong: no frontmatter violations, all descriptions far under the 1,536-char cap, hooks defensively coded. Findings clustered in **'instructional/shipped content references a nonexistent or deprecated API'** — fixed here.

## P1 — correctness
- **wiki skill** taught `gh wiki create/list/edit` — `gh` has **no** wiki subcommand (verified v2.91.0). Rewritten around the wiki git repo (`<repo>.wiki.git`) + the guard-allowlisted `push_wiki.sh`; fixed the inaccurate "using gh CLI" description.
- **pre_commit_gate.sh** emitted deprecated `{"decision":"block"}` → canonical `hookSpecificOutput.permissionDecision:"deny"` (now matches sibling guards dag_workflow.py / prod_guard.py; the agent_guard_adapter already accepts both shapes).
- **add_hook** listed fabricated events `TaskCreated`/`TaskCompleted` → removed; added real `PostToolUseFailure`, `PermissionDenied`, `SessionEnd`, `PreCompact`.

## P2 — quality / future-proofing
- Legacy `[PROJECT-123][type]` PR-title format in canonical **github_workflow** + **start_task** reconciled to ADR-006 `type(PROJECT-123): description`.
- **workflow_state_reminder.sh** + **post_edit_lint.sh**: `additionalContext` nested under `hookSpecificOutput` with `hookEventName`.
- **request_review**: stronger, keyword-rich description.

## P3 — polish
Scoped unrestricted `Bash` → `Bash(git *)`/`Bash(.claude/scripts/*)` in review/status/plan/request_review; `agent: general-purpose` on **audit**; added github_workflow+wiki to dev README; removed dead branch in dag_workflow.py.

## Intentionally NOT changed (would break / inapplicable)
- Dev hooks' `python3` (no `_py.sh` under `.claude/hooks/` — switching breaks them).
- Dev github_workflow's missing ADR-013 prod-boundary section (prod_guard not wired in this source repo).

## Verification
- `ruff` clean; bash `-n` + `py_compile` on all edited scripts pass.
- **1258 passed, 3 skipped**; 702 contract/drift tests green.
- Updated `test_wiki_skill` (asserts real mechanism + regression-guards against `gh wiki`) and `test_issue_metadata_workflow` (asserts canonical hookSpecificOutput shape).
- Canonical edits synced byte-identical to all 6 surfaces.