### PR TITLE
feat(PI-576): Add OpenSSF Scorecard as a scheduled CI job

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,9 +14,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Action refs in scaffolded workflow templates: the github-actions manager cannot parse them ({{#if}} blocks break YAML), so match uses: lines directly. Keeps the scaffolder from shipping stale action pins.",
+      "description": "Action refs in scaffolded workflow templates: the github-actions manager cannot parse them ({{#if}} blocks break YAML), so match uses: lines directly. Keeps the scaffolder from shipping stale action pins. The optional subpath group captures owner/repo as depName for subdirectory actions like github/codeql-action/upload-sarif (#576).",
       "managerFilePatterns": ["/^templates/.*\\.ya?ml\\.tmpl$/"],
-      "matchStrings": ["uses: (?<depName>[^/\\s]+/[^@/\\s]+)@(?<currentValue>v[\\d.]+)"],
+      "matchStrings": ["uses: (?<depName>[^/\\s]+/[^@/\\s]+)(?:/[^@\\s]+)?@(?<currentValue>v[\\d.]+)"],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver-coerced"
     }

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -5,9 +5,13 @@ on:
     branches: [{{base_branch}}]
   pull_request:
     branches: [{{base_branch}}]
-{{#if python}}
   schedule:
-    - cron: "0 3 * * *"  # nightly mutation-testing run (PI-138/#563)
+    # Weekly OpenSSF Scorecard security-posture run (#576). The scorecard job
+    # below is schedule-gated, so it never runs — or blocks — on a PR.
+    - cron: "0 4 * * 1"
+{{#if python}}
+    # Nightly mutation-testing run (PI-138/#563).
+    - cron: "0 3 * * *"
 {{/if python}}
   # Optimization: Only run CI when relevant files change
   # Uncomment and adjust paths as needed for your project
@@ -453,6 +457,47 @@ jobs:
           else
             semgrep scan --error --metrics=off $RULESETS
           fi
+
+  # OpenSSF Scorecard (#576): standardized security-posture scoring (branch
+  # protection, dependency pinning, SAST presence, token permissions, ...).
+  # Schedule-only + non-blocking (NOT in ci-gate's needs) — a score is
+  # informational, mirroring how semgrep/mutmut were introduced. It surfaces the
+  # signal that most of the gates already shipped here would score well against.
+  #
+  # publish_results is FALSE by default: turning a scaffolded project's score
+  # into a PUBLIC entry on the scorecard.dev dashboard is an explicit opt-in the
+  # project owner must choose, never something the scaffolder silently enables.
+  # To opt in, flip publish_results to true below (id-token: write is already
+  # granted so the OIDC upload to the public dashboard works).
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'schedule'
+    permissions:
+      security-events: write   # upload the SARIF result to code scanning
+      id-token: write          # only needed if publish_results is turned on
+      contents: read
+      actions: read            # Scorecard reads workflow/branch-protection state
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # PUBLIC-dashboard publishing stays OFF by default (#576) — flip to
+          # true only to deliberately publish this repo's score to scorecard.dev.
+          publish_results: false
+
+      # In-repo visibility: the score shows up under the Security → Code scanning
+      # tab without ever leaving the repository.
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
 
   # All-green gate (PI #555): the SINGLE required status check for branch
   # protection. Branch protection requires only "CI gate", so the required

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -385,7 +385,10 @@ class TestCiQualityGates:
     def test_mutmut_schedule_absent_for_other_languages(self, tmp_target: Path, language):
         target = _scaffold_language(tmp_target, language)
         ci = (target / ".github" / "workflows" / "ci.yml").read_text()
-        assert "cron:" not in ci, f"schedule trigger must not render for {language}"
+        # The nightly mutation cron is Python-only; the weekly Scorecard cron
+        # (#576) is language-agnostic, so assert on the mutation-specific pieces
+        # rather than the presence of any cron at all.
+        assert "0 3 * * *" not in ci, f"nightly mutation cron must not render for {language}"
         assert "mutation-tests:" not in ci
 
 

--- a/tests/contracts/test_scorecard.py
+++ b/tests/contracts/test_scorecard.py
@@ -1,0 +1,69 @@
+"""#576: OpenSSF Scorecard as a scheduled, non-blocking CI job.
+
+The job must be schedule-only (never per-PR), must NOT be in ci-gate's needs
+(informational, never blocks a merge), must default to publish_results: false
+(no scaffolded project's score becomes public without the owner opting in), and
+must upload SARIF to code scanning for in-repo visibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold_language(target: Path, language: str) -> Path:
+    flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+    scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags), strict=True)
+    return target
+
+
+def _ci(target: Path) -> str:
+    return (target / ".github" / "workflows" / "ci.yml").read_text()
+
+
+class TestScorecardJob:
+    @pytest.mark.parametrize("language", ["python", "node", "go", "rust", "none"])
+    def test_job_present_for_every_language(self, tmp_path: Path, language: str):
+        ci = _ci(_scaffold_language(tmp_path / "p", language))
+        assert "scorecard:" in ci
+        assert "ossf/scorecard-action" in ci
+
+    def test_scheduled_not_per_pr(self, tmp_path: Path):
+        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
+        # A weekly cron drives it, and the job itself is schedule-gated.
+        assert "0 4 * * 1" in ci
+        assert "if: github.event_name == 'schedule'" in ci
+
+    def test_weekly_cron_renders_for_every_language(self, tmp_path: Path):
+        # Unlike the Python-only nightly mutation cron, the weekly Scorecard cron
+        # is language-agnostic.
+        for language in ("python", "node", "go", "rust", "none"):
+            assert "0 4 * * 1" in _ci(_scaffold_language(tmp_path / language, language))
+
+    def test_publish_results_false_by_default(self, tmp_path: Path):
+        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
+        assert "publish_results: false" in ci
+        assert "publish_results: true" not in ci
+
+    def test_sarif_uploaded_to_code_scanning(self, tmp_path: Path):
+        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
+        assert "github/codeql-action/upload-sarif" in ci
+        assert "results.sarif" in ci
+
+    def test_non_blocking_not_in_ci_gate_needs(self, tmp_path: Path):
+        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
+        gate_start = ci.index("ci-gate:")
+        gate_needs_line = next(
+            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
+        )
+        assert "scorecard" not in gate_needs_line, "scorecard must stay non-blocking"
+
+    def test_renders_cleanly_no_template_markers(self, tmp_path: Path):
+        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
+        assert "{{#if" not in ci
+        assert "{{/if" not in ci


### PR DESCRIPTION
## Summary

Adds an **OpenSSF Scorecard** job to `ci.yml.tmpl` — a standardized, widely-recognized security-posture check (branch protection, dependency pinning, SAST presence, token permissions, …) that surfaces the signal most of the gates already shipped in #558–#570 would score well against.

- **Scheduled (weekly), not per-PR** — driven by a new `0 4 * * 1` cron and `if: github.event_name == 'schedule'`, so it never runs or blocks a PR.
- **Non-blocking** — not in `ci-gate`'s `needs`; a score is informational, mirroring how semgrep/mutmut were introduced.
- **`publish_results: false` by default** — turning a scaffolded project's score into a public `scorecard.dev` entry is an explicit opt-in the owner must choose; documented inline how to flip it.
- **SARIF uploaded to code scanning** via `github/codeql-action/upload-sarif` for in-repo visibility (Security → Code scanning).

## Supporting changes

- The weekly Scorecard cron is language-agnostic, so the `on: schedule` block now always renders. The nightly mutation-testing cron stays Python-only.
- Broadened the renovate custom-manager regex to extract `owner/repo` from subdirectory action refs (`github/codeql-action/upload-sarif`), so template action pins stay fresh — this is the first three-segment `uses:` ref in any template.

## Tests

- New `tests/contracts/test_scorecard.py`: job present for every language, schedule-gated, weekly cron renders for every language, `publish_results: false` default, SARIF upload present, non-blocking (absent from `ci-gate` needs), renders with no leftover template markers.
- Updated `test_mutmut_schedule_absent_for_other_languages` to assert the Python-only nightly cron is absent rather than any cron at all (the weekly Scorecard cron is now language-agnostic).

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1mEnAMkaABAqvoa9Qk8SG)_