### PR TITLE
docs: resolve docs index directory links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,9 @@ Architecture decisions, development guides, and references for contributors and 
 | Path | Purpose |
 |---|---|
 | [`positioning.md`](positioning.md) | Where project-init sits in the ecosystem — comparison table + moat |
-| [`adr/`](adr/) | Architecture Decision Records — why decisions were made |
-| [`development/`](development/) | Standards, testing, template system |
-| [`guides/`](guides/) | How-to guides for users and contributors |
+| [`adr/`](adr/adr-001-scaffolder-design.md) | Architecture Decision Records — why decisions were made |
+| [`development/`](development/contributing.md) | Standards, testing, template system |
+| [`guides/`](guides/using-project-init.md) | How-to guides for users and contributors |
 
 ## Agent instruction
 


### PR DESCRIPTION
## Summary
- replace directory-only links in the docs index with concrete Markdown pages MkDocs can resolve
- keep the displayed labels unchanged while pointing ADR, development, and guide rows at existing entry pages

## Validation
- custom Markdown internal link check across `README.md` and `docs/`
- `uvx codespell README.md docs`
- `uv run --extra docs mkdocs build --strict`

Refs #541