### PR TITLE
fix(PI-518): node/go gitignore + gate docs/ tree on --no-docs

### DIFF
--- a/templates/base/docs/explanation/index.md.tmpl
+++ b/templates/base/docs/explanation/index.md.tmpl
@@ -1,4 +1,4 @@
-# Explanation
+{{#if want_docs}}# Explanation
 
 Understanding-oriented discussion: why the system is shaped the way it is,
 trade-offs considered, context that doesn't fit a recipe or a reference
@@ -7,3 +7,4 @@ from here when they need narrative.
 
 *No explanation pages yet. Add the first one as
 `docs/explanation/<topic>.md` and link it here.*
+{{/if want_docs}}

--- a/templates/base/docs/how-to/index.md.tmpl
+++ b/templates/base/docs/how-to/index.md.tmpl
@@ -1,7 +1,8 @@
-# How-to guides
+{{#if want_docs}}# How-to guides
 
 Goal-oriented recipes for someone already working with the project: "How do
 I X?" Each guide solves one real problem, assumes basic familiarity, and
 skips teaching.
 
 *No guides yet. Add the first one as `docs/how-to/<task>.md` and link it here.*
+{{/if want_docs}}

--- a/templates/base/docs/index.md.tmpl
+++ b/templates/base/docs/index.md.tmpl
@@ -1,4 +1,4 @@
-# {{project_name}}
+{{#if want_docs}}# {{project_name}}
 
 {{project_description}}
 
@@ -18,3 +18,4 @@ part of this site) — use the `add_adr` skill to record one.
 > Tip (public repos): [DeepWiki](https://deepwiki.com/) generates free,
 > always-current architecture docs from the repository — link
 > `deepwiki.com/<owner>/<repo>` from your README.
+{{/if want_docs}}

--- a/templates/base/docs/reference/index.md.tmpl
+++ b/templates/base/docs/reference/index.md.tmpl
@@ -1,4 +1,4 @@
-# Reference
+{{#if want_docs}}# Reference
 
 Information-oriented technical description: API signatures, configuration
 keys, CLI flags. Reference states facts — it does not explain or instruct.
@@ -11,3 +11,4 @@ For Python projects, render API docs from docstrings with a
 ```
 
 *Add reference pages as `docs/reference/<area>.md` and link them here.*
+{{/if want_docs}}

--- a/templates/base/docs/tutorials/index.md.tmpl
+++ b/templates/base/docs/tutorials/index.md.tmpl
@@ -1,7 +1,8 @@
-# Tutorials
+{{#if want_docs}}# Tutorials
 
 Learning-oriented, step-by-step lessons. A tutorial takes a newcomer from
 zero to a working result — it teaches by doing, not by explaining.
 
 *No tutorials yet. Add the first one as `docs/tutorials/<topic>.md` and link
 it here.*
+{{/if want_docs}}

--- a/templates/base/dot_gitignore.tmpl
+++ b/templates/base/dot_gitignore.tmpl
@@ -15,7 +15,21 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 
-{{#if graphify}}# Graphify (derived graph artifacts; keep GRAPH_REPORT.md tracked)
+{{#if node}}# Node
+node_modules/
+dist/
+*.tsbuildinfo
+npm-debug.log*
+.npm/
+
+{{/if node}}{{#if go}}# Go
+/bin/
+*.exe
+*.test
+*.out
+vendor/
+
+{{/if go}}{{#if graphify}}# Graphify (derived graph artifacts; keep GRAPH_REPORT.md tracked)
 graphify-out/*
 !graphify-out/GRAPH_REPORT.md
 

--- a/tests/contracts/test_docs_renovate.py
+++ b/tests/contracts/test_docs_renovate.py
@@ -88,6 +88,21 @@ class TestGating:
         assert _render_file("base/renovate.json.tmpl", renovate="true").strip()
         assert _render_file("base/renovate.json.tmpl", renovate="").strip() == ""
 
+    def test_docs_index_gates_on_want_docs(self):
+        # the docs/ Diátaxis tree must also gate on want_docs, not just the
+        # mkdocs/typedoc configs (mini-project sweep: --no-docs left docs/ behind).
+        assert _render_file("base/docs/index.md.tmpl", python="true", want_docs="true").strip()
+        assert _render_file("base/docs/index.md.tmpl", python="true", want_docs="").strip() == ""
+        assert _render_file("base/docs/tutorials/index.md.tmpl", want_docs="").strip() == ""
+
+    def test_gitignore_has_language_blocks(self):
+        # node/go scaffolds must ignore their build dirs; python output unchanged
+        # (mini-project sweep: --language node never ignored node_modules/).
+        py = _render_file("base/dot_gitignore.tmpl", python="true")
+        assert "node_modules/" not in py and "vendor/" not in py
+        assert "node_modules/" in _render_file("base/dot_gitignore.tmpl", node="true")
+        assert "vendor/" in _render_file("base/dot_gitignore.tmpl", go="true")
+
     def test_docs_configs_are_local_only_no_published_site(self):
         # PI-343/ADR-004 retired the GitHub Pages docs.yml; the configs must not
         # claim a publish workflow (Codex ADR-022 review).
@@ -113,6 +128,17 @@ class TestScaffoldGating:
         target = tmp_path / "p"
         scaffold(target, memory_preset("core"), make_variables(renovate=""), strict=True)
         assert not (target / "renovate.json").exists()
+
+    def test_no_docs_omits_docs_tree(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, memory_preset("core"), make_variables(python="true", want_docs=""), strict=True)
+        assert not (target / "docs").exists()
+
+    def test_default_ships_docs_tree(self, tmp_path: Path):
+        target = tmp_path / "p"
+        scaffold(target, memory_preset("core"), make_variables(python="true"), strict=True)
+        assert (target / "docs" / "index.md").is_file()
+        assert (target / "docs" / "tutorials" / "index.md").is_file()
 
 
 def _scaffold_cli(target: Path, *extra: str) -> None:


### PR DESCRIPTION
## What

Found by **scaffolding and running real mini projects** (python lib, node service, go cli, minimal, full RAG+governance) — exercising the actual developer workflow, not just unit invariants.

## Bugs fixed

| # | Bad path | Before | After |
|---|---|---|---|
| 1 | `--language node` | `.gitignore` had no node section → **commits `node_modules/`** | inline-gated `{{#if node}}` block |
| 2 | `--language go` | no go build ignores | `{{#if go}}` block (`bin/`, `*.exe`, `*.test`, `vendor/`) |
| 3 | `--no-docs` | left the whole `docs/` Diátaxis tree (only mkdocs/typedoc *configs* were gated) | `docs/` content now gated on `want_docs` → fully omitted |

Python output stays **byte-identical** (language blocks render empty when off; docs files identical when docs on).

## What worked (the bulk of the sweep) ✅

ruff-check + pytest gates on a real package; `ruff format` of user code; `node --test`; bun-aware node CI (`setup-bun@v2`); memory lint (advisory warns / schema errors); `gen_code_map.py`; all CI workflows valid YAML; **`prod_guard` hook** (emits `permissionDecision: "ask"` for `rm -rf /`, allows `ls`); `dag_workflow`; `--memory none/--no-renovate/--no mkdocs` correctly minimal; full RAG+governance scaffold + memory lint.

## Out of scope (noted)

`ruff format` (not in CI/justfile `lint`, so non-breaking) would reformat 3 shipped `.claude/` Python files on a fresh project — cosmetic; fixing churns byte-identity fixtures.

## Tests

4 contract tests in `test_docs_renovate.py`. Full suite **1534 passed**; ruff clean; byte-identity fixtures unchanged.

Closes #518

https://claude.ai/code/session_01NehbQYZo1dWvcVYaSdArUG