### PR TITLE
chore: Remove LightRAG residue (ADR-024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,7 @@ adopters know what this tool owns and where it defers:
   community plugin or scaffolder covers these.
 - **Knowledge-graph memory**: the community has consolidated around
   [Graphify](https://github.com/safishamsi/graphify) for codebase knowledge
-  graphs. The `obsidian-graphify` preset wires it in (ADR-009); the
-  hand-rolled LightRAG overlay was removed once Graphify landed (PI-172).
+  graphs. The `obsidian-graphify` preset wires it in (ADR-009).
 - **Distributing `.claude/` components**: the official
   [Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins)
   is the standard channel for hooks/skills/agents. This repo doubles as a

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -70,32 +70,6 @@ _MIGRATION_DEFAULTS = {
     "project_init_version_prev": "",
 }
 
-# Presets removed in earlier releases mapped to their successors; upgrade
-# auto-migrates the recorded inputs instead of erroring on "unknown preset"
-# (PI-172, ADR-009). Hand-editing the recorded JSON is not something we ask
-# users to do.
-_REMOVED_PRESETS = {
-    "obsidian-lightrag": {
-        "successor": "obsidian-graphify",
-        "note": (
-            "the obsidian-lightrag preset was removed (ADR-009) — "
-            "re-rendering as obsidian-graphify. LightRAG files appear under "
-            "'removed' (left in place); --apply records the migration."
-        ),
-    },
-}
-
-
-def _migrate_removed_preset(preset_name: str, variables: dict) -> tuple[str, dict]:
-    """Rewrite recorded inputs for a removed preset onto its successor."""
-    successor = _REMOVED_PRESETS[preset_name]["successor"]
-    variables = dict(variables)
-    variables["memory_stack"] = successor
-    variables["graphify"] = "true" if "graphify" in successor else ""
-    variables.pop("lightrag", None)
-    return successor, variables
-
-
 _LANGUAGE_FLAGS = ("python", "node", "go")
 
 
@@ -1370,10 +1344,6 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     except UpgradeError as e:
         sys.stderr.write(f"error: {e}\n")
         return 1
-
-    if preset_name in _REMOVED_PRESETS:
-        sys.stderr.write(f"note: {_REMOVED_PRESETS[preset_name]['note']}\n")
-        preset_name, variables = _migrate_removed_preset(preset_name, variables)
 
     if no_plugin and not variables.get("no_plugin"):
         sys.stderr.write(

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -3,8 +3,7 @@
 .claude/scheduled_tasks.lock
 .claude/.session_setup_stamp
 .claude/settings.local.json
-{{#if memory}}.claude/memory/.lightrag/  # legacy LightRAG work dir — keep ignored after migration (ADR-009)
-.claude/memory/.cache/
+{{#if memory}}.claude/memory/.cache/
 {{/if memory}}.claude/logs/
 .claude/.local/
 

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -20,6 +20,9 @@ Exception (#496): the code-map feature intentionally ADDS
 and the justfile (the `code-map` recipe). Only those keys were re-pinned, after
 verifying every OTHER file still matched the baseline — the move invariant is
 intact for everything else.
+
+Exception (LightRAG cleanup): removing the dead `.claude/memory/.lightrag/`
+gitignore line (ADR-024) re-pinned `.gitignore` only.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_scaffold_graphify.py
+++ b/tests/contracts/test_scaffold_graphify.py
@@ -58,7 +58,3 @@ class TestScaffoldGraphify:
 
     def test_obsidian_layer_included(self):
         assert (self.target / ".claude" / "vault").is_dir()
-
-    def test_no_lightrag_files(self):
-        assert not (self.target / ".claude" / "scripts" / "ingest_sessions.py").exists()
-        assert not (self.target / ".claude" / "memory" / "lightrag.yaml").exists()

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -104,7 +104,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "900188c7f2bc8047e87df035cf4b6a05979005d9e8713e874cbce4c476bda6ff",
+  ".gitignore": "a5af31cdefeb4075cccee64884e5d127c124b65f1bc4253f97956d9cd91dbe2d",
   "AGENTS.md": "5f19145b70299dc67e7cd384582d65a0c43246364c9f1396131fb0bae2565992",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -85,7 +85,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "900188c7f2bc8047e87df035cf4b6a05979005d9e8713e874cbce4c476bda6ff",
+  ".gitignore": "a5af31cdefeb4075cccee64884e5d127c124b65f1bc4253f97956d9cd91dbe2d",
   "AGENTS.md": "3cf2030c156df9d72676f3e425f22e499126238f777988f8f6f795a60b139d24",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -101,7 +101,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "453e9bf64dcbe94af7aa227b46b159f06a6ae25aebb59e62703f68ff81d8e826",
+  ".gitignore": "0ca4b046dc4f8f62896f63143b394a26c6bc0d054cb8bdbe792449b8dc178a6d",
   "AGENTS.md": "5f19145b70299dc67e7cd384582d65a0c43246364c9f1396131fb0bae2565992",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -82,7 +82,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "453e9bf64dcbe94af7aa227b46b159f06a6ae25aebb59e62703f68ff81d8e826",
+  ".gitignore": "0ca4b046dc4f8f62896f63143b394a26c6bc0d054cb8bdbe792449b8dc178a6d",
   "AGENTS.md": "3cf2030c156df9d72676f3e425f22e499126238f777988f8f6f795a60b139d24",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -104,7 +104,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "900188c7f2bc8047e87df035cf4b6a05979005d9e8713e874cbce4c476bda6ff",
+  ".gitignore": "a5af31cdefeb4075cccee64884e5d127c124b65f1bc4253f97956d9cd91dbe2d",
   "AGENTS.md": "5f19145b70299dc67e7cd384582d65a0c43246364c9f1396131fb0bae2565992",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -85,7 +85,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "900188c7f2bc8047e87df035cf4b6a05979005d9e8713e874cbce4c476bda6ff",
+  ".gitignore": "a5af31cdefeb4075cccee64884e5d127c124b65f1bc4253f97956d9cd91dbe2d",
   "AGENTS.md": "3cf2030c156df9d72676f3e425f22e499126238f777988f8f6f795a60b139d24",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -101,7 +101,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "453e9bf64dcbe94af7aa227b46b159f06a6ae25aebb59e62703f68ff81d8e826",
+  ".gitignore": "0ca4b046dc4f8f62896f63143b394a26c6bc0d054cb8bdbe792449b8dc178a6d",
   "AGENTS.md": "5f19145b70299dc67e7cd384582d65a0c43246364c9f1396131fb0bae2565992",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -82,7 +82,7 @@
   ".github/workflows/project-init-upgrade.yml": "130caca76d76c6f25d96e83c87e113e1934282a353d3fe17b41ea6b2df630ce4",
   ".github/workflows/review-status.yml": "1a786ad10cae4cfcdabd7f6829a00755df9d29f2d1f2c702d3ee92f3252df163",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
-  ".gitignore": "453e9bf64dcbe94af7aa227b46b159f06a6ae25aebb59e62703f68ff81d8e826",
+  ".gitignore": "0ca4b046dc4f8f62896f63143b394a26c6bc0d054cb8bdbe792449b8dc178a6d",
   "AGENTS.md": "3cf2030c156df9d72676f3e425f22e499126238f777988f8f6f795a60b139d24",
   "CLAUDE.md": "0d28207113d6949817faa6641b07ccfc57848dcf9561085ef16cb9fb4d2ebe39",
   "CONTRIBUTING.md": "5f7b68696293b5f89eba10e447f18597ef9f18ea2774bcc1f299744c7f17eb04",

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -596,29 +596,6 @@ class TestMigration:
         assert variables["lint_command"] == "uv run ruff check ."
 
 
-class TestRemovedPresets:
-    def test_lightrag_record_auto_migrates_to_graphify(self, tmp_path: Path, capsys):
-        """PI-172: a record naming the removed obsidian-lightrag preset
-        re-renders as obsidian-graphify with corrected variables — users are
-        never asked to hand-edit the recorded JSON (PR #173 review)."""
-        target = tmp_path / "p"
-        _scaffold(target)
-        config = target / _CONFIG_REL
-        config.write_text(
-            config.read_text().replace("  preset: obsidian-only", "  preset: obsidian-lightrag")
-        )
-        rc = main(["upgrade", str(target), "--apply", "--accept-new", "all"])
-        assert rc == 0
-        assert "re-rendering as obsidian-graphify" in capsys.readouterr().err
-        # Successor preset's overlay landed and the record was rewritten.
-        assert (target / ".claude" / "scripts" / "setup_graphify.sh").exists()
-        preset, variables, _, _ = read_scaffold_record(target)
-        assert preset == "obsidian-graphify"
-        assert variables["memory_stack"] == "obsidian-graphify"
-        assert variables["graphify"] == "true"
-        assert "lightrag" not in variables
-
-
 class TestPluginCutoverMigration:
     def test_pre_cutover_record_backfills_fallback_mode(self, tmp_path: Path):
         """PI-165: records written before the cutover lack plugin_mode/


### PR DESCRIPTION
Final cleanup of LightRAG references — sanctioned by ADR-024 ("drop migration support for old obsidian-lightrag records when that code is next touched").

## Removed
- **upgrade.py** — the `_REMOVED_PRESETS` / `_migrate_removed_preset` mechanism. It existed solely for the lightrag→graphify transition (PI-172); with LightRAG gone and no users, an `obsidian-lightrag` record now errors as an unknown preset (acceptable per ADR-009/ADR-024). Re-addable from history if a future preset is ever removed.
- **dot_gitignore.tmpl** — the dead `.claude/memory/.lightrag/` ignore line.
- **README.md** — the historical LightRAG sentence.
- **tests** — `test_no_lightrag_files` and `test_lightrag_record_auto_migrates_to_graphify` (exercised the removed paths).

## Verification
- 1478 tests pass (main's 1480 minus the 2 removed LightRAG tests), ruff clean.
- `.gitignore` byte-identity re-pinned — only that key, after verifying no other drift.
- `grep -i lightrag` over src/templates/README/tests is now clean (only a docstring note explaining the re-pin remains).

No linked issue (chore). ADR-009 and the vault session log are left intact as immutable history.