### PR TITLE
fix(PI-535): Harden never-clobber + idempotence in emission layer

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -1961,11 +1961,17 @@ def _validate_text_inputs(inputs: ScaffoldInputs, parser: argparse.ArgumentParse
         if (
             '"' in value
             or "\\" in value
-            or any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+            # 0x85 (NEL), 0x2028 (LINE SEPARATOR), 0x2029 (PARAGRAPH SEPARATOR)
+            # are > 0x20 so they slip past the C0 check, but Python's
+            # str.splitlines() treats them as line breaks — they'd split a
+            # single-line YAML value mid-parse on a later upgrade (PI-535).
+            or any(
+                ord(ch) < 0x20 or ord(ch) in (0x7F, 0x85, 0x2028, 0x2029) for ch in value
+            )
         ):
             parser.error(
                 f"--{flag} must not contain double-quotes, backslashes, newlines, "
-                "or control characters (they corrupt the generated config.yaml)"
+                "or control/line-separator characters (they corrupt the generated config.yaml)"
             )
 
 

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -1975,6 +1975,27 @@ def _validate_text_inputs(inputs: ScaffoldInputs, parser: argparse.ArgumentParse
             )
 
 
+def _validate_existing_config(target: Path, parser: argparse.ArgumentParser) -> None:
+    """Reject a pre-existing, undecodable ``.claude/config.yaml`` before any writes.
+
+    The scaffold/upgrade readers tolerate non-UTF-8 bytes (errors="ignore") so
+    they don't crash mid-run, but ``write_scaffold_record`` rewrites the config
+    with strict UTF-8 afterwards. Letting the scaffold proceed would fail *late*,
+    after files are written — a partial-write state. Decode-check up front so the
+    run aborts cleanly with nothing changed (PI-535, Codex review).
+    """
+    config = target / ".claude" / "config.yaml"
+    if not config.is_file():
+        return
+    try:
+        config.read_bytes().decode("utf-8")
+    except UnicodeDecodeError:
+        parser.error(
+            f"existing {config} is not valid UTF-8 — fix or remove it before scaffolding "
+            "(project-init reads and rewrites this file as UTF-8)"
+        )
+
+
 def _ensure_target_dir(target: Path, parser: argparse.ArgumentParser) -> None:
     """Create the target directory, rejecting a non-directory target.
 
@@ -2065,6 +2086,7 @@ def main(argv: list[str] | None = None) -> int:
             no_renovate=args.no_renovate,
         )
     _validate_text_inputs(inputs, parser)
+    _validate_existing_config(target, parser)
     _ensure_target_dir(target, parser)
 
     # Agent overlays append to the preset's layers (PI-137); --no-plugin

--- a/src/project_init/capabilities.py
+++ b/src/project_init/capabilities.py
@@ -262,8 +262,10 @@ def emit(
     """Write .claude/CAPABILITIES.md.
 
     A generated inventory (not user-editable), overwritten on every re-run and
-    upgrade. On the *first* scaffold a pre-existing user file at this path is
-    never clobbered — a ``.new`` sibling is written instead (PI-535).
+    upgrade — except that a pre-existing user file at this path is never clobbered
+    on the *first* scaffold, or on a later run while an unmerged ``.new`` sibling
+    from an earlier run is still pending: the render is parked as a ``.new``
+    sibling instead (PI-535).
     """
     from project_init.scaffold import _emit_generated
 

--- a/src/project_init/capabilities.py
+++ b/src/project_init/capabilities.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+import warnings
 from pathlib import Path
 
 from project_init.mcps import servers_for_ids
@@ -90,7 +91,16 @@ def canonical_hooks(variables: dict[str, str]) -> list[tuple[str, str]]:
     )
     try:
         data = json.loads(rendered)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        # The rendered settings.json is the file the project actually ships;
+        # invalid JSON here means the wired hooks are broken, not that there are
+        # none. Surface it instead of silently reporting an empty hook inventory
+        # (PI-535) — e.g. a custom preset with an unescaped quote in a command.
+        warnings.warn(
+            f"settings.json.tmpl rendered invalid JSON ({e}); CAPABILITIES.md will "
+            "list no wired hooks. Check the preset's command values for unescaped quotes.",
+            stacklevel=2,
+        )
         return []
     out: list[tuple[str, str]] = []
     for event, entries in (data.get("hooks") or {}).items():
@@ -242,12 +252,25 @@ def render(variables: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
-def emit(target: Path, variables: dict[str, str]) -> list[Path]:
+def emit(
+    target: Path,
+    variables: dict[str, str],
+    *,
+    first_scaffold: bool = True,
+    conflicts: list[tuple[Path, Path]] | None = None,
+) -> list[Path]:
     """Write .claude/CAPABILITIES.md.
 
-    Always (over)written — it is a generated inventory, not user-editable config.
+    A generated inventory (not user-editable), overwritten on every re-run and
+    upgrade. On the *first* scaffold a pre-existing user file at this path is
+    never clobbered — a ``.new`` sibling is written instead (PI-535).
     """
-    dest = target / _OUTPUT_REL
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(render(variables), encoding="utf-8", newline="\n")
-    return [_OUTPUT_REL]
+    from project_init.scaffold import _emit_generated
+
+    return _emit_generated(
+        target / _OUTPUT_REL,
+        render(variables),
+        first_scaffold=first_scaffold,
+        conflicts=conflicts,
+        rel=_OUTPUT_REL,
+    )

--- a/src/project_init/governance.py
+++ b/src/project_init/governance.py
@@ -127,9 +127,10 @@ def emit(
 ) -> list[Path]:
     """Write ``.claude/governance/ai-bom.generated.md``.
 
-    A generated inventory, overwritten on every re-run and upgrade; on the *first*
-    scaffold a pre-existing user file at this path is preserved as a ``.new``
-    sibling rather than clobbered (PI-535).
+    A generated inventory, overwritten on every re-run and upgrade — except that a
+    pre-existing user file at this path is preserved as a ``.new`` sibling (never
+    clobbered) on the *first* scaffold, or on a later run while an unmerged ``.new``
+    sibling from an earlier run is still pending (PI-535).
     """
     from project_init.scaffold import _emit_generated
 

--- a/src/project_init/governance.py
+++ b/src/project_init/governance.py
@@ -118,9 +118,25 @@ def render_aibom(target: Path, variables: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
-def emit(target: Path, variables: dict[str, str]) -> list[Path]:
-    """Write ``.claude/governance/ai-bom.generated.md`` (always overwritten)."""
-    dest = target / _OUTPUT_REL
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(render_aibom(target, variables), encoding="utf-8", newline="\n")
-    return [_OUTPUT_REL]
+def emit(
+    target: Path,
+    variables: dict[str, str],
+    *,
+    first_scaffold: bool = True,
+    conflicts: list[tuple[Path, Path]] | None = None,
+) -> list[Path]:
+    """Write ``.claude/governance/ai-bom.generated.md``.
+
+    A generated inventory, overwritten on every re-run and upgrade; on the *first*
+    scaffold a pre-existing user file at this path is preserved as a ``.new``
+    sibling rather than clobbered (PI-535).
+    """
+    from project_init.scaffold import _emit_generated
+
+    return _emit_generated(
+        target / _OUTPUT_REL,
+        render_aibom(target, variables),
+        first_scaffold=first_scaffold,
+        conflicts=conflicts,
+        rel=_OUTPUT_REL,
+    )

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -379,7 +379,10 @@ def read_preserve_globs(target: Path) -> list[str]:
     """
     config = target / ".claude" / "config.yaml"
     try:
-        text = config.read_text(encoding="utf-8")
+        # errors="ignore" so a pre-existing non-UTF-8 config.yaml degrades to
+        # "no extra globs" instead of crashing the first scaffold (PI-535) —
+        # consistent with _has_scaffold_record's tolerance of undecodable bytes.
+        text = config.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return []
     # Greedy capture to the last ``]`` so globs with fnmatch character classes
@@ -745,13 +748,19 @@ def scaffold(
     # Per-surface config generation (ADR-017 / PI-366): emit hooks + MCP for the
     # selected GUI surfaces from the canonical surface table + MCP catalog. Runs
     # against the committed target (after _commit_staged in strict mode).
-    created += _emit_generated_files(target, variables, conflicts)
+    created += _emit_generated_files(
+        target, variables, conflicts, first_scaffold=first_scaffold
+    )
 
     return created
 
 
 def _emit_generated_files(
-    target: Path, variables: dict[str, str], conflicts: list[tuple[Path, Path]] | None
+    target: Path,
+    variables: dict[str, str],
+    conflicts: list[tuple[Path, Path]] | None,
+    *,
+    first_scaffold: bool = True,
 ) -> list[Path]:
     """Post-copy generated files.
 
@@ -774,12 +783,45 @@ def _emit_generated_files(
         conflicts=conflicts,
     )
     # Surface-independent capabilities inventory (PI-374).
-    created += capabilities.emit(target, variables)
+    created += capabilities.emit(
+        target, variables, first_scaffold=first_scaffold, conflicts=conflicts
+    )
     # Governance AIBOM (ADR-018, #412): installed MCPs + detected CCR routes. The
     # user-owned ai-declarations.md (seeded by the overlay copy, preserved via
     # config.yaml globs) is never touched here.
     if variables.get("governance"):
         from project_init import governance
 
-        created += governance.emit(target, variables)
+        created += governance.emit(
+            target, variables, first_scaffold=first_scaffold, conflicts=conflicts
+        )
     return created
+
+
+def _emit_generated(
+    dest: Path,
+    content: str,
+    *,
+    first_scaffold: bool,
+    conflicts: list[tuple[Path, Path]] | None,
+    rel: Path,
+) -> list[Path]:
+    """Write an always-regenerated generated file, never-clobbering on first scaffold.
+
+    Generated inventories (CAPABILITIES.md, the AIBOM) are project-init-owned and
+    overwritten on every re-run/upgrade. But on the *first* scaffold a pre-existing
+    user file at that path must not be clobbered — write a ``.new`` sibling instead
+    and record the conflict, mirroring :func:`surfaces.emit` (PI-535). Protection
+    only engages when a *conflicts* list is passed (so the clean-staging render in
+    ``upgrade`` keeps overwriting).
+    """
+    encoded = content.encode("utf-8")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if first_scaffold and conflicts is not None and dest.exists() and dest.read_bytes() != encoded:
+        sibling = _new_sibling(dest, encoded)
+        sibling.write_text(content, encoding="utf-8", newline="\n")
+        rec = rel.parent / sibling.name
+        conflicts.append((rel, rec))
+        return [rec]
+    dest.write_text(content, encoding="utf-8", newline="\n")
+    return [rel]

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -809,15 +809,19 @@ def _emit_generated(
     """Write an always-regenerated generated file, never-clobbering on first scaffold.
 
     Generated inventories (CAPABILITIES.md, the AIBOM) are project-init-owned and
-    overwritten on every re-run/upgrade. But on the *first* scaffold a pre-existing
-    user file at that path must not be clobbered — write a ``.new`` sibling instead
-    and record the conflict, mirroring :func:`surfaces.emit` (PI-535). Protection
+    overwritten on every re-run/upgrade. But on the *first* scaffold — or any later
+    run while an unmerged ``.new`` sibling from an earlier run is still pending — a
+    pre-existing user file at that path must not be clobbered: write a ``.new``
+    sibling and record the conflict, mirroring the template-file protection in
+    :func:`scaffold` (PI-535). The pending-sibling check closes the run-2 data-loss
+    path a plain ``first_scaffold`` guard would leave open (Codex review). Protection
     only engages when a *conflicts* list is passed (so the clean-staging render in
     ``upgrade`` keeps overwriting).
     """
     encoded = content.encode("utf-8")
     dest.parent.mkdir(parents=True, exist_ok=True)
-    if first_scaffold and conflicts is not None and dest.exists() and dest.read_bytes() != encoded:
+    protect = first_scaffold or _has_pending_sibling(dest)
+    if protect and conflicts is not None and dest.exists() and dest.read_bytes() != encoded:
         sibling = _new_sibling(dest, encoded)
         sibling.write_text(content, encoding="utf-8", newline="\n")
         rec = rel.parent / sibling.name

--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -290,7 +290,12 @@ def emit(
     written: list[Path] = []
     for rel, content in planned_files(agents, servers).items():
         dest = target / rel
-        if dest.exists() and dest.read_text(encoding="utf-8") == content:
+        encoded = content.encode("utf-8")
+        # Compare bytes, not decoded text: a non-UTF-8 existing file must not
+        # crash the scaffold (read_text would raise UnicodeDecodeError), and a
+        # CRLF file must register as *different* from the LF render rather than
+        # read-normalize to "identical" and silently drift (PI-535).
+        if dest.exists() and dest.read_bytes() == encoded:
             continue
         if not dest.exists():
             dest.parent.mkdir(parents=True, exist_ok=True)
@@ -298,7 +303,7 @@ def emit(
             written.append(Path(rel))
             continue
         # Exists and differs — surface a .new sibling, never clobber.
-        sibling = _new_sibling(dest, content.encode("utf-8"))
+        sibling = _new_sibling(dest, encoded)
         sibling.write_text(content, encoding="utf-8", newline="\n")
         rec = Path(rel).parent / sibling.name
         written.append(rec)

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -58,6 +58,13 @@ from project_init.scaffold import (
 
 _CONFIG_REL = Path(".claude/config.yaml")
 _VERSION_LINE_RE = re.compile(r"^(\s*project_init_version:\s*).*$", re.MULTILINE)
+# A never-clobber sibling: `<file>.new` or `<file>.new.N` (see scaffold._new_sibling).
+_SIBLING_RE = re.compile(r"\.new(\.\d+)?$")
+
+
+def _is_sibling(rel: Path) -> bool:
+    """True if *rel* is a `.new`/`.new.N` overwrite-protection sibling (PI-535)."""
+    return bool(_SIBLING_RE.search(rel.name))
 
 # Variables that pre-record config files cannot recover; filled with the
 # scaffolder's defaults during migration (see read_scaffold_record).
@@ -358,7 +365,11 @@ def write_scaffold_record(
     manifest: dict[str, str] = {}
     base: dict[str, str] = {}
     for rel in sorted(set(created)):
-        if rel == _CONFIG_REL or _is_preserved(rel, preserve_globs):
+        # A `.new`/`.new.N` sibling is a user-merge artifact (a render parked
+        # next to a file we refused to clobber), not a managed file — recording
+        # it would make the next upgrade report it as spurious `removed` drift
+        # (PI-535).
+        if rel == _CONFIG_REL or _is_preserved(rel, preserve_globs) or _is_sibling(rel):
             continue
         path = target / rel
         if path.is_file():

--- a/tests/contracts/test_emission_hardening.py
+++ b/tests/contracts/test_emission_hardening.py
@@ -142,6 +142,25 @@ def test_capabilities_re_run_overwrites_generated_file(tmp_path: Path):
     assert not (target / ".claude" / "CAPABILITIES.md.new").exists()
 
 
+def test_generated_file_protected_while_new_sibling_pending(tmp_path: Path):
+    """Run-2 data-loss guard (Codex review): once a first scaffold parks a user
+    file as ``.new``, a later run (first_scaffold=False) must keep protecting the
+    original until the user merges the sibling — not silently overwrite it."""
+    target = tmp_path / "p"
+    dest = target / ".claude" / "CAPABILITIES.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("# my own notes\n")
+
+    # Run 1: first scaffold — original preserved, render parked as .new.
+    capabilities.emit(target, make_variables(), first_scaffold=True, conflicts=[])
+    assert dest.read_text() == "# my own notes\n"
+    assert (target / ".claude" / "CAPABILITIES.md.new").is_file()
+
+    # Run 2: NOT first scaffold, but the .new is still unmerged — original kept.
+    capabilities.emit(target, make_variables(), first_scaffold=False, conflicts=[])
+    assert dest.read_text() == "# my own notes\n", "run-2 clobbered the user file"
+
+
 def test_governance_first_scaffold_preserves_pre_existing_file(tmp_path: Path):
     target = tmp_path / "p"
     dest = target / ".claude" / "governance" / "ai-bom.generated.md"

--- a/tests/contracts/test_emission_hardening.py
+++ b/tests/contracts/test_emission_hardening.py
@@ -1,0 +1,238 @@
+"""PI-535: harden never-clobber + idempotence in the generated-file / surface
+emission layer. Edge cases surfaced by an external review pass.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+from project_init import capabilities, governance, surfaces
+from project_init.mcps import servers_for_ids
+from project_init.scaffold import load_preset, read_preserve_globs, scaffold
+from project_init.upgrade import _is_sibling, write_scaffold_record
+from tests.helpers import make_variables
+
+# --- surfaces.emit: byte comparison, not decoded text (A2/C2/A7) ---------------
+
+
+def test_surface_emit_non_utf8_existing_file_does_not_crash(tmp_path: Path):
+    """A pre-existing non-UTF-8 file at a surface path must not crash the scaffold
+    with UnicodeDecodeError — it differs from the render, so it is preserved and
+    the render lands as a .new sibling."""
+    target = tmp_path / "p"
+    dest = target / ".cursor" / "mcp.json"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(b"\xff\xfe not utf-8 at all \x80")
+
+    conflicts: list[tuple[Path, Path]] = []
+    surfaces.emit(
+        target,
+        agents=["claude", "cursor"],
+        servers=servers_for_ids(["context7"]),
+        conflicts=conflicts,
+    )
+
+    assert dest.read_bytes() == b"\xff\xfe not utf-8 at all \x80"  # untouched
+    sibling = target / ".cursor" / "mcp.json.new"
+    assert sibling.is_file()
+    assert (Path(".cursor/mcp.json"), Path(".cursor/mcp.json.new")) in conflicts
+
+
+def test_surface_emit_crlf_existing_file_is_not_seen_as_identical(tmp_path: Path):
+    """A CRLF copy of the canonical render must register as *different* (byte
+    comparison) rather than read-normalize to "identical" and silently drift."""
+    target = tmp_path / "p"
+    servers = servers_for_ids(["context7"])
+    canonical = surfaces.planned_files(["claude", "cursor"], servers)[".cursor/mcp.json"]
+
+    dest = target / ".cursor" / "mcp.json"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(canonical.replace("\n", "\r\n").encode("utf-8"))  # CRLF on disk
+
+    conflicts: list[tuple[Path, Path]] = []
+    surfaces.emit(target, agents=["claude", "cursor"], servers=servers, conflicts=conflicts)
+
+    # The CRLF file is preserved and the LF render is surfaced for review,
+    # instead of being left silently divergent from the manifest.
+    assert b"\r\n" in dest.read_bytes()
+    assert (target / ".cursor" / "mcp.json.new").is_file()
+
+
+# --- .new siblings excluded from the manifest (C5) -----------------------------
+
+
+def test_is_sibling_recognizes_new_suffixes():
+    assert _is_sibling(Path(".cursor/mcp.json.new"))
+    assert _is_sibling(Path("a/b.json.new.3"))
+    assert not _is_sibling(Path(".cursor/mcp.json"))
+    assert not _is_sibling(Path("CODE_MAP.md"))
+
+
+def test_new_siblings_not_recorded_in_manifest(tmp_path: Path):
+    """A surface .new sibling is a user-merge artifact, not a managed file — it
+    must never enter the scaffold manifest (else upgrade reports spurious
+    `removed` drift for it)."""
+    target = tmp_path / "p"
+    cfg = target / ".claude" / "config.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("project_init_version: 0.0.0\n")
+
+    created = [
+        Path(".cursor/mcp.json"),
+        Path(".cursor/mcp.json.new"),  # sibling — must be filtered out
+    ]
+    for rel in created:
+        f = target / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("{}\n")
+
+    write_scaffold_record(target, "core", {}, created, write_merge_base=False)
+    text = cfg.read_text()
+    marker_idx = text.index("manifest:")
+    manifest = json.loads(text[marker_idx:].split("manifest:", 1)[1].strip())
+    assert ".cursor/mcp.json" in manifest
+    assert ".cursor/mcp.json.new" not in manifest
+
+
+# --- read_preserve_globs tolerates a non-UTF-8 config.yaml (C6) ----------------
+
+
+def test_read_preserve_globs_tolerates_non_utf8_config(tmp_path: Path):
+    cfg = tmp_path / ".claude" / "config.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_bytes(b'preserve: ["keep/*"]\n\xff\xfe garbage \x80')
+    # Must not raise UnicodeDecodeError; the readable prefix still yields the glob.
+    assert read_preserve_globs(tmp_path) == ["keep/*"]
+
+
+# --- generated inventories never-clobber on first scaffold (C1) ----------------
+
+
+def test_capabilities_first_scaffold_preserves_pre_existing_file(tmp_path: Path):
+    """A pre-existing user CAPABILITIES.md is preserved as a .new sibling on the
+    first scaffold, not clobbered by the generated inventory."""
+    target = tmp_path / "p"
+    dest = target / ".claude" / "CAPABILITIES.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("# my own notes\n")
+
+    conflicts: list[tuple[Path, Path]] = []
+    capabilities.emit(target, make_variables(), first_scaffold=True, conflicts=conflicts)
+
+    assert dest.read_text() == "# my own notes\n"  # untouched
+    assert (target / ".claude" / "CAPABILITIES.md.new").is_file()
+    assert conflicts  # recorded for review
+
+
+def test_capabilities_re_run_overwrites_generated_file(tmp_path: Path):
+    """On a re-run (not first scaffold) the generated inventory is overwritten —
+    it is project-init-owned, not user-editable."""
+    target = tmp_path / "p"
+    dest = target / ".claude" / "CAPABILITIES.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("# stale generated content\n")
+
+    capabilities.emit(target, make_variables(), first_scaffold=False, conflicts=[])
+
+    assert dest.read_text() != "# stale generated content\n"
+    assert not (target / ".claude" / "CAPABILITIES.md.new").exists()
+
+
+def test_governance_first_scaffold_preserves_pre_existing_file(tmp_path: Path):
+    target = tmp_path / "p"
+    dest = target / ".claude" / "governance" / "ai-bom.generated.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("# hand-written\n")
+
+    conflicts: list[tuple[Path, Path]] = []
+    governance.emit(
+        target,
+        make_variables(governance="true"),
+        first_scaffold=True,
+        conflicts=conflicts,
+    )
+
+    assert dest.read_text() == "# hand-written\n"
+    assert (target / ".claude" / "governance" / "ai-bom.generated.md.new").is_file()
+
+
+def test_full_scaffold_into_dir_with_pre_existing_capabilities(tmp_path: Path):
+    """End-to-end: scaffolding into a dir that already holds a CAPABILITIES.md
+    never destroys it (the core never-clobber invariant, generated-file path)."""
+    target = tmp_path / "p"
+    (target / ".claude").mkdir(parents=True)
+    (target / ".claude" / "CAPABILITIES.md").write_text("# pre-existing\n")
+
+    conflicts: list[tuple[Path, Path]] = []
+    scaffold(
+        target,
+        load_preset("core"),
+        make_variables(),
+        conflicts=conflicts,
+    )
+    assert (target / ".claude" / "CAPABILITIES.md").read_text() == "# pre-existing\n"
+    assert (target / ".claude" / "CAPABILITIES.md.new").is_file()
+
+
+# --- canonical_hooks surfaces a broken settings.json instead of going empty (A3)
+
+
+def test_canonical_hooks_warns_on_invalid_json(monkeypatch):
+    """Invalid rendered settings.json means broken wiring, not zero hooks — it
+    must warn rather than silently return an empty inventory."""
+    monkeypatch.setattr(
+        "project_init.scaffold._render", lambda *a, **k: "{ not valid json,"
+    )
+    with pytest.warns(UserWarning, match="invalid JSON"):
+        hooks = capabilities.canonical_hooks(make_variables())
+    assert hooks == []
+
+
+def test_canonical_hooks_normal_render_is_silent(recwarn):
+    """The happy path must not warn (guards against a noisy false positive)."""
+    warnings.simplefilter("always")
+    capabilities.canonical_hooks(make_variables())
+    assert not [w for w in recwarn if "invalid JSON" in str(w.message)]
+
+
+# --- difflib 3-way fallback agrees with git merge-file on clean merges (C4) -----
+
+_MERGE_CASES = [
+    # (base, ours, theirs) — non-overlapping edits, both should merge cleanly.
+    ("a\nb\nc\n", "A\nb\nc\n", "a\nb\nC\n"),
+    # one-sided edit (upstream unchanged)
+    ("a\nb\nc\n", "a\nB\nc\n", "a\nb\nc\n"),
+    # identical edit on both sides collapses
+    ("a\nb\nc\n", "a\nX\nc\n", "a\nX\nc\n"),
+    # pure insertions at opposite ends
+    ("m\nn\no\n", "head\nm\nn\no\n", "m\nn\no\ntail\n"),
+    # duplicate lines in base (the anchor-collision risk Codex flagged): each
+    # copy edited on a different side, far enough apart to merge cleanly.
+    (
+        "x\ndup\ny\ndup\nz\n",
+        "x\nDUP1\ny\ndup\nz\n",
+        "x\ndup\ny\nDUP2\nz\n",
+    ),
+]
+
+
+@pytest.mark.parametrize("base,ours,theirs", _MERGE_CASES)
+def test_difflib_fallback_matches_git_on_clean_merges(base, ours, theirs):
+    """When git reports a clean merge, the pure-Python fallback (used when git is
+    absent) must produce the same merged content — divergence here means silent
+    corruption on a git-less host."""
+    from project_init.upgrade import _difflib_three_way, _git_three_way
+
+    git_result = _git_three_way(base, ours, theirs)
+    if git_result is None:
+        pytest.skip("git unavailable")
+    git_merged, git_clean = git_result
+    py_merged, py_clean = _difflib_three_way(base, ours, theirs)
+
+    assert py_clean == git_clean, "fallback disagrees with git on clean-vs-conflict"
+    if git_clean:
+        assert py_merged == git_merged, "fallback merged content diverges from git"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -94,8 +94,24 @@ class TestCLI:
 
     @pytest.mark.parametrize(
         "bad_name",
-        ['ev"il', "C:\\projects\\foo", "line\nbreak", "del\x7fchar"],
-        ids=["double-quote", "backslash", "newline", "del-0x7f"],
+        [
+            'ev"il',
+            "C:\\projects\\foo",
+            "line\nbreak",
+            "del\x7fchar",
+            "nel\x85here",
+            "lsep here",
+            "psep here",
+        ],
+        ids=[
+            "double-quote",
+            "backslash",
+            "newline",
+            "del-0x7f",
+            "nel-0x85",
+            "line-sep-2028",
+            "para-sep-2029",
+        ],
     )
     def test_yaml_breaking_name_rejected(self, tmp_path: Path, bad_name: str):
         """Quotes/backslashes/newlines/control chars (incl. DEL) in name/desc/owner

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -137,6 +137,35 @@ class TestCLI:
         assert exc.value.code == 2
         assert not (tmp_path / "p").exists()  # rejected before creating the dir
 
+    def test_non_utf8_existing_config_rejected_before_writes(self, tmp_path: Path):
+        """A pre-existing non-UTF-8 .claude/config.yaml is rejected up front, with
+        nothing written — not a late crash after partial scaffold (PI-535)."""
+        from project_init.__main__ import main
+
+        target = tmp_path / "p"
+        (target / ".claude").mkdir(parents=True)
+        (target / ".claude" / "config.yaml").write_bytes(b"\xff\xfe not utf-8 \x80")
+
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    str(target),
+                    "--non-interactive",
+                    "--name",
+                    "x",
+                    "--description",
+                    "d",
+                    "--language",
+                    "python",
+                    "--preset",
+                    "core",
+                ]
+            )
+        assert exc.value.code == 2
+        # Aborted cleanly: no scaffold artifacts written alongside the bad config.
+        assert not (target / "AGENTS.md").exists()
+        assert not (target / ".claude" / "settings.json").exists()
+
     def test_apostrophe_in_name_allowed(self, tmp_path: Path):
         """Single quotes are safe in double-quoted YAML — must NOT be rejected."""
         from project_init.__main__ import main

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -100,8 +100,8 @@ class TestCLI:
             "line\nbreak",
             "del\x7fchar",
             "nel\x85here",
-            "lsep here",
-            "psep here",
+            "lsep\u2028here",
+            "psep\u2029here",
         ],
         ids=[
             "double-quote",


### PR DESCRIPTION
## What

Batch of emission-layer edge cases from an external review pass (Antigravity + Codex). The core merge/manifest engine is sound; these close crashes and weak spots in the generated-file / surface emission paths.

| Fix | Severity | File |
|---|---|---|
| `surfaces.emit` compares **bytes not decoded text** — non-UTF-8 existing file no longer crashes the scaffold; CRLF file no longer read-normalizes to "identical" and silently drifts | P2 | `surfaces.py` |
| `capabilities`/`governance` emit **never-clobber a pre-existing user file on first scaffold** (`.new` sibling); still overwrite on re-runs/upgrades | P3 | `scaffold.py` (new `_emit_generated`), `capabilities.py`, `governance.py` |
| `.new` siblings **excluded from the scaffold manifest** → no more spurious `removed` drift next upgrade | P3 | `upgrade.py` |
| `read_preserve_globs` **tolerates a non-UTF-8 `config.yaml`** | P3 | `scaffold.py` |
| Input validation **rejects U+0085 / U+2028 / U+2029** line separators (slip past the C0 check, break `splitlines()` YAML parsing) | P3 | `__main__.py` |
| `canonical_hooks` **warns** on invalid rendered `settings.json` instead of silently emptying the hook inventory | P3 | `capabilities.py` |
| Differential test: difflib 3-way fallback **agrees with `git merge-file`** on clean merges (incl. duplicate-anchor lines) | test | `tests/` |

## Investigated, confirmed NOT bugs (no change)

- **`apply_concern` manifest "poisoning" → data loss (claimed P1)** — the cited code path does not exist. `apply_concern` calls the same `apply_drift`; merged files are excluded from the manifest (`upgrade.py:870`), so they can never be classified `changed` and never silently overwritten.
- **version / `declined_additions` regex "comment hijack"** — anchors require the key after only whitespace; a `#`-prefixed comment can't match.
- **endless "merged" re-flag** — intentional (`upgrade.py:867-869`); re-merges cleanly, idempotent.

## Deferred follow-up

- Strict-mode atomicity for generated files (`_emit_generated_files` runs after the strict commit) — architecturally invasive for near-zero benefit; tracked for later.

## Tests

`uv run pytest -n auto` → **1599 passed, 3 skipped**. New module `tests/contracts/test_emission_hardening.py` (16 tests) + extended Unicode-separator cases in `test_cli.py`.

Closes #535

https://claude.ai/code/session_01NehbQYZo1dWvcVYaSdArUG