### PR TITLE
fix: resolve registered scaffold/governance bugs + release v0.5.3 (#552–556)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Sync dev dependencies
-        run: uv sync --extra dev --locked
+        run: uv sync --group dev --locked
 
       - name: Lint (ruff)
         run: uv run ruff check .

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 0.5.2
+version: 0.5.3

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@
 
 # install/sync dev dependencies
 setup:
-    uv sync --extra dev
+    uv sync --group dev
 
 # lint (docstring + complexity gates per pyproject.toml)
 lint:

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -53,7 +53,13 @@ bootstrap() {
     && just --show setup >/dev/null 2>&1; then
     just setup
   elif [ -f pyproject.toml ] && command -v uv >/dev/null 2>&1; then
-    uv sync --extra dev 2>/dev/null || uv sync
+    # PEP 735: project-init scaffolds `dev` as a [dependency-groups] table, so
+    # sync the group (PI #552). A single command with no `2>/dev/null || uv sync`
+    # masking: a real failure must surface as a nonzero exit (→ the "bootstrap
+    # failed" branch below) instead of silently falling back to a dev-less venv
+    # that lies "synced" and caches the stamp so the next session never retries
+    # (PI #553).
+    uv sync --group dev
   elif [ -f package.json ] && command -v bun >/dev/null 2>&1; then
     bun install
   elif [ -f go.mod ] && command -v go >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+docs = [
+    "mkdocs-material>=9.7.6",
+]
+
+# Dev tooling lives in a PEP 735 dependency-group — the layout project-init
+# scaffolds into target projects (`uv sync --group dev`). Dogfooding it here
+# keeps the bootstrap consistent across the repo and its templates (PI #552).
+[dependency-groups]
 dev = [
     "ruff>=0.4",
     "pytest>=8.0",
     "pytest-xdist>=3.0",
-]
-docs = [
-    "mkdocs-material>=9.7.6",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.5.2"
+version = "0.5.3"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,8 +1,8 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.1.0"
+__plugin_version__ = "0.1.1"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_claude/config.yaml.tmpl
+++ b/templates/base/dot_claude/config.yaml.tmpl
@@ -12,7 +12,7 @@ project:
   enforcement: {{enforcement}}      # advisory | hard — see ADR-013 / #251
   project_init_host: {{project_init_host}}  # upstream GitHub host (github.com | *.ghe.com | GHES) — #255/#259
   project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use feat(PI-42):
-  github_project_number: 1 # numeric GitHub Project V2 board number{{#if lifecycle}} (used by board-automation.yml and create_issue.sh){{/if lifecycle}}
+  github_project_number: 1 # numeric GitHub Project V2 board number{{#if lifecycle}} — single source of truth read by board-automation.yml, create_issue.sh, and setup_github.sh (#556){{/if lifecycle}}
 
 language: {{language}}            # python | node | go | none
 

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -303,6 +303,33 @@ jobs:
           # GITLEAKS_LICENSE is required only for organization-owned repos
           # (free key from gitleaks.io). Personal accounts need no license.
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  # All-green gate (PI #555): the SINGLE required status check for branch
+  # protection. Branch protection requires only "CI gate", so the required
+  # context is robust to matrix changes — adding/removing a {{#if python}}Python version{{/if python}}{{#if node}}runtime{{/if node}}{{#if go}}runtime{{/if go}}
+  # never renames the required check, and there is no un-expanded matrix name
+  # (e.g. "Lint and test (3.11)") for GitHub to fail to match against, which is
+  # what left main permanently `blocked` before. `if: always()` so the gate runs
+  # even when an upstream job fails, then fails itself unless every dependency
+  # succeeded.
+  ci-gate:
+    name: CI gate
+    runs-on: ubuntu-24.04
+    needs: [lint-and-test, secret-scan]
+    if: always()
+    steps:
+      - name: Require all upstream jobs to succeed
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Upstream job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required job did not succeed (got: $result)."
+              exit 1
+            fi
+          done
+          echo "All required jobs passed."
 {{#if governance}}
   # ADR-018 (#412): governance-as-code. Presence-triggered — validates every real
   # .claude/governance/**/SYSTEM_CARD.md and fails on missing/placeholder fields,

--- a/templates/base/dot_gitleaks.toml
+++ b/templates/base/dot_gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks config — extends the built-in default ruleset and adds a narrow
+# allowlist for the scaffold record this project generates.
+# Used by the CI "Secret scan (gitleaks)" job (gitleaks-action@v3).
+#
+# Without this file a fresh scaffold fails its first CI run: project-init writes
+# a `manifest:` map of relpath → sha256 into .claude/config.yaml, and the
+# high-entropy hash next to a "secrets.md" path key trips the default
+# generic-api-key rule. Those are content hashes, not secrets (PI #554).
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "project-init scaffold record (content hashes, not secrets)."
+paths = [
+  '''\.claude/config\.yaml''',
+]

--- a/templates/fallback/dot_claude/hooks/session_setup.sh
+++ b/templates/fallback/dot_claude/hooks/session_setup.sh
@@ -53,7 +53,13 @@ bootstrap() {
     && just --show setup >/dev/null 2>&1; then
     just setup
   elif [ -f pyproject.toml ] && command -v uv >/dev/null 2>&1; then
-    uv sync --extra dev 2>/dev/null || uv sync
+    # PEP 735: project-init scaffolds `dev` as a [dependency-groups] table, so
+    # sync the group (PI #552). A single command with no `2>/dev/null || uv sync`
+    # masking: a real failure must surface as a nonzero exit (→ the "bootstrap
+    # failed" branch below) instead of silently falling back to a dev-less venv
+    # that lies "synced" and caches the stamp so the next session never retries
+    # (PI #553).
+    uv sync --group dev
   elif [ -f package.json ] && command -v bun >/dev/null 2>&1; then
     bun install
   elif [ -f go.mod ] && command -v go >/dev/null 2>&1; then

--- a/templates/lifecycle/dot_claude/scripts/create_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/create_issue.sh
@@ -20,6 +20,22 @@ command -v gh >/dev/null 2>&1 || { echo "error: GitHub CLI (gh) not found — in
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PY="$SCRIPT_DIR/../hooks/_py.sh"
 
+# Single source of truth for the GitHub Project board number (PI #556):
+# the PROJECT_NUMBER env var overrides; otherwise read github_project_number
+# from .claude/config.yaml (shared with board-automation.yml / setup_github.sh);
+# default 1. Account-scoped numbering means a real board is rarely #1, so the
+# three consumers must agree or board state silently splits across projects.
+resolve_project_number() {
+  if [ -n "${PROJECT_NUMBER:-}" ]; then
+    printf '%s\n' "$PROJECT_NUMBER"
+    return
+  fi
+  local configured=""
+  configured=$(grep -E '^[[:space:]]*github_project_number:' "$SCRIPT_DIR/../config.yaml" 2>/dev/null \
+    | head -n1 | sed 's/#.*$//' | grep -oE '[0-9]+' | head -n1 || true)
+  printf '%s\n' "${configured:-1}"
+}
+
 VALID_TYPES="feat fix chore docs test"
 VALID_SCALES="epic task"
 VALID_PRIORITIES="high medium low"
@@ -409,13 +425,13 @@ ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 # board. They are also written into the issue body above (PI-201) so the issue
 # is self-contained and passes issue-validation.yml; the board copy makes them
 # sortable/filterable for humans.
-# PROJECT_NUMBER defaults to 1; override with the env var if needed.
+# Board number resolves via resolve_project_number() (config.yaml SSOT, #556).
 # ---------------------------------------------------------------------------
 sync_project_fields() {
   local issue_num="$1"
   local project_num owner repo_name project_data project_id item_id
 
-  project_num="${PROJECT_NUMBER:-1}"
+  project_num="$(resolve_project_number)"
   owner=$(gh repo view --json owner -q .owner.login)
   repo_name=$(gh repo view --json name -q .name)
 

--- a/templates/lifecycle/dot_claude/scripts/setup_github.sh
+++ b/templates/lifecycle/dot_claude/scripts/setup_github.sh
@@ -56,18 +56,23 @@ fi
 PROTECTION=$(mktemp)
 trap 'rm -f "$PROTECTION"' EXIT
 
-# Contexts must match the scaffolded workflows ("<workflow> / <job name>").
-# "CI / Integration tests" is omitted on purpose — that job is documented as
-# user-adjustable; add it here once your integration suite is stable.
+# Contexts must match the bare check-run names GitHub reports — NOT
+# "<workflow> / <job name>" (PI #555). Two traps avoided here:
+#   1. CI's lint job is a matrix, so its check-runs are "Lint and test (3.11)"…
+#      not "Lint and test"; requiring the un-expanded/prefixed name never matches
+#      and leaves the branch permanently `blocked`. Instead require the single
+#      "CI gate" job (ci.yml), which `needs:` the whole matrix + secret scan —
+#      robust to matrix changes and language-agnostic.
+#   2. review/decision is a derived status only posted on review events and is
+#      unsatisfiable for a solo owner (you can't approve your own PR), so it is
+#      NOT required here — it stays the advisory signal monitor_pr.sh treats it as.
 cat > "$PROTECTION" <<'JSON'
 {
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "CI / Lint and test",
-      "CI / Secret scan (gitleaks)",
-      "Validate PR / Check PR title, branch, and linked issue",
-      "review/decision"
+      "CI gate",
+      "Check PR title, branch, and linked issue"
     ]
   },
   "enforce_admins": false,
@@ -120,8 +125,8 @@ elif gh api "repos/$OWNER/$NAME/rulesets" >/dev/null 2>&1; then
     { "type": "required_status_checks", "parameters": {
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
-          { "context": "CI / Lint and test" },
-          { "context": "CI / Secret scan (gitleaks)" } ] } }
+          { "context": "CI gate" },
+          { "context": "Check PR title, branch, and linked issue" } ] } }
   ],
   "bypass_actors": []
 }
@@ -152,6 +157,15 @@ fi
 echo ""
 echo "Provisioning GitHub Project board fields..."
 
+# Single source of truth for the board number (PI #556): the PROJECT_NUMBER env
+# var overrides; otherwise read github_project_number from .claude/config.yaml
+# (shared with board-automation.yml / create_issue.sh); default 1. Account-scoped
+# numbering means a real board is rarely #1, so all three consumers must agree or
+# board state silently splits across projects.
+if [ -z "${PROJECT_NUMBER:-}" ]; then
+  PROJECT_NUMBER=$(grep -E '^[[:space:]]*github_project_number:' "$SCRIPT_DIR/../config.yaml" 2>/dev/null \
+    | head -n1 | sed 's/#.*$//' | grep -oE '[0-9]+' | head -n1 || true)
+fi
 PROJECT_NUMBER="${PROJECT_NUMBER:-1}"
 
 # Use PROJECT_TOKEN if set, otherwise fall through to default gh auth
@@ -205,11 +219,18 @@ else
       echo "  '$field_name' already exists — skipping"
       return 0
     fi
-    if gh api graphql -f query="$mutation" -f projectId="$PROJECT_ID" >/dev/null 2>&1; then
+    # Capture stderr instead of discarding it (PI #556 minor): a swallowed
+    # `2>/dev/null` made a transient/first-call failure look permanent and printed
+    # a bare WARNING even when the mutation actually succeeds on retry, misleading
+    # the user into manual creation. Surface the real GraphQL error so the cause
+    # (scope, rate-limit, transient) is visible.
+    local err
+    if err=$(gh api graphql -f query="$mutation" -f projectId="$PROJECT_ID" 2>&1 >/dev/null); then
       echo "  Created '$field_name'"
     else
       # Repo: $REPO  Project: #$PROJECT_NUMBER
       echo "  WARNING: could not create '$field_name' for $REPO — add it manually:" >&2
+      [ -n "$err" ] && echo "    reason: $err" >&2
       echo "    $WEB_BASE/users/$OWNER/projects/$PROJECT_NUMBER/settings/fields" >&2
     fi
   }

--- a/templates/lifecycle/dot_github/workflows/board-automation.yml
+++ b/templates/lifecycle/dot_github/workflows/board-automation.yml
@@ -5,7 +5,8 @@ name: Board automation
 # Setup:
 #   1. Create a PAT with Projects access.
 #   2. Store it as PROJECT_TOKEN.
-#   3. Set PROJECT_NUMBER to the target project number.
+#   3. Set `github_project_number` in .claude/config.yaml to the target board
+#      (the single source of truth shared with create_issue.sh / setup_github.sh).
 #   4. Optional project fields: Status, Priority, Area, Size.
 
 on:
@@ -24,15 +25,32 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-      # No actions/checkout in this job (it only needs API access); pin the repo
-      # so every `gh` call (e.g. `gh issue view`) works checkout-free instead of
-      # failing on a missing git remote (PI-234).
+      # Pin the repo so every `gh` call (e.g. `gh issue view`) resolves it
+      # explicitly (PI-234).
       GH_REPO: ${{ github.repository }}
       OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
-      PROJECT_NUMBER: 1
 
     steps:
+      # Single source of truth for the board number (PI #556): read
+      # `github_project_number` from .claude/config.yaml instead of a hardcoded
+      # literal that drifts from what create_issue.sh / setup_github.sh provision
+      # to. Account-scoped numbering means a real board is almost never #1, so a
+      # hardcoded 1 here would silently split board state across two projects.
+      # Needs a checkout to read the file; falls back to 1 if unset/absent.
+      - uses: actions/checkout@v6
+      - name: Resolve PROJECT_NUMBER from config.yaml
+        run: |
+          set -euo pipefail
+          num=1
+          if [ -f .claude/config.yaml ]; then
+            parsed=$(grep -E '^[[:space:]]*github_project_number:' .claude/config.yaml \
+              | head -n1 | sed 's/#.*$//' | grep -oE '[0-9]+' | head -n1 || true)
+            [ -n "$parsed" ] && num="$parsed"
+          fi
+          echo "PROJECT_NUMBER=$num" >> "$GITHUB_ENV"
+          echo "Using GitHub Project #$num (from .claude/config.yaml)"
+
       - name: Determine issue and status
         id: context
         env:

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -120,11 +120,17 @@ class TestBranchProtectionBootstrap:
         assert '"allow_force_pushes": false' in script
 
     def test_protection_requires_generated_ci_checks(self):
-        """The required contexts must cover the scaffolded CI workflow's
-        unconditional jobs, or 'require CI green' is an empty promise."""
+        """The required contexts must use the bare check-run names GitHub reports
+        (PI #555): the single "CI gate" job (which `needs:` the matrix + secret
+        scan) plus the PR-format check. The old "CI / Lint and test" /
+        "review/decision" contexts never matched a real check-run and left main
+        permanently `blocked`."""
         script = _SETUP_GITHUB.read_text()
-        assert '"CI / Lint and test"' in script
-        assert '"CI / Secret scan (gitleaks)"' in script
+        assert '"CI gate"' in script
+        assert '"Check PR title, branch, and linked issue"' in script
+        # The un-matchable contexts that caused the deadlock must be gone.
+        assert '"CI / Lint and test"' not in script
+        assert '"review/decision"' not in script
 
     def test_protect_sets_squash_only_merge_policy(self):
         """--protect centralizes the repo merge policy (lifted from the removed

--- a/tests/contracts/test_hook_portability.py
+++ b/tests/contracts/test_hook_portability.py
@@ -60,6 +60,21 @@ def test_session_setup_fingerprint_is_shasum_aware():
         assert "cksum" in text, f"{path}: no POSIX cksum fallback when neither exists"
 
 
+def test_session_setup_syncs_dev_group_without_masking():
+    """PI #552/#553: the Python bootstrap must `uv sync --group dev` (project-init
+    scaffolds `dev` as a PEP 735 dependency-group, so `--extra dev` errors), and
+    must NOT mask the failure behind `2>/dev/null || uv sync` — a degraded,
+    dev-less sync reported as success would cache the stamp and never retry."""
+    for path in _hook_files("session_setup.sh"):
+        code = _code_lines(path.read_text())
+        assert "uv sync --group dev" in code, f"{path}: must sync the dev group"
+        assert "--extra dev" not in code, f"{path}: --extra dev errors on a PEP 735 group"
+        # The silent-masking pattern must be gone so a real failure surfaces.
+        assert "2>/dev/null || uv sync" not in code, (
+            f"{path}: must not mask a failed sync behind a dev-less fallback"
+        )
+
+
 def test_commit_gate_builds_arrays_portably():
     """Staged-file lists are read with a while-loop, not mapfile."""
     for path in _hook_files("pre_commit_gate.sh"):

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -64,6 +64,26 @@ COMBOS = [
 # test_lifecycle_none.py, not byte-identity.
 _GENERATED = {".claude/CAPABILITIES.md"}
 
+# Files added or intentionally edited AFTER the frozen baseline was captured —
+# legitimate content changes, not the static template move this contract guards.
+# Excluded from both sides (same mechanism as the settings.json / CAPABILITIES.md
+# carve-outs); their correctness is covered by the focused template/governance
+# contracts, not byte-identity.
+#   • .gitleaks.toml — new base file shipping with the gitleaks CI job (#554)
+#   • ci.yml — gained the all-green "CI gate" job (#555)
+#   • setup_github.sh — bare required-check contexts + board SSOT (#555/#556)
+#   • create_issue.sh / board-automation.yml / config.yaml — board-number SSOT (#556)
+#   • session_setup.sh — `uv sync --group dev`, no silent-failure masking (#552/#553)
+_ADDED_SINCE_BASELINE = {
+    ".gitleaks.toml",
+    ".github/workflows/ci.yml",
+    ".claude/scripts/setup_github.sh",
+    ".claude/scripts/create_issue.sh",
+    ".github/workflows/board-automation.yml",
+    ".claude/config.yaml",
+    ".claude/hooks/session_setup.sh",
+}
+
 
 def _manifest(target: Path) -> dict[str, str]:
     out: dict[str, str] = {}
@@ -98,7 +118,7 @@ def test_lifecycle_move_byte_identical(preset_name: str, no_plugin: bool, tmp_pa
     # plugin enablement (#476 plugin split) — an intended edit, not move drift.
     # The no-plugin hook gating IS designed byte-identical-when-ON, so it stays
     # in the comparison. The plugin-mode change is covered by test_lifecycle_none.
-    drop = set(_GENERATED)
+    drop = set(_GENERATED) | _ADDED_SINCE_BASELINE
     if not no_plugin:
         drop.add(".claude/settings.json")
     got = {k: v for k, v in got.items() if k not in drop}

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -70,6 +70,26 @@ COMBOS = [
 # Neither is part of the memory move this contract guards.
 _GENERATED = {".claude/CAPABILITIES.md"}
 
+# Files added or intentionally edited AFTER the frozen baseline was captured —
+# legitimate content changes, not the memory move this contract guards. Excluded
+# from both sides (same mechanism as the settings.json / CAPABILITIES.md carve-
+# outs above); their correctness is covered by the focused template/governance
+# contracts, not byte-identity.
+#   • .gitleaks.toml — new base file shipping with the gitleaks CI job (#554)
+#   • ci.yml — gained the all-green "CI gate" job (#555)
+#   • setup_github.sh — bare required-check contexts + board SSOT (#555/#556)
+#   • create_issue.sh / board-automation.yml / config.yaml — board-number SSOT (#556)
+#   • session_setup.sh — `uv sync --group dev`, no silent-failure masking (#552/#553)
+_ADDED_SINCE_BASELINE = {
+    ".gitleaks.toml",
+    ".github/workflows/ci.yml",
+    ".claude/scripts/setup_github.sh",
+    ".claude/scripts/create_issue.sh",
+    ".github/workflows/board-automation.yml",
+    ".claude/config.yaml",
+    ".claude/hooks/session_setup.sh",
+}
+
 
 def _manifest(target: Path) -> dict[str, str]:
     out: dict[str, str] = {}
@@ -103,7 +123,7 @@ def test_memory_move_byte_identical(preset_name: str, no_plugin: bool, tmp_path:
     scaffold(target, preset, variables)
     got = _manifest(target)
 
-    drop = set(_GENERATED)
+    drop = set(_GENERATED) | _ADDED_SINCE_BASELINE
     if not no_plugin:
         drop.add(".claude/settings.json")
     got = {k: v for k, v in got.items() if k not in drop}

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -200,6 +200,44 @@ class TestScaffoldGitHubFiles:
         assert "uv sync --group dev" in content
         assert "uv sync --extra dev" not in content
 
+    def test_ci_has_all_green_gate_job(self):
+        """PI #555: a single 'CI gate' job that `needs:` the matrix + secret scan
+        is the one required status check, so branch protection never references an
+        un-expanded matrix leg GitHub can't match (which left main `blocked`)."""
+        content = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "name: CI gate" in content
+        assert "needs: [lint-and-test, secret-scan]" in content
+        # Must run even when an upstream job fails, then fail unless all succeeded.
+        assert "if: always()" in content
+
+    def test_board_automation_reads_project_number_from_config(self):
+        """PI #556: the board number is read from .claude/config.yaml (the single
+        source of truth shared with create_issue.sh / setup_github.sh), not a
+        hardcoded `PROJECT_NUMBER: 1` that drifts from a real (non-#1) board."""
+        content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
+        assert "github_project_number" in content
+        assert "PROJECT_NUMBER=$num" in content
+        # The hardcoded literal that split board state must be gone.
+        assert "PROJECT_NUMBER: 1" not in content
+
+    def test_setup_github_reads_project_number_from_config(self):
+        """PI #556: setup_github.sh resolves the board number from config.yaml
+        too, so all three consumers agree."""
+        content = (self.target / ".claude" / "scripts" / "setup_github.sh").read_text()
+        assert "github_project_number" in content
+
+    def test_gitleaks_config_shipped(self):
+        """PI #554: the gitleaks secret-scan job ships in base CI, so a matching
+        .gitleaks.toml must ship too — otherwise a fresh scaffold fails its first
+        CI run when gitleaks flags the high-entropy hashes in the generated
+        .claude/config.yaml scaffold record."""
+        cfg = self.target / ".gitleaks.toml"
+        assert cfg.is_file(), ".gitleaks.toml must ship alongside the gitleaks CI job"
+        content = cfg.read_text()
+        assert "useDefault = true" in content
+        # The scaffold record (.claude/config.yaml) must be allowlisted.
+        assert "config" in content and "claude" in content
+
     def test_ci_does_not_hardcode_python_version(self):
         """PI-208: a pinned Python version drifts below requires-python; let uv
         resolve the project's interpreter from .python-version/requires-python.

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -93,7 +93,9 @@ class TestIssueMetadataScaffold:
         content = script.read_text()
         assert "branches/main/protection" in content
         assert "Copilot code review" in content
-        assert "Validate PR / Check PR title, branch, and linked issue" in content
+        # Bare check-run name GitHub actually reports — not the "Validate PR /"
+        # prefixed form, which never matched and left main `blocked` (PI #555).
+        assert "Check PR title, branch, and linked issue" in content
 
     def test_project_init_references_github_setup(self):
         content = (self.target / ".claude" / "project-init.md").read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/uv.lock
+++ b/uv.lock
@@ -431,24 +431,30 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+docs = [
+    { name = "mkdocs-material" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
-docs = [
-    { name = "mkdocs-material" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.6" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "rich", specifier = ">=13.7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["docs"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "ruff", specifier = ">=0.4" },
+]
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
## Summary

Resolves all five open `bug`-labelled issues (surfaced while scaffolding a fresh project with project-init 0.5.2), and cuts the **v0.5.3** bug-fix release (plugin payload **v0.1.1**).

| Issue | Problem | Fix |
|---|---|---|
| **#552** | `session_setup.sh` ran `uv sync --extra dev`, but scaffolded projects declare `dev` as a PEP 735 `[dependency-groups]` table → errors, then silent dev-less venv | `uv sync --group dev` in both hook copies (plugin payload + fallback template); dogfooded the same layout in this repo (pyproject → dependency-group, root justfile + CI → `--group dev`, relocked) |
| **#553** | `2>/dev/null \|\| uv sync` masked the failure and reported false success, caching the stamp so the next session never retried | Removed the masking fallback — a real failure now surfaces via the existing "bootstrap failed" branch |
| **#554** | Fresh scaffold failed its first gitleaks CI run (high-entropy sha256 hashes in the generated `.claude/config.yaml` manifest) | Ship `templates/base/.gitleaks.toml` extending the default ruleset + allowlisting the scaffold record |
| **#555** | `setup_github.sh --protect` left main permanently `blocked` (matrix legs never matched the required contexts; `review/decision` unsatisfiable solo) | Added an all-green **CI gate** job that `needs:` the matrix + secret scan; require that single, matrix-robust context plus the bare PR-format check; dropped `review/decision` |
| **#556** | Board number hardcoded `1` across four places that disagreed → split board state on any non-#1 board | Made `.claude/config.yaml github_project_number` the single source of truth read by `board-automation.yml`, `create_issue.sh`, and `setup_github.sh` (env `PROJECT_NUMBER` still overrides). Also surfaced the real GraphQL error in field provisioning instead of swallowing it |

## Release

Bumps scaffolder `0.5.2 → 0.5.3` (`pyproject.toml`, `__init__.py`, `CITATION.cff`, lockfile) and the `project-init-workflow` plugin payload `0.1.0 → 0.1.1` (its `session_setup.sh` hook changed). Tagging `v0.5.3` after merge triggers `release.yml` → PyPI trusted publishing.

## How existing (pre-fix) projects pick this up

- **Template fixes** (gitleaks config, `setup_github.sh`, `board-automation.yml`, `ci.yml`, fallback hook): run `project-init upgrade` (or `uvx project-init@0.5.3 upgrade`) in the target project. Note `ci.yml`/`setup_github.sh` are overwritten on upgrade unless listed in the project's `preserve:` globs.
- **Plugin hook fix** (default plugin mode): a Claude Code plugin update pulls `project-init-workflow` v0.1.1.

## Tests

- Full suite **1623 passed** (the only 2 failures are pre-existing — they require the `gh` CLI, which isn't installed in the dev sandbox; they pass in CI).
- Added focused coverage for each fix: hook dependency-sync contract, the CI gate job, the board-number SSOT, the shipped gitleaks config, and the corrected required-check contexts.
- Intentionally-edited files are carved out of the frozen byte-identity baselines (the maintainer-intended mechanism, matching the existing `settings.json`/`CAPABILITIES.md` carve-outs) — baselines were **not** regenerated.

Closes #552
Closes #553
Closes #554
Closes #555
Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPMpc7YfPd3SrwMsMHfWWE)_