### PR TITLE
fix: stop scaffold leaking template bytecode into projects

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -526,7 +526,14 @@ def _validate_no_placeholders(rendered_files: list[tuple[Path, str]]) -> None:
 
 
 def _iter_layer_files(layers: list[str]):
-    """Yield (src, layer_dir) for every file across the preset's template layers."""
+    """Yield (src, layer_dir) for every file across the preset's template layers.
+
+    Python bytecode caches are skipped: a developer's local templates/ tree
+    accumulates ``__pycache__/*.pyc`` next to the hook/script sources (after the
+    test suite or any import compiles them), and copying those into scaffolds
+    pollutes the project with stale bytecode that also trips ``upgrade``'s drift
+    report. Never a real template file, on any host (#470 e2e).
+    """
     for layer_name in layers:
         layer_dir = _TEMPLATES_DIR / layer_name
         if not layer_dir.exists():
@@ -534,6 +541,8 @@ def _iter_layer_files(layers: list[str]):
             raise FileNotFoundError(msg)
         for src in sorted(layer_dir.rglob("*")):
             if src.is_dir():
+                continue
+            if "__pycache__" in src.parts or src.suffix in (".pyc", ".pyo"):
                 continue
             yield src, layer_dir
 

--- a/tests/contracts/test_no_bytecode_leak.py
+++ b/tests/contracts/test_no_bytecode_leak.py
@@ -1,0 +1,45 @@
+"""Scaffolds must never contain Python bytecode (#470 e2e bug).
+
+A developer's local templates/ tree accumulates ``__pycache__/*.pyc`` next to
+the hook/script sources; before this guard `scaffold()` copied that compiled
+bytecode straight into every dev-scaffolded project, polluting it AND tripping
+`project-init upgrade`'s drift report (the .pyc landed in the render + manifest).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init import scaffold as sc
+from project_init.scaffold import scaffold
+from tests.helpers import make_variables, memory_preset
+
+
+def test_iter_layer_files_skips_bytecode(tmp_path: Path, monkeypatch):
+    """Non-vacuous: plant a __pycache__/*.pyc in a layer and assert the file
+    iterator skips it (robust even on a clean CI checkout with no real .pyc)."""
+    fake_templates = tmp_path / "templates"
+    layer = fake_templates / "demo"
+    (layer / "__pycache__").mkdir(parents=True)
+    (layer / "__pycache__" / "mod.cpython-312.pyc").write_bytes(b"\x00bytecode")
+    (layer / "real.txt").write_text("hi\n")
+    monkeypatch.setattr(sc, "_TEMPLATES_DIR", fake_templates)
+
+    names = {src.name for src, _ in sc._iter_layer_files(["demo"])}
+    assert "real.txt" in names, "real template file dropped"
+    assert not any(n.endswith((".pyc", ".pyo")) for n in names), (
+        "bytecode leaked through _iter_layer_files"
+    )
+
+
+def test_scaffold_emits_no_bytecode(tmp_path: Path):
+    """End-to-end guard: a real scaffold contains no __pycache__/.pyc even when
+    the (dev) template tree does."""
+    target = tmp_path / "p"
+    scaffold(target, memory_preset("obsidian-only"), make_variables())
+    leaked = [
+        p.relative_to(target).as_posix()
+        for p in target.rglob("*")
+        if "__pycache__" in p.parts or p.suffix in (".pyc", ".pyo")
+    ]
+    assert not leaked, f"scaffold leaked bytecode into the project: {leaked}"


### PR DESCRIPTION
Found by the hands-on **e2e matrix** I ran after epic #470 — scaffolding 6 representative mini-projects and exercising them like a user. Everything was clean except `project-init upgrade`, which reported spurious drift on every project:

```
--- drift: .claude/hooks/__pycache__/dag_workflow.cpython-312.pyc ---
(binary file ... differs)
```

## Root cause

`_iter_layer_files` globs every file in each template layer. A developer's local `templates/` tree carries `__pycache__/*.pyc` next to the hook sources (compiled once the test suite or any import touches them — there are 4 in the tree right now). So `scaffold()` **copied that bytecode into every project** (the e2e `py` project had 2 leaked `.pyc`), and on upgrade the stale `.pyc` landed in the render + manifest → drift. The scaffolded `.gitignore` already lists `__pycache__/`, and the byte-identity manifest already filtered `.pyc` — `scaffold()` itself was the inconsistency.

> Note: end users installing from a clean wheel are less exposed (no template `.pyc` to copy), but any non-clean template tree — every contributor's — hits it. Fixing at the source makes it correct regardless of packaging.

## Fix

`_iter_layer_files` skips any `__pycache__` path part or `.pyc`/`.pyo` suffix — bytecode never enters a scaffold or its manifest.

## Verified

- Fresh python scaffold: **0** `.pyc` (was 2); `upgrade` → **"No drift."**
- New regression test (non-vacuous): plants a `.pyc` in a layer, asserts the iterator skips it; plus an end-to-end no-bytecode assertion.
- Full suite: **1437 passed**, ruff clean.