### PR TITLE
chore(PI-493): Gate cross-stack examples by language/cloud

### DIFF
--- a/templates/base/dot_devcontainer/devcontainer.json.tmpl
+++ b/templates/base/dot_devcontainer/devcontainer.json.tmpl
@@ -6,7 +6,7 @@
   },
 {{/if go}}  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteEnv": {
-    "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:HOME}/.bun/bin:${containerEnv:PATH}"
+    "PATH": "${containerEnv:HOME}/.local/bin:{{#if node}}${containerEnv:HOME}/.bun/bin:{{/if node}}${containerEnv:PATH}"
   },
   "customizations": {
     "vscode": {

--- a/templates/base/dot_dockerignore.tmpl
+++ b/templates/base/dot_dockerignore.tmpl
@@ -4,10 +4,6 @@
 .github
 .claude
 .devcontainer
-.venv
-__pycache__
-*.pyc
-node_modules
 dist
 build
 target
@@ -16,9 +12,13 @@ target
 !.env.example
 *.log
 .DS_Store
+coverage
+.coverage
+{{#if python}}.venv
+__pycache__
+*.pyc
 .pytest_cache
 .ruff_cache
 .mypy_cache
-coverage
-.coverage
-{{/if delivery_service}}
+{{/if python}}{{#if node}}node_modules
+{{/if node}}{{/if delivery_service}}

--- a/templates/base/dot_env.example.tmpl
+++ b/templates/base/dot_env.example.tmpl
@@ -5,7 +5,7 @@
 # Loading order (first match wins):
 #   1. variables already exported in your shell
 #   2. .env, loaded explicitly by your tooling or direnv — nothing here is
-#      loaded implicitly by the scaffold.{{#if python}} For Python: `uv run --env-file .env`.{{/if python}}{{#if node}} For Node: bun auto-loads `.env`.{{/if node}}{{#if go}} For Go: a loader like `godotenv` (or `set -a; . ./.env; set +a`).{{/if go}}
+#      loaded implicitly by the scaffold.{{#if python}} For Python: `uv run --env-file .env`.{{/if python}}{{#if node}} For Node: bun auto-loads `.env`.{{/if node}}{{#if go}} For Go: use a loader like `godotenv` (parse the file; don't `source` it).{{/if go}}
 #
 # Never commit .env: the pre-commit gitleaks scan and CI both enforce this.
 # For team secrets, see .claude/docs/guides/secrets.md (escalation paths).

--- a/templates/base/dot_env.example.tmpl
+++ b/templates/base/dot_env.example.tmpl
@@ -4,9 +4,8 @@
 #
 # Loading order (first match wins):
 #   1. variables already exported in your shell
-#   2. .env, loaded by the tool itself — `uv run --env-file .env`, bun
-#      auto-loads .env, or direnv if your team uses it
-# Nothing here is loaded implicitly by the scaffold; tools opt in.
+#   2. .env, loaded explicitly by your tooling or direnv — nothing here is
+#      loaded implicitly by the scaffold.{{#if python}} For Python: `uv run --env-file .env`.{{/if python}}{{#if node}} For Node: bun auto-loads `.env`.{{/if node}}{{#if go}} For Go: a loader like `godotenv` (or `set -a; . ./.env; set +a`).{{/if go}}
 #
 # Never commit .env: the pre-commit gitleaks scan and CI both enforce this.
 # For team secrets, see .claude/docs/guides/secrets.md (escalation paths).

--- a/templates/base/infra/backend.tf.tmpl
+++ b/templates/base/infra/backend.tf.tmpl
@@ -1,14 +1,24 @@
 {{#if iac_enabled}}# Remote state backend — UNCOMMENT and configure once, then `tofu init`.
 # Left commented because the backend is account-specific and has a bootstrap
 # chicken-and-egg (the bucket/table must exist before init). Never commit
-# credentials; supply them via the environment / OIDC.
+# credentials; supply them via the environment / OIDC. Pick the block for your
+# cloud (delete the other).
 #
+# AWS — S3:
 # terraform {
 #   backend "s3" {
 #     bucket       = "your-tf-state-bucket"
 #     key          = "{{project_name}}/terraform.tfstate"
 #     region       = "your-region"
 #     use_lockfile = true   # native S3 state locking (TF 1.10+/OpenTofu)
+#   }
+# }
+#
+# GCP — GCS:
+# terraform {
+#   backend "gcs" {
+#     bucket = "your-tf-state-bucket"
+#     prefix = "{{project_name}}/state"
 #   }
 # }
 {{/if iac_enabled}}

--- a/tests/contracts/test_cross_stack_examples.py
+++ b/tests/contracts/test_cross_stack_examples.py
@@ -1,0 +1,114 @@
+"""PI-493: language/cloud-gated example snippets in service scaffolds.
+
+A Go/GCP scaffold must not carry Python/Node/AWS example noise. The example
+placeholders (.env.example loader hint, .dockerignore ignores, devcontainer
+PATH, infra/backend.tf) are gated by the existing language/cloud flags. These
+assertions lock the gating so a regression — e.g. un-gating the bun PATH or the
+Python ignores — fails CI rather than silently leaking cross-stack hints.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _service(target: Path, language: str = "python", **extra: str) -> Path:
+    # make_variables sets python/node/go independently of `language` — set them
+    # explicitly to match the requested runtime (mirrors test_parity_bundle).
+    flags = {"python": "", "node": "", "go": ""}
+    flags[language] = "true"
+    scaffold(
+        target,
+        load_preset("obsidian-only"),
+        make_variables(
+            language=language,
+            delivery="service",
+            delivery_service="true",
+            want_devcontainer="true",
+            **flags,
+            **extra,
+        ),
+        strict=True,
+    )
+    return target
+
+
+class TestEnvExampleHint:
+    def test_python_hint_only(self, tmp_path: Path):
+        env = (_service(tmp_path / "p", "python") / ".env.example").read_text()
+        assert "For Python: `uv run --env-file .env`" in env
+        assert "bun" not in env
+        assert "godotenv" not in env
+
+    def test_node_hint_only(self, tmp_path: Path):
+        env = (_service(tmp_path / "n", "node") / ".env.example").read_text()
+        assert "For Node:" in env
+        assert "bun auto-loads" in env
+        assert "uv run" not in env
+        assert "godotenv" not in env
+
+    def test_go_hint_only_and_never_sources_env(self, tmp_path: Path):
+        env = (_service(tmp_path / "g", "go") / ".env.example").read_text()
+        assert "For Go:" in env
+        assert "godotenv" in env
+        assert "uv run" not in env
+        assert "bun" not in env
+        # Hardening (PR #368): never suggest sourcing the user-editable .env —
+        # a stray command in it would execute. Parse, don't source.
+        assert "set -a" not in env
+        assert ". ./.env" not in env
+
+
+class TestDockerignoreGating:
+    def test_python_blocks_gated(self, tmp_path: Path):
+        di = (_service(tmp_path / "p", "python") / ".dockerignore").read_text()
+        assert "__pycache__" in di
+        assert ".venv" in di
+        assert ".mypy_cache" in di
+        assert "node_modules" not in di
+
+    def test_node_block_gated(self, tmp_path: Path):
+        di = (_service(tmp_path / "n", "node") / ".dockerignore").read_text()
+        assert "node_modules" in di
+        assert "__pycache__" not in di
+        assert ".venv" not in di
+
+    def test_go_has_neither_language_block(self, tmp_path: Path):
+        di = (_service(tmp_path / "g", "go") / ".dockerignore").read_text()
+        assert "__pycache__" not in di
+        assert "node_modules" not in di
+        # Generic entries stay for every service language.
+        assert "dist" in di
+        assert ".env" in di
+
+
+class TestDevcontainerPath:
+    def _path(self, target: Path) -> str:
+        config = json.loads((target / ".devcontainer" / "devcontainer.json").read_text())
+        return config["remoteEnv"]["PATH"]
+
+    def test_node_includes_bun(self, tmp_path: Path):
+        assert ".bun/bin" in self._path(_service(tmp_path / "n", "node"))
+
+    def test_python_omits_bun(self, tmp_path: Path):
+        path = self._path(_service(tmp_path / "p", "python"))
+        assert ".bun/bin" not in path
+        assert ".local/bin" in path  # generic tool dir stays for all
+
+    def test_go_omits_bun(self, tmp_path: Path):
+        assert ".bun/bin" not in self._path(_service(tmp_path / "g", "go"))
+
+
+class TestBackendCloudNeutral:
+    def test_shows_both_s3_and_gcs(self, tmp_path: Path):
+        backend = (
+            _service(tmp_path / "g", "go", iac="opentofu", iac_enabled="true")
+            / "infra"
+            / "backend.tf"
+        ).read_text()
+        assert 'backend "s3"' in backend
+        assert 'backend "gcs"' in backend

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -83,7 +83,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -64,7 +64,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -80,7 +80,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -61,7 +61,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -83,7 +83,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -64,7 +64,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -80,7 +80,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -61,7 +61,7 @@
   ".claude/vault/templates/design-note.md": "e4c3e20d57d0b9ff504283a3591542bebc752b5c3161cbbc4515e973f3e4a037",
   ".claude/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".claude/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
-  ".env.example": "f57f6bde0e0255384fbfbda8041226bbceb194a86360a6a16ad73786e8378265",
+  ".env.example": "7c8eb25ab812a3f7b3a63f55e43c20b94132c146126a32459a810d1e0a655e27",
   ".gitattributes": "2ae72de88da561b11a5dc98ee1b8df86473d1d6c43621a558363f68eadceea91",
   ".github/CODEOWNERS": "d3a146e0f1beac204b8aab328697bbbd567a359fe7ce5d93016eadc8cc430672",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",


### PR DESCRIPTION
## Summary
A Go/GCP service scaffold showed Python/Node/AWS-flavored example placeholders (cosmetic, commented-only, but noisy/misleading per project type). Gate them by the existing language/cloud flags — **no new variables**:

- **`.env.example`** — per-language loader hint (`uv run --env-file` / bun / `godotenv`) instead of always naming uv+bun.
- **`.dockerignore`** — Python ignores (`.venv`, `__pycache__`, `*.pyc`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`) behind `{{#if python}}`; `node_modules` behind `{{#if node}}`; generic entries stay for all.
- **`.devcontainer` PATH** — `~/.bun/bin` only for `{{#if node}}` (`.local/bin` stays).
- **`infra/backend.tf`** — cloud-neutral: shows both S3 and GCS backend examples (the engine has no `else`; both commented with "delete the other").

## Found by
`/live_test` E2E pass (proj4 = go + cloud-run + opentofu). Cleanup direction confirmed with the maintainer.

## Fixtures
Only `.env.example` is always-rendered, so only its hash moved in the 8 lifecycle/memory byte-identity fixtures — recomputed by scaffolding exactly as the fixtures do (it's templated, not verbatim-copied). The other three files are gated off (`delivery_service`/`want_devcontainer`/`iac_enabled`) in the default fixtures, so they don't appear there.

## Verification
- Real scaffolds (Go service / Python service / Node service) all render correctly under `--strict`: Go shows a Go env hint + no Python/Node dockerignore blocks + no bun in PATH + both backend examples; Python keeps its block + uv hint + no bun; Node keeps `node_modules` + bun.
- `uv run pytest` → 1450 passed, 3 skipped; ruff clean.

Closes #493