### PR TITLE
docs: Prep v0.6.0 release (migration note + README release line)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ project-init/
 
 ## Status
 
-Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v0.5.1). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
+Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v0.6.0). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
 
 ## License
 

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,28 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "0.6.0": {
+        "summary": (
+            "Robustness + hardening pass (2026-07 review). Re-running the "
+            "scaffolder over a recorded project no longer clobbers files you "
+            "edited after scaffolding — edited/unrecorded managed files are "
+            "parked as `<file>.new` siblings using the recorded content hashes. "
+            "The GitHub lifecycle command-guard closes bypasses (git global "
+            "options, GraphQL merge mutations, interpreter heredocs). Scaffolded "
+            "fixes: the rust/go/node + service justfile no longer defines `build` "
+            "twice (the container recipe is now `image`), `.gitignore` stops "
+            "ignoring committed `.codex/` wiring, monitor_pr.sh requires an "
+            "explicit --admin to override a BLOCKED merge, and several hooks/"
+            "scripts are more portable. CI SHA-pins its Actions and verifies the "
+            "shfmt download against published checksums."
+        ),
+        "action_required": (
+            "No action required for normal use. If you rely on `just build` in a "
+            "service-delivery project, note the container build recipe is now "
+            "`just image` (`just build` is the language build). Re-run "
+            "`project-init upgrade` to pick up the guard/template fixes."
+        ),
+    },
     "0.5.0": {
         "summary": (
             "Base is now à-la-carte and self-explaining (ADR-023, epic #470): a "


### PR DESCRIPTION
## What & why

Release prep for **v0.6.0** (the first release since v0.5.2, bundling the 0.6.0 dev features plus the 2026-07 hardening pass in #590):

- Add a `0.6.0` entry to `src/project_init/migration_notes.py` so `project-init upgrade` shows users what changed and the one behavior note that matters (the `just build` → `just image` rename for service-delivery projects).
- Refresh the README "current release" line (was lagging at v0.5.1) to v0.6.0.

Docs/data only — no code behavior change. `just ci` green locally.

## Related issue

<!-- No tracking issue — release prep. -->

## Checklist

- [x] `just ci` passes locally (lint + full test suite)
- [x] Changes under `templates/` have a matching test in `tests/<layer>/test_*.py` (n/a — no template changes)
- [x] Docs / README updated if behavior or flags changed
- [x] PR title follows Conventional Commits (`type: description` with no issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCDmvD7X6REUPeKASXzDM)_