### PR TITLE
feat(PI-510): Add --json output for orchestrator-driven scaffolding

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import dataclass
 from datetime import date
@@ -335,6 +336,19 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail if any {{...}} placeholder survives rendering (PI-17)",
     )
+    p.add_argument(
+        "--list-presets",
+        action="store_true",
+        help="Print available presets and exit (machine-readable with --json) — for "
+        "orchestrator-driven scaffolding (#510)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON result to stdout instead of the human "
+        "summary (scaffold result, or the preset list with --list-presets); for a "
+        "root orchestrator driving project-init (#510)",
+    )
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p
 
@@ -512,6 +526,85 @@ _MEMORY_NEXT_STEPS = {
         "(engine not bundled — see .claude/docs/guides/using-rag.md)"
     ),
 }
+
+
+def _presets_payload(presets: list[dict]) -> list[dict]:
+    """Machine-readable preset list for an orchestrator (#510).
+
+    Name, description, and the default memory stack each preset scaffolds — enough
+    for a root layer to choose a preset before driving a non-interactive scaffold.
+    """
+    return [
+        {
+            "name": p.get("name", ""),
+            "description": p.get("description", ""),
+            "memory_stack": p.get("vars", {}).get("memory_stack", "none"),
+        }
+        for p in presets
+    ]
+
+
+def _scaffold_result_payload(
+    target: Path, created: list[Path], preset_name: str, variables: dict[str, str]
+) -> dict:
+    """Machine-readable scaffold result for an orchestrator (#510).
+
+    Carries the resolved memory descriptor (the same fields a root layer reads
+    from `.claude/config.yaml`, #498) so the caller can register the new project
+    without a second read. Path fields are present only at the tiers that ship
+    them; `rag_endpoint` is null until a tool is wired (tier 3).
+    """
+    memory: dict[str, object] = {}
+    if variables.get("memory"):
+        memory = {
+            "tier": variables.get("memory_tier", ""),
+            "stack": variables.get("memory_stack", "none"),
+            "memory_path": ".claude/memory",
+        }
+        if variables.get("obsidian"):
+            memory["vault_path"] = ".claude/vault"
+        if variables.get("graphify"):
+            memory["graph_path"] = "graphify-out/graph.json"
+        if variables.get("rag"):
+            memory["rag_endpoint"] = None  # tier 3: present, unset until wired (#495)
+    return {
+        "target": str(target.resolve()),
+        "preset": preset_name,
+        "contract_version": variables.get("project_init_contract_version", ""),
+        "memory": memory,
+        "config": ".claude/config.yaml",
+        "files_created": len(created),
+    }
+
+
+def _emit_scaffold_output(  # noqa: PLR0913 — one arg per piece of the result
+    args, target: Path, created: list[Path], preset: dict, variables: dict, inputs, conflicts
+) -> None:
+    """Emit the post-scaffold result.
+
+    A single JSON line (``--json``, #510) for an orchestrator, or the human rich
+    panel + conflict/MCP notices otherwise.
+    """
+    if args.json:
+        # Machine-readable result — sole stdout line, no rich panels. Conflicts
+        # (unmerged `.new` siblings) are surfaced too.
+        result = _scaffold_result_payload(target, created, preset["name"], variables)
+        result["conflicts"] = [str(sibling) for _orig, sibling in conflicts]
+        print(json.dumps(result))
+        return
+    _print_summary(target, created, preset["name"], variables.get("memory_stack", "none"))
+    if conflicts:
+        _print_conflicts(conflicts)
+    _print_mcp_commands(inputs.selected_mcps)
+
+
+def _emit_preset_list(presets: list[dict], *, as_json: bool) -> None:
+    """Print the preset list for `--list-presets` (#510): JSON array or a human line each."""
+    if as_json:
+        print(json.dumps(_presets_payload(presets)))
+        return
+    for p in _presets_payload(presets):
+        print(f"{p['name']:<20} {p['description']}  [memory: {p['memory_stack']}]")
 
 
 def _print_summary(
@@ -910,6 +1003,8 @@ WIZARD_MECHANICAL_FLAGS: frozenset[str] = frozenset(
         "no_egress",
         "non_interactive",
         "strict",
+        "list_presets",
+        "json",
         "version",
     }
 )
@@ -1700,7 +1795,11 @@ def _resolve_inputs(
         iac = resolve_iac(args.iac)
     except ValueError as e:
         parser.error(str(e))
-    _print_profile_notice(profile, no_plugin=no_plugin, no_egress=args.no_egress)
+    # In --json mode stdout must be the JSON result only (#510); skip the human
+    # profile/egress notice. (It is advisory output, not a silent default — the
+    # JSON result and the recorded config carry the resolved profile.)
+    if not getattr(args, "json", False):
+        _print_profile_notice(profile, no_plugin=no_plugin, no_egress=args.no_egress)
     return ScaffoldInputs(
         project_name=args.name,
         project_description=args.description,
@@ -1771,6 +1870,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    presets = list_presets()
+    if not presets:
+        sys.stderr.write("error: no presets found in templates/presets/\n")
+        return 1
+
+    # Discovery for an orchestrator (#510): list presets and exit, before any
+    # target/preset resolution (no --name/--target needed).
+    if args.list_presets:
+        _emit_preset_list(presets, as_json=args.json)
+        return 0
+
     if args.non_interactive:
         _require_non_interactive_args(args, parser)
 
@@ -1778,10 +1888,6 @@ def main(argv: list[str] | None = None) -> int:
 
     # Select preset BEFORE creating the target directory — a typo'd --preset
     # should fail without leaving an empty dir behind.
-    presets = list_presets()
-    if not presets:
-        sys.stderr.write("error: no presets found in templates/presets/\n")
-        return 1
     preset = _select_preset(args, parser, presets)
     # Memory backend fallback when --memory is absent (#466): the preset's stack
     # (obsidian-only/obsidian-graphify/core's "none"), default obsidian-only.
@@ -1861,10 +1967,7 @@ def main(argv: list[str] | None = None) -> int:
     from project_init.upgrade import write_scaffold_record
 
     write_scaffold_record(target, preset["name"], variables, created)
-    _print_summary(target, created, preset["name"], variables.get("memory_stack", "none"))
-    if conflicts:
-        _print_conflicts(conflicts)
-    _print_mcp_commands(inputs.selected_mcps)
+    _emit_scaffold_output(args, target, created, preset, variables, inputs, conflicts)
     return 0
 
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -533,15 +533,25 @@ def _presets_payload(presets: list[dict]) -> list[dict]:
 
     Name, description, and the default memory stack each preset scaffolds — enough
     for a root layer to choose a preset before driving a non-interactive scaffold.
+    Each preset is re-resolved through ``load_preset`` so ``extends`` inheritance
+    is applied (e.g. ``governed`` inherits ``obsidian-only``'s ``memory_stack``);
+    reading the raw TOML would otherwise advertise the wrong stack (#511 review).
     """
-    return [
-        {
-            "name": p.get("name", ""),
-            "description": p.get("description", ""),
-            "memory_stack": p.get("vars", {}).get("memory_stack", "none"),
-        }
-        for p in presets
-    ]
+    payload = []
+    for p in presets:
+        name = p.get("name", "")
+        try:
+            resolved = load_preset(name) if name else p
+        except ValueError:
+            resolved = p
+        payload.append(
+            {
+                "name": name,
+                "description": resolved.get("description", p.get("description", "")),
+                "memory_stack": resolved.get("vars", {}).get("memory_stack", "none"),
+            }
+        )
+    return payload
 
 
 def _scaffold_result_payload(
@@ -1880,6 +1890,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.list_presets:
         _emit_preset_list(presets, as_json=args.json)
         return 0
+
+    # --json promises a single clean JSON stdout line; interactive prompts/panels
+    # would pollute it, so a scaffold --json run must be non-interactive (#511).
+    if args.json and not args.non_interactive:
+        parser.error("--json requires --non-interactive (interactive prompts would corrupt JSON stdout)")
 
     if args.non_interactive:
         _require_non_interactive_args(args, parser)

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -230,11 +230,11 @@ _MEMORY_TIERS = {
 def memory_tier(memory_stack: str) -> str:
     """Descriptor tier number for *memory_stack* (#498, ADR-024).
 
-    The rung on the recall ladder a root orchestrator (#479) reads to feature-
+    The rung on the recall ladder a root orchestrator (ADR-025) reads to feature-
     detect a child's retrieval surfaces: ``auto``→0, ``obsidian-only``→1,
-    ``obsidian-graphify``→2. ``none`` returns ``""`` (no descriptor — the config
-    memory block is gated out). Single source for the scaffold + the two upgrade
-    emit paths so they never diverge (PI-189).
+    ``obsidian-graphify``→2, ``obsidian-graphify-rag``→3. ``none`` returns ``""``
+    (no descriptor — the config memory block is gated out). Single source for the
+    scaffold + the two upgrade emit paths so they never diverge (PI-189).
     """
     return _MEMORY_TIERS.get(memory_stack, "")
 

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -24,8 +24,8 @@ iac: {{iac}}            # none | opentofu — infrastructure-as-code overlay (AD
   # Stable descriptor (#498): tier + resolved paths a root orchestrator reads to
   # introspect this project. Anchors (memory_path, MEMORY.md) are invariant across
   # tiers; higher tiers only ADD retrieval surfaces (vault, graph).
-  tier: {{memory_tier}}             # 0 auto | 1 obsidian-only | 2 obsidian-graphify
-  stack: {{memory_stack}}{{#if obsidian}}         # obsidian-only | obsidian-graphify{{/if obsidian}}
+  tier: {{memory_tier}}             # 0 auto | 1 obsidian-only | 2 obsidian-graphify | 3 obsidian-graphify-rag
+  stack: {{memory_stack}}{{#if obsidian}}         # obsidian-only | obsidian-graphify | obsidian-graphify-rag{{/if obsidian}}
   memory_path: .claude/memory
 {{#if obsidian}}  vault_path: .claude/vault
 {{/if obsidian}}{{#if graphify}}  graph_path: graphify-out/graph.json

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
+  ".claude/config.yaml": "1c56da0b2b3d2e32372ea74b264664f8c37f39f3b566546399bd1c06f46c4e7a",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
+  ".claude/config.yaml": "1c56da0b2b3d2e32372ea74b264664f8c37f39f3b566546399bd1c06f46c4e7a",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
+  ".claude/config.yaml": "3e8cbdf39f62f61226e072a595b78bd021be3e04e67ef04b6060d9ceb31f1ab7",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
+  ".claude/config.yaml": "3e8cbdf39f62f61226e072a595b78bd021be3e04e67ef04b6060d9ceb31f1ab7",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
+  ".claude/config.yaml": "1c56da0b2b3d2e32372ea74b264664f8c37f39f3b566546399bd1c06f46c4e7a",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "9232c19d3d9317e7c671e67c606ec1101abad71acf3621d0a2ba71943bc6902d",
+  ".claude/config.yaml": "1c56da0b2b3d2e32372ea74b264664f8c37f39f3b566546399bd1c06f46c4e7a",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "9fb25b1dceb1a8be082afe30f236bdf13f11273797239b5f32a332ae06aa0a7c",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
+  ".claude/config.yaml": "3e8cbdf39f62f61226e072a595b78bd021be3e04e67ef04b6060d9ceb31f1ab7",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -3,7 +3,7 @@
   ".claude/agents/README.md": "e2cabfd50c117914d948bcab94cf0a5f3611b97c0fca977bfc418ef7d5aa30cc",
   ".claude/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
   ".claude/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
-  ".claude/config.yaml": "995a8f3a136441a392eebfbaba535e00b36eacc3756bd3f0e24539c8f0af4f9c",
+  ".claude/config.yaml": "3e8cbdf39f62f61226e072a595b78bd021be3e04e67ef04b6060d9ceb31f1ab7",
   ".claude/docs/README.md": "f62199d0d050d02c82e598ab44c791b6eb21c5a121e1899a0003cfb873a5d89b",
   ".claude/docs/adr/adr-001-memory-stack.md": "a7ac4beabd4de49cae82a90252416caf7bcda1d24a2071813a9045a2e2f7424d",
   ".claude/docs/adr/adr-002-mcp-choices.md": "e1125bde3850ace16f17cd9feaf54c21f7318f7eb6ff63bf33eded3cd5c8104a",

--- a/tests/integration/test_json_output.py
+++ b/tests/integration/test_json_output.py
@@ -40,6 +40,24 @@ class TestListPresets:
         out = capsys.readouterr().out
         assert "core" in out and "memory:" in out
 
+    def test_inherited_memory_stack_resolved(self, capsys):
+        # `governed` extends `obsidian-only` and omits memory_stack; the payload
+        # must report the INHERITED stack, not the raw-TOML "none" (#511 review).
+        assert main(["--list-presets", "--json"]) == 0
+        by_name = {p["name"]: p for p in json.loads(capsys.readouterr().out)}
+        assert by_name["governed"]["memory_stack"] == "obsidian-only"
+
+
+class TestJsonRequiresNonInteractive:
+    def test_scaffold_json_without_non_interactive_errors(self, tmp_path):
+        # --json promises clean stdout; an interactive run would pollute it, so
+        # scaffold --json must require --non-interactive (#511 review).
+        import pytest
+
+        with pytest.raises(SystemExit) as exc:
+            main([str(tmp_path / "p"), "--preset", "core", "--json"])
+        assert exc.value.code == 2  # argparse usage error
+
 
 class TestScaffoldResult:
     def test_clean_json_only_stdout(self, tmp_path, capsys):

--- a/tests/integration/test_json_output.py
+++ b/tests/integration/test_json_output.py
@@ -1,0 +1,71 @@
+"""Machine-readable --json output for orchestrator-driven scaffolding (#510).
+
+A root orchestrator (ADR-025) drives `project-init` as an external CLI; --json
+gives it stable, parseable output for preset discovery and scaffold results
+instead of the human rich panels.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from project_init.__main__ import main
+
+
+def _scaffold_json(target: Path, stack: str, capsys) -> dict:
+    rc = main([
+        str(target), "--non-interactive", "--name", "fx", "--description", "d",
+        "--language", "python", "--preset", "core", "--memory", stack, "--json",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # stdout must be JSON ONLY — no rich panel / profile notice leaking in.
+    return json.loads(out)
+
+
+class TestListPresets:
+    def test_json_array(self, capsys):
+        assert main(["--list-presets", "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert isinstance(data, list) and data
+        by_name = {p["name"]: p for p in data}
+        assert "core" in by_name and "obsidian-graphify" in by_name
+        assert by_name["core"]["memory_stack"] == "none"
+        assert {"name", "description", "memory_stack"} <= set(by_name["core"])
+
+    def test_human_list_needs_no_target(self, capsys):
+        # --list-presets must not require --name/--target (discovery, not scaffold).
+        assert main(["--list-presets"]) == 0
+        out = capsys.readouterr().out
+        assert "core" in out and "memory:" in out
+
+
+class TestScaffoldResult:
+    def test_clean_json_only_stdout(self, tmp_path, capsys):
+        data = _scaffold_json(tmp_path / "p", "obsidian-only", capsys)
+        assert data["preset"] == "core"
+        assert data["target"] == str((tmp_path / "p").resolve())
+        assert data["contract_version"] == "1"
+        assert data["files_created"] > 0
+        assert data["memory"]["tier"] == "1"
+        assert data["memory"]["vault_path"] == ".claude/vault"
+        assert "graph_path" not in data["memory"]
+
+    def test_tier3_exposes_rag_endpoint(self, tmp_path, capsys):
+        data = _scaffold_json(tmp_path / "p", "obsidian-graphify-rag", capsys)
+        assert data["memory"]["tier"] == "3"
+        assert data["memory"]["graph_path"] == "graphify-out/graph.json"
+        # present (tier 3) but unset until a tool is wired (#495)
+        assert "rag_endpoint" in data["memory"]
+        assert data["memory"]["rag_endpoint"] is None
+
+    def test_none_has_empty_memory(self, tmp_path, capsys):
+        rc = main([
+            str(tmp_path / "p"), "--non-interactive", "--name", "fx",
+            "--description", "d", "--language", "python", "--preset", "core", "--json",
+        ])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["memory"] == {}
+        assert data["contract_version"] == "1"  # still present for none


### PR DESCRIPTION
## What

Machine-readable `--json` output so the **agentic-os orchestrator** (#509) can drive `project-init` as an external CLI cleanly — the project-init-side polish promised when finishing the descriptor contract (#498).

- **`--list-presets [--json]`** — discover presets (name / description / memory_stack) without needing `--name`/`--target`.
- **`--json` on a scaffold run** — emit a single JSON result (target, preset, the resolved memory descriptor incl. `tier`/paths/`rag_endpoint`, `contract_version`, `files_created`, `conflicts`) as the **sole stdout line**. The profile/egress notice and rich panels are suppressed so stdout stays machine-clean (verified by test).
- Both flags classified as mechanical in `WIZARD_CONCERN_FLAGS` (ADR-023 coverage test).
- Extracted `_emit_scaffold_output` / `_emit_preset_list` to keep `main()` under the complexity gate.

## Also — bug sweep result (#509)

This branch carries the only output from an adversarial bug sweep over the session's merged work (tier-3 RAG seam #506 + contract version #508). The sweep empirically scaffolded all 5 tiers in both modes and ran upgrade round-trips, and found **no correctness, consistency, or data-integrity bugs** — only two P3 doc-consistency nits, both fixed here:

- `config.yaml` tier/stack comment legend now includes tier 3 (`obsidian-graphify-rag`) — re-pinned the 8 byte-identity fixtures (config.yaml only, no other drift).
- `memory_tier()` docstring documents the tier-3 mapping.

## Tests

New `test_json_output.py` (preset list, clean JSON-only stdout, tier-3 `rag_endpoint`, `none` empty memory). Full suite green (1517 passed, 3 skipped); `ruff` clean; byte-identity intact.

Closes #510
