### PR TITLE
fix: model bare gh pr view --json number in live_test stub

### DIFF
--- a/.claude/skills/live_test/SKILL.md
+++ b/.claude/skills/live_test/SKILL.md
@@ -86,6 +86,7 @@ scope** (see Step 4 lifecycle), so its `gh` shapes are deliberately absent from 
 | `gh pr view <n> --json headRefName -q .headRefName` | the current branch name |
 | `gh pr view <n> --json url -q .url` | `https://example.invalid/.../pull/202` |
 | `gh pr view --json number,state` | `{"number":202,"state":"OPEN"}` (PR auto-detect, `check_pr_opened`) |
+| `gh pr view --json number -q .number` | `202` (bare PR-number auto-detect, e.g. `promote_review.sh`) |
 | `gh pr view --json number,reviewDecision` | `{"number":202,"reviewDecision":""}` |
 | `gh pr ready <n>` | exit 0, no output |
 | anything else | log argv, exit 0, empty stdout |
@@ -115,6 +116,7 @@ case "$*" in
   "pr view"*"number,state"*)        echo '{"number":202,"state":"OPEN"}' ;;   # check_pr_opened / PR auto-detect
   "pr view"*"reviewDecision"*)      echo '{"number":202,"reviewDecision":""}' ;;
   "pr view"*"url"*)                 echo "https://example.invalid/livetest-owner/$proj/pull/202" ;;
+  "pr view"*"number"*)              echo "202" ;;                 # bare --json number -q .number (promote_review auto-detect); after the number,state/reviewDecision cases so they win first
   "pr ready"*)                      : ;;
   *)                                : ;;
 esac


### PR DESCRIPTION
## Summary
No-issue harness fix. The `live_test` skill's stateful `gh` stub answered `gh pr view --json number,state` but not the bare `gh pr view --json number -q .number` that `promote_review.sh` uses to auto-detect the PR for the current branch. As a result the lifecycle depth's auto-detect path exited 1 during the live E2E run (it only worked when an explicit PR number was passed).

## Change
Adds a `"pr view"*"number"*) echo "202" ;;` case to the stub, placed **after** the `number,state` and `reviewDecision` cases so those still match first (verified by case-ordering test). Also documents the row in the stub command→response table.

Source-only: the `live_test` skill lives under this repo's `.claude/skills/`, is not in `templates/` and not synced into scaffolded projects — so no template or fixture changes.

## Found by
The same `/live_test` E2E pass that surfaced PI-488 (#489). Both proj3 and proj5 hit this stub gap.

No linked issue (nojira).