### PR TITLE
fix(PI-550): mask free-text flag values in command-guard + release v0.5.2

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -297,6 +297,37 @@ def _strip_heredocs(cmd: str) -> str:
     return _HEREDOC_RE.sub("", cmd)
 
 
+# Free-text flag values carry arbitrary prose (commit messages, issue/PR comment
+# and release bodies, titles) that must not be scanned for command patterns — a
+# `--body` mentioning the literal "git push main" is data, not an invocation.
+_TEXT_FLAG_RE = re.compile(
+    r"""(?P<flag>--body|--message|--title|--notes|-b|-m|-t)   # known free-text flags
+        (?:=|\s+)                                             # = or whitespace separator
+        (?P<q>['"])                                           # opening quote
+        (?P<val>(?:\\.|(?!(?P=q)).)*)                         # value (escapes allowed)
+        (?P=q)                                                # matching closing quote
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_text_flag_values(cmd: str) -> str:
+    """Blank the quoted value of known free-text flags so prose can't trip the
+    pattern rules. Values containing a command substitution (``$(`` or a
+    backtick) are left intact — those ARE executed, so the rules must still see
+    them. Flag values are otherwise inert data: masking loses no real
+    enforcement (an actual ``git push origin main`` uses a positional ref, not a
+    flag value, and stays blocked)."""
+
+    def _blank(m: re.Match[str]) -> str:
+        val = m.group("val")
+        if "$(" in val or "`" in val:
+            return m.group(0)
+        return f'{m.group("flag")} ""'
+
+    return _TEXT_FLAG_RE.sub(_blank, cmd)
+
+
 def _redirect_target_exists(reason: str) -> bool:
     """Best-effort: scan the redirect message for a `.claude/scripts/<name>`
     reference and check whether the file exists. If no reference is found,
@@ -325,9 +356,10 @@ def guard(payload: dict) -> dict | None:
     if not cmd:
         return None
 
-    # Strip heredoc bodies so pattern rules don't fire on body content
-    # (e.g. `gh issue create --body "$(cat <<'EOF'\n...git push...\nEOF\n)"`)
-    cmd_scan = _strip_heredocs(cmd)
+    # Strip heredoc bodies and free-text flag values so pattern rules don't fire
+    # on prose content (e.g. `gh issue create --body "$(cat <<'EOF'\n...git
+    # push...\nEOF\n)"`, or `gh pr comment --body "...git push main..."`).
+    cmd_scan = _strip_text_flag_values(_strip_heredocs(cmd))
 
     for pattern, target, message in COMMAND_RULES:
         if not pattern.search(cmd_scan):

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 0.5.1
+version: 0.5.2

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -297,6 +297,37 @@ def _strip_heredocs(cmd: str) -> str:
     return _HEREDOC_RE.sub("", cmd)
 
 
+# Free-text flag values carry arbitrary prose (commit messages, issue/PR comment
+# and release bodies, titles) that must not be scanned for command patterns — a
+# `--body` mentioning the literal "git push main" is data, not an invocation.
+_TEXT_FLAG_RE = re.compile(
+    r"""(?P<flag>--body|--message|--title|--notes|-b|-m|-t)   # known free-text flags
+        (?:=|\s+)                                             # = or whitespace separator
+        (?P<q>['"])                                           # opening quote
+        (?P<val>(?:\\.|(?!(?P=q)).)*)                         # value (escapes allowed)
+        (?P=q)                                                # matching closing quote
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_text_flag_values(cmd: str) -> str:
+    """Blank the quoted value of known free-text flags so prose can't trip the
+    pattern rules. Values containing a command substitution (``$(`` or a
+    backtick) are left intact — those ARE executed, so the rules must still see
+    them. Flag values are otherwise inert data: masking loses no real
+    enforcement (an actual ``git push origin main`` uses a positional ref, not a
+    flag value, and stays blocked)."""
+
+    def _blank(m: re.Match[str]) -> str:
+        val = m.group("val")
+        if "$(" in val or "`" in val:
+            return m.group(0)
+        return f'{m.group("flag")} ""'
+
+    return _TEXT_FLAG_RE.sub(_blank, cmd)
+
+
 def _redirect_target_exists(reason: str) -> bool:
     """Best-effort: scan the redirect message for a `.claude/scripts/<name>`
     reference and check whether the file exists. If no reference is found,
@@ -325,9 +356,10 @@ def guard(payload: dict) -> dict | None:
     if not cmd:
         return None
 
-    # Strip heredoc bodies so pattern rules don't fire on body content
-    # (e.g. `gh issue create --body "$(cat <<'EOF'\n...git push...\nEOF\n)"`)
-    cmd_scan = _strip_heredocs(cmd)
+    # Strip heredoc bodies and free-text flag values so pattern rules don't fire
+    # on prose content (e.g. `gh issue create --body "$(cat <<'EOF'\n...git
+    # push...\nEOF\n)"`, or `gh pr comment --body "...git push main..."`).
+    cmd_scan = _strip_text_flag_values(_strip_heredocs(cmd))
 
     for pattern, target, message in COMMAND_RULES:
         if not pattern.search(cmd_scan):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.5.1"
+version = "0.5.2"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/templates/lifecycle/dot_claude/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_claude/hooks/dag_workflow.py
@@ -297,6 +297,37 @@ def _strip_heredocs(cmd: str) -> str:
     return _HEREDOC_RE.sub("", cmd)
 
 
+# Free-text flag values carry arbitrary prose (commit messages, issue/PR comment
+# and release bodies, titles) that must not be scanned for command patterns — a
+# `--body` mentioning the literal "git push main" is data, not an invocation.
+_TEXT_FLAG_RE = re.compile(
+    r"""(?P<flag>--body|--message|--title|--notes|-b|-m|-t)   # known free-text flags
+        (?:=|\s+)                                             # = or whitespace separator
+        (?P<q>['"])                                           # opening quote
+        (?P<val>(?:\\.|(?!(?P=q)).)*)                         # value (escapes allowed)
+        (?P=q)                                                # matching closing quote
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_text_flag_values(cmd: str) -> str:
+    """Blank the quoted value of known free-text flags so prose can't trip the
+    pattern rules. Values containing a command substitution (``$(`` or a
+    backtick) are left intact — those ARE executed, so the rules must still see
+    them. Flag values are otherwise inert data: masking loses no real
+    enforcement (an actual ``git push origin main`` uses a positional ref, not a
+    flag value, and stays blocked)."""
+
+    def _blank(m: re.Match[str]) -> str:
+        val = m.group("val")
+        if "$(" in val or "`" in val:
+            return m.group(0)
+        return f'{m.group("flag")} ""'
+
+    return _TEXT_FLAG_RE.sub(_blank, cmd)
+
+
 def _redirect_target_exists(reason: str) -> bool:
     """Best-effort: scan the redirect message for a `.claude/scripts/<name>`
     reference and check whether the file exists. If no reference is found,
@@ -325,9 +356,10 @@ def guard(payload: dict) -> dict | None:
     if not cmd:
         return None
 
-    # Strip heredoc bodies so pattern rules don't fire on body content
-    # (e.g. `gh issue create --body "$(cat <<'EOF'\n...git push...\nEOF\n)"`)
-    cmd_scan = _strip_heredocs(cmd)
+    # Strip heredoc bodies and free-text flag values so pattern rules don't fire
+    # on prose content (e.g. `gh issue create --body "$(cat <<'EOF'\n...git
+    # push...\nEOF\n)"`, or `gh pr comment --body "...git push main..."`).
+    cmd_scan = _strip_text_flag_values(_strip_heredocs(cmd))
 
     for pattern, target, message in COMMAND_RULES:
         if not pattern.search(cmd_scan):

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -28,6 +28,12 @@ Exception (PI-526): the concern-decoupled skills `save_memory`, `status`, and
 `session_summary` gained deterministic presence-checks in their bodies — a
 deliberate fix, not move-drift. Only those three SKILL.md hashes were re-pinned
 (no_plugin combos), after verifying every other file still matched.
+
+Exception (PI-550): `dag_workflow.py` gained `_strip_text_flag_values` so the
+command-guard no longer false-positives on blocked-command phrases inside
+free-text flag values (`--body`/`-m`/`--title`/`--notes`). A deliberate guard
+fix, not move-drift. Only the `.claude/hooks/dag_workflow.py` hash was re-pinned
+across all four combos, after verifying every other file still matched.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -34,6 +34,12 @@ Exception (PI-526): the concern-decoupled skills `save_memory`, `status`, and
 write to `.claude/memory/` or `.claude/vault/` when that concern was declined) —
 a deliberate fix, not move-drift. Only those three SKILL.md hashes were re-pinned
 (no_plugin combos), after verifying every other file still matched.
+
+Exception (PI-550): `dag_workflow.py` gained `_strip_text_flag_values` so the
+command-guard no longer false-positives on blocked-command phrases inside
+free-text flag values. A deliberate guard fix, not move-drift. Only the
+`.claude/hooks/dag_workflow.py` hash was re-pinned across all four combos, after
+verifying every other file still matched.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "6bccb22869a6630e0b8fe739a509a5277ce6fad249093e622f1a9466b7687789",
   ".claude/hooks/pre_commit_gate.sh": "060072ea89a9c8fbd6feea761e58af330b84e24a302a815faa2facdd10e7b0b8",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/prod_guard.py": "b801d9f46b0b91f3af75e3b8b55fae869561e1f4f1bb161ef8c9812d2516ef9f",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "6bccb22869a6630e0b8fe739a509a5277ce6fad249093e622f1a9466b7687789",
   ".claude/hooks/pre_commit_gate.sh": "060072ea89a9c8fbd6feea761e58af330b84e24a302a815faa2facdd10e7b0b8",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/prod_guard.py": "b801d9f46b0b91f3af75e3b8b55fae869561e1f4f1bb161ef8c9812d2516ef9f",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "6bccb22869a6630e0b8fe739a509a5277ce6fad249093e622f1a9466b7687789",
   ".claude/hooks/pre_commit_gate.sh": "060072ea89a9c8fbd6feea761e58af330b84e24a302a815faa2facdd10e7b0b8",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/prod_guard.py": "b801d9f46b0b91f3af75e3b8b55fae869561e1f4f1bb161ef8c9812d2516ef9f",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "6bccb22869a6630e0b8fe739a509a5277ce6fad249093e622f1a9466b7687789",
   ".claude/hooks/pre_commit_gate.sh": "060072ea89a9c8fbd6feea761e58af330b84e24a302a815faa2facdd10e7b0b8",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "b143f12e5f94ecd7b78ed7c9b0e99e5db16b541c1e7edf0870ac86ea38fa863d",
+  ".claude/hooks/dag_workflow.py": "04d34eebb7ae9184ffe40cf0dfe04bfa75b8df10add87853229ff0f596191357",
   ".claude/hooks/prod_guard.py": "b801d9f46b0b91f3af75e3b8b55fae869561e1f4f1bb161ef8c9812d2516ef9f",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -285,6 +285,47 @@ class TestGuardSteering:
         out = _run_guard_hook(hook, {"tool_input": {"command": cmd}}, cwd=tmp_path)
         assert out is None
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # #550: a blocked-command phrase living inside a free-text flag value
+            # is prose, not an invocation, and must not trip the guard.
+            'gh issue comment 5 --body "see the blocked git push main screenshot"',
+            'gh pr comment 5 -b "do not git push origin main here"',
+            "git commit -m 'docs: explain why git push main is blocked'",
+            'gh release create v1 --notes "no more git push master"',
+            'gh issue comment 5 --body="quoting git push origin main inline"',
+            'gh pr edit 5 --title "git push main guard fix" --body "x"',
+        ],
+    )
+    def test_allows_blocked_phrase_inside_text_flag_value(self, cmd: str, tmp_path: Path):
+        """#550: free-text flag values (--body/-b, --message/-m, --title/-t,
+        --notes) are masked before pattern scanning, so prose mentioning a
+        blocked command does not produce a false-positive denial."""
+        out = _run_guard({"tool_input": {"command": cmd}}, cwd=tmp_path)
+        assert out is None
+
+    def test_still_blocks_command_substitution_inside_body(self, tmp_path: Path):
+        """#550 evasion guard: a value containing a command substitution IS
+        executed, so masking must leave it intact and the inner merge must
+        still be caught (monitor_pr.sh redirect exists in this repo)."""
+        out = _run_guard(
+            {"tool_input": {"command": 'gh pr comment 5 --body "$(gh pr merge 9)"'}},
+            cwd=tmp_path,
+        )
+        assert _denied(out)
+        assert "monitor_pr.sh" in _deny_reason(out)
+
+    def test_masked_flag_does_not_hide_a_real_following_push(self, tmp_path: Path):
+        """#550: masking a flag value must not swallow a real push-to-main that
+        follows it in the same command line."""
+        out = _run_guard(
+            {"tool_input": {"command": 'git commit -m "wip" && git push origin main'}},
+            cwd=tmp_path,
+        )
+        assert _denied(out)
+        assert "main/master" in _deny_reason(out)
+
     def test_innocuous_command_passes(self, tmp_path: Path):
         out = _run_guard({"tool_input": {"command": "ls -la"}}, cwd=tmp_path)
         assert out is None

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
Fixes a command-guard false positive: a blocked-command phrase inside a quoted **free-text flag value** (`gh issue/pr comment --body`, `git commit -m`, `gh release create --notes`, `--title`) was scanned as if it were an invocation and denied. Hit twice this session while posting issue comments whose body text mentioned the blocked phrase.

## Fix
New `_strip_text_flag_values` blanks the quoted value of `--body`/`-b`, `--message`/`-m`, `--title`/`-t`, `--notes` before pattern scanning — same shape as the existing heredoc-body stripping. Values containing a command substitution (`$(...)` or backticks) are left intact, so real invocations are still caught. An actual push to the default branch uses a positional ref (not a flag value) and stays blocked.

## Changes
- Source of truth `templates/lifecycle/dot_claude/hooks/dag_workflow.py`; `.claude/hooks` copy kept byte-identical; `sync_plugin.py` propagated to the lifecycle plugin (all three copies identical).
- Regression tests in `test_dag_workflow.py`: free-text-flag bodies pass; command-substitution inside a body and real push/merge still blocked; a masked flag does not swallow a following real push.
- Re-pinned only the `.claude/hooks/dag_workflow.py` hash in the lifecycle + memory byte-identity baselines (documented PI-550 exception in both test docstrings).
- Version bump 0.5.1 -> 0.5.2 (`pyproject.toml`, `__init__.py`, `CITATION.cff`).

## Verification
- Full suite: 1618 passed, 3 skipped.
- `ruff check`: clean.

Closes #550
