### PR TITLE
fix(PI-491): Ship the base plan skill to non-Claude surfaces

### DIFF
--- a/templates/amp/dot_agents/skills/plan/SKILL.md
+++ b/templates/amp/dot_agents/skills/plan/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: plan
+description: TDD-style planning — understand requirements, write tests first, then implement with numbered steps
+when_to_use: Use for non-trivial features or bug fixes. Plan before code to reduce rework and improve test coverage.
+allowed-tools: Read Grep Glob Bash(git *)
+---
+
+Plan this work in 5 phases. Format output clearly so it's actionable.
+
+## Phase 1 — Understand the requirement
+
+Ask clarifying questions if needed. Answer: What is the core change? Why now? What's the acceptance criteria?
+
+## Phase 2 — Acceptance tests (write them first)
+
+Write the test assertions **before** implementation code:
+
+```bash
+# Example: test that a function returns X when given Y
+assert_equals(parse_config("key=val"), {"key": "val"})
+assert_throws(parse_config("broken"), ParseError)
+```
+
+## Phase 3 — Implementation plan
+
+Numbered steps for implementation. Link to files (`path:line_number`). Estimate scope (1-2h, half-day, day+).
+
+## Phase 4 — Risks and scope
+
+- What could go wrong?
+- Is this change backward compatible?
+- Do other parts of the system depend on this behavior?
+
+## Phase 5 — Definition of done
+
+When is this complete?
+- Tests pass
+- Behavior works end-to-end
+- Error cases handled
+- Documentation updated if needed

--- a/templates/antigravity/dot_agents/skills/plan/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/plan/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: plan
+description: TDD-style planning — understand requirements, write tests first, then implement with numbered steps
+when_to_use: Use for non-trivial features or bug fixes. Plan before code to reduce rework and improve test coverage.
+allowed-tools: Read Grep Glob Bash(git *)
+---
+
+Plan this work in 5 phases. Format output clearly so it's actionable.
+
+## Phase 1 — Understand the requirement
+
+Ask clarifying questions if needed. Answer: What is the core change? Why now? What's the acceptance criteria?
+
+## Phase 2 — Acceptance tests (write them first)
+
+Write the test assertions **before** implementation code:
+
+```bash
+# Example: test that a function returns X when given Y
+assert_equals(parse_config("key=val"), {"key": "val"})
+assert_throws(parse_config("broken"), ParseError)
+```
+
+## Phase 3 — Implementation plan
+
+Numbered steps for implementation. Link to files (`path:line_number`). Estimate scope (1-2h, half-day, day+).
+
+## Phase 4 — Risks and scope
+
+- What could go wrong?
+- Is this change backward compatible?
+- Do other parts of the system depend on this behavior?
+
+## Phase 5 — Definition of done
+
+When is this complete?
+- Tests pass
+- Behavior works end-to-end
+- Error cases handled
+- Documentation updated if needed

--- a/templates/codex/dot_agents/skills/plan/SKILL.md
+++ b/templates/codex/dot_agents/skills/plan/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: plan
+description: TDD-style planning — understand requirements, write tests first, then implement with numbered steps
+when_to_use: Use for non-trivial features or bug fixes. Plan before code to reduce rework and improve test coverage.
+allowed-tools: Read Grep Glob Bash(git *)
+---
+
+Plan this work in 5 phases. Format output clearly so it's actionable.
+
+## Phase 1 — Understand the requirement
+
+Ask clarifying questions if needed. Answer: What is the core change? Why now? What's the acceptance criteria?
+
+## Phase 2 — Acceptance tests (write them first)
+
+Write the test assertions **before** implementation code:
+
+```bash
+# Example: test that a function returns X when given Y
+assert_equals(parse_config("key=val"), {"key": "val"})
+assert_throws(parse_config("broken"), ParseError)
+```
+
+## Phase 3 — Implementation plan
+
+Numbered steps for implementation. Link to files (`path:line_number`). Estimate scope (1-2h, half-day, day+).
+
+## Phase 4 — Risks and scope
+
+- What could go wrong?
+- Is this change backward compatible?
+- Do other parts of the system depend on this behavior?
+
+## Phase 5 — Definition of done
+
+When is this complete?
+- Tests pass
+- Behavior works end-to-end
+- Error cases handled
+- Documentation updated if needed

--- a/templates/junie/dot_junie/skills/plan/SKILL.md
+++ b/templates/junie/dot_junie/skills/plan/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: plan
+description: TDD-style planning — understand requirements, write tests first, then implement with numbered steps
+when_to_use: Use for non-trivial features or bug fixes. Plan before code to reduce rework and improve test coverage.
+allowed-tools: Read Grep Glob Bash(git *)
+---
+
+Plan this work in 5 phases. Format output clearly so it's actionable.
+
+## Phase 1 — Understand the requirement
+
+Ask clarifying questions if needed. Answer: What is the core change? Why now? What's the acceptance criteria?
+
+## Phase 2 — Acceptance tests (write them first)
+
+Write the test assertions **before** implementation code:
+
+```bash
+# Example: test that a function returns X when given Y
+assert_equals(parse_config("key=val"), {"key": "val"})
+assert_throws(parse_config("broken"), ParseError)
+```
+
+## Phase 3 — Implementation plan
+
+Numbered steps for implementation. Link to files (`path:line_number`). Estimate scope (1-2h, half-day, day+).
+
+## Phase 4 — Risks and scope
+
+- What could go wrong?
+- Is this change backward compatible?
+- Do other parts of the system depend on this behavior?
+
+## Phase 5 — Definition of done
+
+When is this complete?
+- Tests pass
+- Behavior works end-to-end
+- Error cases handled
+- Documentation updated if needed

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -17,20 +17,28 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TEMPLATE_SKILLS = _REPO_ROOT / "templates" / "fallback" / "dot_claude" / "skills"
 # Lifecycle skills moved to the lifecycle_fallback overlay (#476); agent surfaces
 # carry the FULL set (core + lifecycle), synced together.
-_LIFECYCLE_FALLBACK_SKILLS = _REPO_ROOT / "templates" / "lifecycle_fallback" / "dot_claude" / "skills"
+_LIFECYCLE_FALLBACK_SKILLS = (
+    _REPO_ROOT / "templates" / "lifecycle_fallback" / "dot_claude" / "skills"
+)
 _CODEX_SKILLS = _REPO_ROOT / "templates" / "codex" / "dot_agents" / "skills"
 _ANTIGRAVITY_SKILLS = _REPO_ROOT / "templates" / "antigravity" / "dot_agents" / "skills"
 _AMP_SKILLS = _REPO_ROOT / "templates" / "amp" / "dot_agents" / "skills"
 _JUNIE_SKILLS = _REPO_ROOT / "templates" / "junie" / "dot_junie" / "skills"
 
 
+_BASE_PLAN = _REPO_ROOT / "templates" / "base" / "dot_claude" / "skills" / "plan" / "SKILL.md.tmpl"
+
+
 def _canonical_skill_map() -> dict[str, Path]:
     """The full skill set the agent surfaces carry: core (fallback) + lifecycle
-    (lifecycle_fallback), synced together by `just sync-plugin` (#476)."""
+    (lifecycle_fallback), synced together by `just sync-plugin` (#476), plus the
+    base `plan` skill (PI-491). `plan` is a no-variable SKILL.md.tmpl, so its
+    template bytes equal the rendered SKILL.md the surfaces ship."""
     out: dict[str, Path] = {}
     for root in (_TEMPLATE_SKILLS, _LIFECYCLE_FALLBACK_SKILLS):
         for p in root.glob("*/SKILL.md"):
             out[p.parent.name] = p
+    out["plan"] = _BASE_PLAN
     return out
 
 
@@ -69,9 +77,7 @@ class TestAgentSelection:
         fall back to claude-only (PR #167 review)."""
         import project_init.__main__ as cli
 
-        answers = iter(
-            ["proj", "desc", "python", "@owner", "none", "codex,windsurf", "codex"]
-        )
+        answers = iter(["proj", "desc", "python", "@owner", "none", "codex,windsurf", "codex"])
         monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(answers))
         monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
@@ -254,6 +260,28 @@ class TestSyncedCopiesInRepo:
                 f"antigravity skill {name} drifted — run `just sync-plugin`"
             )
 
+    def test_base_plan_shipped_to_every_surface(self):
+        """PI-491: the base `plan` skill (the one project-local skill on the
+        Claude path) is bundled to every non-Claude surface so the per-surface
+        set matches the CAPABILITIES inventory. It is shipped verbatim as a
+        rendered SKILL.md, which is only sound while plan carries no variables —
+        guard that invariant here so a future `{{var}}` fails loudly."""
+        assert "{{" not in _BASE_PLAN.read_text(encoding="utf-8"), (
+            "plan gained a variable — it can no longer ship verbatim to surfaces; "
+            "render it per-project or drop it from _ship_base_plan"
+        )
+        for label, skills_dir in (
+            ("codex", _CODEX_SKILLS),
+            ("antigravity", _ANTIGRAVITY_SKILLS),
+            ("amp", _AMP_SKILLS),
+            ("junie", _JUNIE_SKILLS),
+        ):
+            plan = skills_dir / "plan" / "SKILL.md"
+            assert plan.is_file(), f"{label} missing the plan skill — run `just sync-plugin`"
+            assert plan.read_bytes() == _BASE_PLAN.read_bytes(), (
+                f"{label} plan skill drifted — run `just sync-plugin`"
+            )
+
     def test_amp_and_junie_skill_sources_in_sync(self):
         """PI-397: Amp (.agents/skills) and Junie (.junie/skills) carry the same
         canonical SKILL.md set, synced via `just sync-plugin`."""
@@ -279,9 +307,7 @@ class TestAgentGuardAdapter:
             "cursor": {"command": command},  # beforeShellExecution: top-level
             "antigravity": {"toolCall": {"args": {"CommandLine": command}}},
         }
-        payload = json.dumps(
-            surface_payloads.get(dialect, {"tool_input": {"command": command}})
-        )
+        payload = json.dumps(surface_payloads.get(dialect, {"tool_input": {"command": command}}))
         proc = subprocess.run(
             [sys.executable, str(adapter), dialect],
             input=payload,

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -125,13 +125,32 @@ def _sync_hooks(scripts: list[Path], plugin_root: Path, synced: list[str]) -> No
         synced.append(f"{plugin_root.name}/hooks/{script.name}")
 
 
+def _ship_base_plan(dest: Path) -> None:
+    """Copy the base `plan` skill into a surface layer as a rendered SKILL.md.
+
+    Renames SKILL.md.tmpl -> SKILL.md (PI-491). `plan` is the one project-local
+    skill (templates/base/.../skills) and is a
+    template only by convention — it carries no ``{{variables}}``, so its
+    rendered bytes equal the template bytes and it is sound to ship verbatim.
+    That invariant is guarded by test_agent_overlays; a future variable in plan
+    would render per-project and must NOT be shipped this way.
+    """
+    src = TEMPLATE_CLAUDE / "skills" / "plan"
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in sorted(src.iterdir()):
+        if f.is_file():
+            name = f.name[:-5] if f.name.endswith(".tmpl") else f.name
+            shutil.copy2(f, dest / name)
+
+
 def _sync_agent_skills() -> list[str]:
     """Byte-identical SKILL.md trees per surface (Codex/Antigravity/Amp/Junie).
 
     Codex/Antigravity/Amp use `.agents/skills`; Junie uses `.junie/skills`. Each
     layer ships its own copy of the FULL skill set so the surface works
     standalone — all discover `<dir>/<name>/SKILL.md` natively, no command
-    pointers (PI-386, PI-397).
+    pointers (PI-386, PI-397). The full set is the core + lifecycle skills plus
+    the base `plan` skill (PI-491), so it matches the CAPABILITIES inventory.
     """
     synced = []
     for label, dest in (
@@ -145,6 +164,8 @@ def _sync_agent_skills() -> list[str]:
         for skill_dir in all_skill_dirs():
             shutil.copytree(skill_dir, dest / skill_dir.name)
             synced.append(f"{label}:skills/{skill_dir.name}")
+        _ship_base_plan(dest / "plan")
+        synced.append(f"{label}:skills/plan")
     return synced
 
 


### PR DESCRIPTION
## Summary
`CAPABILITIES.md` counted the `plan` skill (13 total), but the per-surface "FULL skill set" generator (`_sync_agent_skills`, via `all_skill_dirs()` = core + lifecycle) dropped it — so codex/antigravity/amp/junie each shipped only 12 standalone `.agents/skills/` (or `.junie/skills/`) files. The inventory overstated what non-Claude surfaces could actually discover.

`plan` was excluded because it's a `SKILL.md.tmpl` and the rule is "templated skills stay scaffold-only" — but `plan` carries **zero** `{{variables}}`, so its rendered bytes equal the template. The fix ships it to every surface, renaming `.tmpl` → `.md` on copy.

## Found by
`/live_test` E2E pass (proj5, multi-surface). Direction (ship vs scope-the-inventory) confirmed with the maintainer.

## Changes
- `tools/sync_plugin.py` — `_ship_base_plan()` copies the base `plan` skill into each surface layer, stripping `.tmpl`.
- `templates/{codex,antigravity,amp}/dot_agents/skills/plan/SKILL.md` + `templates/junie/dot_junie/skills/plan/SKILL.md` — generated copies (byte-identical to the base).
- `tests/contracts/test_agent_overlays.py` — `plan` is now canonical (so `set(template) == set(surface)` holds), **plus** a new guard test asserting `plan/SKILL.md.tmpl` has no `{{` so a future variable can't silently ship unrendered.

## Verification
- `uv run pytest` → 1450 passed, 3 skipped; lint clean.
- Real scaffold (`--agents claude,codex,antigravity`): `.agents/skills/` now has **13** incl. `plan`, CAPABILITIES says **13**, and `.agents/skills/plan/SKILL.md` is byte-identical to `.claude/skills/plan/SKILL.md`.

Closes #491