### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 0.5.3
+version: 0.6.0

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.5.3"
+version = "0.6.0"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,8 +1,8 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.1.1"
+__plugin_version__ = "0.2.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## What & why

The `0.5.3` version bump from #556 was never tagged/released (the last published GitHub Release / PyPI version is `v0.5.2`). This PR absorbs that pending bump plus everything merged in #566 (mypy --strict, Rust language support, TypeScript strict scaffold, strict `.golangci.yml`, shellcheck+shfmt gate, mutmut activation, Semgrep, the package-existence supply-chain guard) into a single release.

Minor bump (`0.6.0`, not a patch) since this is new backward-compatible functionality, not just fixes.

Also bumps the `project-init-workflow` plugin (`0.1.1` → `0.2.0`): its payload gained a new hook (`package_guard.py`).

## Changes

- `pyproject.toml`: `version = "0.6.0"`
- `src/project_init/__init__.py`: `__version__ = "0.6.0"`, `__plugin_version__ = "0.2.0"`
- `plugins/project-init-workflow/.claude-plugin/plugin.json`: `"version": "0.2.0"`
- `CITATION.cff`: `version: 0.6.0`
- `uv.lock`: self-reference synced

All three version-sync points (`pyproject.toml` / `__init__.py` / `CITATION.cff`) are covered by `tests/contracts/test_release_engineering.py`'s existing consistency tests — verified passing locally.

## Next step after merge

Tag `v0.6.0` and push the tag to trigger `.github/workflows/release.yml` (build, changelog via git-cliff, GitHub Release, PyPI publish via trusted OIDC publishing).

## Checklist

- [x] `just ci` passes locally (only pre-existing `gh`-CLI-unavailable failures remain, unrelated to this change)
- [x] Commit title follows Conventional Commits (`chore: description`, no scope — no issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9tJV9FobSzP1Spnhxte3)_