### PR TITLE
feat(PI-498): Standardize the cross-project memory descriptor

### DIFF
--- a/docs/development/memory-descriptor.md
+++ b/docs/development/memory-descriptor.md
@@ -1,0 +1,62 @@
+# Memory descriptor (cross-project introspection)
+
+**Status:** Accepted — implements #498, extends [ADR-024](../adr/adr-024-memory-tier-model.md).
+
+Every scaffolded project records a **stable, machine-readable memory descriptor**
+so a root orchestrator (spike #479) and cross-project skills can introspect any
+child *identically* and degrade by tier — "if a graph exists, query it; else
+grep". This is the per-project half of the Agentic-OS contract; the cross-project
+aggregation protocol is #479's concern, not this one.
+
+## The contract
+
+The authoritative record is the `memory:` block in each project's
+`.claude/config.yaml` (machine-read by `upgrade` and any orchestrator). The same
+facts are surfaced for humans / non-Claude surfaces in `.claude/CAPABILITIES.md`
+(regenerated every run, ADR-017).
+
+```yaml
+memory:
+  tier: 2                                  # 0 auto | 1 obsidian-only | 2 obsidian-graphify
+  stack: obsidian-graphify
+  memory_path: .claude/memory              # anchor — always present when memory is on
+  vault_path: .claude/vault                # present at tier >= 1
+  graph_path: graphify-out/graph.json      # present at tier >= 2
+```
+
+A vault-free `none` project ships **no** `memory:` block (its absence *is* the
+signal — there is no memory backend to introspect).
+
+## Tier → resolved paths
+
+| tier | stack | memory_path | vault_path | graph_path |
+|---|---|---|---|---|
+| — | none | (absent) | — | — |
+| 0 | auto | `.claude/memory` | — | — |
+| 1 | obsidian-only | `.claude/memory` | `.claude/vault` | — |
+| 2 | obsidian-graphify | `.claude/memory` | `.claude/vault` | `graphify-out/graph.json` |
+
+## Invariants (ADR-024)
+
+- **Anchors never move.** `.claude/memory/MEMORY.md`, `.claude/docs/adr/`, and
+  (when present) `.claude/vault/` are at the same path on every tier. Higher tiers
+  only *add* retrieval surfaces (the right-hand columns); they never relocate an
+  anchor. An orchestrator can therefore assume the anchors and feature-detect the
+  rest.
+- **Derived from `memory_stack`, in lockstep.** `tier` and the path gates come from
+  the recorded `memory_stack` via `scaffold.memory_tier()` and the
+  `memory`/`obsidian`/`graphify` gate vars — emitted identically by
+  `__main__._build_variables`, `upgrade._backfill_variables`, and
+  `upgrade._migrate_semantic_config`, so scaffold and upgrade never diverge (PI-189).
+
+## Reading it
+
+```python
+import tomllib  # config.yaml's memory block is YAML; parse with a YAML reader,
+# or read the JSON `scaffold.variables` record appended by project-init upgrade,
+# which carries `memory_tier`/`memory_stack` directly.
+```
+
+A future root layer (#479) walks its registry of child projects, reads each
+descriptor, and builds a cross-project view — but that aggregation format is
+defined by #479, not here.

--- a/docs/development/memory-descriptor.md
+++ b/docs/development/memory-descriptor.md
@@ -51,10 +51,17 @@ signal — there is no memory backend to introspect).
 
 ## Reading it
 
+The `memory:` block is YAML — read it with any YAML parser. Or, stdlib-only,
+read the JSON scaffold-record block project-init writes to the same file (its
+`variables:` line is single-line JSON carrying `memory_tier`/`memory_stack`):
+
 ```python
-import tomllib  # config.yaml's memory block is YAML; parse with a YAML reader,
-# or read the JSON `scaffold.variables` record appended by project-init upgrade,
-# which carries `memory_tier`/`memory_stack` directly.
+import json, re
+
+config_text = (project / ".claude" / "config.yaml").read_text(encoding="utf-8")
+m = re.search(r"^  variables: (\{.*\})$", config_text, re.MULTILINE)
+descriptor = json.loads(m.group(1)) if m else {}
+tier, stack = descriptor.get("memory_tier"), descriptor.get("memory_stack")
 ```
 
 A future root layer (#479) walks its registry of child projects, reads each

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - Memory tier model: adr/adr-024-memory-tier-model.md
   - Development:
     - Template system: development/template-system.md
+    - Memory descriptor: development/memory-descriptor.md
     - Non-CLI surface matrix: development/non-cli-surface-matrix.md
     - Testing: development/testing.md
     - Measurement methodology: development/measurement-methodology.md

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -20,6 +20,7 @@ from project_init.scaffold import (
     list_presets,
     load_preset,
     marketplace_source_vars,
+    memory_tier,
     overlay_layers,
     scaffold,
 )
@@ -1533,6 +1534,7 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         # authenticates to a cloud via OIDC, so the contract doc ships for them.
         "cloud_oidc": ("true" if (inputs.deploy in _DEPLOY_OIDC or inputs.iac != "none") else ""),
         "memory_stack": memory_stack,
+        "memory_tier": memory_tier(memory_stack),
         "memory": "true" if has_memory else "",
         # GitHub lifecycle tier (#476): the recorded value + the gate flag, plus
         # the inverse flag for the engine's else-less {{#if}} blocks (e.g. the

--- a/src/project_init/capabilities.py
+++ b/src/project_init/capabilities.py
@@ -151,6 +151,27 @@ def _chosen_options(variables: dict[str, str]) -> list[tuple[str, str]]:
     ]
 
 
+def _memory_descriptor(variables: dict[str, str]) -> list[tuple[str, str]]:
+    """The memory tier + resolved paths a root orchestrator reads (#498, ADR-024).
+
+    Anchors are invariant across tiers; higher tiers only add retrieval surfaces.
+    Derived from ``memory_stack`` exactly as the config record / gate vars are.
+    """
+    stack = variables.get("memory_stack", "none") or "none"
+    if stack == "none":
+        return [("Tier", "— (no memory backend)")]
+    rows = [
+        ("Tier", variables.get("memory_tier", "") or "?"),
+        ("Stack", stack),
+        ("memory_path", ".claude/memory"),
+    ]
+    if variables.get("obsidian"):
+        rows.append(("vault_path", ".claude/vault"))
+    if variables.get("graphify"):
+        rows.append(("graph_path", "graphify-out/graph.json"))
+    return rows
+
+
 def _table(headers: tuple[str, str], rows: list[tuple[str, str]]) -> list[str]:
     out = [f"| {headers[0]} | {headers[1]} |", "|---|---|"]
     for a, b in rows:
@@ -177,6 +198,13 @@ def render(variables: dict[str, str]) -> str:
         "## Chosen options",
         "",
         *_table(("Option", "Value"), _chosen_options(variables)),
+        "",
+        "## Memory",
+        "",
+        "Tier + resolved paths a root orchestrator (#479) reads to introspect this",
+        "project. Anchors are invariant across tiers; higher tiers only add surfaces.",
+        "",
+        *_table(("Field", "Value"), _memory_descriptor(variables)),
         "",
         f"## Skills ({len(skills)})",
         "",

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -212,6 +212,21 @@ def generate_preset(name: str, *, extends: str, description: str = "", version: 
 _AGENT_LAYERS = ("codex", "antigravity", "amp", "junie")
 
 
+_MEMORY_TIERS = {"auto": "0", "obsidian-only": "1", "obsidian-graphify": "2"}
+
+
+def memory_tier(memory_stack: str) -> str:
+    """Descriptor tier number for *memory_stack* (#498, ADR-024).
+
+    The rung on the recall ladder a root orchestrator (#479) reads to feature-
+    detect a child's retrieval surfaces: ``auto``→0, ``obsidian-only``→1,
+    ``obsidian-graphify``→2. ``none`` returns ``""`` (no descriptor — the config
+    memory block is gated out). Single source for the scaffold + the two upgrade
+    emit paths so they never diverge (PI-189).
+    """
+    return _MEMORY_TIERS.get(memory_stack, "")
+
+
 def memory_layers(memory_stack: str) -> list[str]:
     """Template layers contributed by the memory backend (#466, #497).
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -49,6 +49,7 @@ from project_init.scaffold import (
     _new_sibling,
     load_preset,
     marketplace_source_vars,
+    memory_tier,
     overlay_layers,
     read_preserve_globs,
     scaffold,
@@ -511,6 +512,7 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "memory": "" if stack == "none" else "true",
+        "memory_tier": memory_tier(stack),
         # Lifecycle (#476): a pre-record config ALWAYS shipped the GitHub
         # lifecycle (it was force-bundled in base), so reconstruct it as ON —
         # it is an opt-OUT, NOT one of the opt-in overlays defaulted off below.
@@ -562,6 +564,7 @@ def _backfill_variables(variables: dict) -> dict:
         # Memory gate (#466): "" only for the vault-free `none` stack. The
         # obsidian/graphify substring checks already yield "" for none.
         "memory": "" if stack == "none" else "true",
+        "memory_tier": memory_tier(stack),
         "lifecycle_tier": ltier,
         "lifecycle": "" if ltier == "none" else "true",
         "lifecycle_off": "true" if ltier == "none" else "",

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -20,10 +20,15 @@ deploy: {{deploy_target}}            # none | cloud-run | fly | k8s | registry |
 iac: {{iac}}            # none | opentofu — infrastructure-as-code overlay (ADR-015)
 
 {{#if memory}}memory:
+  # Stable descriptor (#498): tier + resolved paths a root orchestrator reads to
+  # introspect this project. Anchors (memory_path, MEMORY.md) are invariant across
+  # tiers; higher tiers only ADD retrieval surfaces (vault, graph).
+  tier: {{memory_tier}}             # 0 auto | 1 obsidian-only | 2 obsidian-graphify
   stack: {{memory_stack}}{{#if obsidian}}         # obsidian-only | obsidian-graphify{{/if obsidian}}
+  memory_path: .claude/memory
 {{#if obsidian}}  vault_path: .claude/vault
-{{/if obsidian}}  memory_path: .claude/memory
-
+{{/if obsidian}}{{#if graphify}}  graph_path: graphify-out/graph.json
+{{/if graphify}}
 {{/if memory}}mcps:
   installed: {{installed_mcps_yaml}}
 

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -18,6 +18,10 @@ Exception (#496): the code-map feature intentionally ADDS
 `.claude/scripts/gen_code_map.py` and edits AGENTS.md + the justfile. Only those
 three keys were re-pinned, after verifying every other file still matched the
 baseline — the move invariant is intact for everything else.
+
+Exception (#497/#498): later features re-pinned `lint_memory.sh` (staleness) and
+`.claude/config.yaml` (memory descriptor) the same way — only the intentionally
+changed key, after verifying no other drift.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -20,6 +20,10 @@ Exception (#496): the code-map feature intentionally ADDS
 and the justfile (the `code-map` recipe). Only those keys were re-pinned, after
 verifying every OTHER file still matched the baseline — the move invariant is
 intact for everything else.
+
+Exception (#498): the memory descriptor intentionally edits `.claude/config.yaml`
+(adds `tier` + `graph_path` to the `memory:` block). Only that key was re-pinned,
+after verifying every other file still matched.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_none.py
+++ b/tests/contracts/test_memory_none.py
@@ -98,6 +98,17 @@ class TestVariableContract:
         # The vault-free stack maps to the `core` preset, NOT load_preset("none").
         assert preset_name == ("core" if stack == "none" else stack)
 
+    @pytest.mark.parametrize(
+        "stack,tier", [("none", ""), ("auto", "0"), ("obsidian-only", "1"), ("obsidian-graphify", "2")]
+    )
+    def test_memory_tier_parity(self, stack, tier):
+        """`memory_tier` (#498) must be emitted identically by all three paths."""
+        assert _build_variables(load_preset("core"), _inputs(stack))["memory_tier"] == tier
+        assert _backfill_variables({"memory_stack": stack})["memory_tier"] == tier
+        lines = ["language: python", "memory:", f"  stack: {stack}"]
+        _p, variables, _m = _migrate_semantic_config(lines)
+        assert variables["memory_tier"] == tier
+
     def test_migrate_no_memory_section_is_core_not_obsidian(self):
         # A core project renders config.yaml with NO `memory:` block. With the
         # JSON record stripped, the semantic fallback must default to `none`/core

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "ce4459a9d2ba614c14fa60e9c8734ba28ba7d8bea57c44a2a2f4c9d59a2ca210",
+  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "ce4459a9d2ba614c14fa60e9c8734ba28ba7d8bea57c44a2a2f4c9d59a2ca210",
+  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "80635f82a8013b2b17ce1a2e22d0c826b5ee180444b30a74beeb562318c08494",
+  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "80635f82a8013b2b17ce1a2e22d0c826b5ee180444b30a74beeb562318c08494",
+  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "ce4459a9d2ba614c14fa60e9c8734ba28ba7d8bea57c44a2a2f4c9d59a2ca210",
+  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "ce4459a9d2ba614c14fa60e9c8734ba28ba7d8bea57c44a2a2f4c9d59a2ca210",
+  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "80635f82a8013b2b17ce1a2e22d0c826b5ee180444b30a74beeb562318c08494",
+  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "80635f82a8013b2b17ce1a2e22d0c826b5ee180444b30a74beeb562318c08494",
+  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -116,6 +116,10 @@ def make_variables(**overrides: str) -> dict[str, str]:
         defaults["graphify"] = "true" if stack == "obsidian-graphify" else ""
     if "memory" not in overrides:
         defaults["memory"] = "" if stack == "none" else "true"
+    if "memory_tier" not in overrides:
+        from project_init.scaffold import memory_tier
+
+        defaults["memory_tier"] = memory_tier(stack)
     # Mirror the lifecycle variable contract (#476): the `lifecycle` gate
     # derives from lifecycle_tier unless a test overrides it explicitly.
     if "lifecycle" not in overrides:

--- a/tests/integration/test_memory_descriptor.py
+++ b/tests/integration/test_memory_descriptor.py
@@ -1,0 +1,103 @@
+"""Cross-project memory descriptor (#498, ADR-024).
+
+Every scaffold records a stable `tier` + resolved paths (config.yaml authoritative,
+CAPABILITIES.md human surface) so a root orchestrator (#479) can introspect any
+child identically. Anchors are invariant across tiers; higher tiers only add
+retrieval surfaces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.__main__ import main
+from project_init.scaffold import memory_tier
+
+
+def _scaffold(target: Path, preset: str) -> None:
+    rc = main([
+        str(target), "--non-interactive", "--name", "fx", "--description", "d",
+        "--language", "python", "--preset", preset,
+    ])
+    assert rc == 0
+
+
+def _memory_block(target: Path) -> str:
+    text = (target / ".claude" / "config.yaml").read_text()
+    # the memory: block ends at the next top-level key (mcps:)
+    return text.partition("\nmemory:")[2].partition("\nmcps:")[0]
+
+
+class TestMemoryTierDerivation:
+    def test_tier_numbers(self):
+        assert memory_tier("auto") == "0"
+        assert memory_tier("obsidian-only") == "1"
+        assert memory_tier("obsidian-graphify") == "2"
+        assert memory_tier("none") == ""  # no descriptor
+
+
+class TestConfigDescriptor:
+    @pytest.mark.parametrize(
+        "preset,tier,has_vault,has_graph",
+        [
+            ("auto", "0", False, False),
+            ("obsidian-only", "1", True, False),
+            ("obsidian-graphify", "2", True, True),
+        ],
+    )
+    def test_tier_and_paths_recorded(self, tmp_path, preset, tier, has_vault, has_graph):
+        target = tmp_path / "p"
+        _scaffold(target, preset)
+        block = _memory_block(target)
+        assert f"tier: {tier}" in block
+        assert "memory_path: .claude/memory" in block  # anchor always present
+        assert ("vault_path: .claude/vault" in block) is has_vault
+        assert ("graph_path: graphify-out/graph.json" in block) is has_graph
+
+    def test_none_has_no_descriptor(self, tmp_path):
+        target = tmp_path / "p"
+        _scaffold(target, "core")
+        assert "\nmemory:" not in (target / ".claude" / "config.yaml").read_text()
+
+    def test_anchor_path_invariant_across_tiers(self, tmp_path):
+        """memory_path is the same on every tier that has memory (ADR-024 anchor)."""
+        for preset in ("auto", "obsidian-only", "obsidian-graphify"):
+            target = tmp_path / preset
+            _scaffold(target, preset)
+            assert "memory_path: .claude/memory" in _memory_block(target)
+
+
+class TestCapabilitiesSurface:
+    def test_capabilities_memory_section(self, tmp_path):
+        target = tmp_path / "p"
+        _scaffold(target, "obsidian-graphify")
+        caps = (target / ".claude" / "CAPABILITIES.md").read_text()
+        section = caps.partition("## Memory")[2].partition("## Skills")[0]
+        assert "| Tier | 2 |" in section
+        assert "| graph_path | graphify-out/graph.json |" in section
+
+    def test_capabilities_none_reports_no_backend(self, tmp_path):
+        target = tmp_path / "p"
+        _scaffold(target, "core")
+        caps = (target / ".claude" / "CAPABILITIES.md").read_text()
+        assert "no memory backend" in caps.partition("## Memory")[2].partition("## Skills")[0]
+
+
+class TestUpgradeRoundTrip:
+    def test_descriptor_survives_upgrade(self, tmp_path, capsys):
+        target = tmp_path / "p"
+        _scaffold(target, "obsidian-graphify")
+        capsys.readouterr()
+        assert main(["upgrade", str(target)]) == 0
+        assert "No drift" in capsys.readouterr().out
+        assert "tier: 2" in _memory_block(target)
+
+    def test_record_carries_memory_tier(self, tmp_path):
+        from project_init.upgrade import read_scaffold_record
+
+        target = tmp_path / "p"
+        _scaffold(target, "obsidian-only")
+        _preset, variables, _manifest, _migrated = read_scaffold_record(target)
+        assert variables["memory_tier"] == "1"


### PR DESCRIPTION
Implements #498 (extends ADR-024): every scaffold records a **stable tier + resolved paths** so a root orchestrator (#479) and cross-project skills can introspect any child identically and degrade by tier.

## What changed
- **Authoritative record** — `.claude/config.yaml` `memory:` block gains `tier` (0/1/2) and `graph_path` (`graphify-out/graph.json`, the one path not previously machine-readable). `memory_path`/`vault_path` already there. A `none` project ships **no** block — its absence *is* the signal.
- **Single-source derivation** — new `scaffold.memory_tier()` feeds the tier number to all **three** lockstep emit paths (`_build_variables`, `upgrade._backfill_variables`, `_migrate_semantic_config`), so scaffold and upgrade never diverge (PI-189). Legacy records backfill `memory_tier` from the recorded `memory_stack`.
- **Human/cross-surface surface** — `capabilities.py` gains a `## Memory` section (regenerated every run, ADR-017).
- **Contract doc** — `docs/development/memory-descriptor.md` documents the schema + the ADR-024 anchor-invariant guarantee (higher tiers only *add* surfaces; anchors never move).

## Scope boundary
The cross-project **aggregation protocol** (a root reading many children) is **#479's** deliverable, not this PR. This ships only the per-project descriptor it consumes.

## Verification
- 1494 tests pass, 3 skipped; ruff clean.
- New `test_memory_descriptor.py`: per-tier record, capabilities surface, upgrade round-trip, anchor invariance; plus a tier-parity check across all three emit paths.
- `config.yaml` byte-identity re-pinned — only that key, after verifying no other drift.

Closes #498

https://claude.ai/code/session_01TP6MVitGjpHgzJE34ZwSBt