### PR TITLE
feat(PI-528): concern add/remove subcommands (engine + toggle concerns)

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -1606,6 +1606,57 @@ def _upgrade_main(argv: list[str]) -> int:
     return rc
 
 
+def _concern_main(argv: list[str], *, enable: bool) -> int:
+    """Parse and run `project-init add|remove <concern>` (#528)."""
+    import argparse
+
+    from project_init.concerns import CONCERNS, MEMORY_STACKS, apply_concern
+    from project_init.upgrade import (
+        _enforce_clean_tree,
+        _git_worktree_status,
+        _print_undo_hint,
+    )
+
+    verb = "add" if enable else "remove"
+    tail = "" if enable else " and deletes its files (byte-unmodified only)"
+    p = argparse.ArgumentParser(
+        prog=f"project-init {verb}",
+        description=(
+            f"{verb.capitalize()} a concern on an already-scaffolded project, without "
+            f"re-running the wizard. Re-renders the shared wiring with the concern "
+            f"flipped {'on' if enable else 'off'}{tail}."
+        ),
+    )
+    p.add_argument("concern", help="one of: " + ", ".join(CONCERNS))
+    if enable:
+        stacks = ", ".join(s for s in MEMORY_STACKS if s != "none")
+        p.add_argument("value", nargs="?", help=f"for `add memory`: a stack ({stacks})")
+    p.add_argument("--target", default=".", help="scaffolded project dir (default: .)")
+    p.add_argument(
+        "--apply", action="store_true", help="apply changes (default: dry-run report)"
+    )
+    p.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="permit --apply on a dirty git work tree (default: refuse)",
+    )
+    args = p.parse_args(argv)
+    target = Path(args.target).resolve()
+    value = getattr(args, "value", None)
+
+    git_status = None
+    if args.apply:
+        git_status = _git_worktree_status(target)
+        blocked = _enforce_clean_tree(git_status, allow_dirty=args.allow_dirty, target=target)
+        if blocked is not None:
+            return blocked
+
+    rc = apply_concern(target, args.concern, enable=enable, value=value, apply=args.apply)
+    if args.apply and rc == 0:
+        _print_undo_hint(git_status, target)
+    return rc
+
+
 def _build_variables(preset: dict, inputs: ScaffoldInputs) -> dict[str, str]:
     """Assemble the template render context from the resolved inputs."""
     project_name = inputs.project_name
@@ -1914,10 +1965,14 @@ def _ensure_target_dir(target: Path, parser: argparse.ArgumentParser) -> None:
 def main(argv: list[str] | None = None) -> int:
     """Run the scaffolding CLI; return the process exit code."""
     argv = list(sys.argv[1:]) if argv is None else list(argv)
-    if argv[:1] == ["upgrade"]:
-        return _upgrade_main(argv[1:])
-    if argv[:1] == ["preset"]:
-        return _preset_main(argv[1:])
+    _subcommands = {
+        "upgrade": lambda a: _upgrade_main(a),
+        "add": lambda a: _concern_main(a, enable=True),
+        "remove": lambda a: _concern_main(a, enable=False),
+        "preset": lambda a: _preset_main(a),
+    }
+    if argv[:1] and argv[0] in _subcommands:
+        return _subcommands[argv[0]](argv[1:])
     parser = _build_parser()
     args = parser.parse_args(argv)
 

--- a/src/project_init/concerns.py
+++ b/src/project_init/concerns.py
@@ -1,0 +1,291 @@
+"""``project-init add`` / ``remove`` — toggle a concern on an existing scaffold.
+
+First slice of the concern add/remove feature (#523). Built directly on the
+``upgrade`` engine: read the scaffold record, mutate the chosen concern's
+template variables, re-render to a staging tree, diff against the project, and
+apply. ``remove`` additionally **deletes** the files that the concern uniquely
+owned — but only those byte-identical to the recorded manifest hash, so a user's
+edits are never destroyed (they are kept and reported instead).
+
+``.claude/memory/`` and ``.claude/vault/`` are in ``scaffold._PRESERVE_DIRS``, so
+``compute_drift`` never lists them as removed: ``remove memory`` downgrades the
+tier and unwires it, but the user's accumulated notes stay on disk. Explicit
+source-data deletion/transfer (``--purge`` / ``--export``) is a later slice.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from project_init import __version__
+from project_init.scaffold import memory_tier, read_preserve_globs
+from project_init.upgrade import (
+    UpgradeError,
+    _hash_bytes,
+    _is_preserved,
+    _render_staging,
+    apply_drift,
+    compute_drift,
+    read_base,
+    read_scaffold_record,
+)
+
+# Memory is a tier value, not a boolean — add/remove walks the ladder.
+MEMORY_STACKS = (
+    "none",
+    "auto",
+    "obsidian-only",
+    "obsidian-graphify",
+    "obsidian-graphify-rag",
+)
+
+
+class ConcernError(Exception):
+    """A bad concern name or value supplied to add/remove."""
+
+
+def _set_memory(v: dict, stack: str) -> None:
+    if stack not in MEMORY_STACKS:
+        raise ConcernError(
+            f"unknown memory stack {stack!r}; choose one of {', '.join(MEMORY_STACKS)}"
+        )
+    v["memory_stack"] = stack
+    v["memory"] = "" if stack == "none" else "true"
+    v["obsidian"] = "true" if "obsidian" in stack else ""
+    v["graphify"] = "true" if "graphify" in stack else ""
+    v["rag"] = "true" if "rag" in stack else ""
+    v["memory_tier"] = memory_tier(stack)
+
+
+def _set_lifecycle(v: dict, *, enable: bool) -> None:
+    v["lifecycle_tier"] = "github" if enable else "none"
+    v["lifecycle"] = "true" if enable else ""
+    v["lifecycle_off"] = "" if enable else "true"
+
+
+def _flag_setter(name: str):
+    def setter(v: dict, *, enable: bool) -> None:
+        v[name] = "true" if enable else ""
+
+    return setter
+
+
+# Boolean concerns: flipped ON by `add`, OFF by `remove`. Each maps to the
+# template variable(s) that gate its overlay layer + its {{#if}} blocks.
+_BOOL_CONCERNS = {
+    "lifecycle": _set_lifecycle,
+    "governance": _flag_setter("governance"),
+    "observability": _flag_setter("observability"),
+    "multi-model": _flag_setter("multi_model"),
+    "docs": _flag_setter("want_docs"),
+    "renovate": _flag_setter("renovate"),
+}
+
+# `memory` first so help text leads with the one that takes a value.
+CONCERNS = ("memory", *_BOOL_CONCERNS)
+
+
+def _mutate(variables: dict, concern: str, *, enable: bool, value: str | None) -> None:
+    """Apply the concern toggle to *variables* in place."""
+    if concern == "memory":
+        # `add memory <stack>` needs a stack; `remove memory` → none.
+        stack = value if enable else "none"
+        if stack is None:
+            raise ConcernError(
+                "`add memory` needs a stack, e.g. `add memory obsidian-only` "
+                f"(one of {', '.join(s for s in MEMORY_STACKS if s != 'none')})"
+            )
+        _set_memory(variables, stack)
+    elif concern in _BOOL_CONCERNS:
+        if value is not None:
+            raise ConcernError(f"`{concern}` takes no value (got {value!r})")
+        _BOOL_CONCERNS[concern](variables, enable=enable)
+    else:
+        raise ConcernError(f"unknown concern {concern!r}; choose from {', '.join(CONCERNS)}")
+
+
+def _advisory(concern: str, *, enable: bool) -> str | None:
+    """A one-line note printed after certain toggles (lifecycle blast radius)."""
+    if concern == "lifecycle" and not enable:
+        return (
+            "Removed project-init's GitHub-lifecycle wiring (hooks, scripts, "
+            "workflows, templates). If you're moving to GitLab or another forge, "
+            "your code agent can rework the equivalent — project-init does not "
+            "manage that for you."
+        )
+    return None
+
+
+def _delete_orphans(
+    target: Path, removed: list[Path], manifest: dict
+) -> tuple[list[Path], list[Path]]:
+    """Delete concern files that are byte-identical to the recorded manifest.
+
+    Returns ``(deleted, kept)``. A removed file whose current bytes differ from
+    the recorded hash was edited by the user — it is kept and reported, never
+    deleted. ``removed`` already excludes preserved dirs (memory/vault) and the
+    config record (compute_drift skips them), so source data is safe here.
+    """
+    deleted: list[Path] = []
+    kept: list[Path] = []
+    for rel in removed:
+        f = target / rel
+        if not f.is_file():
+            continue
+        recorded = manifest.get(rel.as_posix())
+        if recorded is not None and _hash_bytes(f.read_bytes()) == recorded:
+            f.unlink()
+            deleted.append(rel)
+        else:
+            kept.append(rel)
+    _prune_empty_dirs(target, deleted)
+    return deleted, kept
+
+
+def _seed_preserved(
+    target: Path, staging: Path, rendered: list[Path], *, write: bool
+) -> list[Path]:
+    """Preserved-dir files (memory/vault scaffold) that don't exist yet.
+
+    ``compute_drift``/``apply_drift`` skip preserved dirs entirely — which keeps a
+    user's notes safe on ``remove`` but also means ``add memory`` would never lay
+    down the ``.claude/memory/`` skeleton. Returns the files that are missing (so a
+    dry run can report them); with *write*, copies them — existing user content is
+    never overwritten.
+    """
+    preserve_globs = read_preserve_globs(target)
+    seeded: list[Path] = []
+    for rel in rendered:
+        if not _is_preserved(rel, preserve_globs):
+            continue
+        dest = target / rel
+        if dest.exists():
+            continue
+        src = staging / rel
+        if not src.is_file():
+            continue
+        if write:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+        seeded.append(rel)
+    return seeded
+
+
+def _prune_empty_dirs(target: Path, deleted: list[Path]) -> None:
+    """Remove now-empty parent directories left by deleted files (up to target)."""
+    seen: set[Path] = set()
+    for rel in deleted:
+        d = (target / rel).parent
+        while d != target and d not in seen and d.is_dir():
+            seen.add(d)
+            try:
+                next(d.iterdir())
+                break  # not empty
+            except StopIteration:
+                d.rmdir()
+                d = d.parent
+
+
+def apply_concern(
+    target: Path,
+    concern: str,
+    *,
+    enable: bool,
+    value: str | None = None,
+    apply: bool,
+) -> int:
+    """Toggle *concern* on the scaffold at *target*; return a process exit code.
+
+    Without *apply* this is a dry run: it reports what would change and deletes
+    nothing. With *apply* it re-renders the shared wiring with the concern's flag
+    flipped, lands the concern's files (add) or deletes its orphaned files
+    (remove, byte-unmodified only), and refreshes ``.claude/config.yaml``.
+    """
+    verb = "add" if enable else "remove"
+    try:
+        preset_name, variables, manifest, _migrated = read_scaffold_record(target)
+    except UpgradeError as e:
+        sys.stderr.write(f"error: {e}\n")
+        return 1
+
+    new_vars = dict(variables)
+    new_vars["project_init_version"] = __version__
+    try:
+        _mutate(new_vars, concern, enable=enable, value=value)
+    except ConcernError as e:
+        sys.stderr.write(f"error: {e}\n")
+        return 1
+
+    if new_vars == {**variables, "project_init_version": __version__}:
+        print(f"{concern} is already {'present' if enable else 'absent'} — nothing to do.")
+        return 0
+
+    staging_root = Path(tempfile.mkdtemp(prefix="project-init-concern-"))
+    staging = staging_root / "render"
+    try:
+        try:
+            rendered = _render_staging(preset_name, new_vars, staging)
+        except Exception as e:  # noqa: BLE001 — any render failure is fatal here
+            sys.stderr.write(f"error: re-render failed: {e}\n")
+            return 1
+
+        report = compute_drift(target, staging, rendered, manifest, read_base(target))
+        deleted: list[Path] = []
+        kept: list[Path] = []
+
+        if apply:
+            apply_drift(target, staging, report, preset_name, new_vars)
+            deleted, kept = _delete_orphans(target, report.removed, manifest)
+        seeded = _seed_preserved(target, staging, report.rendered, write=apply)
+
+        _print_summary(verb, concern, report, deleted, kept, seeded, applied=apply)
+        note = _advisory(concern, enable=enable)
+        if note:
+            print(f"\nnote: {note}")
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+    return 0
+
+
+def _print_summary(  # noqa: PLR0913 — one list per drift category, all distinct
+    verb: str,
+    concern: str,
+    report,
+    deleted: list[Path],
+    kept: list[Path],
+    seeded: list[Path],
+    *,
+    applied: bool,
+) -> None:
+    head = "Applied" if applied else "Dry run (no --apply) —"
+    print(f"{head} {verb} {concern}:")
+    added = list(report.new) + list(seeded)
+    changed = report.changed + report.merged + report.conflicts
+    if added:
+        print(f"  added ({len(added)}): " + ", ".join(p.as_posix() for p in sorted(added)[:8]))
+    if changed:
+        print(
+            f"  re-rendered ({len(changed)}): "
+            + ", ".join(p.as_posix() for p in sorted(changed)[:8])
+        )
+    if applied:
+        if deleted:
+            print(
+                f"  deleted ({len(deleted)}): "
+                + ", ".join(p.as_posix() for p in sorted(deleted)[:8])
+            )
+        if kept:
+            print(
+                f"  KEPT — user-modified, not deleted ({len(kept)}): "
+                + ", ".join(p.as_posix() for p in sorted(kept))
+            )
+    elif report.removed:
+        print(
+            f"  would delete ({len(report.removed)}): "
+            + ", ".join(p.as_posix() for p in sorted(report.removed)[:8])
+        )
+    if not applied:
+        print("  (re-run with --apply to make these changes)")

--- a/tests/integration/test_concern_add_remove.py
+++ b/tests/integration/test_concern_add_remove.py
@@ -1,0 +1,188 @@
+"""PI-528: `project-init add|remove <concern>` engine (#523 slice 1).
+
+Scaffolds a project, then toggles a concern via ``apply_concern`` and asserts the
+files, wiring, and config record move correctly — and, critically, that ``remove``
+never deletes a user-modified file or memory/vault source data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.concerns import apply_concern
+from project_init.scaffold import load_preset, overlay_layers, scaffold
+from project_init.upgrade import write_scaffold_record
+from tests.helpers import make_variables
+
+
+def _scaffold(
+    target: Path,
+    *,
+    memory_stack: str = "none",
+    lifecycle: bool = False,
+    governance: bool = False,
+    observability: bool = False,
+) -> Path:
+    base = load_preset("core")
+    extra = overlay_layers(
+        [],
+        no_plugin=False,
+        memory_stack=memory_stack,
+        lifecycle=lifecycle,
+        governance=governance,
+        observability=observability,
+    )
+    preset = {**base, "layers": [*base["layers"], *extra]}
+    variables = make_variables(
+        memory_stack=memory_stack,
+        lifecycle_tier="github" if lifecycle else "none",
+        governance="true" if governance else "",
+        observability="true" if observability else "",
+        plugin_mode="true",
+        no_plugin="",
+    )
+    created = scaffold(target, preset, variables)
+    # The CLI appends the scaffold record after scaffold() (__main__.py); mirror
+    # that so read_scaffold_record parses the full recorded variables instead of
+    # falling back to semantic-config reconstruction (which loses governance etc.).
+    write_scaffold_record(target, "core", variables, created)
+    return target
+
+
+def _config(target: Path) -> str:
+    return (target / ".claude/config.yaml").read_text()
+
+
+class TestAdd:
+    def test_add_governance_lands_files_and_flips_config(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        assert not (target / ".claude/governance").exists()
+        rc = apply_concern(target, "governance", enable=True, apply=True)
+        assert rc == 0
+        assert (target / ".claude/governance/README.md").is_file()
+        assert '"governance": "true"' in _config(target)
+
+    def test_dry_run_changes_nothing(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        rc = apply_concern(target, "governance", enable=True, apply=False)
+        assert rc == 0
+        assert not (target / ".claude/governance").exists()
+        assert '"governance": "true"' not in _config(target)
+
+    def test_add_memory_walks_the_tier(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", memory_stack="none")
+        assert not (target / ".claude/memory").exists()
+        apply_concern(target, "memory", enable=True, value="auto", apply=True)
+        assert (target / ".claude/memory/MEMORY.md").is_file()
+        assert '"memory_stack": "auto"' in _config(target)
+
+    def test_add_memory_requires_stack(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p")
+        rc = apply_concern(target, "memory", enable=True, value=None, apply=True)
+        assert rc == 1
+        assert "needs a stack" in capsys.readouterr().err
+
+
+class TestRemove:
+    def test_remove_deletes_unmodified_concern_files(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", governance=True)
+        assert (target / ".claude/governance/README.md").is_file()
+        apply_concern(target, "governance", enable=False, apply=True)
+        assert not (target / ".claude/governance/README.md").exists()
+        assert '"governance": "true"' not in _config(target)
+
+    def test_remove_keeps_user_modified_file(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p", governance=True)
+        edited = target / ".claude/governance/README.md"
+        edited.write_text(edited.read_text() + "\nMY EDIT\n")
+        apply_concern(target, "governance", enable=False, apply=True)
+        # The edited file survives and is reported; siblings are deleted.
+        assert edited.is_file()
+        assert "MY EDIT" in edited.read_text()
+        assert "KEPT" in capsys.readouterr().out
+
+    def test_remove_memory_preserves_source_data(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p", memory_stack="obsidian-only")
+        note = target / ".claude/vault/knowledge/my-note.md"
+        note.write_text("# my hard-won knowledge\n")
+        apply_concern(target, "memory", enable=False, apply=True)
+        # Tier downgraded in the record, but the user's vault note is untouched.
+        assert '"memory_stack": "none"' in _config(target)
+        assert note.is_file()
+        assert "hard-won" in note.read_text()
+
+    def test_remove_lifecycle_prints_advisory(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p", lifecycle=True)
+        apply_concern(target, "lifecycle", enable=False, apply=True)
+        out = capsys.readouterr().out
+        assert "another forge" in out
+
+    def test_remove_already_absent_is_noop(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p")
+        rc = apply_concern(target, "governance", enable=False, apply=True)
+        assert rc == 0
+        assert "nothing to do" in capsys.readouterr().out
+
+
+class TestRoundTripAndErrors:
+    def test_add_then_remove_round_trips(self, tmp_path: Path):
+        target = _scaffold(tmp_path / "p")
+        apply_concern(target, "observability", enable=True, apply=True)
+        assert (target / ".claude/observability").exists() or '"observability": "true"' in _config(
+            target
+        )
+        apply_concern(target, "observability", enable=False, apply=True)
+        assert '"observability": "true"' not in _config(target)
+
+    def test_unknown_concern_errors(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p")
+        rc = apply_concern(target, "telepathy", enable=True, apply=True)
+        assert rc == 1
+        assert "unknown concern" in capsys.readouterr().err
+
+    def test_bool_concern_rejects_value(self, tmp_path: Path, capsys):
+        target = _scaffold(tmp_path / "p")
+        rc = apply_concern(target, "governance", enable=True, value="x", apply=True)
+        assert rc == 1
+        assert "takes no value" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("concern", ["governance", "observability", "renovate", "docs"])
+    def test_remove_then_add_is_idempotent_record(self, tmp_path: Path, concern: str):
+        # renovate/docs default ON; governance/observability default OFF in core.
+        target = _scaffold(tmp_path / concern)
+        apply_concern(target, concern, enable=False, apply=True)
+        apply_concern(target, concern, enable=True, apply=True)
+        # A second add is a clean no-op (already present) or re-applies cleanly.
+        rc = apply_concern(target, concern, enable=True, apply=True)
+        assert rc == 0
+
+
+class TestCLIDispatch:
+    """`main()` routes `add`/`remove` to the engine and parses args (#528)."""
+
+    def test_cli_add_dry_run(self, tmp_path: Path, capsys):
+        from project_init.__main__ import main
+
+        target = _scaffold(tmp_path / "p")
+        rc = main(["add", "governance", "--target", str(target)])
+        assert rc == 0
+        assert "governance" in capsys.readouterr().out
+        assert not (target / ".claude/governance").exists()  # dry run: untouched
+
+    def test_cli_add_memory_with_stack_value(self, tmp_path: Path):
+        from project_init.__main__ import main
+
+        target = _scaffold(tmp_path / "p")
+        rc = main(["add", "memory", "auto", "--target", str(target), "--apply"])
+        assert rc == 0
+        assert (target / ".claude/memory/MEMORY.md").is_file()
+
+    def test_cli_remove_dispatches(self, tmp_path: Path):
+        from project_init.__main__ import main
+
+        target = _scaffold(tmp_path / "p", governance=True)
+        rc = main(["remove", "governance", "--target", str(target), "--apply"])
+        assert rc == 0
+        assert not (target / ".claude/governance/README.md").exists()


### PR DESCRIPTION
Closes #528. Refs #523, #500.

First slice of #523: `project-init add <concern>` / `remove <concern>`, built on the upgrade engine. `remove` deletes orphaned concern files only when byte-identical to the recorded manifest (keeps user edits); memory/vault source data is preserved automatically.

(Draft — implementation in follow-up commits.)