### PR TITLE
chore(PI-463): pin shell:bash on hooks + document Git for Windows + add Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,59 @@ jobs:
           cd /tmp/macos-target
           out=$(/bin/bash .claude/hooks/_py.sh -c "print('resolver-ok')")
           test "$out" = "resolver-ok"
+
+  # PI-463: native Windows (non-WSL) runs hooks through Git Bash when Git for
+  # Windows is present (the documented prerequisite). This is the Git Bash
+  # oracle — it proves the scaffolded bash hooks fire on Windows, catching
+  # CRLF / exec-bit / _py.sh-resolution breakage the Linux/macOS jobs can't.
+  # Gated to shell/template changes like the macOS job.
+  windows-portability:
+    name: Windows Git Bash portability
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash  # GitHub's "bash" on Windows is Git Bash — the supported path
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+
+      - name: Confirm bash is Git Bash
+        run: bash --version | head -1
+
+      - name: Scaffold a project
+        run: |
+          uv run project-init ./win-target \
+            --non-interactive --preset obsidian-only --name win \
+            --description "windows portability" --language python --no-plugin --strict
+
+      - name: SessionStart bootstrap runs under Git Bash
+        run: |
+          cd ./win-target
+          bash .claude/hooks/session_setup.sh
+          test -f .claude/.session_setup_stamp
+
+      - name: Commit gate runs under Git Bash against a staged file
+        run: |
+          cd ./win-target
+          git init -q
+          git config user.email ci@example.com
+          git config user.name ci
+          printf 'x = 1\n' > sample.py
+          git add sample.py
+          # PreToolUse hook: reads tool JSON on stdin, must exit 0 for a clean file.
+          printf '%s' '{"tool_input":{"command":"git commit -m test"}}' \
+            | bash .claude/hooks/pre_commit_gate.sh
+          echo "pre_commit_gate.sh exit: $?"
+
+      - name: _py.sh resolves an interpreter on Windows
+        run: |
+          cd ./win-target
+          out=$(bash .claude/hooks/_py.sh -c "print('resolver-ok')")
+          test "$out" = "resolver-ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
               - '**/*.sh.tmpl'
               - 'templates/**/hooks/**'
               - 'templates/**/scripts/**'
+              - 'templates/**/settings.json.tmpl'
+              - 'plugins/**/hooks/**'
+              - '.github/workflows/ci.yml'
 
   # PI-363 Layer 3: the real bash-3.2 oracle. macos-latest ships bash 3.2 as
   # /bin/bash and BSD coreutils — the genuine stock-Mac environment — so it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,9 @@ jobs:
   # PI-463: native Windows (non-WSL) runs hooks through Git Bash when Git for
   # Windows is present (the documented prerequisite). This is the Git Bash
   # oracle — it proves the scaffolded bash hooks fire on Windows, catching
-  # CRLF / exec-bit / _py.sh-resolution breakage the Linux/macOS jobs can't.
-  # Gated to shell/template changes like the macOS job.
+  # CRLF and _py.sh interpreter-resolution breakage the Linux/macOS jobs can't.
+  # (Hooks run via `bash <script>`, so exec bits aren't exercised here — that
+  # is covered on Linux by test_packaging.) Gated to shell/template changes.
   windows-portability:
     name: Windows Git Bash portability
     needs: changes
@@ -238,21 +239,28 @@ jobs:
       - name: Confirm bash is Git Bash
         run: bash --version | head -1
 
-      - name: Scaffold a project
+      # Scaffold OUTSIDE the repo checkout: session_setup.sh resolves its root as
+      # ${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}, so a target inside
+      # the project-init checkout would climb to the parent repo. RUNNER_TEMP is a
+      # sibling of the workspace; cygpath -u makes it a bash-clean path.
+      - name: Scaffold a project (outside the repo tree)
         run: |
-          uv run project-init ./win-target \
+          target="$(cygpath -u "$RUNNER_TEMP")/win-target"
+          echo "WIN_TARGET=$target" >> "$GITHUB_ENV"
+          uv run project-init "$target" \
             --non-interactive --preset obsidian-only --name win \
             --description "windows portability" --language python --no-plugin --strict
 
       - name: SessionStart bootstrap runs under Git Bash
         run: |
-          cd ./win-target
-          bash .claude/hooks/session_setup.sh
+          cd "$WIN_TARGET"
+          # CLAUDE_PROJECT_DIR is what Claude Code itself sets on every hook fire.
+          CLAUDE_PROJECT_DIR="$WIN_TARGET" bash .claude/hooks/session_setup.sh
           test -f .claude/.session_setup_stamp
 
       - name: Commit gate runs under Git Bash against a staged file
         run: |
-          cd ./win-target
+          cd "$WIN_TARGET"
           git init -q
           git config user.email ci@example.com
           git config user.name ci
@@ -260,11 +268,11 @@ jobs:
           git add sample.py
           # PreToolUse hook: reads tool JSON on stdin, must exit 0 for a clean file.
           printf '%s' '{"tool_input":{"command":"git commit -m test"}}' \
-            | bash .claude/hooks/pre_commit_gate.sh
+            | CLAUDE_PROJECT_DIR="$WIN_TARGET" bash .claude/hooks/pre_commit_gate.sh
           echo "pre_commit_gate.sh exit: $?"
 
       - name: _py.sh resolves an interpreter on Windows
         run: |
-          cd ./win-target
+          cd "$WIN_TARGET"
           out=$(bash .claude/hooks/_py.sh -c "print('resolver-ok')")
           test "$out" = "resolver-ok"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Distribution rationale: [ADR-008](https://github.com/VytCepas/project-init/blob/
 ### Platform requirements
 
 macOS, Linux, and WSL work out of the box. The scaffolded hooks and lifecycle
-scripts are bash (single bash-3.2 floor, ADR-017) — so on **native Windows
+scripts are bash (a single bash-3.2 portability floor, epic #359) — so on **native Windows
 (non-WSL)** you need **[Git for Windows](https://gitforwindows.org/)** (it ships
 `bash`/`sh` + coreutils), and you should run from a **Git Bash** shell. Claude
 Code then runs hooks through Git Bash automatically; the wired hooks also pin

--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ uv tool install git+https://github.com/VytCepas/project-init@v0.3.0
 
 Distribution rationale: [ADR-008](https://github.com/VytCepas/project-init/blob/main/docs/adr/adr-008-distribution-channel.md) (git channel), [ADR-011](https://github.com/VytCepas/project-init/blob/main/docs/adr/adr-011-pypi-trusted-publishing.md) (PyPI via trusted publishing).
 
+### Platform requirements
+
+macOS, Linux, and WSL work out of the box. The scaffolded hooks and lifecycle
+scripts are bash (single bash-3.2 floor, ADR-017) — so on **native Windows
+(non-WSL)** you need **[Git for Windows](https://gitforwindows.org/)** (it ships
+`bash`/`sh` + coreutils), and you should run from a **Git Bash** shell. Claude
+Code then runs hooks through Git Bash automatically; the wired hooks also pin
+`"shell": "bash"` to make that explicit. Without Git for Windows, Claude Code
+falls back to PowerShell, which can't run a bash hook — so the enforcement
+hooks won't fire. PowerShell-only is not a supported target; there are no
+`.ps1` equivalents by design. (WSL remains the smoothest Windows path.)
+
 ## Use
 
 ### Option 1: Inside a Claude Code session (interactive)

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -208,6 +208,7 @@ git commit --allow-empty -m "test: verify hooks"
 | `uv: command not found` | Add `export PATH="$HOME/.local/bin:$PATH"` to shell profile |
 | `bunx: command not found` when adding MCPs | `curl -fsSL https://bun.sh/install \| bash` |
 | Hooks don't fire on commit | Check `python3 --version`; hooks need `python3` on PATH |
+| Hooks never fire on native Windows | Install [Git for Windows](https://gitforwindows.org/) and run from Git Bash. The hooks are bash; without Git Bash, Claude Code falls back to PowerShell, which can't run them. PowerShell-only is unsupported (no `.ps1` variants). WSL avoids this entirely. |
 | Unrendered `{{...}}` in output | Re-run with `--strict` to surface the missing variable |
 | `lint_memory.sh` reports errors | Each file in `memory/` needs a matching entry in `MEMORY.md` |
 | CRLF line ending errors on WSL | Edit and commit from inside WSL, not Git Bash on Windows |

--- a/plugins/project-init-workflow/hooks/hooks.json
+++ b/plugins/project-init-workflow/hooks/hooks.json
@@ -5,6 +5,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/session_setup.sh",
             "timeout": 300
           }
@@ -17,16 +18,19 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/pre_commit_gate.sh",
             "timeout": 60
           },
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/github_command_guard.sh",
             "timeout": 10
           },
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/_py.sh \"${CLAUDE_PLUGIN_ROOT}\"/hooks/prod_guard.py",
             "timeout": 10
           }
@@ -39,6 +43,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/post_edit_lint.sh",
             "timeout": 30
           }
@@ -50,6 +55,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/workflow_state_reminder.sh",
             "timeout": 10
           }

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -27,6 +27,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_setup.sh",
             "timeout": 300
           }
@@ -39,16 +40,19 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre_commit_gate.sh",
             "timeout": 60
           },
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/github_command_guard.sh",
             "timeout": 10
           },
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/_py.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prod_guard.py",
             "timeout": 10
           }
@@ -61,6 +65,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_edit_lint.sh",
             "timeout": 30
           }
@@ -72,6 +77,7 @@
         "hooks": [
           {
             "type": "command",
+            "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/workflow_state_reminder.sh",
             "timeout": 10
           }

--- a/tests/contracts/test_hook_portability.py
+++ b/tests/contracts/test_hook_portability.py
@@ -8,9 +8,13 @@ templates and the derived plugin payload (kept in sync by tools/sync_plugin.py).
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -32,9 +36,7 @@ def _hook_files(name: str) -> list[Path]:
 
 def _code_lines(text: str) -> str:
     """Strip comment-only lines so a builtin named in a comment doesn't trip."""
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
 
 @pytest.mark.parametrize("name", _ALWAYS_ON)
@@ -64,3 +66,43 @@ def test_commit_gate_builds_arrays_portably():
         code = _code_lines(path.read_text())
         assert "while IFS= read -r" in code, f"{path}: expected portable read loop"
         assert "STAGED_PY+=(" in code and "STAGED_JS+=(" in code
+
+
+def _command_hooks(hooks_block: dict) -> list[dict]:
+    """Flatten every command-type hook object across all events."""
+    out: list[dict] = []
+    for event_entries in hooks_block.values():
+        for entry in event_entries:
+            for hook in entry.get("hooks", []):
+                if hook.get("type") == "command":
+                    out.append(hook)
+    return out
+
+
+def test_plugin_hooks_pin_bash_shell():
+    """PI-463: every command hook pins shell:bash so native Windows uses Git
+    Bash (and never silently falls back to PowerShell, which can't run a bash
+    shebang or expand POSIX $CLAUDE_PLUGIN_ROOT)."""
+    config = json.loads(
+        (_REPO_ROOT / "plugins" / "project-init-workflow" / "hooks" / "hooks.json").read_text()
+    )
+    cmds = _command_hooks(config["hooks"])
+    assert cmds, "plugin hooks.json must define at least one command hook"
+    for hook in cmds:
+        assert hook.get("shell") == "bash", (
+            f'plugin hook {hook.get("command")!r} must set "shell": "bash"'
+        )
+
+
+def test_scaffolded_settings_hooks_pin_bash_shell(tmp_path: Path):
+    """The --no-plugin scaffold wires hooks in settings.json; each must pin
+    shell:bash for the same native-Windows reason (PI-463)."""
+    target = tmp_path / "proj"
+    scaffold(target, fallback_preset(), fallback_variables())
+    settings = json.loads((target / ".claude" / "settings.json").read_text())
+    cmds = _command_hooks(settings.get("hooks", {}))
+    assert cmds, "no-plugin settings.json must wire command hooks"
+    for hook in cmds:
+        assert hook.get("shell") == "bash", (
+            f'settings.json hook {hook.get("command")!r} must set "shell": "bash"'
+        )


### PR DESCRIPTION
## Why

Native Windows (non-WSL) runs Claude Code hooks through **Git Bash if present, else PowerShell** (official fallback chain). Our scaffolded hooks use POSIX `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PLUGIN_ROOT}` expansion + bash `.sh` scripts — so without Git for Windows they silently no-op under PowerShell. The supported path (install Git for Windows, work from Git Bash) was **real but undocumented**, and nothing signalled bash-intent on the hook objects.

Surfaced while scoping native-Windows testing for `/live_test` (#460).

## What

- **Pin `"shell": "bash"`** on every command hook in `templates/base/dot_claude/settings.json.tmpl` and the plugin `plugins/project-init-workflow/hooks/hooks.json`. Officially supported; identical schema in plugin hooks.json; it's already the default so it's a no-op on WSL/macOS/Linux — it makes the Windows shell explicit and signals intent.
- **Contract test** (`test_hook_portability.py`) asserting every command hook carries the pin, across both the no-plugin `settings.json` and the plugin payload.
- **Docs**: Git for Windows as the native-Windows prerequisite (README platform note + `using-project-init` troubleshooting row). PowerShell-only stays a non-goal — no `.ps1` variants, per the bash-3.2 floor (ADR-017/#359).
- **`windows-latest` Git Bash CI job** mirroring `macos-portability` (gated to shell/template changes): scaffold `--no-plugin`, then run `session_setup` / `pre_commit_gate` / `_py.sh` under Git Bash so the happy path can't silently regress.

## Verification

- Full suite green (1263 passed, 3 skipped); `ruff check` clean.
- Rendered no-plugin `settings.json` has 6 valid `shell:bash` pins; plugin mode unchanged (hooks via plugin).
- New contract tests pass over both trees.

## Out of scope

- PowerShell `.ps1` hook variants (contradicts the single bash-floor ADR).
- Per-surface (codex/cursor/antigravity) `hooks.json` — different non-Claude schemas; not the `shell` field's domain.

Closes #463

https://claude.ai/code/session_0138Pr9iuPEPmMi8Cztj5B9U