### PR TITLE
fix(PI-488): Guard OpenTofu (tofu) in prod_guard deny-table

### DIFF
--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -36,7 +36,11 @@ from pathlib import Path
 # names, which the ask/allowlist paths absorb cheaply.
 _SEG = r"[^|;&]*?"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"\bterraform\s+(destroy|apply\s+.*-destroy)\b"), "terraform destroy"),
+    # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
+    # way (PI-488). Routine non-interactive `apply -auto-approve` is intentionally
+    # not flagged; only destroy / apply-with-destroy is.
+    (re.compile(r"\b(?:terraform|tofu)\s+(destroy|apply\s+.*-destroy)\b"),
+     "terraform/tofu destroy"),
     (re.compile(rf"\bkubectl\b{_SEG}\bdelete\b"), "kubectl delete"),
     (re.compile(rf"\bhelm\b{_SEG}\b(uninstall|delete)\b"), "helm uninstall"),
     (re.compile(rf"\baws\b{_SEG}\b(delete|terminate|remove)\S*\b"), "aws delete/terminate"),

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -37,10 +37,13 @@ from pathlib import Path
 _SEG = r"[^|;&]*?"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
-    # way (PI-488). Routine non-interactive `apply -auto-approve` is intentionally
-    # not flagged; only destroy / apply-with-destroy is.
-    (re.compile(r"\b(?:terraform|tofu)\s+(destroy|apply\s+.*-destroy)\b"),
-     "terraform/tofu destroy"),
+    # way (PI-488). `(?:-\S+\s+)*` tolerates global options before the verb
+    # (e.g. `tofu -chdir=infra destroy`) like _SEG does for the other rules, but
+    # stays flag-specific (only skips leading `-tokens`) so a read-only
+    # `plan -destroy` is NOT flagged. Routine `apply -auto-approve` is
+    # intentionally not flagged; only destroy / apply-with-destroy is.
+    (re.compile(r"\b(?:terraform|tofu)\s+(?:-\S+\s+)*(destroy|apply\s+.*-destroy)\b"),
+     "terraform/tofu destroy/apply -destroy"),
     (re.compile(rf"\bkubectl\b{_SEG}\bdelete\b"), "kubectl delete"),
     (re.compile(rf"\bhelm\b{_SEG}\b(uninstall|delete)\b"), "helm uninstall"),
     (re.compile(rf"\baws\b{_SEG}\b(delete|terminate|remove)\S*\b"), "aws delete/terminate"),

--- a/templates/base/dot_claude/hooks/prod_guard.py
+++ b/templates/base/dot_claude/hooks/prod_guard.py
@@ -36,7 +36,11 @@ from pathlib import Path
 # names, which the ask/allowlist paths absorb cheaply.
 _SEG = r"[^|;&]*?"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"\bterraform\s+(destroy|apply\s+.*-destroy)\b"), "terraform destroy"),
+    # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
+    # way (PI-488). Routine non-interactive `apply -auto-approve` is intentionally
+    # not flagged; only destroy / apply-with-destroy is.
+    (re.compile(r"\b(?:terraform|tofu)\s+(destroy|apply\s+.*-destroy)\b"),
+     "terraform/tofu destroy"),
     (re.compile(rf"\bkubectl\b{_SEG}\bdelete\b"), "kubectl delete"),
     (re.compile(rf"\bhelm\b{_SEG}\b(uninstall|delete)\b"), "helm uninstall"),
     (re.compile(rf"\baws\b{_SEG}\b(delete|terminate|remove)\S*\b"), "aws delete/terminate"),

--- a/templates/base/dot_claude/hooks/prod_guard.py
+++ b/templates/base/dot_claude/hooks/prod_guard.py
@@ -37,10 +37,13 @@ from pathlib import Path
 _SEG = r"[^|;&]*?"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
-    # way (PI-488). Routine non-interactive `apply -auto-approve` is intentionally
-    # not flagged; only destroy / apply-with-destroy is.
-    (re.compile(r"\b(?:terraform|tofu)\s+(destroy|apply\s+.*-destroy)\b"),
-     "terraform/tofu destroy"),
+    # way (PI-488). `(?:-\S+\s+)*` tolerates global options before the verb
+    # (e.g. `tofu -chdir=infra destroy`) like _SEG does for the other rules, but
+    # stays flag-specific (only skips leading `-tokens`) so a read-only
+    # `plan -destroy` is NOT flagged. Routine `apply -auto-approve` is
+    # intentionally not flagged; only destroy / apply-with-destroy is.
+    (re.compile(r"\b(?:terraform|tofu)\s+(?:-\S+\s+)*(destroy|apply\s+.*-destroy)\b"),
+     "terraform/tofu destroy/apply -destroy"),
     (re.compile(rf"\bkubectl\b{_SEG}\bdelete\b"), "kubectl delete"),
     (re.compile(rf"\bhelm\b{_SEG}\b(uninstall|delete)\b"), "helm uninstall"),
     (re.compile(rf"\baws\b{_SEG}\b(delete|terminate|remove)\S*\b"), "aws delete/terminate"),

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -19,6 +19,9 @@ DESTRUCTIVE = [
     # OpenTofu parity (PI-488): the `tofu` fork must be guarded like terraform.
     "tofu destroy -auto-approve",
     "tofu apply -destroy",
+    # Global options before the verb must not slip past the guard (Codex P2).
+    "tofu -chdir=infra destroy -auto-approve",
+    "terraform -chdir=./infra apply -destroy",
     "kubectl delete namespace prod",
     "helm uninstall api --namespace prod",
     "aws ec2 terminate-instances --instance-ids i-123",
@@ -43,6 +46,10 @@ SAFE = [
     # Parity: routine OpenTofu reads/applies are not destructive (PI-488).
     "tofu plan",
     "tofu apply -auto-approve",
+    # `plan -destroy` only PREVIEWS a destroy — read-only, must stay unflagged
+    # even though the flag-skip tolerates global options (Codex P2 review).
+    "tofu plan -destroy",
+    "tofu -chdir=infra apply -auto-approve",
     "kubectl get pods -n prod",
     "aws s3 ls",
     "git status",

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -16,6 +16,9 @@ _HOOK = _REPO_ROOT / "templates" / "base" / "dot_claude" / "hooks" / "prod_guard
 
 DESTRUCTIVE = [
     "terraform destroy -auto-approve",
+    # OpenTofu parity (PI-488): the `tofu` fork must be guarded like terraform.
+    "tofu destroy -auto-approve",
+    "tofu apply -destroy",
     "kubectl delete namespace prod",
     "helm uninstall api --namespace prod",
     "aws ec2 terminate-instances --instance-ids i-123",
@@ -37,6 +40,9 @@ DESTRUCTIVE = [
 
 SAFE = [
     "terraform plan",
+    # Parity: routine OpenTofu reads/applies are not destructive (PI-488).
+    "tofu plan",
+    "tofu apply -auto-approve",
     "kubectl get pods -n prod",
     "aws s3 ls",
     "git status",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -23,7 +23,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -23,7 +23,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -22,7 +22,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -22,7 +22,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -23,7 +23,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -23,7 +23,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -22,7 +22,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -22,7 +22,7 @@
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "5e346c9796d9189bfc11fcbccdf24432980f4cde436cc3d374ea7623d995c1c8",
   ".claude/hooks/pre_commit_gate.sh": "527c1c3ee56013d3db24f8fff33c2d5b1606d736d234b37691221c9853f8aeb9",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/hooks/session_setup.sh": "7eda14864cf1d4c179cdcfe949beefef5c61f0f139567e38e02ef336dd0c0929",
   ".claude/hooks/workflow_state_reminder.sh": "b2316d64d01c72ce50693a272877516339cd8655b4e6a6bff74071306fd717d0",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "86cb63f991e76a581866e68077fbfd4827ee039e9515512c68384e6c2132669b",
+  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
-  ".claude/hooks/prod_guard.py": "686b3a0dc1949890ccfa4b49643d13e65ed5d01e0ce4433e410a3749f0b41c93",
+  ".claude/hooks/prod_guard.py": "387e3f0c886f47cceb61d25df651e9d149f0b5f179adc9fa9da15c0587416993",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",
   ".claude/memory/SCHEMA.md": "5c7191cb5946a603a9e1f715837f2783fe4bf736d87334cf45b853892fab9102",


### PR DESCRIPTION
## Summary
`prod_guard.py`'s `DENY_RULES` only matched the `terraform` binary. A project scaffolded with `--iac opentofu` uses the **`tofu`** binary exclusively, so its single most-relevant destructive command was unguarded: `tofu destroy -auto-approve` and `tofu apply -destroy` were never flagged.

OpenTofu is a CLI-identical Terraform fork, so this folds both into one alternation rule for **parity**. Routine non-interactive `apply -auto-approve` stays unflagged (matching existing terraform behavior — no new false positives on normal CI applies).

## Found by
The repeatable `/live_test` E2E pass (2026-06-25), proj4 = `--iac opentofu` go service. This was the only P2 across the 5-project matrix.

## Changes
- `templates/base/dot_claude/hooks/prod_guard.py` — single `(?:terraform|tofu)` rule (source of truth).
- `plugins/project-init-workflow/hooks/prod_guard.py` — synced via `tools/sync_plugin.py` (byte-identical to the template copy).
- `tests/contracts/test_prod_guard.py` — tofu parity cases: `tofu destroy -auto-approve` + `tofu apply -destroy` flagged; `tofu plan` + `tofu apply -auto-approve` pass.
- 8 lifecycle/memory byte-identity fixtures — updated **only** the `prod_guard.py` hash (the one verbatim-copied file that changed); every other hash untouched, which still proves no other rendered byte drifted.

## Verification
- `uv run pytest` → 1443 passed, 3 skipped.
- Real firing: `tofu destroy -auto-approve` → `deny` (autonomous); `tofu apply -auto-approve` → passes.

Closes #488