### PR TITLE
feat(PI-574): Generate a CycloneDX SBOM in release, attach to Releases

### DIFF
--- a/templates/base/dot_claude/rules/go.md
+++ b/templates/base/dot_claude/rules/go.md
@@ -11,6 +11,7 @@ go build ./...
 go test ./... -count=1
 just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always runs this
 just audit          # dependency CVE/advisory scan (govulncheck) — CI always runs this
+just sbom           # CycloneDX SBOM via cyclonedx-gomod (#574) — release.yml attaches it to Releases
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
 golangci-lint fmt   # gofumpt (stricter than gofmt) — no separate binary needed
 ```

--- a/templates/base/dot_claude/rules/node.md
+++ b/templates/base/dot_claude/rules/node.md
@@ -14,4 +14,5 @@ bun run <script>  # run a package.json script
 bunx <package>    # run a binary (replaces npx)
 bun run lint      # lint
 bun test          # tests
+just sbom         # CycloneDX SBOM via cdxgen (#574) — release.yml attaches it to Releases
 ```

--- a/templates/base/dot_claude/rules/python.md
+++ b/templates/base/dot_claude/rules/python.md
@@ -18,6 +18,7 @@ uv run pytest -n auto -q          # tests (parallel mode, requires pytest-xdist)
 uv run pytest -q --tb=short       # tests (single-threaded fallback)
 just test-cov                     # tests + coverage gate (>= 70%, per justfile) — CI always runs this
 just audit                        # dependency CVE/advisory scan (pip-audit) — CI always runs this
+just sbom                         # CycloneDX SBOM of runtime deps (#574) — release.yml attaches it to Releases
 ```
 
 ruff lints; it does not type-check. `just typecheck` (mypy, strict) is a separate

--- a/templates/base/dot_claude/rules/rust.md
+++ b/templates/base/dot_claude/rules/rust.md
@@ -11,6 +11,7 @@ cargo build
 cargo test
 cargo llvm-cov --fail-under-lines 70              # tests + coverage gate — CI always runs this (`just test-cov`)
 cargo audit                                       # dependency CVE/advisory scan (`just audit`) — CI always runs this
+cargo cyclonedx --format json                     # CycloneDX SBOM (`just sbom`, #574) — release.yml attaches it to Releases
 cargo clippy -- -D warnings -D clippy::pedantic   # pedantic + cognitive-complexity gate per clippy.toml
 cargo fmt --check                                 # verifies only; `cargo fmt` (no flag) writes changes
 ```

--- a/templates/base/dot_github/workflows/release.yml.tmpl
+++ b/templates/base/dot_github/workflows/release.yml.tmpl
@@ -56,6 +56,14 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/*.whl, dist/*.tar.gz"
+
+      # CycloneDX SBOM of the runtime dependency tree, attached to the Release
+      # below (#574). --no-dev so the SBOM reflects what ships, not dev tooling;
+      # uvx runs cyclonedx-py isolated so it doesn't pollute the scanned .venv.
+      - name: Generate CycloneDX SBOM
+        run: |
+          uv sync --no-dev
+          uvx --from cyclonedx-bom cyclonedx-py environment .venv -o sbom.cdx.json
 {{/if python}}{{#if node}}
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -71,6 +79,13 @@ jobs:
           else
             echo "no build script in package.json — skipping"
           fi
+
+      # CycloneDX SBOM via cdxgen (#574) — reads bun's lockfile (@cyclonedx/
+      # cyclonedx-npm shells out to npm and rejects bun, so cdxgen is used here).
+      - name: Generate CycloneDX SBOM
+        run: |
+          bun install --frozen-lockfile 2>/dev/null || bun install
+          bunx @cyclonedx/cdxgen -t bun -o sbom.cdx.json
 {{/if node}}{{#if go}}
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -79,20 +94,33 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+      # CycloneDX SBOM via cyclonedx-gomod (#574).
+      - name: Generate CycloneDX SBOM
+        run: |
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+          "$(go env GOPATH)/bin/cyclonedx-gomod" mod -json -output sbom.cdx.json
 {{/if go}}{{#if rust}}
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build
         run: cargo build --release
+
+      # CycloneDX SBOM via cargo-cyclonedx (#574) — emits <crate>.cdx.json.
+      - name: Generate CycloneDX SBOM
+        run: |
+          cargo install cargo-cyclonedx
+          cargo cyclonedx --format json --spec-version 1.5
 {{/if rust}}
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-{{#if python}}          files: |
-            dist/*.whl
+          files: |
+{{#if python}}            dist/*.whl
             dist/*.tar.gz
-{{/if python}}          generate_release_notes: true
+{{/if python}}            *.cdx.json
+          generate_release_notes: true
 
   publish:
     name: Publish to registry

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -48,6 +48,13 @@ test-mutation:
 audit:
     uv run --with pip-audit pip-audit
 
+# generate a CycloneDX SBOM of the runtime dependency tree (#574). release.yml
+# attaches this to GitHub Releases; run locally on demand. --no-dev so it
+# reflects what ships; uvx keeps cyclonedx-py out of the scanned .venv.
+sbom:
+    uv sync --no-dev
+    uvx --from cyclonedx-bom cyclonedx-py environment .venv -o sbom.cdx.json
+
 # what CI runs
 ci: lint typecheck test-cov audit
 
@@ -96,6 +103,11 @@ docs:
 audit:
     bun audit
 
+# generate a CycloneDX SBOM of the dependency tree (#574). release.yml attaches
+# this to GitHub Releases. cdxgen reads bun's lockfile (cyclonedx-npm rejects bun).
+sbom:
+    bunx @cyclonedx/cdxgen -t bun -o sbom.cdx.json
+
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
@@ -140,6 +152,12 @@ docs:
 # once, on your machine (CI installs it per-run).
 audit:
     govulncheck ./...
+
+# generate a CycloneDX SBOM of the module dependency tree (#574). release.yml
+# attaches this to GitHub Releases.
+# requires cyclonedx-gomod: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+sbom:
+    cyclonedx-gomod mod -json -output sbom.cdx.json
 
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:
@@ -189,6 +207,12 @@ docs:
 # (CI installs it per-run as a prebuilt binary).
 audit:
     cargo audit
+
+# generate a CycloneDX SBOM of the crate dependency tree (#574). release.yml
+# attaches this (<crate>.cdx.json) to GitHub Releases.
+# requires cargo-cyclonedx: cargo install cargo-cyclonedx
+sbom:
+    cargo cyclonedx --format json --spec-version 1.5
 
 # scan staged changes for secrets (same scan as the pre-commit git hook)
 scan:

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -103,6 +103,9 @@ _ADDED_SINCE_BASELINE = {
     "justfile",
     ".claude/hooks/post_edit_lint.sh",
     ".claude/rules/python.md",
+    # node.md gained the `just sbom` (#574) / `just license` (#579) reference
+    # lines — a deliberate content edit, like the other rules files here.
+    ".claude/rules/node.md",
     ".claude/rules/go.md",
     ".claude/hooks/_py.sh",
     ".claude/scripts/gh_host.sh",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -109,6 +109,9 @@ _ADDED_SINCE_BASELINE = {
     ".claude/hooks/post_edit_lint.sh",
     ".claude/rules/python.md",
     ".claude/rules/go.md",
+    # node.md gained the `just sbom` (#574) / `just license` (#579) reference
+    # lines — a deliberate content edit, like the other rules files here.
+    ".claude/rules/node.md",
     ".claude/hooks/session_setup.sh",
     ".claude/hooks/_py.sh",
     ".claude/scripts/gh_host.sh",

--- a/tests/contracts/test_sbom.py
+++ b/tests/contracts/test_sbom.py
@@ -1,0 +1,100 @@
+"""#574: generate a CycloneDX SBOM per language, attached to GitHub Releases.
+
+release.yml (library delivery) generates a CycloneDX SBOM with each ecosystem's
+native generator and attaches it to the Release. A `just sbom` recipe generates
+one on demand regardless of delivery mode. The per-language rules doc mentions it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import make_variables
+
+
+def _scaffold(target: Path, **overrides: str) -> Path:
+    scaffold(target, load_preset("obsidian-only"), make_variables(**overrides), strict=True)
+    return target
+
+
+def _library(target: Path, language: str) -> Path:
+    flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+    return _scaffold(target, delivery="library", delivery_library="true", language=language, **flags)
+
+
+def _release(target: Path) -> str:
+    return (target / ".github" / "workflows" / "release.yml").read_text()
+
+
+# The generator each ecosystem's SBOM step must invoke (all verified working).
+GENERATORS = {
+    "python": "cyclonedx-py environment",
+    "node": "@cyclonedx/cdxgen",
+    "go": "cyclonedx-gomod",
+    "rust": "cargo cyclonedx",
+}
+
+
+class TestReleaseSbom:
+    @pytest.mark.parametrize("language", list(GENERATORS))
+    def test_release_generates_sbom(self, tmp_path: Path, language: str):
+        release = _release(_library(tmp_path / language, language))
+        assert "Generate CycloneDX SBOM" in release
+        assert GENERATORS[language] in release
+
+    @pytest.mark.parametrize("language", list(GENERATORS))
+    def test_sbom_attached_to_release(self, tmp_path: Path, language: str):
+        release = _release(_library(tmp_path / language, language))
+        # The Release step's files: list globs every generated CycloneDX file.
+        assert "*.cdx.json" in release
+
+    def test_node_uses_cdxgen_not_cyclonedx_npm(self, tmp_path: Path):
+        """cyclonedx-npm shells out to npm and rejects bun, so cdxgen is used."""
+        release = _release(_library(tmp_path / "node", "node"))
+        assert "-t bun" in release
+        # The generator actually invoked is cdxgen, never a cyclonedx-npm command
+        # (the string may appear in an explanatory comment, so check invocations).
+        assert "bunx @cyclonedx/cdxgen" in release
+        assert "bunx @cyclonedx/cyclonedx-npm" not in release
+
+    @pytest.mark.parametrize("language", list(GENERATORS))
+    def test_renders_cleanly(self, tmp_path: Path, language: str):
+        release = _release(_library(tmp_path / language, language))
+        assert "{{#if" not in release and "{{/if" not in release
+
+
+class TestSbomRecipe:
+    @pytest.mark.parametrize(
+        "language,needle",
+        [
+            ("python", "cyclonedx-py environment"),
+            ("node", "@cyclonedx/cdxgen"),
+            ("go", "cyclonedx-gomod"),
+            ("rust", "cargo cyclonedx"),
+        ],
+    )
+    def test_sbom_recipe_present(self, tmp_path: Path, language: str, needle: str):
+        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+        justfile = (_scaffold(tmp_path / language, language=language, **flags) / "justfile").read_text()
+        assert "sbom:" in justfile
+        assert needle in justfile
+
+    def test_recipe_present_regardless_of_delivery(self, tmp_path: Path):
+        # SBOM-on-demand is not tied to library delivery; a prototype has it too.
+        justfile = (_scaffold(tmp_path / "proto", delivery="prototype") / "justfile").read_text()
+        assert "sbom:" in justfile
+
+
+class TestSbomDocumented:
+    @pytest.mark.parametrize(
+        "language,rules_file",
+        [("python", "python.md"), ("node", "node.md"), ("go", "go.md"), ("rust", "rust.md")],
+    )
+    def test_rules_mention_sbom(self, tmp_path: Path, language: str, rules_file: str):
+        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+        target = _scaffold(tmp_path / language, language=language, **flags)
+        rules = (target / ".claude" / "rules" / rules_file).read_text()
+        assert "sbom" in rules.lower() or "cyclonedx" in rules.lower()


### PR DESCRIPTION
## Summary

No SBOM was generated anywhere. This adds per-language **CycloneDX** SBOM generation, wired into `release.yml` (library delivery) so the SBOM is attached to the GitHub Release alongside the artifacts — matching the existing changelog-generation pattern (an SBOM matters at the point something ships, not on every PR). A `just sbom` recipe generates one on demand.

Each ecosystem's native, free/open-source generator:

| Language | Generator | Command |
|---|---|---|
| Python | `cyclonedx-py` | `uvx --from cyclonedx-bom cyclonedx-py environment .venv` |
| Node | `@cyclonedx/cdxgen` | `bunx @cyclonedx/cdxgen -t bun` |
| Go | `cyclonedx-gomod` | `cyclonedx-gomod mod -json` |
| Rust | `cargo-cyclonedx` | `cargo cyclonedx --format json` |

The Release step's `files:` list globs `*.cdx.json` so it picks up the SBOM for every language (Rust emits `<crate>.cdx.json`).

**Node uses `cdxgen`, not `cyclonedx-npm`** — I verified `@cyclonedx/cyclonedx-npm` shells out to npm and rejects bun (`Unsupported NPM version`), so the ticket's parenthetical was optimistic; `cdxgen -t bun` reads bun's lockfile correctly.

## Verified against real dependency trees

Every generator was run locally against a real project with a third-party dependency and confirmed to emit a valid CycloneDX BOM (not just that the tool installs):
- Python → CycloneDX 1.6, 12 components from the repo's own `.venv`
- Node/bun → CycloneDX 1.7, resolved `is-odd` + transitive `is-number`
- Go → CycloneDX 1.6, `github.com/google/uuid`
- Rust → CycloneDX, `itoa`

## Tests & docs

- New `tests/contracts/test_sbom.py`: release generates the SBOM with the right generator per language, `*.cdx.json` attached, node uses cdxgen not cyclonedx-npm, `just sbom` recipe present regardless of delivery mode, rules doc mentions it.
- `.claude/rules/{python,node,go,rust}.md` document `just sbom`.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1mEnAMkaABAqvoa9Qk8SG)_