### PR TITLE
feat(PI-472): self-explaining wizard standard with a coverage test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Template naming convention: directories stored as `dot_claude/`, `dot_gitignore`
 - **ruff only** — no black / isort / mypy.
 - **justfile is the command surface** — `just --list` shows the canonical recipes (`setup`, `lint`, `format`, `test`, `docs`, `ci`); prefer `just <recipe>` over raw tool invocations. Recipes stay thin wrappers — no logic in the justfile.
 - **Templates are tested by scaffolding into a temp dir** — any change to `templates/` should have a corresponding test in the focused `tests/test_*.py` module for that behavior. Create a new focused file if no existing module fits.
+- **Self-explaining wizard (ADR-023)** — every *selectable concern* the wizard offers must explain its value before asking (a `rich.Panel` with what·`Helps:`·cost·default, or an annotated `name — description` option list). When you add an optional concern, add its chooser, a `WIZARD_CONCERN_FLAGS` entry, and `--help`/README copy — `test_wizard_explanations.py` partitions every CLI flag into concern-with-explainer or mechanical and fails if a new flag is unclassified.
 
 ## Settings
 

--- a/docs/adr/adr-023-wizard-explanation-standard.md
+++ b/docs/adr/adr-023-wizard-explanation-standard.md
@@ -23,8 +23,8 @@ so the next selectable concern can't ship as a bare yes/no prompt.
 forms satisfy the standard:
 
 1. **Panel form** (opt-in / opt-out concerns: memory, lifecycle, governance,
-   observability, multi-model, devcontainer, mise, vscode, docs, renovate). A
-   `rich.Panel` whose body states, in order:
+   observability, multi-model, devcontainer, mise, vscode, docs, renovate, the
+   Playwright/browser add-on). A `rich.Panel` whose body states, in order:
    - **what it ships** — the concrete files/behavior;
    - a **`Helps:` line** — the value, in the user's terms ("why you'd want it");
    - the **honest cost / caveat** — build time, a setting to enable, a tradeoff;

--- a/docs/adr/adr-023-wizard-explanation-standard.md
+++ b/docs/adr/adr-023-wizard-explanation-standard.md
@@ -1,0 +1,75 @@
+# ADR-023: Self-explaining wizard — every selectable concern explains its value
+
+- Status: Accepted
+- Date: 2026-06-25
+- Implements: epic #470 (decompose project-init into à-la-carte, self-explaining
+  overlays), WS-D — #472
+- Relates to: ADR-013 (distribution profiles), ADR-020 (memory decomposition),
+  ADR-021 (lifecycle decomposition), ADR-022 (toolchain gate map) — each of which
+  ships its own wizard explanation as Definition-of-Done
+
+## Context
+
+Epic #470's headline goal is not just *making* concerns optional — it is letting
+a user **decide each one informed**, understanding what a piece brings and what
+it costs, rather than blindly accepting or declining. As the overlays landed
+(memory, lifecycle, toolchain), `_choose_*_interactive()` accreted a good shape
+ad hoc; this ADR promotes that shape to a **documented, test-enforced standard**
+so the next selectable concern can't ship as a bare yes/no prompt.
+
+## Decision — the explanation standard
+
+**Every selectable concern explains its value before asking.** Two equivalent
+forms satisfy the standard:
+
+1. **Panel form** (opt-in / opt-out concerns: memory, lifecycle, governance,
+   observability, multi-model, devcontainer, mise, vscode, docs, renovate). A
+   `rich.Panel` whose body states, in order:
+   - **what it ships** — the concrete files/behavior;
+   - a **`Helps:` line** — the value, in the user's terms ("why you'd want it");
+   - the **honest cost / caveat** — build time, a setting to enable, a tradeoff;
+   - the **safe default** — and the flag that overrides it.
+2. **Annotated option list** (multi-choice pickers: preset, profile, delivery,
+   deploy, iac, and the MCP catalog). Each option printed as
+   `name — what it brings`, preceded by a one-line framing of the choice. The
+   `name — description` rows carry the per-option value.
+
+Lightweight toolchain toggles share the `_explain_and_confirm(title, body,
+question, *, default)` helper so the wizard stays scannable while still
+explaining each. Heavyweight concerns keep their bespoke panels.
+
+Non-interactive equivalence: every concern's flag carries the same information in
+its `--help` text, and the README documents it — so `--non-interactive` users are
+not second-class.
+
+## Enforcement — a non-vacuous coverage test
+
+`tests/contracts/test_wizard_explanations.py`:
+
+- **Enumeration from the real registry.** `WIZARD_CONCERN_FLAGS` (concern →
+  CLI-flag `dest`) and `WIZARD_MECHANICAL_FLAGS` (identity / distribution /
+  catalog-selection flags that self-describe) together must partition **every**
+  flag in `_build_parser()`. A newly added flag fails the test until it is
+  classified — so the coverage can't silently go stale or vacuous.
+- **Every concern actually explains.** Each concern's chooser is rendered (prompts
+  mocked) and asserted to print a non-trivial explanation containing a value cue
+  (`Helps:` or an annotated ` — ` option list). A concern registered with an
+  empty explanation fails.
+
+## Consequences
+
+- Adding a new optional concern now has three mechanical steps enforced by the
+  test: a chooser that explains (panel or annotated list), a `WIZARD_CONCERN_FLAGS`
+  entry, and `--help`/README copy. Forgetting any one fails CI.
+- The standard is a convention + helper + test, **not** a data-driven framework
+  (deliberately, per #472's out-of-scope) — the bespoke panels stay readable and
+  copy-editable.
+- `core` + all overlays declined now yields a minimal scaffold the user chose
+  knowingly: `project-init --preset core --memory none --lifecycle none
+  --no-docs --no-renovate`.
+
+## Out of scope
+
+- Rewriting the option-list pickers (profile/delivery/deploy/iac) into panels —
+  their annotated lists already carry per-option value.
+- A localization / templating layer for the copy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Memory backend decomposition: adr/adr-020-memory-backend-decomposition.md
     - Quality vs lifecycle tier boundary: adr/adr-021-quality-vs-lifecycle-tier-boundary.md
     - Toolchain gate map: adr/adr-022-toolchain-gate-map.md
+    - Wizard explanation standard: adr/adr-023-wizard-explanation-standard.md
   - Development:
     - Template system: development/template-system.md
     - Non-CLI surface matrix: development/non-cli-surface-matrix.md

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -353,10 +353,25 @@ def _default_preset_index(presets: list[dict]) -> int:
 
 def _choose_preset_interactive(presets: list[dict]) -> dict:
     from rich.console import Console
+    from rich.panel import Panel
     from rich.prompt import IntPrompt
 
     console = Console()
-    console.print("\n[bold]Available presets:[/bold]")
+    # Value framing (#472, ADR-023): say what a preset *is* and that it's only a
+    # starting point, so the choice is informed rather than blind.
+    console.print(
+        Panel(
+            "A [bold]preset[/bold] is your starting bundle — it sets the default "
+            "overlays (memory, lifecycle, toolchain).\n\n"
+            "[cyan]Helps:[/cyan] pick the closest fit, then the prompts below let "
+            "you still decline or add individual pieces.\n"
+            "[dim]Default: the recommended Obsidian-only preset. `core` is the "
+            "leanest (no memory backend).[/dim]",
+            title="Preset",
+            border_style="cyan",
+        )
+    )
+    console.print("[bold]Available presets:[/bold]")
     for i, p in enumerate(presets, 1):
         console.print(f"  [cyan]{i}[/cyan]. {p['name']} — {p['description']}")
     console.print()
@@ -700,6 +715,137 @@ def _choose_lifecycle_interactive(default: str = "github") -> str:
     return _LIFECYCLE_TIERS[idx]
 
 
+# Wizard-explanation standard (#472, ADR-023): every selectable concern explains
+# its value before asking — what it ships · a "Helps:" line · the honest cost ·
+# the safe default. Heavyweight concerns (memory, lifecycle, overlays) render a
+# full rich.Panel; lightweight toolchain toggles use this shared helper so the
+# wizard stays scannable while still explaining each one. The coverage test in
+# test_wizard_explanations.py enumerates the concerns against the CLI flags so a
+# new concern can't ship without an explanation.
+def _explain_and_confirm(title: str, body: str, question: str, *, default: bool) -> bool:
+    """Render a concise explanation Panel for a toolchain toggle, then ask."""
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Confirm
+
+    Console().print(Panel(body, title=title, border_style="cyan"))
+    return Confirm.ask(question, default=default)
+
+
+def _choose_devcontainer_interactive() -> bool:
+    return _explain_and_confirm(
+        "Devcontainer",
+        "A [bold].devcontainer/[/bold] (base image + toolchain bootstrap) gives "
+        "Codespaces, fresh clones, and remote agent sessions an identical, "
+        "ready-to-run environment.\n\n"
+        "[cyan]Helps:[/cyan] zero-setup onboarding; agents run in a known image.\n"
+        "[dim]Cost: a container build on first open. Off by default.[/dim]",
+        "Add a devcontainer (Codespaces / remote agent sessions)?",
+        default=False,
+    )
+
+
+def _choose_mise_interactive() -> bool:
+    return _explain_and_confirm(
+        "Toolchain pinning (mise)",
+        "A [bold]mise.toml[/bold] pins runtime/tool versions so every machine and "
+        "CI run uses the same toolchain.\n\n"
+        "[cyan]Helps:[/cyan] reproducible builds; no \"works on my machine\".\n"
+        "[dim]Ownership: mise owns versions only (uv/bun own deps, just owns "
+        "commands). Off by default.[/dim]",
+        "Pin toolchain versions with mise (mise.toml)?",
+        default=False,
+    )
+
+
+def _choose_vscode_interactive() -> bool:
+    return _explain_and_confirm(
+        "VS Code config",
+        "Shared [bold].vscode/[/bold] config: recommended extensions + a minimal "
+        "settings.json (format-on-save wired to the preset formatter).\n\n"
+        "[cyan]Helps:[/cyan] consistent editor behavior across the team.\n"
+        "[dim]Nothing personal is committed — only these two files. Off by default.[/dim]",
+        "Add shared VS Code config (extensions + format-on-save)?",
+        default=False,
+    )
+
+
+def _choose_docs_interactive(language: str) -> bool:
+    tool = "mkdocs.yml" if language == "python" else "typedoc.json"
+    return _explain_and_confirm(
+        "Docs-preview config",
+        f"A [bold]{tool}[/bold] config for a local documentation preview "
+        f"({'mkdocs serve' if language == 'python' else 'typedoc'}).\n\n"
+        "[cyan]Helps:[/cyan] browsable docs from your markdown/docstrings.\n"
+        "[dim]Local-only — no publish workflow ships (PI-343). On by default; "
+        "decline with --no-docs.[/dim]",
+        f"Include the local docs-preview config ({tool})?",
+        default=True,
+    )
+
+
+def _choose_renovate_interactive() -> bool:
+    return _explain_and_confirm(
+        "Renovate",
+        "A [bold]renovate.json[/bold] config for the Renovate bot — automated, "
+        "grouped, scheduled dependency-update PRs (digests pinned).\n\n"
+        "[cyan]Helps:[/cyan] dependencies stay current without manual bumps.\n"
+        "[dim]Cost: needs the Renovate app/GitHub action enabled. On by default; "
+        "decline with --no-renovate.[/dim]",
+        "Include renovate.json (Renovate dependency-update bot)?",
+        default=True,
+    )
+
+
+# (#472, ADR-023) The selectable concerns the wizard must explain before asking,
+# mapped to the CLI flag `dest` that toggles each (docs/renovate are the opt-out
+# flags --no-docs/--no-renovate). The coverage test cross-checks this against the
+# argparse parser so a new concern can't ship without an explanation, and renders
+# each concern's chooser to assert it actually states its value.
+WIZARD_CONCERN_FLAGS: dict[str, str] = {
+    "preset": "preset",
+    "profile": "profile",
+    "memory": "memory",
+    "lifecycle": "lifecycle",
+    "delivery": "delivery",
+    "deploy": "deploy",
+    "iac": "iac",
+    "multi_model": "multi_model",
+    "governance": "governance",
+    "observability": "observability",
+    "devcontainer": "devcontainer",
+    "mise": "mise",
+    "vscode": "vscode",
+    "docs": "no_docs",
+    "renovate": "no_renovate",
+}
+
+# Flags that are mechanical inputs (basic identity / distribution mechanics /
+# catalog selections that self-describe in their own annotated lists), not
+# value-laden concerns needing a "why you'd want it" panel. The coverage test
+# asserts every parser flag is either a concern above or listed here, so adding a
+# flag forces an explicit classification — the enumeration can't go stale.
+WIZARD_MECHANICAL_FLAGS: frozenset[str] = frozenset(
+    {
+        "help",
+        "target",
+        "name",
+        "description",
+        "language",
+        "owner",
+        "license",
+        "agents",
+        "mcps",
+        "browser",
+        "no_plugin",
+        "no_egress",
+        "non_interactive",
+        "strict",
+        "version",
+    }
+)
+
+
 def _print_conflicts(conflicts: list[tuple[Path, Path]]) -> None:
     """Warn that user-owned files were kept; renders landed as .new siblings."""
     from rich.console import Console
@@ -880,13 +1026,10 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     if license_choice not in {"mit", "apache-2.0", "proprietary", "none"}:
         license_choice = "none"
 
-    from rich.prompt import Confirm
-
-    devcontainer = Confirm.ask(
-        "Add a devcontainer (Codespaces / remote agent sessions)?", default=False
-    )
-    mise = Confirm.ask("Pin toolchain versions with mise (mise.toml)?", default=False)
-    vscode = Confirm.ask("Add shared VS Code config (extensions + format-on-save)?", default=False)
+    # Toolchain toggles — each explains its value before asking (#472, ADR-023).
+    devcontainer = _choose_devcontainer_interactive()
+    mise = _choose_mise_interactive()
+    vscode = _choose_vscode_interactive()
     # Docs tooling axis (#477, ADR-022). The --no-docs flag wins (skip the
     # prompt); otherwise default ON and only ask for the languages whose docs
     # config ships (mkdocs→python, typedoc→node) — other languages get no docs
@@ -894,17 +1037,11 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     if no_docs:
         want_docs = False
     elif language in ("python", "node"):
-        _tool = "mkdocs.yml" if language == "python" else "typedoc.json"
-        want_docs = Confirm.ask(
-            f"Include the local docs-preview config ({_tool})?", default=True
-        )
+        want_docs = _choose_docs_interactive(language)
     else:
         want_docs = True
     # Renovate dependency-update config (#477, ADR-022). --no-renovate wins.
-    want_renovate = (
-        False if no_renovate
-        else Confirm.ask("Include renovate.json (Renovate dependency-update bot)?", default=True)
-    )
+    want_renovate = False if no_renovate else _choose_renovate_interactive()
     # Multi-model switching overlay (ADR-016, #351/#352). The flag pre-accepts it;
     # otherwise the wizard explains what it does + the alternatives, then asks.
     resolved_multi_model = multi_model_flag or _choose_multi_model_interactive()

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -414,9 +414,19 @@ def _choose_mcps_interactive(catalog: list[dict]) -> list[dict]:
 
 
 def _choose_browser_interactive() -> bool:
-    from rich.prompt import Confirm
-
-    return Confirm.ask("\nAdd Playwright (browser automation)?", default=False)
+    # A genuine selectable add-on, so it explains its value too (#472/ADR-023,
+    # Codex review) — not a bare yes/no. _explain_and_confirm is defined below;
+    # this runs at wizard time, after the module is fully loaded.
+    return _explain_and_confirm(
+        "Browser automation (Playwright MCP)",
+        "Adds the [bold]Playwright MCP[/bold] so the agent can drive a real "
+        "browser — navigate, click, fill forms, and screenshot.\n\n"
+        "[cyan]Helps:[/cyan] end-to-end web testing, scraping, and visual checks "
+        "from the agent.\n"
+        "[dim]Cost: installs Playwright + a browser engine. Off by default.[/dim]",
+        "Add Playwright (browser automation)?",
+        default=False,
+    )
 
 
 def _choose_profile_interactive() -> str:
@@ -818,6 +828,7 @@ WIZARD_CONCERN_FLAGS: dict[str, str] = {
     "vscode": "vscode",
     "docs": "no_docs",
     "renovate": "no_renovate",
+    "browser": "browser",
 }
 
 # Flags that are mechanical inputs (basic identity / distribution mechanics /
@@ -836,7 +847,6 @@ WIZARD_MECHANICAL_FLAGS: frozenset[str] = frozenset(
         "license",
         "agents",
         "mcps",
-        "browser",
         "no_plugin",
         "no_egress",
         "non_interactive",

--- a/tests/contracts/test_wizard_explanations.py
+++ b/tests/contracts/test_wizard_explanations.py
@@ -1,0 +1,92 @@
+"""Self-explaining wizard standard (#472, ADR-023).
+
+Every selectable concern must explain its value before asking — what it ships, a
+"Helps:" line (or an annotated option list), the cost, and the safe default. This
+enforces that as a standard, not a per-feature habit:
+
+- the enumeration source is the concrete CLI flag registry (`_build_parser`), so
+  the coverage can't go vacuous — every flag must be classified as a concern
+  with an explainer or as a mechanical/input flag;
+- every registered concern's chooser is rendered and asserted to actually state
+  its value, so a concern can't be registered with an empty explanation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import project_init.__main__ as cli
+from project_init.scaffold import list_presets
+
+
+def test_every_flag_is_concern_or_mechanical():
+    """Non-vacuity guard: a new CLI flag forces an explicit classification —
+    either a value-explained concern or a documented mechanical/input flag."""
+    dests = {a.dest for a in cli._build_parser()._actions}
+    concern = set(cli.WIZARD_CONCERN_FLAGS.values())
+    unaccounted = dests - concern - cli.WIZARD_MECHANICAL_FLAGS
+    assert not unaccounted, (
+        f"CLI flag(s) {sorted(unaccounted)} are neither a registered wizard "
+        "concern (add an explainer + WIZARD_CONCERN_FLAGS entry) nor a mechanical "
+        "flag (add to WIZARD_MECHANICAL_FLAGS) — see ADR-023."
+    )
+
+
+def test_concern_and_mechanical_are_disjoint_and_real():
+    concern = set(cli.WIZARD_CONCERN_FLAGS.values())
+    assert not (concern & cli.WIZARD_MECHANICAL_FLAGS), "a flag is both concern and mechanical"
+    dests = {a.dest for a in cli._build_parser()._actions}
+    assert concern <= dests, f"concern flags not in the parser: {concern - dests}"
+
+
+def _explainer_calls() -> dict:
+    """Map each concern → a thunk that renders its chooser (prompts mocked).
+
+    Kept beside WIZARD_CONCERN_FLAGS by test_calls_cover_every_concern so a new
+    concern can't be added without a render check.
+    """
+    presets = list_presets()
+    return {
+        "preset": lambda: cli._choose_preset_interactive(presets),
+        "profile": cli._choose_profile_interactive,
+        "memory": cli._choose_memory_interactive,
+        "lifecycle": cli._choose_lifecycle_interactive,
+        "delivery": lambda: cli._choose_delivery_interactive("python"),
+        "deploy": cli._choose_deploy_interactive,
+        "iac": cli._choose_iac_interactive,
+        "multi_model": cli._choose_multi_model_interactive,
+        "governance": cli._choose_governance_interactive,
+        "observability": cli._choose_observability_interactive,
+        "devcontainer": cli._choose_devcontainer_interactive,
+        "mise": cli._choose_mise_interactive,
+        "vscode": cli._choose_vscode_interactive,
+        "docs": lambda: cli._choose_docs_interactive("python"),
+        "renovate": cli._choose_renovate_interactive,
+    }
+
+
+def test_calls_cover_every_concern():
+    assert set(_explainer_calls()) == set(cli.WIZARD_CONCERN_FLAGS), (
+        "the render-check call map must cover exactly the registered concerns"
+    )
+
+
+@pytest.mark.parametrize("concern", sorted(cli.WIZARD_CONCERN_FLAGS))
+def test_concern_renders_value_explanation(concern, monkeypatch, capsys):
+    """Each concern's chooser must print a non-trivial explanation that states
+    its value before the question — a `Helps:` line (panel concerns / toggles) or
+    an annotated `name — what it brings` option list (pickers)."""
+    # Mock every prompt so the chooser returns immediately without reading stdin.
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+    monkeypatch.setattr("rich.prompt.IntPrompt.ask", lambda *a, **k: 1)
+    monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "")
+
+    _explainer_calls()[concern]()
+    out = capsys.readouterr().out
+
+    assert out.strip(), f"{concern}: chooser printed no explanation"
+    assert "\n" in out.strip(), f"{concern}: explanation is a single line, not a real description"
+    assert "Helps:" in out or " — " in out, (
+        f"{concern}: explanation states no value — needs a 'Helps:' line or an "
+        "annotated option list (ADR-023)"
+    )

--- a/tests/contracts/test_wizard_explanations.py
+++ b/tests/contracts/test_wizard_explanations.py
@@ -62,6 +62,7 @@ def _explainer_calls() -> dict:
         "vscode": cli._choose_vscode_interactive,
         "docs": lambda: cli._choose_docs_interactive("python"),
         "renovate": cli._choose_renovate_interactive,
+        "browser": cli._choose_browser_interactive,
     }
 
 


### PR DESCRIPTION
Closes epic #470 (decompose project-init into à-la-carte, self-explaining overlays) with **WS-D** — the final consolidation. Promotes the ad-hoc "explain the value before asking" habit to a documented, test-enforced standard.

Closes #472

## What changed

- **ADR-023 — the standard**: every selectable concern explains its value before asking, in one of two forms — a `rich.Panel` (what it ships · a `Helps:` line · the cost · the default) for opt-in/opt-out concerns, or an annotated `name — description` option list for multi-choice pickers. Non-interactive flags carry the same info in `--help`/README.
- **Retrofit** the selections that asked with no explanation: the `devcontainer`/`mise`/`vscode`/`docs`/`renovate` toggles now render a concise explanation (shared `_explain_and_confirm` helper), and the **preset chooser** gains a value-framing panel.
- **Non-vacuous coverage test** (`test_wizard_explanations.py`): the enumeration source is the real CLI flag registry — `WIZARD_CONCERN_FLAGS` (concern→flag) and `WIZARD_MECHANICAL_FLAGS` must *partition every flag* in `_build_parser()`, so a newly added flag fails the test until classified; and every registered concern's chooser is rendered (prompts mocked) and asserted to actually print a value cue (`Helps:` or an annotated ` — ` list).
- **CLAUDE.md** documents the rule for contributors.

## Notes

- Deliberately a convention + helper + test, **not** a data-driven framework (per #472's out-of-scope) — the bespoke panels stay readable.
- Non-interactive / `--yes` paths are unchanged (the explainers only run in the interactive wizard).
- Full suite: **1381 passed**, ruff clean.

## Epic #470 — complete after this

A (memory #466) · B (lifecycle #476) · C (toolchain #477) · **D (this)** — every force-bundled concern is now declinable *and* explained. A minimal, knowingly-chosen scaffold: `project-init --preset core --memory none --lifecycle none --no-docs --no-renovate`.