### PR TITLE
chore(PI-458): finish_pr verifies branch matches PR head before pushing

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -500,6 +500,12 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
         )
         return 1
     current = _current_branch()
+    if current is None:
+        sys.stderr.write(
+            f"finish: no current branch (detached HEAD or not a git repo) — check out "
+            f"PR #{pr_number}'s head '{head}' and re-run.\n"
+        )
+        return 1
     if current != head:
         sys.stderr.write(
             f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -482,14 +482,33 @@ def cmd_promote(pr_number: int | None) -> int:
 
 def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     """Push, promote, then hand off to monitor_pr.sh for CI/review/merge."""
-    rc = cmd_push(None, 3)
-    if rc != 0:
-        return rc
+    # Resolve the PR BEFORE pushing so we push that PR's head branch, never
+    # whatever happens to be checked out. Pushing the current branch first let
+    # a concurrent branch switch make `finish` push an unrelated branch (PI-458).
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
+    code, head = _gh(
+        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
+    )
+    head = head.strip()
+    if code != 0 or not head:
+        sys.stderr.write(
+            f"finish: cannot resolve head branch for PR #{pr_number} — refusing to push.\n"
+        )
+        return 1
+    current = _current_branch()
+    if current != head:
+        sys.stderr.write(
+            f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "
+            f"'{head}'. Check out '{head}' and re-run — refusing to push the wrong branch.\n"
+        )
+        return 1
+    rc = cmd_push(head, 3)
+    if rc != 0:
+        return rc
     rc = cmd_promote(pr_number)
     if rc != 0:
         return rc

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -500,6 +500,12 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
         )
         return 1
     current = _current_branch()
+    if current is None:
+        sys.stderr.write(
+            f"finish: no current branch (detached HEAD or not a git repo) — check out "
+            f"PR #{pr_number}'s head '{head}' and re-run.\n"
+        )
+        return 1
     if current != head:
         sys.stderr.write(
             f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "

--- a/plugins/project-init-workflow/hooks/dag_workflow.py
+++ b/plugins/project-init-workflow/hooks/dag_workflow.py
@@ -482,14 +482,33 @@ def cmd_promote(pr_number: int | None) -> int:
 
 def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     """Push, promote, then hand off to monitor_pr.sh for CI/review/merge."""
-    rc = cmd_push(None, 3)
-    if rc != 0:
-        return rc
+    # Resolve the PR BEFORE pushing so we push that PR's head branch, never
+    # whatever happens to be checked out. Pushing the current branch first let
+    # a concurrent branch switch make `finish` push an unrelated branch (PI-458).
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
+    code, head = _gh(
+        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
+    )
+    head = head.strip()
+    if code != 0 or not head:
+        sys.stderr.write(
+            f"finish: cannot resolve head branch for PR #{pr_number} — refusing to push.\n"
+        )
+        return 1
+    current = _current_branch()
+    if current != head:
+        sys.stderr.write(
+            f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "
+            f"'{head}'. Check out '{head}' and re-run — refusing to push the wrong branch.\n"
+        )
+        return 1
+    rc = cmd_push(head, 3)
+    if rc != 0:
+        return rc
     rc = cmd_promote(pr_number)
     if rc != 0:
         return rc

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -500,6 +500,12 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
         )
         return 1
     current = _current_branch()
+    if current is None:
+        sys.stderr.write(
+            f"finish: no current branch (detached HEAD or not a git repo) — check out "
+            f"PR #{pr_number}'s head '{head}' and re-run.\n"
+        )
+        return 1
     if current != head:
         sys.stderr.write(
             f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "

--- a/templates/base/dot_claude/hooks/dag_workflow.py
+++ b/templates/base/dot_claude/hooks/dag_workflow.py
@@ -482,14 +482,33 @@ def cmd_promote(pr_number: int | None) -> int:
 
 def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     """Push, promote, then hand off to monitor_pr.sh for CI/review/merge."""
-    rc = cmd_push(None, 3)
-    if rc != 0:
-        return rc
+    # Resolve the PR BEFORE pushing so we push that PR's head branch, never
+    # whatever happens to be checked out. Pushing the current branch first let
+    # a concurrent branch switch make `finish` push an unrelated branch (PI-458).
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
+    code, head = _gh(
+        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
+    )
+    head = head.strip()
+    if code != 0 or not head:
+        sys.stderr.write(
+            f"finish: cannot resolve head branch for PR #{pr_number} — refusing to push.\n"
+        )
+        return 1
+    current = _current_branch()
+    if current != head:
+        sys.stderr.write(
+            f"finish: checked-out branch '{current}' is not PR #{pr_number}'s head "
+            f"'{head}'. Check out '{head}' and re-run — refusing to push the wrong branch.\n"
+        )
+        return 1
+    rc = cmd_push(head, 3)
+    if rc != 0:
+        return rc
     rc = cmd_promote(pr_number)
     if rc != 0:
         return rc

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -593,3 +594,45 @@ class TestPushForceWithLease:
             cwd=work, capture_output=True, text=True,
         )
         assert proc.returncode == 0, proc.stderr
+
+
+class TestFinishBranchGuard:
+    """PI-458: `finish` must push the PR's head branch, never whatever is
+    checked out — a concurrent branch switch once made it push an unrelated
+    branch."""
+
+    def test_finish_refuses_when_current_branch_mismatches_pr_head(self, monkeypatch):
+        mod = _load_module(SOURCE_HOOK)
+        # PR #99's head is feat/PI-99-x, but a different branch is checked out.
+        monkeypatch.setattr(mod, "_current_branch", lambda: "chore/PI-50-other")
+        monkeypatch.setattr(
+            mod, "_gh",
+            lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
+        )
+        pushed: list = []
+        monkeypatch.setattr(mod, "cmd_push", lambda *a, **k: pushed.append(a) or 0)
+        monkeypatch.setattr(mod, "cmd_promote", lambda *a, **k: 0)
+
+        rc = mod.cmd_finish(99, None)
+
+        assert rc == 1, "finish must refuse when checked-out branch != PR head"
+        assert pushed == [], "finish must NOT push when the branch mismatches"
+
+    def test_finish_pushes_pr_head_branch_on_match(self, monkeypatch):
+        mod = _load_module(SOURCE_HOOK)
+        monkeypatch.setattr(mod, "_current_branch", lambda: "feat/PI-99-x")
+        monkeypatch.setattr(
+            mod, "_gh",
+            lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
+        )
+        pushed: list = []
+        monkeypatch.setattr(mod, "cmd_push", lambda branch, *a, **k: pushed.append(branch) or 0)
+        monkeypatch.setattr(mod, "cmd_promote", lambda *a, **k: 0)
+        monkeypatch.setattr(
+            mod.subprocess, "run", lambda *a, **k: types.SimpleNamespace(returncode=0)
+        )
+
+        rc = mod.cmd_finish(99, None)
+
+        assert rc == 0
+        assert pushed == ["feat/PI-99-x"], "finish must push the PR's head branch by name"

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -618,6 +618,21 @@ class TestFinishBranchGuard:
         assert rc == 1, "finish must refuse when checked-out branch != PR head"
         assert pushed == [], "finish must NOT push when the branch mismatches"
 
+    def test_finish_refuses_on_detached_head(self, monkeypatch):
+        mod = _load_module(SOURCE_HOOK)
+        monkeypatch.setattr(mod, "_current_branch", lambda: None)
+        monkeypatch.setattr(
+            mod, "_gh",
+            lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
+        )
+        pushed: list = []
+        monkeypatch.setattr(mod, "cmd_push", lambda *a, **k: pushed.append(a) or 0)
+
+        rc = mod.cmd_finish(99, None)
+
+        assert rc == 1, "finish must refuse when there is no current branch"
+        assert pushed == []
+
     def test_finish_pushes_pr_head_branch_on_match(self, monkeypatch):
         mod = _load_module(SOURCE_HOOK)
         monkeypatch.setattr(mod, "_current_branch", lambda: "feat/PI-99-x")


### PR DESCRIPTION
Closes #458

## Problem
`dag_workflow.py cmd_finish` pushed the **current** branch (`cmd_push(None, 3)`) *before* resolving which PR it was finishing. If HEAD moved mid-run (concurrent session activity), `finish` pushed the wrong branch. Observed during PR #455's merge: `finish_pr.sh 455` pushed an unrelated PI-450 branch.

## Fix
`cmd_finish` now:
1. Resolves the PR number first (arg or `_detect_pr_number`).
2. Reads its head branch via `gh pr view <n> --json headRefName`.
3. **Refuses to push (fail-closed) if the checked-out branch != PR head** — with a message telling the user to check out the right branch.
4. Pushes by explicit branch name.

`monitor_pr.sh` was already safe (operates purely by PR number); this closes the one roaming path.

## Scope
Applied identically to all 3 byte-identical copies (`templates/base`, plugin payload, dev `.claude/hooks`); synced + parity-checked.

## Tests
- `TestFinishBranchGuard`: mismatch → returns 1, **never** pushes; match → pushes the PR's head branch by name.
- Existing source/template-match contract still passes (copies identical).
- Full suite: 1260 passed, 3 skipped; ruff clean.