### PR TITLE
fix(PI-516): Harden scaffolder bad-paths found in e2e sweep

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -1871,6 +1871,41 @@ def _preset_main(argv: list[str]) -> int:
     return 0
 
 
+def _validate_text_inputs(inputs: ScaffoldInputs, parser: argparse.ArgumentParser) -> None:
+    """Reject text fields that would corrupt the rendered config.yaml.
+
+    name/description/owner are embedded into a double-quoted YAML string in
+    config.yaml; a literal double-quote, newline, or control character there
+    produces invalid YAML (which then breaks ``upgrade`` and descriptor reads).
+    These are short single-line fields, so a clean rejection beats silent
+    corruption (e2e sweep).
+    """
+    for flag, value in (
+        ("name", inputs.project_name),
+        ("description", inputs.project_description),
+        ("owner", inputs.owner),
+    ):
+        if '"' in value or any(ord(ch) < 32 for ch in value):
+            parser.error(
+                f"--{flag} must not contain double-quotes, newlines, or control "
+                "characters (they corrupt the generated config.yaml)"
+            )
+
+
+def _ensure_target_dir(target: Path, parser: argparse.ArgumentParser) -> None:
+    """Create the target directory, rejecting a non-directory target.
+
+    ``mkdir(exist_ok=True)`` would otherwise raise an uncaught FileExistsError
+    when the target already exists as a file/symlink (e2e sweep).
+    """
+    if target.exists() and not target.is_dir():
+        parser.error(f"target {target} exists and is not a directory")
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # e.g. PermissionError on a read-only parent
+        parser.error(f"cannot create target {target}: {exc.strerror or exc}")
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the scaffolding CLI; return the process exit code."""
     argv = list(sys.argv[1:]) if argv is None else list(argv)
@@ -1942,7 +1977,8 @@ def main(argv: list[str] | None = None) -> int:
             no_docs=args.no_docs,
             no_renovate=args.no_renovate,
         )
-    target.mkdir(parents=True, exist_ok=True)
+    _validate_text_inputs(inputs, parser)
+    _ensure_target_dir(target, parser)
 
     # Agent overlays append to the preset's layers (PI-137); --no-plugin
     # restores the shared hooks/skills copies via the fallback layer

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -1875,20 +1875,25 @@ def _validate_text_inputs(inputs: ScaffoldInputs, parser: argparse.ArgumentParse
     """Reject text fields that would corrupt the rendered config.yaml.
 
     name/description/owner are embedded into a double-quoted YAML string in
-    config.yaml; a literal double-quote, newline, or control character there
-    produces invalid YAML (which then breaks ``upgrade`` and descriptor reads).
-    These are short single-line fields, so a clean rejection beats silent
-    corruption (e2e sweep).
+    config.yaml; a literal double-quote, backslash (an invalid/lossy YAML escape,
+    as in a Windows-style path), newline, or control character there produces
+    invalid YAML (which then breaks ``upgrade`` and descriptor reads). These are
+    short single-line fields, so a clean rejection beats silent corruption
+    (e2e sweep; Codex/Copilot review).
     """
     for flag, value in (
         ("name", inputs.project_name),
         ("description", inputs.project_description),
         ("owner", inputs.owner),
     ):
-        if '"' in value or any(ord(ch) < 32 for ch in value):
+        if (
+            '"' in value
+            or "\\" in value
+            or any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+        ):
             parser.error(
-                f"--{flag} must not contain double-quotes, newlines, or control "
-                "characters (they corrupt the generated config.yaml)"
+                f"--{flag} must not contain double-quotes, backslashes, newlines, "
+                "or control characters (they corrupt the generated config.yaml)"
             )
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -68,6 +68,102 @@ class TestCLI:
         with pytest.raises(SystemExit):
             main(["--non-interactive"])
 
+    def test_target_is_existing_file_rejected_cleanly(self, tmp_path: Path):
+        """A target that exists as a file must fail with a clean parser error,
+        not an uncaught FileExistsError from mkdir(exist_ok=True) (e2e sweep)."""
+        from project_init.__main__ import main
+
+        target = tmp_path / "afile"
+        target.write_text("x")
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    str(target),
+                    "--non-interactive",
+                    "--name",
+                    "p",
+                    "--description",
+                    "d",
+                    "--language",
+                    "python",
+                    "--preset",
+                    "core",
+                ]
+            )
+        assert exc.value.code == 2  # argparse parser.error exit code
+
+    def test_quote_in_name_rejected_keeps_config_valid(self, tmp_path: Path):
+        """A double-quote in name/description/owner is rejected — it would corrupt
+        the double-quoted YAML value in config.yaml (e2e sweep)."""
+        from project_init.__main__ import main
+
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    str(tmp_path / "p"),
+                    "--non-interactive",
+                    "--name",
+                    'ev"il',
+                    "--description",
+                    "d",
+                    "--language",
+                    "python",
+                    "--preset",
+                    "core",
+                ]
+            )
+        assert exc.value.code == 2
+        assert not (tmp_path / "p").exists()  # rejected before creating the dir
+
+    def test_apostrophe_in_name_allowed(self, tmp_path: Path):
+        """Single quotes are safe in double-quoted YAML — must NOT be rejected."""
+        from project_init.__main__ import main
+
+        target = tmp_path / "p"
+        rc = main(
+            [
+                str(target),
+                "--non-interactive",
+                "--name",
+                "Vy's tool",
+                "--description",
+                "A 'fast' one",
+                "--language",
+                "python",
+                "--preset",
+                "core",
+            ]
+        )
+        assert rc == 0
+        assert 'Vy\'s tool' in (target / ".claude" / "config.yaml").read_text()
+
+    def test_target_mkdir_oserror_reported_cleanly(self, tmp_path: Path, monkeypatch):
+        """A mkdir OSError (e.g. PermissionError on a read-only parent) must surface
+        as a clean parser error, not an uncaught traceback (e2e sweep)."""
+        from project_init import __main__
+        from project_init.__main__ import main
+
+        def boom(*_a, **_k):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(__main__.Path, "mkdir", boom)
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    str(tmp_path / "sub"),
+                    "--non-interactive",
+                    "--name",
+                    "p",
+                    "--description",
+                    "d",
+                    "--language",
+                    "python",
+                    "--preset",
+                    "core",
+                ]
+            )
+        assert exc.value.code == 2
+
 
 class TestCLIGovernanceFlags:
     """PI-145: --license and --owner render governance files."""

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -92,9 +92,15 @@ class TestCLI:
             )
         assert exc.value.code == 2  # argparse parser.error exit code
 
-    def test_quote_in_name_rejected_keeps_config_valid(self, tmp_path: Path):
-        """A double-quote in name/description/owner is rejected — it would corrupt
-        the double-quoted YAML value in config.yaml (e2e sweep)."""
+    @pytest.mark.parametrize(
+        "bad_name",
+        ['ev"il', "C:\\projects\\foo", "line\nbreak", "del\x7fchar"],
+        ids=["double-quote", "backslash", "newline", "del-0x7f"],
+    )
+    def test_yaml_breaking_name_rejected(self, tmp_path: Path, bad_name: str):
+        """Quotes/backslashes/newlines/control chars (incl. DEL) in name/desc/owner
+        are rejected — each would corrupt config.yaml's double-quoted YAML value
+        (e2e sweep + Codex/Copilot review)."""
         from project_init.__main__ import main
 
         with pytest.raises(SystemExit) as exc:
@@ -103,7 +109,7 @@ class TestCLI:
                     str(tmp_path / "p"),
                     "--non-interactive",
                     "--name",
-                    'ev"il',
+                    bad_name,
                     "--description",
                     "d",
                     "--language",


### PR DESCRIPTION
## What

A full **e2e QA sweep** of the scaffolder (happy-path matrix across every memory tier / preset / language + overlays, plus a deliberate bad-path battery) found three unhandled paths that produced **uncaught tracebacks or silent config corruption**. This hardens them.

## Bugs fixed

| # | Bad path | Before | After |
|---|---|---|---|
| 1 | `target` is an existing **file** | `FileExistsError` traceback (mkdir `exist_ok=True` only tolerates a dir) | clean `parser.error` rc=2 |
| 2 | read-only parent / any **mkdir OSError** | `PermissionError` traceback | clean `parser.error` rc=2 |
| 3 | a `"` / newline / control char in `--name`/`--description`/`--owner` | **invalid `config.yaml`** (`name: "ev"il"`) → breaks `upgrade` + descriptor | rejected before any dir is created |

## Notes from the sweep

- **No template-injection vuln:** `{{...}}` passed via `--name` is preserved literally, never re-rendered. ✅
- Bug #3 only affected the top `project:` YAML block — the JSON scaffold-record escaped correctly. Single quotes/apostrophes are **still allowed** (safe in double-quoted YAML); only `"`/newline/control are rejected.
- Everything else in the sweep passed: all 5 memory tiers, all languages, overlays (`--governance/--observability/--multi-model/--no-docs/--no-renovate`), `--no-plugin/--strict/--agents`, invalid `--memory/--preset/--language`, `--json` guard, `--list-presets`, `upgrade` (drift + non-scaffolded), **memory lint** (dangling-ref warns advisory rc=0; invalid type / missing field / missing index-file ERROR rc=1), and the `setup_rag.sh`/`setup_graphify.sh` missing-`uv` guards.

## Changes

- `_ensure_target_dir()` — reject non-dir target; `try/except OSError` → clean error.
- `_validate_text_inputs()` — reject quote/newline/control in name/description/owner.
- `tests/integration/test_cli.py` — 4 regression tests.

## Tests

Full suite **1525 passed, 3 skipped**; ruff clean; config.yaml byte-identity unchanged for normal inputs.

Closes #516

https://claude.ai/code/session_01NehbQYZo1dWvcVYaSdArUG