### PR TITLE
feat(PI-575): Add SLSA build provenance attestation to release artifacts

### DIFF
--- a/templates/base/dot_github/workflows/deploy.yml.tmpl
+++ b/templates/base/dot_github/workflows/deploy.yml.tmpl
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # OIDC for the SLSA provenance attestation (#575)
+      attestations: write   # write the attestation for the pushed image
     outputs:
       image: ${{ steps.meta.outputs.image }}
       digest: ${{ steps.build.outputs.digest }}
@@ -51,6 +53,16 @@ jobs:
           tags: ${{ steps.meta.outputs.image }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Attest provenance for the exact digest being promoted (SLSA Build L3,
+      # #575). push-to-registry stores the attestation in GHCR next to the image
+      # so `gh attestation verify oci://<image>@<digest>` works for any puller.
+      - name: Attest build provenance (container image)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ steps.meta.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   # --- promote the SAME digest to staging automatically ---
   deploy-staging:

--- a/templates/base/dot_github/workflows/registry-publish.yml.tmpl
+++ b/templates/base/dot_github/workflows/registry-publish.yml.tmpl
@@ -17,6 +17,13 @@ jobs:
   publish:
     name: Build + push image to GHCR
     runs-on: ubuntu-24.04
+    # Job-level perms override the workflow block; id-token + attestations back
+    # the SLSA provenance attestation (#575).
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
 
@@ -36,6 +43,7 @@ jobs:
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push (SHA-pinned, by digest)
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -43,4 +51,14 @@ jobs:
           tags: ${{ steps.meta.outputs.image }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Attest provenance for the published image digest (SLSA Build L3, #575).
+      # push-to-registry stores it in GHCR so `gh attestation verify
+      # oci://<image>@<digest>` works for any puller.
+      - name: Attest build provenance (container image)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ steps.meta.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 {{/if deploy_registry}}

--- a/templates/base/dot_github/workflows/release.yml.tmpl
+++ b/templates/base/dot_github/workflows/release.yml.tmpl
@@ -10,6 +10,14 @@
 #      → Actions → Variables), or `gh variable set PUBLISH_ENABLED --body true`.
 #
 # Cutting a release: bump the version, then `git tag vX.Y.Z && git push --tags`.
+#
+# SLSA build provenance (#575): the release job attests the built wheel/sdist
+# with actions/attest-build-provenance — a first-party action using GitHub's own
+# OIDC + the public-good Sigstore instance (no key management, no cost), which
+# gets the artifact to SLSA Build Level 3. Verify a released artifact with:
+#   gh attestation verify <file.whl> --repo <owner>/<repo>
+# (delivery=service scaffolds attest the container image digest the same way in
+# deploy.yml / registry-publish.yml.)
 name: Release
 
 on:
@@ -23,6 +31,13 @@ jobs:
   release:
     name: Build + GitHub Release
     runs-on: ubuntu-24.04
+    # Job-level perms override the workflow block, so contents: write is
+    # restated for the release step; id-token + attestations back the SLSA
+    # provenance attestation (#575).
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,6 +50,12 @@ jobs:
 
       - name: Build wheel + sdist
         run: uv build
+
+      # Attest the exact artifacts about to be released (SLSA Build L3, #575).
+      - name: Attest build provenance (wheel + sdist)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "dist/*.whl, dist/*.tar.gz"
 {{/if python}}{{#if node}}
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/tests/contracts/test_provenance.py
+++ b/tests/contracts/test_provenance.py
@@ -1,0 +1,88 @@
+"""#575: SLSA build provenance attestation on release artifacts.
+
+The library release job attests the built wheel/sdist; the delivery=service
+deploy/registry workflows attest the pushed container-image digest. Every path
+uses actions/attest-build-provenance (first-party, OIDC + Sigstore, SLSA Build
+L3) and grants the id-token + attestations permissions it needs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+def _library(target: Path, language: str = "python") -> Path:
+    flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+    return _scaffold(target, delivery="library", delivery_library="true", language=language, **flags)
+
+
+def _service_deploy(target: Path, deploy: str) -> Path:
+    container = deploy in ("cloud-run", "fly", "k8s", "custom")
+    return _scaffold(
+        target,
+        delivery="service",
+        delivery_service="true",
+        language="python",
+        deploy_target=deploy,
+        deploy_enabled="true" if deploy != "none" else "",
+        deploy_container="true" if container else "",
+        deploy_registry="true" if deploy == "registry" else "",
+        deploy_cloud_run="true" if deploy == "cloud-run" else "",
+        deploy_fly="true" if deploy == "fly" else "",
+        deploy_k8s="true" if deploy == "k8s" else "",
+    )
+
+
+class TestReleaseArtifactProvenance:
+    def test_python_release_attests_wheel_and_sdist(self, tmp_path: Path):
+        release = (_library(tmp_path / "lib") / ".github" / "workflows" / "release.yml").read_text()
+        assert "actions/attest-build-provenance" in release
+        assert "dist/*.whl" in release and "dist/*.tar.gz" in release
+
+    def test_release_job_has_attestation_permissions(self, tmp_path: Path):
+        release = (_library(tmp_path / "lib") / ".github" / "workflows" / "release.yml").read_text()
+        assert "id-token: write" in release
+        assert "attestations: write" in release
+        # contents: write must be restated at job level (perms override).
+        assert "contents: write" in release
+
+    def test_release_process_documents_verify(self, tmp_path: Path):
+        release = (_library(tmp_path / "lib") / ".github" / "workflows" / "release.yml").read_text()
+        assert "gh attestation verify" in release
+        assert "SLSA" in release
+
+    def test_renders_cleanly(self, tmp_path: Path):
+        release = (_library(tmp_path / "lib") / ".github" / "workflows" / "release.yml").read_text()
+        assert "{{#if" not in release and "{{/if" not in release
+
+
+class TestContainerImageProvenance:
+    def test_deploy_attests_image_digest(self, tmp_path: Path):
+        deploy = (_service_deploy(tmp_path / "svc", "cloud-run") / ".github" / "workflows" / "deploy.yml").read_text()
+        assert "actions/attest-build-provenance" in deploy
+        assert "subject-digest: ${{ steps.build.outputs.digest }}" in deploy
+        assert "push-to-registry: true" in deploy
+        assert "id-token: write" in deploy
+        assert "attestations: write" in deploy
+
+    def test_registry_publish_attests_image_digest(self, tmp_path: Path):
+        reg = (_service_deploy(tmp_path / "reg", "registry") / ".github" / "workflows" / "registry-publish.yml").read_text()
+        assert "actions/attest-build-provenance" in reg
+        # The build step needs an id so its digest output can be referenced.
+        assert "id: build" in reg
+        assert "subject-digest: ${{ steps.build.outputs.digest }}" in reg
+        assert "push-to-registry: true" in reg
+        assert "id-token: write" in reg
+        assert "attestations: write" in reg
+
+    def test_renders_cleanly(self, tmp_path: Path):
+        deploy = (_service_deploy(tmp_path / "svc", "fly") / ".github" / "workflows" / "deploy.yml").read_text()
+        assert "{{#if" not in deploy and "{{/if" not in deploy


### PR DESCRIPTION
## Summary

Released artifacts carried no build provenance. This adds `actions/attest-build-provenance@v4` — a first-party GitHub action using GitHub's own OIDC + the public-good Sigstore instance (no key management, no cost) — reaching **SLSA Build Level 3** in a few lines.

- **`release.yml`** (library delivery): attests the built wheel/sdist (`dist/*.whl, dist/*.tar.gz`) immediately after `uv build`.
- **`deploy.yml`** (delivery=service, container deploy): attests the pushed image digest with `push-to-registry: true` so the attestation lives in GHCR next to the image.
- **`registry-publish.yml`** (delivery=service, registry): same image-digest attestation; the build step gains an `id` so its `outputs.digest` is referenceable.

Each job grants `id-token: write` + `attestations: write` (restating the other permissions it overrides at job level).

## Docs

The release-process comment block at the top of `release.yml.tmpl` documents verifying a released artifact:
```
gh attestation verify <file.whl> --repo <owner>/<repo>
```

## Tests

New `tests/contracts/test_provenance.py`: wheel/sdist attested with the right permissions, release process documents `gh attestation verify` + SLSA, container image digest attested (`push-to-registry`, `id: build`, permissions) in both `deploy.yml` and `registry-publish.yml`, all rendering cleanly.

## Note on verification

Per "verified with a real `gh attestation verify` run": that requires an actual tagged release/publish, which happens inside a scaffolded project. Here the scaffolder is verified by rendering the workflows and asserting the attestation steps + permissions are correct. The artifact attestation is scoped to Python's wheel/sdist (the only artifacts the release job attaches); other languages have no single stable release-artifact path.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1mEnAMkaABAqvoa9Qk8SG)_