### PR TITLE
feat(PI-498): Finish the Agentic-OS memory descriptor contract

### DIFF
--- a/docs/development/memory-descriptor.md
+++ b/docs/development/memory-descriptor.md
@@ -18,7 +18,7 @@ facts are surfaced for humans / non-Claude surfaces in `.claude/CAPABILITIES.md`
 
 ```yaml
 project:
-  project_init_contract_version: 1         # descriptor-contract schema version (top-level); absent ⇒ v0
+  project_init_contract_version: 1         # key path: project.project_init_contract_version (in the project: block, NOT in memory:); absent ⇒ v0
 memory:
   tier: 3                                  # 0 auto | 1 obsidian-only | 2 obsidian-graphify | 3 obsidian-graphify-rag
   stack: obsidian-graphify-rag
@@ -29,10 +29,11 @@ memory:
 ```
 
 A vault-free `none` project ships **no** `memory:` block (its absence *is* the
-signal — there is no memory backend to introspect). **Contract versioning is
-deliberately top-level (`project.project_init_contract_version`), not nested in
-`memory:`**, precisely so it survives the `none` case; a child config that
-predates the field is **contract v0** by the reader's rule below.
+signal — there is no memory backend to introspect). **Contract versioning lives
+at key path `project.project_init_contract_version` (inside the always-present
+`project:` block, deliberately NOT nested in `memory:`)**, precisely so it
+survives the `none` case; a child config that predates the field is **contract
+v0** by the reader's rule below.
 
 ## Tier → resolved paths
 

--- a/docs/development/memory-descriptor.md
+++ b/docs/development/memory-descriptor.md
@@ -3,10 +3,11 @@
 **Status:** Accepted — implements #498, extends [ADR-024](../adr/adr-024-memory-tier-model.md).
 
 Every scaffolded project records a **stable, machine-readable memory descriptor**
-so a root orchestrator (spike #479) and cross-project skills can introspect any
-child *identically* and degrade by tier — "if a graph exists, query it; else
-grep". This is the per-project half of the Agentic-OS contract; the cross-project
-aggregation protocol is #479's concern, not this one.
+so a root orchestrator ([ADR-025](../adr/adr-025-agentic-os-root-layer.md)) and
+cross-project skills can introspect any child *identically* and degrade by tier —
+"if a graph exists, query it; else grep". This is the per-project half of the
+Agentic-OS contract; the cross-project aggregation shape is ADR-025's concern,
+not this one.
 
 ## The contract
 
@@ -16,25 +17,41 @@ facts are surfaced for humans / non-Claude surfaces in `.claude/CAPABILITIES.md`
 (regenerated every run, ADR-017).
 
 ```yaml
+project:
+  project_init_contract_version: 1         # descriptor-contract schema version (top-level); absent ⇒ v0
 memory:
-  tier: 2                                  # 0 auto | 1 obsidian-only | 2 obsidian-graphify
-  stack: obsidian-graphify
+  tier: 3                                  # 0 auto | 1 obsidian-only | 2 obsidian-graphify | 3 obsidian-graphify-rag
+  stack: obsidian-graphify-rag
   memory_path: .claude/memory              # anchor — always present when memory is on
   vault_path: .claude/vault                # present at tier >= 1
   graph_path: graphify-out/graph.json      # present at tier >= 2
+  rag_endpoint:                            # present at tier 3 (ADR-024 §4); empty until a tool is wired (#495)
 ```
 
 A vault-free `none` project ships **no** `memory:` block (its absence *is* the
-signal — there is no memory backend to introspect).
+signal — there is no memory backend to introspect). **Contract versioning is
+deliberately top-level (`project.project_init_contract_version`), not nested in
+`memory:`**, precisely so it survives the `none` case; a child config that
+predates the field is **contract v0** by the reader's rule below.
 
 ## Tier → resolved paths
 
-| tier | stack | memory_path | vault_path | graph_path |
-|---|---|---|---|---|
-| — | none | (absent) | — | — |
-| 0 | auto | `.claude/memory` | — | — |
-| 1 | obsidian-only | `.claude/memory` | `.claude/vault` | — |
-| 2 | obsidian-graphify | `.claude/memory` | `.claude/vault` | `graphify-out/graph.json` |
+| tier | stack | memory_path | vault_path | graph_path | rag_endpoint |
+|---|---|---|---|---|---|
+| — | none | (absent) | — | — | — |
+| 0 | auto | `.claude/memory` | — | — | — |
+| 1 | obsidian-only | `.claude/memory` | `.claude/vault` | — | — |
+| 2 | obsidian-graphify | `.claude/memory` | `.claude/vault` | `graphify-out/graph.json` | — |
+| 3 | obsidian-graphify-rag | `.claude/memory` | `.claude/vault` | `graphify-out/graph.json` | present (may be empty — engine not bundled, #495) |
+
+## Reader rules (orchestrator-side, ADR-025)
+
+- **Feature-detect, don't assume.** Treat a missing `memory:` block as "no memory
+  backend," a missing `project_init_contract_version` as **contract v0**, and a
+  missing `rag_endpoint` (any tier < 3) as "no RAG surface." Never hard-require a
+  tier-3 field on a lower-tier child.
+- **Degrade by tier.** `tier >= 3` and `rag_endpoint` set → query RAG; `>= 2` →
+  query `graph_path` before grep; `>= 0` → grep `memory_path` (`MEMORY.md` first).
 
 ## Invariants (ADR-024)
 
@@ -64,6 +81,6 @@ descriptor = json.loads(m.group(1)) if m else {}
 tier, stack = descriptor.get("memory_tier"), descriptor.get("memory_stack")
 ```
 
-A future root layer (#479) walks its registry of child projects, reads each
-descriptor, and builds a cross-project view — but that aggregation format is
-defined by #479, not here.
+A future root layer ([ADR-025](../adr/adr-025-agentic-os-root-layer.md)) walks its
+registry of child projects, reads each descriptor, and builds a cross-project view
+— but that aggregation shape is defined by ADR-025, not here.

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -16,6 +16,7 @@ from project_init.mcps import (
     format_installed_mcps_yaml,
 )
 from project_init.scaffold import (
+    CONTRACT_VERSION,
     TemplateRenderError,
     list_presets,
     load_preset,
@@ -1535,6 +1536,7 @@ def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
         "project_description": project_description,
         "created_date": date.today().isoformat(),
         "project_init_version": __version__,
+        "project_init_contract_version": CONTRACT_VERSION,
         "project_init_url": __repo_url__,
         # Host-aware plugin-marketplace source (ADR-013, #248) — replaces the
         # github.com-only removeprefix. Provides project_init_repo + _url +

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -212,6 +212,13 @@ def generate_preset(name: str, *, extends: str, description: str = "", version: 
 _AGENT_LAYERS = ("codex", "antigravity", "amp", "junie")
 
 
+# Version of the machine-readable descriptor contract a root orchestrator reads
+# (#498, ADR-025): the config.yaml `memory:` block schema + the top-level
+# descriptor fields. Bumped only when that contract changes shape — independent
+# of project_init_version (the tool version). A child config that PREDATES this
+# field is contract v0 by the reader's rule; the scaffolder always stamps current.
+CONTRACT_VERSION = "1"
+
 _MEMORY_TIERS = {
     "auto": "0",
     "obsidian-only": "1",

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -767,11 +767,18 @@ def _mirror_mode(src: Path, dest: Path) -> None:
         dest.chmod(dest.stat().st_mode | 0o111)
 
 
-# Visible observability fields injected into the human `project:` block on upgrade
-# when a pre-#247/#248/#259 config lacks them (config.yaml is not re-rendered on
-# upgrade, so otherwise they live only in the hidden record). (key, comment) —
-# the value comes from the recorded/backfilled variables (#259).
-_PROJECT_OBSERVABILITY = (
+# Visible `project:` fields injected into the human config on upgrade when a
+# pre-existing config lacks them (config.yaml is not re-rendered on upgrade, so
+# otherwise they live only in the hidden record). (key, comment) — the value
+# comes from the recorded/backfilled variables. Inserted after the
+# project_init_version line, in declaration order. The contract version leads so
+# a pre-field project actually advances past v0 on `upgrade --apply` (#498,
+# ADR-025) — an orchestrator reads the visible YAML, not the hidden record.
+_PROJECT_VISIBLE_FIELDS = (
+    (
+        "project_init_contract_version",
+        "descriptor-contract schema a root orchestrator reads (#498, ADR-025); absent ⇒ v0",
+    ),
     ("project_init_plugin_version", "plugin payload version (ADR-010)"),
     ("profile", "individual | standalone | org — distribution profile (ADR-013)"),
     ("enforcement", "advisory | hard — see ADR-013 / #251"),
@@ -787,8 +794,8 @@ _UPDATES_BLOCK = (
 )
 
 
-def _ensure_observability_fields(text: str, variables: dict) -> str:
-    """Surface the observability record in the hand-editable config (#259).
+def _ensure_visible_project_fields(text: str, variables: dict) -> str:
+    """Surface recorded `project:` fields in the hand-editable config (#259, #498).
 
     Idempotent. Operates on the human section only (above the scaffold-record
     marker) so injected lines survive ``write_scaffold_record``'s strip-and-
@@ -799,7 +806,7 @@ def _ensure_observability_fields(text: str, variables: dict) -> str:
     head, sep, tail = text.partition(_RECORD_MARKER)
     missing = [
         f"  {key}: {variables.get(key, '')}  # {comment}"
-        for key, comment in _PROJECT_OBSERVABILITY
+        for key, comment in _PROJECT_VISIBLE_FIELDS
         if not re.search(rf"(?m)^\s+{re.escape(key)}:", head)
     ]
     if missing:
@@ -854,7 +861,7 @@ def apply_drift(
     if config_path.exists():
         text = config_path.read_text(encoding="utf-8")
         text = _VERSION_LINE_RE.sub(rf"\g<1>{variables['project_init_version']}", text, count=1)
-        text = _ensure_observability_fields(text, variables)
+        text = _ensure_visible_project_fields(text, variables)
         config_path.write_text(text, encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)
 
     # Only files whose on-disk content now equals the render are recorded —

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -45,6 +45,7 @@ from project_init.scaffold import (
     _GOVERNANCE_USER_FILES,
     _PRESERVE_DIRS,
     _RECORD_MARKER,
+    CONTRACT_VERSION,
     _matches_preserve_glob,
     _new_sibling,
     load_preset,
@@ -493,6 +494,11 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "project_description": fields.get("project.description", ""),
         "created_date": fields.get("project.created", ""),
         "project_init_version": fields.get("project.project_init_version", "0"),
+        # Staging re-renders current templates, so the descriptor contract is
+        # current (#498). A pre-field config.yaml stays user-owned and is not
+        # re-rendered, so it simply lacks the line — the orchestrator reads that
+        # absence as contract v0.
+        "project_init_contract_version": CONTRACT_VERSION,
         "language": language,
         "memory_stack": stack,
         "installed_mcps": ", ".join(installed_ids) if installed_ids else "none",
@@ -551,6 +557,10 @@ def _backfill_variables(variables: dict) -> dict:
     url = v.get("project_init_url", _MIGRATION_DEFAULTS["project_init_url"])
 
     derived: dict[str, str] = {
+        # Descriptor contract (#498): a pre-field record backfills to current so
+        # the staging strict-render succeeds; a post-field record carries its own
+        # value, which the setdefault below preserves.
+        "project_init_contract_version": CONTRACT_VERSION,
         "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "rag": "true" if "rag" in stack else "",

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -494,11 +494,14 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict, dict]:
         "project_description": fields.get("project.description", ""),
         "created_date": fields.get("project.created", ""),
         "project_init_version": fields.get("project.project_init_version", "0"),
-        # Staging re-renders current templates, so the descriptor contract is
-        # current (#498). A pre-field config.yaml stays user-owned and is not
-        # re-rendered, so it simply lacks the line — the orchestrator reads that
-        # absence as contract v0.
-        "project_init_contract_version": CONTRACT_VERSION,
+        # Descriptor contract (#498): preserve an explicitly recorded value (a
+        # post-field config.yaml that only lost its JSON record), else default to
+        # current since staging re-renders current templates. config.yaml stays
+        # user-owned and is not re-rendered, so a truly pre-field project simply
+        # lacks the line — the orchestrator reads that absence as contract v0.
+        "project_init_contract_version": fields.get(
+            "project.project_init_contract_version", CONTRACT_VERSION
+        ),
         "language": language,
         "memory_stack": stack,
         "installed_mcps": ", ".join(installed_ids) if installed_ids else "none",

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -6,6 +6,7 @@ project:
   description: "{{project_description}}"
   created: {{created_date}}
   project_init_version: {{project_init_version}}
+  project_init_contract_version: {{project_init_contract_version}}  # descriptor-contract schema a root orchestrator reads (#498, ADR-025); absent ⇒ v0
   project_init_plugin_version: {{project_init_plugin_version}}  # plugin payload version (ADR-010)
   profile: {{profile}}     # individual | standalone | org — distribution profile (ADR-013)
   enforcement: {{enforcement}}      # advisory | hard — see ADR-013 / #251

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -20,7 +20,8 @@ three keys were re-pinned, after verifying every other file still matched the
 baseline — the move invariant is intact for everything else.
 
 Exception (#497/#498): later features re-pinned `lint_memory.sh` (staleness) and
-`.claude/config.yaml` (memory descriptor) the same way — only the intentionally
+`.claude/config.yaml` (memory descriptor `tier`/`graph_path`, then the top-level
+`project_init_contract_version`, ADR-025) the same way — only the intentionally
 changed key, after verifying no other drift.
 """
 

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -22,8 +22,9 @@ verifying every OTHER file still matched the baseline — the move invariant is
 intact for everything else.
 
 Exception (#498): the memory descriptor intentionally edits `.claude/config.yaml`
-(adds `tier` + `graph_path` to the `memory:` block). Only that key was re-pinned,
-after verifying every other file still matched.
+(adds `tier` + `graph_path` to the `memory:` block, and later a top-level
+`project_init_contract_version` to the `project:` block, ADR-025). Only that key
+was re-pinned, after verifying every other file still matched.
 
 Exception (LightRAG cleanup): removing the dead `.claude/memory/.lightrag/`
 gitignore line (ADR-024) re-pinned `.gitignore` only.

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
+  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
+  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
+  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
+  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
+  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "f19abc65702a41a3c32fa0bbc6b21832171470036839f8a057eab0cd3c3bd6c8",
+  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
+  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "e02946cae7d26f6eb3e236ac837b8bda44864f3a960fe304e8f6e4caba6b562d",
+  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,6 +30,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "project_description": "A test project",
         "created_date": "2026-01-01",
         "project_init_version": "0.1.0",
+        "project_init_contract_version": "1",
         "project_init_url": "https://github.com/example/project-init",
         "project_init_repo": "example/project-init",
         "project_init_repo_url": "https://github.com/example/project-init.git",

--- a/tests/integration/test_memory_descriptor.py
+++ b/tests/integration/test_memory_descriptor.py
@@ -112,3 +112,41 @@ class TestUpgradeRoundTrip:
         _scaffold(target, "obsidian-only")
         _preset, variables, _manifest, _migrated = read_scaffold_record(target)
         assert variables["memory_tier"] == "1"
+
+
+class TestContractVersion:
+    """Top-level `project_init_contract_version` (#498, ADR-025): a stable schema
+    version a root orchestrator reads. Deliberately top-level (not nested in
+    `memory:`) so it survives the vault-free `none` case; absent ⇒ v0 (reader)."""
+
+    def test_present_even_for_none_project(self, tmp_path):
+        # `core` has no memory backend, but the contract version is top-level —
+        # the exact opt-out case a nested version would have missed (Codex review).
+        target = tmp_path / "p"
+        _scaffold(target, "core")
+        text = (target / ".claude" / "config.yaml").read_text()
+        assert "project_init_contract_version: 1" in text
+        assert "\nmemory:" not in text  # still no memory block
+
+    def test_present_for_memory_project(self, tmp_path):
+        target = tmp_path / "p"
+        _scaffold(target, "obsidian-graphify")
+        assert "project_init_contract_version: 1" in (
+            target / ".claude" / "config.yaml"
+        ).read_text()
+
+    def test_backfill_fills_absent_and_preserves_present(self):
+        """Backward-compat: a pre-field record backfills to current (so strict
+        re-render works); an explicit recorded value is preserved (setdefault)."""
+        from project_init.upgrade import _backfill_variables
+
+        absent = _backfill_variables({"memory_stack": "obsidian-only", "language": "python"})
+        assert absent["project_init_contract_version"] == "1"
+        present = _backfill_variables(
+            {
+                "memory_stack": "obsidian-only",
+                "language": "python",
+                "project_init_contract_version": "0",
+            }
+        )
+        assert present["project_init_contract_version"] == "0"

--- a/tests/integration/test_memory_descriptor.py
+++ b/tests/integration/test_memory_descriptor.py
@@ -115,9 +115,10 @@ class TestUpgradeRoundTrip:
 
 
 class TestContractVersion:
-    """Top-level `project_init_contract_version` (#498, ADR-025): a stable schema
-    version a root orchestrator reads. Deliberately top-level (not nested in
-    `memory:`) so it survives the vault-free `none` case; absent ⇒ v0 (reader)."""
+    """Descriptor contract version (#498, ADR-025): a stable schema version a root
+    orchestrator reads, at key path `project.project_init_contract_version` — in
+    the always-present `project:` block, deliberately NOT nested in `memory:`, so
+    it survives the vault-free `none` case; absent ⇒ v0 (reader)."""
 
     def test_present_even_for_none_project(self, tmp_path):
         # `core` has no memory backend, but the contract version is top-level —
@@ -150,3 +151,20 @@ class TestContractVersion:
             }
         )
         assert present["project_init_contract_version"] == "0"
+
+    def test_semantic_migration_preserves_explicit_version(self):
+        """A record-less config.yaml that still carries an explicit contract
+        version must keep it through migration, not be forced to current (Copilot
+        #508 review)."""
+        from project_init.upgrade import _migrate_semantic_config
+
+        lines = [
+            "project:\n",
+            '  name: "x"\n',
+            "  project_init_contract_version: 2\n",
+            "language: python\n",
+            "memory:\n",
+            "  stack: obsidian-only\n",
+        ]
+        _preset, variables, _manifest = _migrate_semantic_config(lines)
+        assert variables["project_init_contract_version"] == "2"

--- a/tests/integration/test_memory_descriptor.py
+++ b/tests/integration/test_memory_descriptor.py
@@ -168,3 +168,28 @@ class TestContractVersion:
         ]
         _preset, variables, _manifest = _migrate_semantic_config(lines)
         assert variables["project_init_contract_version"] == "2"
+
+    def test_upgrade_injects_visible_line_for_pre_field_project(self, tmp_path, capsys):
+        """A project whose visible config predates the field must GAIN the line on
+        `upgrade --apply` — config.yaml is not re-rendered, so without targeted
+        injection an orchestrator would read the upgraded child as v0 (Codex #508
+        P1)."""
+        target = tmp_path / "p"
+        _scaffold(target, "obsidian-only")
+        config = target / ".claude" / "config.yaml"
+        # Simulate a pre-field project: drop the visible line from the project:
+        # block ONLY (above the record marker) — leave the hidden record's
+        # variables JSON intact, exactly the state of a pre-field scaffold.
+        head, sep, tail = config.read_text().partition("# --- scaffold record")
+        head = "\n".join(
+            ln for ln in head.splitlines() if "project_init_contract_version" not in ln
+        )
+        config.write_text(head + "\n" + sep + tail)
+        assert "project_init_contract_version" not in config.read_text().partition(
+            "# --- scaffold record"
+        )[0]
+        capsys.readouterr()
+        assert main(["upgrade", str(target), "--apply"]) == 0
+        # The visible project: block (above the record marker) now carries it.
+        head = config.read_text().partition("# --- scaffold record")[0]
+        assert "project_init_contract_version: 1" in head


### PR DESCRIPTION
## What

Finishes **#498** — the per-project memory descriptor a root orchestrator reads — now that **ADR-025** (#479) settled the root-layer shape. This is **WS-0** of the agentic-OS plan (the small, `project_init`-side readiness; the orchestrator itself is a separate repo per ADR-025). Plan locked via grill + 2 rounds of Codex review (`PLAN.md`).

## Changes

- **`project_init_contract_version` (top-level in `config.yaml`).** A stable schema version for the descriptor contract, distinct from `project_init_version` (the tool version). `CONTRACT_VERSION` lives in `scaffold.py`; emitted on scaffold and both `upgrade` paths. **Deliberately top-level, not nested in `memory:`**, so it survives the vault-free `none` case (which has no `memory:` block); **absent ⇒ contract v0** by the reader's rule. Backfill uses `setdefault` → preserves an explicit recorded value (backward-compat).
- **Reconciled `docs/development/memory-descriptor.md`** to the *shipped* schema: tier 3 + `rag_endpoint`, the contract-version field, and explicit **orchestrator reader rules** (feature-detect; degrade by tier; tolerate absent `rag_endpoint`).
- **Re-pinned the 8 byte-identity fixtures** — `config.yaml` hash only, after verifying no other file drifted (the documented surgical re-pin); recorded the exception in both test docstrings.
- **Focused tests:** field present even for `none`, present for memory projects, and backfill fills-absent / preserves-present.

## Why this shape

Addresses two Codex plan-review findings directly: **#3** (version must be top-level, not nested in `memory:`, or it fails exactly for opt-out projects) and **#4** (reconcile the one canonical descriptor doc first; orchestrator must tolerate absent `rag_endpoint`). `project_init`'s charter is untouched — this is a deterministic line, no service/LLM.

## Tests

Full suite green (1510 passed, 3 skipped); `ruff` clean; byte-identity drift confirmed to be `config.yaml`-only across all 8 fixtures.

Closes #498
