### PR TITLE
chore: Release 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.4.0"
+version = "0.5.0"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,28 @@ import re
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "0.5.0": {
+        "summary": (
+            "Base is now à-la-carte and self-explaining (ADR-023, epic #470): a "
+            "core preset plus opt-out concerns — --memory none, --lifecycle "
+            "none, --no-docs, --no-renovate. Memory gains a tiered model "
+            "(ADR-024): memory/ split from vault/ as an auto tier with a "
+            "staleness lint, a low-token code-map for agents, and an opt-in "
+            "tier-3 code-RAG engine (--memory obsidian-graphify-rag, "
+            "cocoindex-code, keyless/on-device, ADR-026). Adds --observability "
+            "and --governance overlays, the "
+            "agentic-OS cross-project memory descriptor contract, and "
+            "orchestrator-friendly --json scaffold output."
+        ),
+        "action_required": (
+            "No action required to keep current behaviour — the new concerns "
+            "default ON (opt-out), so an upgrade scaffolds the same surface as "
+            "before. Tier-3 RAG is opt-in: scaffold with "
+            "--memory obsidian-graphify-rag, then run "
+            "`.claude/scripts/setup_rag.sh` in the project to install the "
+            "engine."
+        ),
+    },
     "0.4.0": {
         "summary": (
             "Delivery model (--delivery library|service|prototype) drives the "

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Cut the **0.5.0** release: bump version in `pyproject.toml` and `src/project_init/__init__.py`, and add the 0.5.0 migration note (`migration_notes.py`).

Tagging `v0.5.0` after merge triggers `release.yml` → GitHub Release (auto-changelog from Conventional Commits) → PyPI trusted publish.

## Headline changes since 0.4.0
- **À-la-carte, self-explaining base** (ADR-023, epic #470): `core` preset + opt-out concerns — `--memory none`, `--lifecycle none`, `--no-docs`, `--no-renovate`.
- **Tiered memory model** (ADR-024): `memory/` split from `vault/` as an auto tier + staleness lint, low-token code-map for agents, opt-in **tier-3 code-RAG** (`--memory obsidian-graphify-rag`, cocoindex-code, keyless/on-device, ADR-026).
- **`--observability`** and **`--governance`** overlays.
- **Agentic-OS** cross-project memory descriptor contract + orchestrator-friendly **`--json`** scaffold output.
- Stack of scaffolder hardening fixes from the e2e sweeps.

## Verification
- `uv run ruff check .` — clean
- `uv run pytest -n auto` — 1534 passed, 3 skipped
- Tag/version sync verified locally (`v$pyproject.version == __version__`)

nojira (release chore).

https://claude.ai/code/session_01NehbQYZo1dWvcVYaSdArUG