### PR TITLE
docs(PI-521): discoverability quick-wins

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use project-init, please cite it using these metadata."
+title: project-init
+type: software
+authors:
+  - given-names: Vytautas
+    family-names: Čepas
+    email: vyt.cepas.ve@gmail.com
+repository-code: https://github.com/VytCepas/project-init
+url: https://vytcepas.github.io/project-init/
+license: Apache-2.0
+version: 0.5.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # project-init
 
 [![CI](https://github.com/VytCepas/project-init/actions/workflows/ci.yml/badge.svg)](https://github.com/VytCepas/project-init/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/project-init)](https://pypi.org/project/project-init/)
+[![Python versions](https://img.shields.io/pypi/pyversions/project-init)](https://pypi.org/project/project-init/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 Scaffolder for agentic-development infrastructure. One command drops a `.claude/` folder into any project so Claude Code (and other agents) have memory, docs, hooks, and curated MCPs ready to go.
 
@@ -91,7 +94,7 @@ Two honest caveats hold across all of it:
 
 Two install paths — pick by how you'll invoke it:
 
-**CLI-only, from PyPI** (after the first published release; ADR-011). Gives
+**CLI-only, from [PyPI](https://pypi.org/project/project-init/)** (ADR-011). Gives
 you the `project-init` command — no `/project-init` slash command:
 
 ```bash
@@ -335,7 +338,9 @@ Run `project-init --help` and pick from `core` (vault-free), `auto` (memory file
 ## Positioning in the ecosystem
 
 Where project-init sits relative to the (fast-moving) community landscape, so
-adopters know what this tool owns and where it defers:
+adopters know what this tool owns and where it defers. For the full
+four-category comparison and the moat, see
+[docs/positioning.md](docs/positioning.md):
 
 - **What this scaffolder owns**: project infrastructure files (CI workflows,
   `.gitignore`, GitHub issue/PR templates and board automation),

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Architecture decisions, development guides, and references for contributors and 
 
 | Path | Purpose |
 |---|---|
+| [`positioning.md`](positioning.md) | Where project-init sits in the ecosystem — comparison table + moat |
 | [`adr/`](adr/) | Architecture Decision Records — why decisions were made |
 | [`development/`](development/) | Standards, testing, template system |
 | [`guides/`](guides/) | How-to guides for users and contributors |

--- a/docs/guides/org-fork-lifecycle.md
+++ b/docs/guides/org-fork-lifecycle.md
@@ -49,8 +49,9 @@ import on EMU.
 
 The fork owns its releases:
 
-1. Bump the version in `src/project_init/__init__.py` (`__version__`) and
-   `pyproject.toml`, on a branch → PR → merge.
+1. Bump the version in `src/project_init/__init__.py` (`__version__`),
+   `pyproject.toml`, and `CITATION.cff` (`version:`), on a branch → PR → merge.
+   A contract test (`test_release_engineering.py`) enforces that all three agree.
 2. Tag the release — `release.yml` triggers on a tag push:
    `git tag vX.Y.Z && git push origin vX.Y.Z`. If your org's rulesets or the
    workflow guard restrict tag pushes, create the tag via the API instead:

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,36 @@
+# Positioning in the ecosystem
+
+**project-init builds an agent a workshop, not a note.** It does not sit *inside* any
+single competitor category — it sits **underneath** all of them. Each adjacent category
+owns one slice of "get an agent productive in a repo"; project-init's bet is that the
+slices are weak in isolation and the value is the opinionated, wired-together,
+**enforced** whole.
+
+## The four adjacent categories
+
+| Category | Examples | What they own | Overlap with project-init | What we have that they don't |
+|---|---|---|---|---|
+| **Instruction-file generators** | `/init`, ClaudeForge, DevTk.AI, design.dev | A generated `CLAUDE.md`/`AGENTS.md`, one-shot | We also emit `AGENTS.md` + `CLAUDE.md` (and resolve the redirect split) | Enforcement of what the file *says* (git hooks, lifecycle DAG, CI gates); an `upgrade` path so it doesn't rot; actual infra, not just description |
+| **Component catalogs / marketplaces** | davila7/claude-code-templates, awesome-claude-code, rohitg00 toolkit | À-la-carte install of skills/hooks/agents | Same primitives; we *also* ship a marketplace (`.claude-plugin/marketplace.json`, plugin-first) | An opinionated internally-consistent whole, not a parts bin; project infrastructure (CI, `.gitignore`, issue/PR templates, board automation); deterministic tested preset composition |
+| **Spec-driven / workflow methods** | GitHub Spec Kit, BMAD, Claude Flow, Superpowers | Methodology / process discipline | We also encode a process (the GitHub lifecycle DAG) | Infrastructure-first, not methodology-first; narrow deterministic enforcement at the git/CI boundary. **Complementary** — runs on top of us |
+| **Stack templates** | Vstorm FastAPI+Next, claudefast, claude-code-templates project mode | A working app skeleton for a specific stack | Both produce a ready-to-go project dir | Stack-agnostic, app-agnostic agent infra; never-clobber overlay so we layer *onto* their output |
+
+## The slice nobody else owns (the moat)
+
+1. **Project infrastructure files** — CI workflows, `.gitignore`, issue/PR templates, board
+   automation, env/secrets pattern, CODEOWNERS/SECURITY/CONTRIBUTING.
+2. **Enforced GitHub lifecycle** — DAG-guarded issue → branch → PR → review → merge, blocked
+   at the git/CI boundary (the only enforcement that binds every agent surface; ADR-007).
+3. **Deterministic, tested, upgradeable rendering** — preset composition validated by
+   scaffolding into temp dirs, plus a real `upgrade` with 3-way merge so scaffolds don't drift.
+
+Everything else (instruction files, component distribution, knowledge-graph memory via
+Graphify) we adopt the community standard for rather than reinvent — itself a selling point.
+
+## Compose, don't compete
+
+project-init's never-clobber `.new` overlay means it layers **onto** the output of the tools
+above rather than replacing them. Run it *over* a Spec-Kit / BMAD / FastAPI-template project
+and it adds the infrastructure + enforcement slice without touching what they generated. The
+stance is **interop, not integration**: we do not vendor other tools' methodologies, and we
+do not frame ourselves as an alternative to them — they are complementary layers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
 
 nav:
   - Home: README.md
+  - Positioning: positioning.md
   - Guide:
     - Using project-init: guides/using-project-init.md
     - Org fork lifecycle (runbook): guides/org-fork-lifecycle.md

--- a/tests/contracts/test_release_engineering.py
+++ b/tests/contracts/test_release_engineering.py
@@ -83,7 +83,7 @@ class TestInstallScriptPinning:
         pull only happens on an explicit main checkout."""
         content = self._script()
         assert "checkout -q main" in content
-        assert "checkout -q \"$REF\"" in content
+        assert 'checkout -q "$REF"' in content
 
 
 class TestVersionConsistency:
@@ -92,6 +92,15 @@ class TestVersionConsistency:
         init = (_REPO_ROOT / "src" / "project_init" / "__init__.py").read_text()
         version = pyproject["project"]["version"]
         assert f'__version__ = "{version}"' in init
+
+    def test_citation_version_matches_pyproject(self):
+        # CITATION.cff is a third version file (with pyproject.toml and __init__.py);
+        # assert the exact unquoted CFF field line so it can't drift on release.
+        # String match, not yaml.load — pyyaml is not a dependency.
+        pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+        citation = (_REPO_ROOT / "CITATION.cff").read_text()
+        version = pyproject["project"]["version"]
+        assert f"version: {version}" in citation
 
     def test_readme_documents_pinning_and_update(self):
         content = (_REPO_ROOT / "README.md").read_text()


### PR DESCRIPTION
Closes #521. Refs #480, #500.

Low-effort discoverability batch, plan hardened via grill + 4 Codex review rounds.

## Changes
- **README badges**: PyPI version, Python versions, License (Apache-2.0) + fix stale "after first published release" install copy (PyPI live, v0.5.0)
- **`docs/positioning.md`**: four-category comparison table + moat + compose-don't-compete (from spike #469); wired into mkdocs nav; linked from `docs/README.md` and root README
- **`CITATION.cff`** (CFF 1.2.0) + `test_citation_version_matches_pyproject` contract test pinning its version to `pyproject.toml`; CITATION.cff added to the release version-bump checklist

## Done outside this PR
- ✅ GitHub Discussions enabled
- ✅ Deferred items ticketed: #523 (à-la-carte add-one-skill/hook), #524 (interop tests)

## Owner handoff (manual, not in this PR)
- [ ] Social preview image (Settings → Social preview)
- [ ] Submit to `awesome-claude-code`
- [ ] Submit `project-init-workflow` to the official Claude Code plugin marketplace
- [ ] Pin a few `good first issue`s