### PR TITLE
docs(PI-479): Add ADR-025 agentic-OS root-layer spike + design note

### DIFF
--- a/docs/adr/adr-025-agentic-os-root-layer.md
+++ b/docs/adr/adr-025-agentic-os-root-layer.md
@@ -1,0 +1,146 @@
+# ADR-025: The agentic-OS root layer is a separate tool over a multirepo, consuming each project's descriptor
+
+- Status: Accepted
+- Date: 2026-06-26
+- Implements: spike #479 (evaluate a root-level agentic_os layer above project_init)
+- Relates to: ADR-001 (scaffolder design / no LLM), ADR-017 (per-surface generator /
+  capabilities), ADR-020 (memory backend is à-la-carte), ADR-024 (memory-tier model,
+  #478), #498 (cross-project memory descriptor), #495 (tier-3 RAG — parked)
+- Scope guard: this ADR decides *shape and boundary only*. It authorizes **no
+  implementation** — see "Explicit do-NOT-build boundary" below.
+
+## Context
+
+`project_init` is a per-project scaffolder: it drops a `.claude/` layout into one
+repo and exits (ADR-001 — deterministic file-ops, no long-running service, no LLM
+calls, stay small). A recurring question (#479) is whether a **root-level
+"agentic-OS" layer** should sit *above* it for cross-project concerns: global
+memory, an MCP/tool registry, a project index, and — the concrete trigger —
+**tier-3 RAG**, which ADR-024 §4 positions as worthwhile only at multi-project /
+monorepo scale and therefore cannot justify living inside any single scaffold.
+
+"Agentic OS" is two different things and the distinction decides feasibility:
+
+- **(a) infrastructure OS** — scheduling, isolation, a runtime, observability.
+  Multi-year, not on the table.
+- **(b) personal OS / "local mission control"** — context + memory + tool
+  aggregation across the projects you already have. Achievable in 2026.
+
+This ADR is about (b). It answers #479's four questions: where the capability
+lives, the minimum viable root layer, collision with `project_init`'s
+constraints, and the aggregation contract.
+
+## Decision
+
+### 1. A separate root tool — not a feature inside `project_init`
+
+The cross-project layer is its **own tool**, distinct from `project_init`, that
+*calls* `project_init` to bootstrap repos and *reads* what each scaffold exposes.
+
+Rationale, tied to existing constraints:
+
+- A root orchestrator is intrinsically **stateful and long-running** (a project
+  registry, a refreshable index, possibly a daemon/MCP). `project_init`'s charter
+  (ADR-001) forbids exactly that. Folding the root layer in would break the
+  charter that makes the scaffolder safe to reason about.
+- The dependency direction must stay **one-way**: scaffolder produces, orchestrator
+  consumes. A scaffolder that knew about a root registry would couple every
+  scaffold to an orchestrator that most projects will never run.
+- It keeps the blast radius small: the orchestrator can fail, change fast, or be
+  abandoned without touching the deterministic scaffolder or any scaffolded repo.
+
+`project_init`'s *only* obligation toward the root layer is to make every child
+**introspectable by a stable contract** (§4) — which is already most-built (#498).
+
+### 2. A multirepo + registry, not a monorepo, and never branches-as-projects
+
+The root layer operates over **N independent repos**, each carrying its own
+`.claude/` descriptor; the orchestrator keeps a registry (a list of project roots)
+and indexes across them.
+
+- **Monorepo (per-subtree scaffold)** is *supported but not required*: if a user
+  keeps projects as subtrees, `project_init` scaffolds each `packages/*/.claude/`
+  and the orchestrator walks subtrees. Same descriptor contract; different walk.
+- **Branches-as-projects is rejected.** A git branch is a temporal version of one
+  tree, not a multiplexer for N projects. Using branches to hold parallel projects
+  breaks history, CI, and the descriptor's one-root assumption.
+
+The contract in §4 is identical for the multirepo and monorepo shapes — only the
+*discovery walk* differs (registry of roots vs. subtree glob). That is the point:
+the orchestrator integrates **natively via the descriptor**, not via bespoke
+per-project hooks.
+
+### 3. Minimum viable root layer (what (b) is, concretely)
+
+The smallest useful orchestrator is three read-only capabilities over the
+registry — no writes back into child repos, no runtime:
+
+1. **Project registry** — a list of project roots (multirepo) or a subtree glob
+   (monorepo). Hand-maintained or discovered by globbing for `.claude/config.yaml`.
+2. **Memory aggregation** — read each project's `.claude/memory/MEMORY.md` (the
+   stable anchor, ADR-024) into a global view; optionally a global
+   `~/.claude/memory/` that links back to per-project facts.
+3. **Tool/MCP inventory** — union of each project's `.claude/CAPABILITIES.md`
+   (ADR-017) so "which projects expose which MCP/skill" is answerable centrally.
+
+Tier-3 RAG (#495), when built, is the *fourth* capability and lives **here**: one
+cross-corpus index over the aggregated memory/vault/code of all registered
+projects, reading the `rag_endpoint` descriptor field to know where (if anywhere)
+a per-project engine already exists.
+
+### 4. The aggregation contract: the descriptor each child already exposes
+
+The orchestrator reads, per project, the **memory descriptor** standardized in
+#498 / ADR-024 — no new per-project artifact is required:
+
+- **Anchor (invariant across tiers):** `.claude/config.yaml` `memory:` block with
+  `tier`, `stack`, `memory_path`, and (tier-gated) `vault_path`, `graph_path`,
+  `rag_endpoint`; plus `.claude/CAPABILITIES.md` as the human-readable mirror.
+- **Degrade-by-tier:** a cross-project skill reads `memory.tier` and picks its
+  retrieval path — `tier ≥ 3` → query the RAG endpoint; `≥ 2` → query the graph;
+  `≥ 0` → grep `memory_path`. The anchors never move between tiers; higher tiers
+  only *add* surfaces, so a reader written against tier 0 keeps working at tier 3.
+- **Discovery:** glob for `.claude/config.yaml`; its presence + the `memory:` block
+  *is* the registration breadcrumb. No callback, no daemon, no write-back.
+
+This is why §1's "separate tool" is cheap to start: the contract is data the
+scaffolder already emits, and §3's MVP is three readers over it.
+
+### 5. Collision check against `project_init`'s constraints
+
+- **No long-running service / no LLM (ADR-001):** preserved. Those constraints
+  bind the *scaffolder*; the orchestrator is a different tool and may be stateful
+  and may call an LLM (e.g. RAG). The boundary is the repo, not the ecosystem.
+- **Stay small:** preserved. `project_init` gains nothing here beyond finishing
+  the descriptor (#498). The orchestrator's weight lives in its own codebase.
+- **Deterministic scaffolds:** preserved. Reading a descriptor is non-mutating;
+  the orchestrator never writes back into a scaffolded repo as part of this shape.
+
+## Explicit do-NOT-build boundary
+
+This ADR authorizes **no code**. In particular, do **not**, on the strength of
+this decision alone:
+
+- build the orchestrator tool, a registry format, a daemon, or an MCP server;
+- build tier-3 RAG or pick its engine (that is #495, decided by a hands-on test);
+- add any write-back, callback, or registration *hook* into scaffolded projects —
+  discovery is pull-only via the descriptor;
+- add cross-project features *inside* `project_init` (violates §1);
+- touch the (a) infrastructure-OS surface (scheduling/isolation/runtime).
+
+The only `project_init`-side follow-up this unblocks is **finishing #498** (the
+`rag_endpoint` field — shipped with the tier-3 seam, #505 — plus a one-page
+"contract a root project reads" doc). The orchestrator itself is a separate
+future project, started only on an explicit, separate decision.
+
+## Consequences
+
+- #498 is unblocked: its schema is now pinned (the `memory:` descriptor + the
+  degrade-by-tier read contract) and its dependency on this spike is resolved.
+- #495 (RAG) gains a home: it is an orchestrator capability over the aggregated
+  corpus, not a per-project engine — consistent with ADR-024 §4's positioning.
+- `project_init` keeps its charter intact; the cross-project ambition is recorded
+  as a *separate tool* with a do-not-build boundary, not scope-crept into the
+  scaffolder.
+- A companion design note (`.claude/vault/design/agentic-os-root-layer.md`)
+  sketches the layer and the aggregation contract for when the build is greenlit.

--- a/docs/adr/adr-025-agentic-os-root-layer.md
+++ b/docs/adr/adr-025-agentic-os-root-layer.md
@@ -96,6 +96,12 @@ The orchestrator reads, per project, the **memory descriptor** standardized in
 - **Anchor (invariant across tiers):** `.claude/config.yaml` `memory:` block with
   `tier`, `stack`, `memory_path`, and (tier-gated) `vault_path`, `graph_path`,
   `rag_endpoint`; plus `.claude/CAPABILITIES.md` as the human-readable mirror.
+  *Field availability:* tiers 0–2 (`tier`/`stack`/`memory_path`/`vault_path`/
+  `graph_path`) ship today via #498; the tier-3 `rag_endpoint` field is added by
+  the seam PR (#505/#506) and is only present on `obsidian-graphify-rag` scaffolds
+  — a tier-0–2 child simply omits it, which the degrade-by-tier read already
+  handles. This ADR documents the *target* contract; it does not assume every
+  child exposes `rag_endpoint` before its scaffold opts into tier 3.
 - **Degrade-by-tier:** a cross-project skill reads `memory.tier` and picks its
   retrieval path — `tier ≥ 3` → query the RAG endpoint; `≥ 2` → query the graph;
   `≥ 0` → grep `memory_path`. The anchors never move between tiers; higher tiers

--- a/docs/adr/adr-025-agentic-os-root-layer.md
+++ b/docs/adr/adr-025-agentic-os-root-layer.md
@@ -142,5 +142,5 @@ future project, started only on an explicit, separate decision.
 - `project_init` keeps its charter intact; the cross-project ambition is recorded
   as a *separate tool* with a do-not-build boundary, not scope-crept into the
   scaffolder.
-- A companion design note (`.claude/vault/design/agentic-os-root-layer.md`)
+- A companion design note (`docs/development/agentic-os-root-layer.md`)
   sketches the layer and the aggregation contract for when the build is greenlit.

--- a/docs/development/agentic-os-root-layer.md
+++ b/docs/development/agentic-os-root-layer.md
@@ -1,0 +1,80 @@
+# Design note — agentic-OS root layer (#479)
+
+One-page sketch of the cross-project layer that sits *above* `project_init`.
+Decision recorded in [ADR-025](../adr/adr-025-agentic-os-root-layer.md);
+this note is the buildable picture for when it is greenlit. **Not built yet.**
+
+## Shape (one diagram)
+
+```
+                ┌─────────────────────────────────────────┐
+                │  agentic-os  (SEPARATE tool — stateful,  │
+                │  may call an LLM; NOT project_init)      │
+                │                                          │
+                │  registry │ memory-aggregate │ MCP-inv  │
+                │                  │  tier-3 RAG (=#495)    │
+                └───────▲──────────────────▲───────────────┘
+                        │ reads descriptor │  (pull-only, non-mutating)
+        ┌───────────────┴───┐   ┌──────────┴────────┐   ┌─────────────────┐
+        │ repoA/.claude/    │   │ repoB/.claude/    │   │ pkgs/c/.claude/ │
+        │ config.yaml(memory)│   │ config.yaml       │   │ config.yaml     │
+        │ MEMORY.md, CAPS.md │   │ MEMORY.md, CAPS.md│   │ ...             │
+        └────────────────────┘   └───────────────────┘   └─────────────────┘
+          multirepo: registry of roots          monorepo: subtree glob
+                        ▲
+                        │ project_init scaffolds each (one-way: produce → consume)
+```
+
+`project_init` only *produces* the descriptor; `agentic-os` only *consumes* it.
+The arrow never reverses — no callback/registration hook back into a child repo.
+
+## The aggregation contract (what the root reads per project)
+
+Source of truth = `.claude/config.yaml` `memory:` block (#498 / ADR-024);
+`.claude/CAPABILITIES.md` is the human mirror. All anchors invariant across tiers:
+
+| Field | Always? | Meaning to the orchestrator |
+|---|---|---|
+| `tier` | yes (if memory) | 0–3 — selects the retrieval path (degrade-by-tier) |
+| `stack` | yes | `auto` / `obsidian-only` / `obsidian-graphify` / `obsidian-graphify-rag` |
+| `memory_path` | yes | `.claude/memory` — grep anchor; `MEMORY.md` is the index |
+| `vault_path` | tier ≥ 1 | `.claude/vault` — human notes |
+| `graph_path` | tier ≥ 2 | `graphify-out/graph.json` — code structure |
+| `rag_endpoint` | tier 3 | per-project RAG engine, or empty (seam only — #495/#505) |
+
+**Degrade-by-tier read (the one rule every cross-project skill follows):**
+
+```
+tier >= 3 and rag_endpoint set → query RAG, then confirm against anchors
+tier >= 2                       → query graph_path before grep
+tier >= 0                       → grep memory_path; MEMORY.md first
+no memory: block                → project opted out; skip retrieval
+```
+
+A reader written against tier 0 keeps working at tier 3 (higher tiers only add
+surfaces). **Discovery = glob for `.claude/config.yaml`** — its presence is the
+registration breadcrumb; no daemon, no write-back.
+
+## MVP (three read-only capabilities, then RAG)
+
+1. **Registry** — list of roots (multirepo) or subtree glob (monorepo).
+2. **Memory aggregate** — union of each `MEMORY.md` into a global view.
+3. **MCP/tool inventory** — union of each `CAPABILITIES.md`.
+4. *(later)* **Tier-3 RAG (#495)** — one cross-corpus index over all registered
+   projects' memory/vault/code; reads `rag_endpoint` to reuse a per-project engine
+   if present. Same hard constraints as ADR-024 §4 (upstream tool, no key on the
+   default path, derived/gitignored index).
+
+## Boundary (carried from ADR-025)
+
+Do **not** build the orchestrator, a registry format, a daemon, RAG, or any
+write-back hook on the strength of the spike. The only `project_init`-side
+follow-up unblocked is **finishing #498** (the `rag_endpoint` field shipped with
+#505; plus a short "contract a root project reads" doc). The (a) infrastructure-OS
+surface (scheduling/isolation/runtime) is explicitly out of scope.
+
+## Open questions for the build decision (not now)
+
+- Registry format: a hand-maintained `~/.claude/projects.toml` vs. discovery-only glob.
+- Does the orchestrator ship as a CLI, an MCP server, or both?
+- RAG A-vs-B (#495): distinct vector rung vs. one tool replacing Graphify.

--- a/docs/development/agentic-os-root-layer.md
+++ b/docs/development/agentic-os-root-layer.md
@@ -25,6 +25,9 @@ this note is the buildable picture for when it is greenlit. **Not built yet.**
                         │ project_init scaffolds each (one-way: produce → consume)
 ```
 
+*(In the diagram `CAPS.md` is the generated `.claude/CAPABILITIES.md`, abbreviated
+to fit the box; `config.yaml(memory)` is its `memory:` descriptor block.)*
+
 `project_init` only *produces* the descriptor; `agentic-os` only *consumes* it.
 The arrow never reverses — no callback/registration hook back into a child repo.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - Toolchain gate map: adr/adr-022-toolchain-gate-map.md
     - Wizard explanation standard: adr/adr-023-wizard-explanation-standard.md
     - Memory tier model: adr/adr-024-memory-tier-model.md
+    - Agentic-OS root layer: adr/adr-025-agentic-os-root-layer.md
   - Development:
     - Template system: development/template-system.md
     - Memory descriptor: development/memory-descriptor.md


### PR DESCRIPTION
## What

Resolves the **#479 spike**: should a root-level *agentic-OS* layer sit above `project_init` for cross-project concerns (global memory, MCP/tool registry, project index, tier-3 RAG)? Deliverable is an ADR + a design note + an explicit do-NOT-build boundary — **no code**.

## Decision (ADR-025)

- **A separate tool, not a feature in `project_init`.** A root orchestrator is intrinsically stateful/long-running (and may call an LLM for RAG) — exactly what the scaffolder's ADR-001 charter forbids. Keeping it separate preserves the one-way dependency (scaffolder *produces*, orchestrator *consumes*) and the scaffolder's small, deterministic charter.
- **A multirepo + registry, not a monorepo; branches-as-projects rejected.** Monorepo-per-subtree is supported (same contract, different walk); a git branch is a temporal version of one tree, not a project multiplexer.
- **Native integration via the descriptor, not hooks.** The orchestrator reads each project's #498 `memory:` descriptor (`tier`/`stack`/paths/`rag_endpoint`) and degrades by tier (≥3 → RAG, ≥2 → graph, ≥0 → grep). Discovery = glob for `.claude/config.yaml`; pull-only, no write-back.
- **RAG (#495) lives in the root layer** as one cross-corpus capability over the aggregated corpus — consistent with ADR-024 §4's "worth it only at multi-project scale" positioning.

## Files

- `docs/adr/adr-025-agentic-os-root-layer.md` — integrate-vs-separate + multirepo-vs-monorepo rationale tied to existing constraints, the aggregation/degrade-by-tier contract, the collision check, and an explicit **do-NOT-build boundary**.
- `docs/development/agentic-os-root-layer.md` — one-page buildable sketch (diagram, contract table, MVP). Placed under `docs/` because this repo gitignores `.claude/*`; the issue's `.claude/vault/design/` path is the *scaffolded-project* convention, not this repo's.

## Boundary

Authorizes no implementation. The only `project_init`-side follow-up unblocked is **finishing #498** (the `rag_endpoint` field already shipped with the tier-3 seam in #505; plus a short "contract a root project reads" doc). The orchestrator, RAG engine, and any registration hook are deferred to a separate, explicit decision.

Closes #479
