### PR TITLE
docs(PI-512): Aggregate-by-tier + connection/transport model for agentic-os

### DIFF
--- a/docs/development/agentic-os-root-layer.md
+++ b/docs/development/agentic-os-root-layer.md
@@ -68,6 +68,61 @@ registration breadcrumb; no daemon, no write-back.
    if present. Same hard constraints as ADR-024 §4 (upstream tool, no key on the
    default path, derived/gitignored index).
 
+## Aggregate-by-tier (the orchestrator-side mirror of degrade-by-tier)
+
+Each recall tier has a tier-appropriate cross-project aggregation strategy. This
+is the producer→consumer mirror of the per-project *degrade-by-tier* read rule:
+the descriptor's `tier` + paths (already shipped, #498) tell the orchestrator
+exactly which strategy to apply per project.
+
+| Tier | Per-project artifact | OS cross-project strategy | Cost | Engine |
+|---|---|---|---|---|
+| **0 auto** | `.claude/memory/MEMORY.md` (flat facts) | **direct-merge** — read + union each `MEMORY.md`; may cross-link facts between projects | cheapest | deterministic, no LLM |
+| **1 obsidian** | `.claude/vault/` (human prose) | **grep** for cheap recall, **or agent-synthesis** to summarize the "why" across projects | grep cheap / synthesis costly | LLM only for synthesis |
+| **2 graphify** | `graphify-out/graph.json` | **federate** — read each project's `graph_path`, union the code graphs | moderate | graphify CLI (per-repo) |
+| **3 rag** | `rag_endpoint` (or none) | **federated** (query each project's engine, merge) **or central** (one OS index over all corpora) | highest | a RAG tool (#495) |
+
+**Mixed-tier fleet.** Projects sit at different tiers; the orchestrator retrieves
+each project at *its own* tier (the highest its descriptor supports) and unions
+the results. Tier 1 is **high-value but high-cost** (the vault holds the *why*,
+but synthesizing prose needs an LLM) — not "least useful"; fall back to grep when
+you don't want to pay for synthesis. Build order follows cost: **deterministic
+first** (L0 direct-merge, L2 graph federation), then the LLM-assisted layers
+(L1 synthesis, L3 RAG).
+
+**Engines vs scaffolder.** `project-init` only *scaffolds the seam* for each tier
+(the graphify/RAG `setup_*.sh` + the descriptor field); it never runs an index.
+The orchestrator may *invoke* `project-init` to add a seam to a project that lacks
+one (a delegated write), but the **graphify CLI** / **RAG tool** build the indices
+and the **OS** federates/aggregates them.
+
+## Connection / transport model (already thought through)
+
+Three distinct edges, three different answers — only one is a network protocol:
+
+- **OS ↔ child projects — filesystem pull, no live connection.** The OS globs for
+  `.claude/config.yaml`, reads the descriptor + `MEMORY.md`/`graph.json`/vault.
+  Projects are passive file trees: **no daemon, no server, no write-back** in a
+  child (ADR-025 pull-only). The lone exception is **tier-3 *federated* RAG**,
+  where a project may expose a `rag_endpoint` the OS *queries* (that endpoint is
+  the project's own RAG tool, not a project-init service).
+- **OS ↔ harnesses (Claude Code / Cowork / Codex / …) — client-server via MCP.**
+  The OS is the MCP server; harnesses are clients. stdio local for the MVP; a
+  separately-gated HTTP/streamable adapter (own auth/threat model) only if remote
+  access is ever needed. This is the agnostic seam.
+- **OS ↔ other agents/orchestrators — A2A, deferred.** [A2A](https://a2aprotocol.ai)
+  (agent-to-agent) is the right protocol *if* you later run specialized agents or
+  federate across machines/users that must coordinate. Premature for a single-user
+  local OS; the headless core + MCP doesn't preclude adding an A2A adapter later.
+- **p2p — out of scope.** Only relevant for multi-machine/multi-user federation
+  (several people's agentic-OSes sharing), which conflicts with the small/local/
+  single-user charter. If ever needed it's a sync layer over the registry, not a
+  core concern.
+
+So between the OS and its projects there is deliberately **no client-server or
+p2p** — it's reads. The only client-server is **MCP** to the harnesses; **A2A**
+and **p2p** are future seams, not MVP needs.
+
 ## Boundary (carried from ADR-025)
 
 Do **not** build the orchestrator, a registry format, a daemon, RAG, or any

--- a/docs/development/agentic-os-root-layer.md
+++ b/docs/development/agentic-os-root-layer.md
@@ -80,13 +80,17 @@ exactly which strategy to apply per project.
 | **0 auto** | `.claude/memory/MEMORY.md` (flat facts) | **direct-merge** — read + union each `MEMORY.md`; may cross-link facts between projects | cheapest | deterministic, no LLM |
 | **1 obsidian** | `.claude/vault/` (human prose) | **grep** for cheap recall, **or agent-synthesis** to summarize the "why" across projects | grep cheap / synthesis costly | LLM only for synthesis |
 | **2 graphify** | `graphify-out/graph.json` | **federate** — read each project's `graph_path`, union the code graphs | moderate | graphify CLI (per-repo) |
-| **3 rag** | `rag_endpoint` (or none) | **federated** (query each project's engine, merge) **or central** (one OS index over all corpora) | highest | a RAG tool (#495) |
+| **3 rag** | `rag_endpoint` (present at tier 3; may be empty until a tool is wired) | **federated** (query each project's engine, merge) **or central** (one OS index over all corpora) | highest | a RAG tool (#495) |
 
-**Mixed-tier fleet.** Projects sit at different tiers; the orchestrator retrieves
-each project at *its own* tier (the highest its descriptor supports) and unions
-the results. Tier 1 is **high-value but high-cost** (the vault holds the *why*,
-but synthesizing prose needs an LLM) — not "least useful"; fall back to grep when
-you don't want to pay for synthesis. Build order follows cost: **deterministic
+**Mixed-tier fleet.** Projects sit at different tiers, and the strategies are
+**additive, not exclusive** — exactly like the per-project ladder where higher
+tiers only *add* surfaces. Every project with memory contributes its **tier-0
+`MEMORY.md` merge** (the universal baseline); a tier-≥2 project *also* contributes
+its graph, and a tier-3 project *also* its RAG surface. The fleet view is the
+union of all those layers across all projects, not "highest tier only." Tier 1 is
+**high-value but high-cost** (the vault holds the *why*, but synthesizing prose
+needs an LLM) — not "least useful"; fall back to grep when you don't want to pay
+for synthesis. Build order follows cost: **deterministic
 first** (L0 direct-merge, L2 graph federation), then the LLM-assisted layers
 (L1 synthesis, L3 RAG).
 
@@ -131,8 +135,21 @@ follow-up unblocked is **finishing #498** (the `rag_endpoint` field shipped with
 #505; plus a short "contract a root project reads" doc). The (a) infrastructure-OS
 surface (scheduling/isolation/runtime) is explicitly out of scope.
 
+## Tier-3 default topology + engine (provisional — #495 research)
+
+A 2026 deep-research pass (logged on #495) provisionally resolves two of the
+below: **default tier-3 topology = central** (one OS-level index over all repos,
+project-filtered — better-supported and more maintainable than federated for a
+solo dev; federated stays the fallback for a project that wired its own engine via
+`rag_endpoint`). Provisional engine = **`codebase-memory-mcp`** (on-device,
+no-key, MCP-native, dual AST-graph + vectors), with **LEANN** as the uv-native
+fallback. Because that engine is dual, the **A-vs-B** question leans **B** (one
+tool could replace the Graphify rung, collapsing tiers 2+3) — but that supersedes
+ADR-009 and rests on first-party quality claims, so it is gated on a hands-on
+bake-off (incl. comparing its AST-graph depth against Graphify) before any build.
+
 ## Open questions for the build decision (not now)
 
 - Registry format: a hand-maintained `~/.claude/projects.toml` vs. discovery-only glob.
 - Does the orchestrator ship as a CLI, an MCP server, or both?
-- RAG A-vs-B (#495): distinct vector rung vs. one tool replacing Graphify.
+- RAG A-vs-B (#495): provisionally **B** (one tool replaces Graphify) — confirm on the bake-off.


### PR DESCRIPTION
## What

Locks two things ADR-025/PLAN left to the orchestrator, before WS-1 starts — pure docs, no scaffolder change (the descriptor contract is code-complete, #498).

**Aggregate-by-tier matrix** (orchestrator-side mirror of degrade-by-tier): per recall tier, the cross-project strategy, cost, and deterministic-vs-LLM —

| Tier | Strategy | Cost | Engine |
|---|---|---|---|
| 0 auto | direct-merge `MEMORY.md` | cheapest | deterministic |
| 1 obsidian | grep, or agent-synthesis | cheap / costly | LLM for synthesis |
| 2 graphify | federate `graph.json` | moderate | graphify CLI |
| 3 rag | federated **or** central | highest | RAG tool (#495) |

Plus: mixed-tier fleet handling (retrieve each project at its own tier, union results); build order = deterministic-first; and the clarification that **project-init scaffolds seams** while the engines (graphify CLI, RAG tool) index and the OS aggregates.

**Connection/transport model** (answering 'client-server / p2p / A2A?'): OS↔projects = **filesystem pull**, no daemon/server in children (tier-3 federated RAG querying `rag_endpoint` is the lone exception); OS↔harnesses = **MCP client-server** (stdio MVP, HTTP gated); **A2A deferred**; **p2p out of scope**.

## Why here

The design note lives in project-init docs until the `agentic-os` repo exists; mirrored to tracking issue #509. No code change.

Closes #512