### PR TITLE
chore(PI-568): add dependency vulnerability (CVE/advisory) scanning to CI

### DIFF
--- a/templates/base/dot_claude/rules/go.md
+++ b/templates/base/dot_claude/rules/go.md
@@ -10,6 +10,12 @@ alwaysApply: false
 go build ./...
 go test ./... -count=1
 just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always runs this
+just audit          # dependency CVE/advisory scan (govulncheck) — CI always runs this
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
 golangci-lint fmt   # gofumpt (stricter than gofmt) — no separate binary needed
 ```
+
+`govulncheck` (`go install golang.org/x/vuln/cmd/govulncheck@latest`) only
+reports vulnerabilities actually reachable from your code, not every
+advisory touching a transitive dependency — a lower false-positive rate than
+a plain dependency-list scan.

--- a/templates/base/dot_claude/rules/python.md
+++ b/templates/base/dot_claude/rules/python.md
@@ -17,6 +17,7 @@ uv run --with "mypy>=1.10" mypy src/  # type check (strict mode, per mypy.ini)
 uv run pytest -n auto -q          # tests (parallel mode, requires pytest-xdist)
 uv run pytest -q --tb=short       # tests (single-threaded fallback)
 just test-cov                     # tests + coverage gate (>= 70%, per justfile) — CI always runs this
+just audit                        # dependency CVE/advisory scan (pip-audit) — CI always runs this
 ```
 
 ruff lints; it does not type-check. `just typecheck` (mypy, strict) is a separate

--- a/templates/base/dot_claude/rules/rust.md
+++ b/templates/base/dot_claude/rules/rust.md
@@ -10,13 +10,14 @@ alwaysApply: false
 cargo build
 cargo test
 cargo llvm-cov --fail-under-lines 70              # tests + coverage gate — CI always runs this (`just test-cov`)
+cargo audit                                       # dependency CVE/advisory scan (`just audit`) — CI always runs this
 cargo clippy -- -D warnings -D clippy::pedantic   # pedantic + cognitive-complexity gate per clippy.toml
 cargo fmt --check                                 # verifies only; `cargo fmt` (no flag) writes changes
 ```
 
-`cargo llvm-cov` needs `cargo install cargo-llvm-cov` + `rustup component add
-llvm-tools-preview` once locally; CI installs both per-run (a prebuilt binary,
-not a source compile).
+`cargo llvm-cov`/`cargo audit` need `cargo install cargo-llvm-cov cargo-audit`
++ `rustup component add llvm-tools-preview` once locally; CI installs all of
+it per-run (prebuilt binaries, not a source compile).
 
 The compiler is the type checker — no separate strict-mode gate needed.
 `-D warnings` (`.cargo/config.toml`) is the Rust analog to `mypy --strict` /

--- a/templates/base/dot_claude/rules/rust.md
+++ b/templates/base/dot_claude/rules/rust.md
@@ -15,9 +15,11 @@ cargo clippy -- -D warnings -D clippy::pedantic   # pedantic + cognitive-complex
 cargo fmt --check                                 # verifies only; `cargo fmt` (no flag) writes changes
 ```
 
-`cargo llvm-cov`/`cargo audit` need `cargo install cargo-llvm-cov cargo-audit`
-+ `rustup component add llvm-tools-preview` once locally; CI installs all of
-it per-run (prebuilt binaries, not a source compile).
+`cargo llvm-cov` needs `cargo install cargo-llvm-cov` + `rustup component add
+llvm-tools-preview` once locally; `cargo audit` only needs `cargo install
+cargo-audit` (no llvm-tools-preview — that component is specific to
+llvm-cov's instrumentation, not the advisory-database lookup `cargo audit`
+does). CI installs both binaries per-run (prebuilt, not a source compile).
 
 The compiler is the type checker — no separate strict-mode gate needed.
 `-D warnings` (`.cargo/config.toml`) is the Rust analog to `mypy --strict` /

--- a/templates/base/dot_claude/rules/typescript.md
+++ b/templates/base/dot_claude/rules/typescript.md
@@ -10,6 +10,7 @@ alwaysApply: false
 bunx tsc --noEmit   # type check (strict mode, per tsconfig.base.json)
 bunx eslint .        # lint (type-aware: no-floating-promises, no-unsafe-*, per eslint.config.mjs)
 bun test             # tests + coverage gate (>= 70%, per bunfig.toml) — always on, no extra flag needed
+bun audit            # dependency CVE/advisory scan — CI always runs this
 ```
 
 `tsconfig.base.json` is a direct structural analog to `mypy --strict` /

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -141,6 +141,13 @@ jobs:
       # no src/ yet (same guard as typecheck).
       - name: Tests — parallel, coverage-gated
         run: just test-cov
+
+      # Dependency vulnerability scan (PI-568). Complements package_guard.py,
+      # which only blocks installing a package that doesn't exist or looks
+      # typosquatted — this catches a real, correctly-spelled dependency
+      # already in the lockfile with a known CVE/advisory.
+      - name: Dependency vulnerability scan (pip-audit)
+        run: just audit
 {{/if python}}
 {{#if node}}
       - name: Install Bun
@@ -179,6 +186,10 @@ jobs:
 
       - name: Tests
         run: just test
+
+      # Dependency vulnerability scan (PI-568).
+      - name: Dependency vulnerability scan (bun audit)
+        run: just audit
 {{/if node}}
 {{#if go}}
       - name: Set up Go
@@ -215,6 +226,17 @@ jobs:
       # the setup-go action just installed, nothing extra to provision.
       - name: Tests — coverage-gated
         run: just test-cov
+
+      # Dependency vulnerability scan (PI-568). govulncheck is the official
+      # Go team tool — only reports vulnerabilities actually reachable from
+      # your code, not every advisory touching a transitive dependency.
+      - name: Install govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Dependency vulnerability scan (govulncheck)
+        run: just audit
 {{/if go}}
 {{#if rust}}
       # Bundles Swatinem/rust-cache internally — no separate cache step needed.
@@ -235,11 +257,12 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v4
 
-      # Prebuilt binary — avoids a ~1min `cargo install` compile per run.
-      - name: Install cargo-llvm-cov
+      # Prebuilt binaries — avoids a multi-minute `cargo install` compile per
+      # run for either tool.
+      - name: Install cargo-llvm-cov + cargo-audit
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,cargo-audit
 
       - name: Lint
         run: just lint
@@ -247,6 +270,11 @@ jobs:
       # Coverage-gated (PI-569).
       - name: Tests — coverage-gated
         run: just test-cov
+
+      # Dependency vulnerability scan against the RustSec advisory database
+      # (PI-568).
+      - name: Dependency vulnerability scan (cargo audit)
+        run: just audit
 {{/if rust}}
 
       - name: Post failure summary

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -41,8 +41,15 @@ test-mutation:
     uv run --with mutmut mutmut run
     uv run --with mutmut mutmut export-cicd-stats
 
+# dependency vulnerability scan against known CVEs/advisories (PI-568).
+# complements package_guard.py, which only blocks installing a package that
+# doesn't exist or looks typosquatted — this catches a real, correctly-
+# spelled dependency with a known vulnerability already in the lockfile.
+audit:
+    uv run --with pip-audit pip-audit
+
 # what CI runs
-ci: lint typecheck test-cov
+ci: lint typecheck test-cov audit
 
 # serve the docs site locally
 docs:
@@ -85,12 +92,16 @@ test:
 docs:
     bunx typedoc
 
+# dependency vulnerability scan against known CVEs/advisories (PI-568)
+audit:
+    bun audit
+
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
 # what CI runs
-ci: lint typecheck test
+ci: lint typecheck test audit
 {{/if node}}{{#if go}}# justfile — the canonical command interface (scaffolded by project-init).
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
@@ -124,12 +135,18 @@ test-cov:
 docs:
     @echo "pkg.go.dev renders Go doc comments — nothing to build locally"
 
+# dependency vulnerability scan against known CVEs/advisories (PI-568).
+# requires govulncheck: `go install golang.org/x/vuln/cmd/govulncheck@latest`
+# once, on your machine (CI installs it per-run).
+audit:
+    govulncheck ./...
+
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
 # what CI runs
-ci: lint test-cov
+ci: lint test-cov audit
 {{/if go}}{{#if rust}}# justfile — the canonical command interface (scaffolded by project-init).
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
@@ -167,12 +184,18 @@ test-cov:
 docs:
     @echo "docs.rs renders published crate docs — nothing to build locally"
 
+# dependency vulnerability scan against known CVEs/advisories (PI-568).
+# requires cargo-audit: `cargo install cargo-audit` once, on your machine
+# (CI installs it per-run as a prebuilt binary).
+audit:
+    cargo audit
+
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
 # what CI runs
-ci: lint test-cov
+ci: lint test-cov audit
 {{/if rust}}{{#if delivery_service}}
 # --- container parity (delivery=service): same image local and in cloud ---
 

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -68,18 +68,20 @@ class TestJustfilePerLanguage:
         assert "gitleaks git --pre-commit" in _recipe_body(text, "scan")
 
     def test_ci_recipe_is_pure_dependency(self, tmp_path: Path):
-        """`ci: lint typecheck test-cov` — recipes referencing recipes, no
-        duplicated commands. `test-cov`, not `test` (PI-569): CI must always
-        run the coverage-gated variant."""
+        """`ci: lint typecheck test-cov audit` — recipes referencing recipes,
+        no duplicated commands. `test-cov`, not `test` (PI-569): CI must
+        always run the coverage-gated variant. `audit` (PI-568): CI must
+        always run the dependency vulnerability scan too."""
         target = _scaffold_language(tmp_path / "p", "python")
         text = (target / "justfile").read_text()
-        assert re.search(r"^ci: lint typecheck test-cov\s*$", text, re.MULTILINE)
+        assert re.search(r"^ci: lint typecheck test-cov audit\s*$", text, re.MULTILINE)
 
     def test_node_ci_recipe_includes_typecheck(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "node")
         text = (target / "justfile").read_text()
-        assert re.search(r"^ci: lint typecheck test\s*$", text, re.MULTILINE)
+        assert re.search(r"^ci: lint typecheck test audit\s*$", text, re.MULTILINE)
         assert "tsc --noEmit" in _recipe_body(text, "typecheck")
+        assert "bun audit" in _recipe_body(text, "audit")
 
     def test_python_typecheck_tolerates_missing_src(self, tmp_path: Path):
         """A fresh scaffold has no src/ yet — `mypy src/` errors on a missing
@@ -98,14 +100,16 @@ class TestJustfilePerLanguage:
     def test_go_ci_recipe_uses_coverage_variant(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "g", "go")
         text = (target / "justfile").read_text()
-        assert re.search(r"^ci: lint test-cov\s*$", text, re.MULTILINE)
+        assert re.search(r"^ci: lint test-cov audit\s*$", text, re.MULTILINE)
         assert "go tool cover -func" in _recipe_body(text, "test-cov")
+        assert "govulncheck ./..." in _recipe_body(text, "audit")
 
     def test_rust_ci_recipe_uses_coverage_variant(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "r", "rust")
         text = (target / "justfile").read_text()
-        assert re.search(r"^ci: lint test-cov\s*$", text, re.MULTILINE)
+        assert re.search(r"^ci: lint test-cov audit\s*$", text, re.MULTILINE)
         assert "cargo llvm-cov --fail-under-lines" in _recipe_body(text, "test-cov")
+        assert "cargo audit" in _recipe_body(text, "audit")
 
     def test_python_test_recipe_is_self_contained(self, tmp_path: Path):
         """PI-180: `-n auto` needs pytest-xdist; pull it in on demand so a

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -389,6 +389,58 @@ class TestCiQualityGates:
         assert "mutation-tests:" not in ci
 
 
+class TestVulnerabilityScanGate:
+    """PI-568: dependency vulnerability (CVE/advisory) scan per language,
+    blocking — part of the single `lint-and-test` job so ci-gate's existing
+    `needs: [lint-and-test, ...]` covers it with no gate-list change needed."""
+
+    def test_python_audit_wired(self, tmp_target: Path):
+        target = _scaffold_language(tmp_target, "python")
+        justfile = (target / "justfile").read_text()
+        assert "audit:" in justfile
+        assert "pip-audit" in justfile
+        assert "ci: lint typecheck test-cov audit" in justfile
+
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just audit" in ci
+
+    def test_node_audit_wired(self, tmp_target: Path):
+        target = _scaffold_language(tmp_target, "node")
+        justfile = (target / "justfile").read_text()
+        assert "audit:" in justfile
+        assert "bun audit" in justfile
+        assert "ci: lint typecheck test audit" in justfile
+
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just audit" in ci
+
+    def test_go_audit_wired(self, tmp_target: Path):
+        target = _scaffold_language(tmp_target, "go")
+        justfile = (target / "justfile").read_text()
+        assert "audit:" in justfile
+        assert "govulncheck ./..." in justfile
+        assert "ci: lint test-cov audit" in justfile
+
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just audit" in ci
+        assert "golang.org/x/vuln/cmd/govulncheck" in ci
+
+    def test_rust_audit_wired(self, tmp_target: Path):
+        target = _scaffold_language(tmp_target, "rust")
+        justfile = (target / "justfile").read_text()
+        assert "audit:" in justfile
+        assert "cargo audit" in justfile
+        assert "ci: lint test-cov audit" in justfile
+
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just audit" in ci
+        assert "cargo-audit" in ci
+
+    def test_audit_absent_for_no_language(self, tmp_target: Path):
+        target = _scaffold_language(tmp_target, "none")
+        assert not (target / "justfile").exists()
+
+
 class TestBashLintGate:
     """PI-562: shellcheck + shfmt gate .claude/**/*.sh regardless of language —
     bash agent infra always ships, so the gate isn't tied to any one language."""


### PR DESCRIPTION
## Summary

Stacked on #572 (PI-569) — this PR's diff is audit-gate-only; #572 needs to merge first, then this PR's base should be retargeted to `main`.

New `audit` recipe per language, wired blocking into `just ci` and CI (part of the existing `lint-and-test` job as a step, so `ci-gate`'s `needs: [lint-and-test, ...]` already covers it — no gate-list change needed):

- **python**: `pip-audit`, scanning the just-synced venv directly (no separate requirements file needed) — verified against a real known-CVE `requests==2.19.1` pin.
- **node**: `bun audit` — verified against a real known-CVE `lodash==4.17.15`.
- **go**: `govulncheck` (the official Go team tool — only reports advisories actually reachable from your code via call-graph analysis, not every advisory touching a transitive dependency, so a lower false-positive rate than a plain dependency-list scan). Installed via `go install` + `$GITHUB_PATH` export in CI.
- **rust**: `cargo audit` against the RustSec advisory database. CI installs both `cargo-llvm-cov` and `cargo-audit` as prebuilt binaries via `taiki-e/install-action` (avoids a multi-minute `cargo install` source compile for either).

**Known verification gap, disclosed rather than glossed over:** go/rust's actual advisory-database fetch (`vuln.go.dev`, RustSec's `advisory-db` git clone) couldn't be exercised end-to-end in this sandbox — both hosts return 403 from this environment's network policy, unlike `pypi.org`/`registry.npmjs.org` which are allowlisted here. Both tools installed correctly and ran up to that network call (confirmed via `-version`/local dry runs); GitHub-hosted Actions runners have normal internet access to both, so this is a sandbox limitation, not a tooling gap — flagging it rather than claiming full parity with the python/node verification.

**Deliberately not attempting severity-tiered filtering** (e.g. "only fail on high/critical", as originally scoped in #568's issue text) — none of the four tools expose a clean built-in mechanism for it across their differently-shaped advisory data (CVSS scores aren't consistently present across PyPA/npm/RustSec/OSV-Go feeds), and hand-rolling four different JSON-parsing severity filters adds real fragility for unclear benefit. Fails on any reported advisory instead, the same standard gitleaks/semgrep already apply in this pipeline.

## Test plan

- [x] Full suite green except the two pre-existing `gh`-CLI-unavailable failures (environmental, predate this change)
- [x] pip-audit and bun audit verified end-to-end against real known-CVE dependencies (both correctly exit non-zero)
- [x] govulncheck and cargo-audit verified to install and run correctly; the actual advisory-database round-trip could not be exercised in this sandbox (see above)

Closes #568


---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9tJV9FobSzP1Spnhxte3)_