### PR TITLE
chore(PI-569): enforce a blocking test coverage threshold in CI

### DIFF
--- a/templates/base/bunfig.toml.tmpl
+++ b/templates/base/bunfig.toml.tmpl
@@ -1,0 +1,9 @@
+{{#if node}}# bunfig.toml — quality gates for project code (scaffolded by project-init).
+# `bun test` picks this up automatically, so the coverage gate needs no extra
+# CLI flag anywhere (justfile, CI, or a developer's terminal) — PI-569.
+
+[test]
+coverage = true
+# Tune to your project's baseline, same as ruff/mypy/golangci's thresholds.
+coverageThreshold = 0.7
+{{/if node}}

--- a/templates/base/bunfig.toml.tmpl
+++ b/templates/base/bunfig.toml.tmpl
@@ -6,4 +6,9 @@
 coverage = true
 # Tune to your project's baseline, same as ruff/mypy/golangci's thresholds.
 coverageThreshold = 0.7
+# Explicit, not relying on the current default (verified byte-identical
+# report either way on bun 1.3.11 — set anyway so a future bun version
+# changing that default can't silently start counting *.test.ts lines
+# toward the gate).
+coverageSkipTestFiles = true
 {{/if node}}

--- a/templates/base/dot_claude/rules/go.md
+++ b/templates/base/dot_claude/rules/go.md
@@ -9,6 +9,7 @@ alwaysApply: false
 ```bash
 go build ./...
 go test ./... -count=1
+just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always runs this
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
 golangci-lint fmt   # gofumpt (stricter than gofmt) — no separate binary needed
 ```

--- a/templates/base/dot_claude/rules/python.md
+++ b/templates/base/dot_claude/rules/python.md
@@ -16,6 +16,7 @@ uv run ruff format .              # format
 uv run --with "mypy>=1.10" mypy src/  # type check (strict mode, per mypy.ini)
 uv run pytest -n auto -q          # tests (parallel mode, requires pytest-xdist)
 uv run pytest -q --tb=short       # tests (single-threaded fallback)
+just test-cov                     # tests + coverage gate (>= 70%, per justfile) — CI always runs this
 ```
 
 ruff lints; it does not type-check. `just typecheck` (mypy, strict) is a separate

--- a/templates/base/dot_claude/rules/rust.md
+++ b/templates/base/dot_claude/rules/rust.md
@@ -9,9 +9,14 @@ alwaysApply: false
 ```bash
 cargo build
 cargo test
+cargo llvm-cov --fail-under-lines 70              # tests + coverage gate — CI always runs this (`just test-cov`)
 cargo clippy -- -D warnings -D clippy::pedantic   # pedantic + cognitive-complexity gate per clippy.toml
 cargo fmt --check                                 # verifies only; `cargo fmt` (no flag) writes changes
 ```
+
+`cargo llvm-cov` needs `cargo install cargo-llvm-cov` + `rustup component add
+llvm-tools-preview` once locally; CI installs both per-run (a prebuilt binary,
+not a source compile).
 
 The compiler is the type checker — no separate strict-mode gate needed.
 `-D warnings` (`.cargo/config.toml`) is the Rust analog to `mypy --strict` /

--- a/templates/base/dot_claude/rules/typescript.md
+++ b/templates/base/dot_claude/rules/typescript.md
@@ -9,6 +9,7 @@ alwaysApply: false
 ```bash
 bunx tsc --noEmit   # type check (strict mode, per tsconfig.base.json)
 bunx eslint .        # lint (type-aware: no-floating-promises, no-unsafe-*, per eslint.config.mjs)
+bun test             # tests + coverage gate (>= 70%, per bunfig.toml) — always on, no extra flag needed
 ```
 
 `tsconfig.base.json` is a direct structural analog to `mypy --strict` /

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -133,18 +133,14 @@ jobs:
       - name: Typecheck
         run: just typecheck
 
-      # Coverage gate (PI-138): activates automatically once pytest-cov is in
-      # dev dependencies; runs plain tests until then. Tune --cov-fail-under
-      # in the justfile's test-cov recipe to your project's baseline.
+      # Coverage gate (PI-138/PI-569): always on, not conditional — pytest-cov
+      # is pulled in ephemerally via `uv run --with`, the same pattern mypy
+      # (PI-558) and mutmut (PI-563) use, so there's no dev-dependency to
+      # forget to add. Tune --cov-fail-under in the justfile's test-cov
+      # recipe to your project's baseline; it no-ops on a fresh scaffold with
+      # no src/ yet (same guard as typecheck).
       - name: Tests — parallel, coverage-gated
-        run: |
-          if uv run python -c "import pytest_cov" 2>/dev/null; then
-            just test-cov
-          else
-            echo "pytest-cov not installed — running without the coverage gate."
-            echo "Add pytest-cov to dev dependencies to enable it."
-            just test
-          fi
+        run: just test-cov
 {{/if python}}
 {{#if node}}
       - name: Install Bun
@@ -215,15 +211,18 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v4
 
-      - name: Tests
-        run: just test
+      # Coverage-gated (PI-569) — go tool cover ships with the Go toolchain
+      # the setup-go action just installed, nothing extra to provision.
+      - name: Tests — coverage-gated
+        run: just test-cov
 {{/if go}}
 {{#if rust}}
       # Bundles Swatinem/rust-cache internally — no separate cache step needed.
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy, rustfmt
+          # llvm-tools-preview: required by cargo-llvm-cov (PI-569).
+          components: clippy, rustfmt, llvm-tools-preview
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
       - name: Install shfmt
@@ -236,11 +235,18 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v4
 
+      # Prebuilt binary — avoids a ~1min `cargo install` compile per run.
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
       - name: Lint
         run: just lint
 
-      - name: Tests
-        run: just test
+      # Coverage-gated (PI-569).
+      - name: Tests — coverage-gated
+        run: just test-cov
 {{/if rust}}
 
       - name: Post failure summary

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -25,9 +25,11 @@ format:
 test:
     uv run --with pytest-xdist pytest -n auto --tb=short -q
 
-# tests with the coverage gate (CI runs this when pytest-cov is installed)
+# tests with the coverage gate (CI always runs this, not `test` — PI-569).
+# no-op on a fresh scaffold with no src/ yet, same guard as `typecheck`:
+# 0% coverage on zero code would trip --cov-fail-under before any code exists.
 test-cov:
-    uv run --with pytest-xdist --with pytest-cov pytest -n auto --tb=short -q --cov --cov-fail-under=70
+    if [ -d src ]; then uv run --with pytest-xdist --with pytest-cov pytest -n auto --tb=short -q --cov=src --cov-fail-under=70; else echo "No src/ directory yet — nothing to measure coverage on."; fi
 
 # mutation testing on core logic (slow; requires [tool.mutmut] source_paths
 # in your own pyproject.toml, scoped to deterministic pure-logic modules —
@@ -36,6 +38,9 @@ test-mutation:
     uv run --with mutmut mutmut run
     uv run --with mutmut mutmut export-cicd-stats
 
+# what CI runs
+ci: lint typecheck test-cov
+
 # serve the docs site locally
 docs:
     uv run --with mkdocs-material --with "mkdocstrings[python]" mkdocs serve
@@ -43,9 +48,6 @@ docs:
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
-
-# what CI runs
-ci: lint typecheck test
 
 # regenerate .claude/docs/CODE_MAP.md (low-token "what does what" map; read before grepping)
 code-map:
@@ -72,7 +74,7 @@ typecheck:
 format:
     bunx @biomejs/biome format --write .
 
-# run the test suite
+# run the test suite (coverage-gated per bunfig.toml — PI-569)
 test:
     bun test
 
@@ -109,6 +111,12 @@ format:
 test:
     go test ./...
 
+# tests with the coverage gate (CI always runs this, not `test` — PI-569).
+# tune the "70" threshold to your project's baseline.
+test-cov:
+    go test -coverprofile=coverage.out ./...
+    go tool cover -func=coverage.out | tail -1 | awk '{ pct = $3; sub("%", "", pct); if (pct + 0 < 70) { print "Coverage " pct "% is below the 70% gate"; exit 1 } else { print "Coverage " pct "% meets the 70% gate" } }'
+
 # docs: nothing to build — pkg.go.dev renders doc comments
 docs:
     @echo "pkg.go.dev renders Go doc comments — nothing to build locally"
@@ -118,7 +126,7 @@ scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
 # what CI runs
-ci: lint test
+ci: lint test-cov
 {{/if go}}{{#if rust}}# justfile — the canonical command interface (scaffolded by project-init).
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
@@ -145,6 +153,13 @@ format:
 test:
     cargo test
 
+# tests with the coverage gate (CI always runs this, not `test` — PI-569).
+# requires cargo-llvm-cov: `cargo install cargo-llvm-cov` + `rustup component
+# add llvm-tools-preview`, once, on your machine (CI installs it per-run).
+# tune the "70" threshold to your project's baseline.
+test-cov:
+    cargo llvm-cov --fail-under-lines 70
+
 # docs: nothing to build locally — docs.rs renders published crate docs
 docs:
     @echo "docs.rs renders published crate docs — nothing to build locally"
@@ -154,7 +169,7 @@ scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
 # what CI runs
-ci: lint test
+ci: lint test-cov
 {{/if rust}}{{#if delivery_service}}
 # --- container parity (delivery=service): same image local and in cloud ---
 

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -115,7 +115,7 @@ test:
 # tune the "70" threshold to your project's baseline.
 test-cov:
     go test -coverprofile=coverage.out ./...
-    go tool cover -func=coverage.out | tail -1 | awk '{ pct = $3; sub("%", "", pct); if (pct + 0 < 70) { print "Coverage " pct "% is below the 70% gate"; exit 1 } else { print "Coverage " pct "% meets the 70% gate" } }'
+    go tool cover -func=coverage.out | tail -n 1 | awk '{ pct = $3; sub("%", "", pct); if (pct + 0 < 70) { print "Coverage " pct "% is below the 70% gate"; exit 1 } else { print "Coverage " pct "% meets the 70% gate" } }'
 
 # docs: nothing to build — pkg.go.dev renders doc comments
 docs:

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -26,10 +26,13 @@ test:
     uv run --with pytest-xdist pytest -n auto --tb=short -q
 
 # tests with the coverage gate (CI always runs this, not `test` — PI-569).
-# no-op on a fresh scaffold with no src/ yet, same guard as `typecheck`:
-# 0% coverage on zero code would trip --cov-fail-under before any code exists.
+# without src/ yet, still run the plain test suite (tests/ may exist before
+# src/ does) — only the coverage instrumentation/threshold is skipped, since
+# 0% coverage on zero application code would trip --cov-fail-under before any
+# code exists. Silently skipping pytest entirely here would let a real test
+# failure through `just ci` unnoticed.
 test-cov:
-    if [ -d src ]; then uv run --with pytest-xdist --with pytest-cov pytest -n auto --tb=short -q --cov=src --cov-fail-under=70; else echo "No src/ directory yet — nothing to measure coverage on."; fi
+    if [ -d src ]; then uv run --with pytest-xdist --with pytest-cov pytest -n auto --tb=short -q --cov=src --cov-fail-under=70; else uv run --with pytest-xdist pytest -n auto --tb=short -q; fi
 
 # mutation testing on core logic (slow; requires [tool.mutmut] source_paths
 # in your own pyproject.toml, scoped to deterministic pure-logic modules —

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -33,9 +33,7 @@ _COMMANDS = {
 
 
 def _scaffold_language(target: Path, language: str) -> Path:
-    flags = {
-        lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")
-    }
+    flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
     lint, fmt, test = _COMMANDS.get(language, ("", "", ""))
     variables = fallback_variables(
         language=language, lint_command=lint, format_command=fmt, test_command=test, **flags
@@ -70,10 +68,12 @@ class TestJustfilePerLanguage:
         assert "gitleaks git --pre-commit" in _recipe_body(text, "scan")
 
     def test_ci_recipe_is_pure_dependency(self, tmp_path: Path):
-        """`ci: lint typecheck test` — recipes referencing recipes, no duplicated commands."""
+        """`ci: lint typecheck test-cov` — recipes referencing recipes, no
+        duplicated commands. `test-cov`, not `test` (PI-569): CI must always
+        run the coverage-gated variant."""
         target = _scaffold_language(tmp_path / "p", "python")
         text = (target / "justfile").read_text()
-        assert re.search(r"^ci: lint typecheck test\s*$", text, re.MULTILINE)
+        assert re.search(r"^ci: lint typecheck test-cov\s*$", text, re.MULTILINE)
 
     def test_node_ci_recipe_includes_typecheck(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "node")
@@ -94,6 +94,18 @@ class TestJustfilePerLanguage:
         target = _scaffold_language(tmp_path / "p", "python")
         text = (target / "justfile").read_text()
         assert "--cov-fail-under" in _recipe_body(text, "test-cov")
+
+    def test_go_ci_recipe_uses_coverage_variant(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "g", "go")
+        text = (target / "justfile").read_text()
+        assert re.search(r"^ci: lint test-cov\s*$", text, re.MULTILINE)
+        assert "go tool cover -func" in _recipe_body(text, "test-cov")
+
+    def test_rust_ci_recipe_uses_coverage_variant(self, tmp_path: Path):
+        target = _scaffold_language(tmp_path / "r", "rust")
+        text = (target / "justfile").read_text()
+        assert re.search(r"^ci: lint test-cov\s*$", text, re.MULTILINE)
+        assert "cargo llvm-cov --fail-under-lines" in _recipe_body(text, "test-cov")
 
     def test_python_test_recipe_is_self_contained(self, tmp_path: Path):
         """PI-180: `-n auto` needs pytest-xdist; pull it in on demand so a

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -117,6 +117,17 @@ class TestJustfilePerLanguage:
             assert "-n auto" in body
             assert "--with pytest-xdist" in body, f"{recipe} must not require a declared xdist"
 
+    def test_python_coverage_recipe_still_runs_tests_without_src(self, tmp_path: Path):
+        """PI-569 review fix: a project can have tests/ before src/ exists —
+        the missing-src/ guard must drop only the coverage flags, not skip
+        pytest entirely (that would let a real test failure through `just
+        ci`/`test-cov` silently)."""
+        target = _scaffold_language(tmp_path / "p", "python")
+        body = _recipe_body((target / "justfile").read_text(), "test-cov")
+        assert "if [ -d src ]" in body
+        else_branch = body.split("else", 1)[1]
+        assert "pytest" in else_branch, "the no-src/ branch must still invoke pytest"
+
     def test_python_setup_uses_dependency_group(self, tmp_path: Path):
         """PI-209: dev deps live in [dependency-groups] (what `uv add --dev`
         writes), so `setup` must `uv sync --group dev`, not `--extra dev`."""

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -169,6 +169,9 @@ class TestNodeToolchain:
         config = tomllib.loads((self.target / "bunfig.toml").read_text())
         assert config["test"]["coverage"] is True
         assert config["test"]["coverageThreshold"] == 0.7
+        # PI-569 review fix: explicit, not relying on bun's current default —
+        # a *.test.ts file must never count toward the application-code gate.
+        assert config["test"]["coverageSkipTestFiles"] is True
 
 
 class TestGoToolchain:

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -96,6 +96,7 @@ class TestPythonToolchain:
         assert not (self.target / "typedoc.json").exists()
         assert not (self.target / "clippy.toml").exists()
         assert not (self.target / "tsconfig.base.json").exists()
+        assert not (self.target / "bunfig.toml").exists()
 
 
 class TestNodeToolchain:
@@ -162,6 +163,13 @@ class TestNodeToolchain:
         assert not (self.target / "mypy.ini").exists()
         assert not (self.target / "clippy.toml").exists()
 
+    def test_bunfig_coverage_gate_rendered(self):
+        """PI-569: `bun test` picks up bunfig.toml automatically — no extra
+        CLI flag needed anywhere (justfile, CI, or a developer's terminal)."""
+        config = tomllib.loads((self.target / "bunfig.toml").read_text())
+        assert config["test"]["coverage"] is True
+        assert config["test"]["coverageThreshold"] == 0.7
+
 
 class TestGoToolchain:
     @pytest.fixture(autouse=True)
@@ -202,6 +210,18 @@ class TestGoToolchain:
         assert not (self.target / "mypy.ini").exists()
         assert not (self.target / "clippy.toml").exists()
         assert not (self.target / "tsconfig.base.json").exists()
+        assert not (self.target / "bunfig.toml").exists()
+
+    def test_coverage_gate_wired(self):
+        """PI-569: blocking, not conditional — go tool cover ships with the
+        Go toolchain, nothing extra to provision."""
+        justfile = (self.target / "justfile").read_text()
+        assert "test-cov:" in justfile
+        assert "go tool cover -func" in justfile
+        assert "ci: lint test-cov" in justfile
+
+        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just test-cov" in ci
 
 
 class TestRustToolchain:
@@ -232,6 +252,21 @@ class TestRustToolchain:
         assert not (self.target / "mypy.ini").exists()
         assert not (self.target / ".golangci.yml").exists()
         assert not (self.target / "tsconfig.base.json").exists()
+        assert not (self.target / "bunfig.toml").exists()
+
+    def test_coverage_gate_wired(self):
+        """PI-569: blocking, not conditional — CI installs cargo-llvm-cov as
+        a prebuilt binary (taiki-e/install-action), no source compile."""
+        justfile = (self.target / "justfile").read_text()
+        assert "test-cov:" in justfile
+        assert "cargo llvm-cov --fail-under-lines" in justfile
+        assert "ci: lint test-cov" in justfile
+
+        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just test-cov" in ci
+        assert "taiki-e/install-action" in ci
+        assert "cargo-llvm-cov" in ci
+        assert "llvm-tools-preview" in ci
 
 
 class TestNoLanguage:
@@ -251,6 +286,7 @@ class TestNoLanguage:
             ".cargo/config.toml",
             "tsconfig.base.json",
             "tsconfig.json",
+            "bunfig.toml",
             ".github/workflows/docs.yml",
         ):
             assert not (target / name).exists(), f"{name} must not render for language=none"
@@ -314,8 +350,15 @@ class TestCiQualityGates:
         self.ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
 
     def test_coverage_gate_present(self):
-        assert "--cov-fail-under" in self.ci
-        assert "pytest_cov" in self.ci, "gate must activate only when pytest-cov is installed"
+        """PI-569: unconditional, not gated on pytest-cov happening to be a
+        persisted dev dependency — `--with pytest-cov` ephemeral-installs it
+        the same way mypy/mutmut are ephemeral-installed."""
+        assert "just test-cov" in self.ci
+        assert "if uv run python -c" not in self.ci, "coverage gate must not be conditional"
+
+        justfile = (self.target / "justfile").read_text()
+        assert "--cov-fail-under" in justfile
+        assert "--cov=src" in justfile
 
     def test_mutmut_job_active_and_non_blocking(self):
         """PI-563: mutmut graduated from a commented placeholder to a real,


### PR DESCRIPTION
## Summary

Stacked on #571 (PI-570) — this PR's diff is coverage-gate-only; #571 needs to merge first, then this PR's base should be retargeted to `main`.

Found and fixed a real dead-gate bug while implementing this: the Python coverage gate (PI-138) was conditional on `import pytest_cov` succeeding in the *persisted* venv, but `test-cov`'s own command ephemeral-installs pytest-cov via `uv run --with` — so that check always failed and every scaffolded project silently ran plain `test` in CI, never the coverage-gated variant. The gate has been dead code since it shipped.

**Changed:**
- **python**: `test-cov` unconditional in CI (`just test-cov`, not the `import pytest_cov`-gated branch); `just ci` now runs `test-cov`. Guarded for a fresh scaffold with no `src/` yet — verified `--cov-fail-under=70` fails hard with 0% coverage on an empty project before the fix, same class of bug as the PI-558 mypy fresh-scaffold issue.
- **node**: new `bunfig.toml` (`coverage = true`, `coverageThreshold = 0.7`) — `bun test` enforces it automatically, verified it exits 1 when coverage is under threshold and exits 0 when the threshold is loosened, no separate recipe or CLI flag needed.
- **go**: new `test-cov` recipe — `go test -coverprofile` + `go tool cover -func` piped through an awk threshold check, verified against real partial coverage (50% output correctly fails a 70% gate, passes a 40% gate).
- **rust**: new `test-cov` recipe — `cargo llvm-cov --fail-under-lines`, verified against real partial coverage. CI installs `cargo-llvm-cov` as a prebuilt binary via `taiki-e/install-action` (not a source compile, ~1 min saved per run) plus the `llvm-tools-preview` component it needs.

All four thresholds default to 70%, matching the pre-existing (if previously dead) Python baseline.

## Test plan

- [x] Full suite green except the two pre-existing `gh`-CLI-unavailable failures (environmental, predate this change)
- [x] Verified the pre-fix bug: `--cov-fail-under` failing on a fresh scaffold with no `src/`, and the conditional never actually enabling in the first place
- [x] Every new coverage command verified against a real partial-coverage sample with the actual tool installed (pytest-cov, bun 1.3.11, go 1.24, cargo-llvm-cov 0.8.7) — confirmed each correctly passes above threshold and fails below it

Closes #569


---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9tJV9FobSzP1Spnhxte3)_