### PR TITLE
fix(PI-592): scaffolder robustness — typecheck stubs + audit fixes

### DIFF
--- a/src/project_init/concerns.py
+++ b/src/project_init/concerns.py
@@ -21,7 +21,7 @@ import tempfile
 from pathlib import Path
 
 from project_init import __version__
-from project_init.scaffold import memory_tier, read_preserve_globs
+from project_init.scaffold import _GOVERNANCE_USER_FILES, memory_tier, read_preserve_globs
 from project_init.upgrade import (
     UpgradeError,
     _hash_bytes,
@@ -178,15 +178,37 @@ def _seed_preserved(
     return seeded
 
 
-def _orphaned_preserved(target: Path, rendered: list[Path]) -> list[Path]:
-    """Preserved source files present on disk but no longer in the new render.
+# Preserved source data each concern owns: path prefixes (trailing "/") or
+# exact paths that --purge/--export on `remove <concern>` may touch. Concerns
+# absent here own no preserved source data, so purging them is meaningless.
+_CONCERN_SOURCE_SCOPE: dict[str, tuple[str, ...]] = {
+    "memory": (".claude/memory/", ".claude/vault/"),
+    "governance": tuple(sorted(_GOVERNANCE_USER_FILES)),
+}
+
+
+def _in_source_scope(rel: Path, scope: tuple[str, ...]) -> bool:
+    posix = rel.as_posix()
+    return any(posix == s or (s.endswith("/") and posix.startswith(s)) for s in scope)
+
+
+def _orphaned_preserved(target: Path, rendered: list[Path], concern: str) -> list[Path]:
+    """Preserved source files of *concern* on disk but not in the new render.
 
     Preserved files (``.claude/memory/``, ``.claude/vault/``, governance user
     files) are normally kept on every re-render. After a toggle that drops their
     concern, the new staging render no longer produces them — so a preserved file
     whose path is absent from *rendered* is orphaned source data, the target of
     ``--purge`` / ``--export``.
+
+    Scoped to the toggled concern's own source data (``_CONCERN_SOURCE_SCOPE``):
+    every user note under ``.claude/`` is preserved and absent from a fresh
+    render, so an unscoped sweep would let ``remove docs --purge`` delete the
+    user's entire vault — data the concern being removed never owned.
     """
+    scope = _CONCERN_SOURCE_SCOPE.get(concern, ())
+    if not scope:
+        return []
     preserve_globs = read_preserve_globs(target)
     rendered_set = {r.as_posix() for r in rendered}
     claude = target / ".claude"
@@ -197,7 +219,11 @@ def _orphaned_preserved(target: Path, rendered: list[Path]) -> list[Path]:
         if not p.is_file():
             continue
         rel = p.relative_to(target)
-        if _is_preserved(rel, preserve_globs) and rel.as_posix() not in rendered_set:
+        if (
+            _in_source_scope(rel, scope)
+            and _is_preserved(rel, preserve_globs)
+            and rel.as_posix() not in rendered_set
+        ):
             out.append(rel)
     return out
 
@@ -244,22 +270,29 @@ def _prune_empty_dirs(target: Path, deleted: list[Path]) -> None:
             d.rmdir()
 
 
-def _validate_flags(*, enable: bool, purge: bool, export_dir: Path | None) -> str | None:
+def _validate_flags(
+    *, concern: str, enable: bool, purge: bool, export_dir: Path | None
+) -> str | None:
     """Return an error message if the purge/export flags are misused, else None."""
     if (purge or export_dir is not None) and enable:
         return "--purge/--export apply to `remove`, not `add`"
     if purge and export_dir is not None:
         return "--purge and --export are mutually exclusive"
+    if (purge or export_dir is not None) and concern not in _CONCERN_SOURCE_SCOPE:
+        owners = ", ".join(sorted(_CONCERN_SOURCE_SCOPE))
+        return (
+            f"`{concern}` owns no preserved source data — --purge/--export only apply to: {owners}"
+        )
     return None
 
 
-def _apply_source(
-    target: Path, report, *, apply: bool, purge: bool, export_dir: Path | None
+def _apply_source(  # noqa: PLR0913 — mirrors apply_concern's flag surface
+    target: Path, report, concern: str, *, apply: bool, purge: bool, export_dir: Path | None
 ) -> list[Path]:
     """Compute orphaned preserved source data; delete/move it when *apply*."""
     if not (purge or export_dir is not None):
         return []
-    source = _orphaned_preserved(target, report.rendered)
+    source = _orphaned_preserved(target, report.rendered, concern)
     if apply:
         _purge_or_export(target, source, purge=purge, export_dir=export_dir)
     return source
@@ -283,12 +316,15 @@ def apply_concern(  # noqa: PLR0913 — flags map 1:1 to the add/remove CLI opti
     (remove, byte-unmodified only), and refreshes ``.claude/config.yaml``.
 
     *purge* / *export_dir* (remove only, mutually exclusive) act on **orphaned
-    preserved source data** — the user's ``.claude/memory/`` / ``.claude/vault/``
-    notes that ``remove`` keeps by default: *purge* deletes them, *export_dir*
-    moves them out first. Without either, source data is left in place.
+    preserved source data owned by the toggled concern** — the user's
+    ``.claude/memory/`` / ``.claude/vault/`` notes for ``memory``, the
+    governance user files for ``governance`` — that ``remove`` keeps by
+    default: *purge* deletes them, *export_dir* moves them out first. Without
+    either, source data is left in place. Concerns that own no source data
+    reject the flags outright.
     """
     verb = "add" if enable else "remove"
-    flag_error = _validate_flags(enable=enable, purge=purge, export_dir=export_dir)
+    flag_error = _validate_flags(concern=concern, enable=enable, purge=purge, export_dir=export_dir)
     if flag_error:
         sys.stderr.write(f"error: {flag_error}\n")
         return 1
@@ -318,7 +354,7 @@ def apply_concern(  # noqa: PLR0913 — flags map 1:1 to the add/remove CLI opti
     staging = staging_root / "render"
     try:
         try:
-            rendered = _render_staging(preset_name, new_vars, staging)
+            rendered = _render_staging(preset_name, new_vars, staging, detect_root=target)
         except Exception as e:  # noqa: BLE001 — any render failure is fatal here
             sys.stderr.write(f"error: re-render failed: {e}\n")
             return 1
@@ -329,7 +365,9 @@ def apply_concern(  # noqa: PLR0913 — flags map 1:1 to the add/remove CLI opti
         if apply:
             apply_drift(target, staging, report, preset_name, new_vars)
             deleted, kept = _delete_orphans(target, report.removed, manifest)
-        source = _apply_source(target, report, apply=apply, purge=purge, export_dir=export_dir)
+        source = _apply_source(
+            target, report, concern, apply=apply, purge=purge, export_dir=export_dir
+        )
         seeded = _seed_preserved(target, staging, report.rendered, write=apply)
 
         _print_summary(verb, concern, report, deleted, kept, seeded, applied=apply)

--- a/src/project_init/concerns.py
+++ b/src/project_init/concerns.py
@@ -130,8 +130,12 @@ def _delete_orphans(
 
     Returns ``(deleted, kept)``. A removed file whose current bytes differ from
     the recorded hash was edited by the user — it is kept and reported, never
-    deleted. ``removed`` already excludes preserved dirs (memory/vault) and the
-    config record (compute_drift skips them), so source data is safe here.
+    deleted. ``removed`` is drawn from the recorded manifest, which never holds
+    the user's own source data (their memory/vault notes are preserved and were
+    never recorded), so a concern's accumulated notes are safe here. Template-
+    owned files a concern uniquely ships *are* deleted — including a template
+    README inside a now-removed memory/vault dir (READMEs are managed, not
+    preserved; #592 review) — but only when byte-identical to the record.
     """
     deleted: list[Path] = []
     kept: list[Path] = []

--- a/src/project_init/governance.py
+++ b/src/project_init/governance.py
@@ -144,9 +144,19 @@ def emit(
     """
     from project_init.scaffold import _emit_generated
 
+    # Detect CCR routes from the live project (detect_root) so upgrade/remove
+    # don't clobber the user's real routes with staging's template default. But
+    # on `add multi_model` the live project has no config yet (it's the file
+    # being added) — fall back to the freshly-rendered one in *target* (staging)
+    # that apply is about to install, so the AIBOM reflects the routes actually
+    # being added rather than an empty table.
+    root = detect_root or target
+    if detect_root is not None and not (detect_root / _CCR_CONFIG_REL).is_file():
+        root = target
+
     return _emit_generated(
         target / _OUTPUT_REL,
-        render_aibom(detect_root or target, variables),
+        render_aibom(root, variables),
         first_scaffold=first_scaffold,
         conflicts=conflicts,
         rel=_OUTPUT_REL,

--- a/src/project_init/governance.py
+++ b/src/project_init/governance.py
@@ -73,8 +73,15 @@ def extract_ccr_routes(config_path: Path) -> dict[str, list]:
     return {"routes": routes, "providers": providers}
 
 
-def render_aibom(target: Path, variables: dict[str, str]) -> str:
-    """Build the AIBOM markdown from the recorded selection + emitted overlays."""
+def render_aibom(detect_root: Path, variables: dict[str, str]) -> str:
+    """Build the AIBOM markdown from the recorded selection + emitted overlays.
+
+    *detect_root* is the project root whose live CCR config is inspected. On a
+    plain scaffold that is the scaffold target; on upgrade/add/remove it must be
+    the real project, NOT the staging render — staging holds the pristine
+    template ``config.json``, so detecting there would report template-default
+    routes and clobber the user's actual ones on ``--apply``.
+    """
     by_id = {m["id"]: m for m in MCP_CATALOG}
     by_id[PLAYWRIGHT_MCP["id"]] = PLAYWRIGHT_MCP
     servers = servers_for_ids(_mcp_ids(variables))
@@ -101,7 +108,7 @@ def render_aibom(target: Path, variables: dict[str, str]) -> str:
     lines += ["", "## Detected CCR routes", ""]
 
     if variables.get("multi_model"):
-        ccr = extract_ccr_routes(target / _CCR_CONFIG_REL)
+        ccr = extract_ccr_routes(detect_root / _CCR_CONFIG_REL)
         if ccr["routes"]:
             lines += ["| Role | Provider | Model |", "|---|---|---|"]
             for role, provider, model in ccr["routes"]:
@@ -124,6 +131,7 @@ def emit(
     *,
     first_scaffold: bool = True,
     conflicts: list[tuple[Path, Path]] | None = None,
+    detect_root: Path | None = None,
 ) -> list[Path]:
     """Write ``.claude/governance/ai-bom.generated.md``.
 
@@ -131,12 +139,14 @@ def emit(
     pre-existing user file at this path is preserved as a ``.new`` sibling (never
     clobbered) on the *first* scaffold, or on a later run while an unmerged ``.new``
     sibling from an earlier run is still pending (PI-535).
+
+    *detect_root* — see :func:`render_aibom`; defaults to *target*.
     """
     from project_init.scaffold import _emit_generated
 
     return _emit_generated(
         target / _OUTPUT_REL,
-        render_aibom(target, variables),
+        render_aibom(detect_root or target, variables),
         first_scaffold=first_scaffold,
         conflicts=conflicts,
         rel=_OUTPUT_REL,

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -31,7 +31,11 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
             "shfmt download against published checksums."
         ),
         "action_required": (
-            "No action required for normal use. If you rely on `just build` in a "
+            "Python projects: `just ci` now includes a blocking strict-mypy "
+            "`typecheck` gate (new in 0.6.0). Pre-existing untyped code can turn "
+            "CI red on upgrade — either fix the reported errors, or soften "
+            "mypy.ini (`strict = False`) / drop `typecheck` from the `ci:` "
+            "recipe while you migrate. If you rely on `just build` in a "
             "service-delivery project, note the container build recipe is now "
             "`just image` (`just build` is the language build). Re-run "
             "`project-init upgrade` to pick up the guard/template fixes."

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -451,6 +451,10 @@ def _should_preserve(rel_path: Path, target: Path, preserve_globs: list[str] | N
     An explicit user glob outranks the README refresh rule — otherwise
     ``preserve: ["README.md"]`` would be silently ineffective while ``upgrade``
     honors the same glob (2026-07 review).
+
+    KEEP IN SYNC with ``upgrade._is_preserved``, which encodes the same
+    governance/glob/README/preserve-dir policy at manifest-recording time. If
+    the two disagree about what is "managed", scaffold and upgrade drift apart.
     """
     dest = target / rel_path
     if not dest.exists():

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -130,6 +130,15 @@ def _check_preset_compat(preset: dict) -> None:
     minimum = preset.get("min_project_init_version")
     if not minimum:
         return
+    # A malformed marker (e.g. a hand-authored two-component "1.0") must be a
+    # hard error: _version_tuple would sort it lowest (0,0,0), silently
+    # disabling the compat gate the preset author asked for.
+    if parse_version(str(minimum)) is None:
+        msg = (
+            f"preset {preset.get('name')!r} has an unparseable "
+            f"min_project_init_version {minimum!r} — use X.Y.Z."
+        )
+        raise ValueError(msg)
     from project_init import __version__
 
     if _version_tuple(__version__) < _version_tuple(minimum):
@@ -758,15 +767,22 @@ def _has_scaffold_record(config_file: Path) -> bool:
         return False
 
 
-def scaffold(
+def scaffold(  # noqa: PLR0913 — orthogonal engine knobs, all keyword-only
     target: Path,
     preset: dict,
     variables: dict[str, str],
     *,
     strict: bool = False,
     conflicts: list[tuple[Path, Path]] | None = None,
+    detect_root: Path | None = None,
 ) -> list[Path]:
     """Copy + render template layers into *target*. Return created file paths.
+
+    *detect_root* is where generated inventories read the project's live state
+    (e.g. the AIBOM's CCR route detection); defaults to *target*. Upgrade/
+    add/remove render into a staging dir, whose freshly-copied template configs
+    would otherwise shadow the real project's — they pass the real project root
+    here.
 
     A .tmpl file whose rendered output is empty or whitespace-only is skipped
     entirely (see :func:`_emit_file`) — this is how language-specific config
@@ -865,7 +881,7 @@ def scaffold(
     # selected GUI surfaces from the canonical surface table + MCP catalog. Runs
     # against the committed target (after _commit_staged in strict mode).
     created += _emit_generated_files(
-        target, variables, conflicts, first_scaffold=first_scaffold
+        target, variables, conflicts, first_scaffold=first_scaffold, detect_root=detect_root
     )
 
     return created
@@ -877,6 +893,7 @@ def _emit_generated_files(
     conflicts: list[tuple[Path, Path]] | None,
     *,
     first_scaffold: bool = True,
+    detect_root: Path | None = None,
 ) -> list[Path]:
     """Post-copy generated files.
 
@@ -909,7 +926,11 @@ def _emit_generated_files(
         from project_init import governance
 
         created += governance.emit(
-            target, variables, first_scaffold=first_scaffold, conflicts=conflicts
+            target,
+            variables,
+            first_scaffold=first_scaffold,
+            conflicts=conflicts,
+            detect_root=detect_root,
         )
     return created
 

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -345,6 +345,12 @@ def _three_way_merge(base: str, ours: str, theirs: str) -> tuple[str, bool]:
 
 
 def _is_preserved(rel: Path, preserve_globs: list[str] | None = None) -> bool:
+    # KEEP IN SYNC with scaffold._should_preserve: this is the manifest-time
+    # (path-only) view of the same governance/glob/README/preserve-dir policy
+    # that _should_preserve applies at render-time (plus its disk-state and
+    # config-record checks). If the two disagree about what is "managed", the
+    # scaffold that refreshes a file and the upgrade that records it drift apart
+    # — the exact README-parked-as-.new bug this classification fixes.
     if rel.as_posix() in _GOVERNANCE_USER_FILES:
         return True
     if _matches_preserve_glob(rel, preserve_globs or []):

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from project_init.scaffold import (
+    _ALWAYS_OVERWRITE,
     _GOVERNANCE_USER_FILES,
     _PRESERVE_DIRS,
     _RECORD_MARKER,
@@ -344,11 +345,19 @@ def _three_way_merge(base: str, ours: str, theirs: str) -> tuple[str, bool]:
 
 
 def _is_preserved(rel: Path, preserve_globs: list[str] | None = None) -> bool:
-    if any(part in _PRESERVE_DIRS for part in rel.parts):
-        return True
     if rel.as_posix() in _GOVERNANCE_USER_FILES:
         return True
-    return _matches_preserve_glob(rel, preserve_globs or [])
+    if _matches_preserve_glob(rel, preserve_globs or []):
+        return True
+    # Mirror scaffold._should_preserve: READMEs are template-owned and always
+    # refreshed, even inside memory/vault (unless a user glob catches them
+    # above). They must therefore be *managed* — recorded in the manifest and
+    # drift-tracked — or a re-run would find no recorded hash, assume the user
+    # owns them, and park every template-side README refresh as a `.new`
+    # sibling plus a spurious conflict (2026-07 review).
+    if rel.name in _ALWAYS_OVERWRITE:
+        return False
+    return any(part in _PRESERVE_DIRS for part in rel.parts)
 
 
 def _strip_record(text: str) -> str:
@@ -718,7 +727,9 @@ def _unified_diff(rel: Path, old: bytes, new: bytes) -> str:
     )
 
 
-def _render_staging(preset_name: str, variables: dict, staging: Path) -> list[Path]:
+def _render_staging(
+    preset_name: str, variables: dict, staging: Path, detect_root: Path | None = None
+) -> list[Path]:
     preset = load_preset(preset_name)
     # Agent overlays (PI-137) are layers appended at scaffold time, not part of
     # the preset definition — re-derive them from the recorded agents via the
@@ -739,7 +750,10 @@ def _render_staging(preset_name: str, variables: dict, staging: Path) -> list[Pa
     )
     if extra:
         preset = {**preset, "layers": list(preset["layers"]) + extra}
-    return scaffold(staging, preset, variables, strict=True)
+    # detect_root: generated inventories (AIBOM CCR routes) must inspect the
+    # real project's config, not the pristine template copy in staging —
+    # otherwise --apply replaces detected routes with template defaults.
+    return scaffold(staging, preset, variables, strict=True, detect_root=detect_root)
 
 
 def _classify_conflict(
@@ -1515,7 +1529,7 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     staging = staging_root / "render"
     try:
         try:
-            rendered = _render_staging(preset_name, variables, staging)
+            rendered = _render_staging(preset_name, variables, staging, detect_root=target)
         except Exception as e:  # noqa: BLE001 — any render failure is fatal here
             sys.stderr.write(f"error: re-render failed: {e}\n")
             return 1

--- a/templates/auto/dot_claude/scripts/lint_memory.sh
+++ b/templates/auto/dot_claude/scripts/lint_memory.sh
@@ -142,14 +142,18 @@ fi
 
 VAULT_DIR="$ROOT/.claude/vault"
 if [ -d "$VAULT_DIR" ]; then
-  # Collect all wikilink targets from vault notes
-  all_links="$(grep -roh '\[\[[^]]*\]\]' "$VAULT_DIR" 2>/dev/null | sed 's/\[\[//;s/\]\]//' | sort -u || true)"
+  # Collect all wikilink targets from vault notes, normalized to the target
+  # note's bare name: strip |alias and #heading suffixes and any path prefix.
+  all_links="$(grep -roh '\[\[[^]]*\]\]' "$VAULT_DIR" 2>/dev/null | sed 's/\[\[//;s/\]\]//;s/[|#].*$//;s#.*/##' | sort -u || true)"
 
   while IFS= read -r -d '' file; do
     name="$(basename "$file" .md)"
-    # Check if any other note links to this one
+    # Check if any other note links to this one. -Fx: the note name must match
+    # a link target exactly as a fixed string — an unanchored regex match lets
+    # metacharacters in note names ("plan(v2)") misfire and lets any note whose
+    # name is a substring of another's ("foo" vs "[[foobar]]") pass as linked.
     if [ -n "$all_links" ]; then
-      if ! echo "$all_links" | grep -q "$name"; then
+      if ! echo "$all_links" | grep -Fxq "$name"; then
         warn "$(basename "$file"): no inbound wikilinks (orphan note)"
       fi
     fi

--- a/templates/base/Dockerfile.tmpl
+++ b/templates/base/Dockerfile.tmpl
@@ -41,12 +41,18 @@ EXPOSE 8080
 # TODO: replace with your app's start command (e.g. bun run start)
 CMD ["bun", "run", "start"]
 {{/if node}}{{#if go}}# --- build stage: compile a static binary ---
-FROM golang:1.23 AS build
+# Keep this Go version in step with mise.toml's `go` pin — a go.mod created
+# under a newer toolchain fails the build with "go.mod requires go >= X".
+FROM golang:1.24 AS build
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /app/server ./...
+# Build the main package at the module root. `go build -o <file> ./...` breaks
+# as soon as a second package exists ("cannot write multiple packages to
+# non-directory") — point this at your entrypoint (e.g. ./cmd/server) if your
+# main package lives elsewhere.
+RUN CGO_ENABLED=0 go build -o /app/server .
 
 # --- runtime stage: distroless, no shell/toolchain ---
 FROM gcr.io/distroless/static-debian12 AS runtime

--- a/templates/base/dot_claude/scripts/gh_host.sh
+++ b/templates/base/dot_claude/scripts/gh_host.sh
@@ -57,8 +57,14 @@ gh_api_base() {
 
 # Distribution profile recorded by project-init in .claude/config.yaml (#247);
 # defaults to individual when unset. Gates org-only hard enforcement (#251).
+# Anchored on this file's own location (.claude/scripts/ -> ../config.yaml),
+# NOT the caller's cwd — a cwd-relative read silently resolves to the
+# 'individual' default from any subdirectory, which would let monitor_pr.sh
+# admin-merge past org branch protection and setup_github.sh skip the org
+# ruleset.
 gh_profile() {
-  local cfg=".claude/config.yaml" prof=""
+  local cfg prof=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
   [ -f "$cfg" ] && prof=$(sed -nE 's/^[[:space:]]*profile:[[:space:]]*([a-z]+).*/\1/p' "$cfg" | head -1)
   printf '%s\n' "${prof:-individual}"
 }

--- a/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
+++ b/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
@@ -80,7 +80,10 @@ if [ "$PROFILE" = "org" ]; then
       j=$(resolve_reviewer "$r") || true
       if [ -n "$j" ]; then parts+=("$j"); else echo "WARNING: could not resolve reviewer '$r' — skipping." >&2; fi
     done
-    reviewers_json="[$(IFS=,; echo "${parts[*]}")]"
+    # parts can be empty when every --reviewer failed to resolve; the ${arr[*]+}
+    # guard keeps that path on bash < 4.4 (macOS 3.2), where expanding an empty
+    # array under `set -u` is fatal, so it reaches the UNCHANGED warning below.
+    reviewers_json="[$(IFS=,; echo ${parts[*]+"${parts[*]}"})]"
   fi
   if [ "$reviewers_json" = "[]" ]; then
     # Do NOT PUT an empty-reviewers payload — that would WIPE any reviewers already

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -185,13 +185,19 @@ jobs:
           mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      # Fresh scaffolds have no lockfile yet — fall back to a plain install.
+      # Fresh scaffolds have no lockfile — or even a package.json (`bun
+      # install` errors without one). Fall back to a plain install, or to
+      # `just setup`, which seeds package.json with the lint toolchain that
+      # eslint.config.mjs imports, so the Lint step below works on the very
+      # first CI run.
       - name: Install dependencies
         run: |
           if [ -f bun.lock ] || [ -f bun.lockb ]; then
             bun install --frozen-lockfile
-          else
+          elif [ -f package.json ]; then
             bun install
+          else
+            just setup
           fi
 
       - name: Lint
@@ -215,8 +221,10 @@ jobs:
 
       # The action installs + caches golangci-lint on CI; locally `just lint`
       # runs the same `golangci-lint run` against the same .golangci.yml.
+      # v8+ of the action is required for golangci-lint v2 — v6 caps the tool
+      # at v1.64.8, which rejects the scaffolded `version: "2"` config.
       - name: Lint (golangci-lint)
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
       - name: Install shfmt
@@ -330,7 +338,9 @@ jobs:
 {{#if python}}
   # Optimization #2: Split heavyweight tests into separate job
   # Only run integration/smoke tests after fast lint+unit tests pass
-  # Adjust this job based on your actual integration test needs
+  # Adjust this job based on your actual integration test needs.
+  # Non-blocking (NOT in ci-gate's needs) — add it there once your
+  # integration suite is stable enough to gate merges.
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-24.04
@@ -407,6 +417,9 @@ jobs:
   # for the SAME image the deploy overlay promotes. Tests are pinned HOST-based
   # above (the language matrix). This job only builds (push: false) — the deploy
   # overlay (#323) builds and pushes the real digest to a registry.
+  # Non-blocking (NOT in ci-gate's needs): the Trivy scan informs; deploy.yml's
+  # build-push does not depend on it, so gate on it deliberately if you want a
+  # vulnerable image to block merges.
   build-image:
     name: Build image (build-once)
     runs-on: ubuntu-24.04
@@ -637,8 +650,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # Full version pin: ossf/scorecard-action publishes no floating `v2`
+      # major tag (only exact vX.Y.Z tags), so `@v2` fails to resolve.
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -661,10 +676,13 @@ jobs:
   # what left main permanently `blocked` before. `if: always()` so the gate runs
   # even when an upstream job fails, then fails itself unless every dependency
   # succeeded.
+  # The governance job (when the overlay is on) is in the gate's needs: its
+  # comment calls it "the enforcement boundary", which is only true if a
+  # failing gate actually blocks the merge.
   ci-gate:
     name: CI gate
     runs-on: ubuntu-24.04
-    needs: [lint-and-test, secret-scan]
+    needs: [lint-and-test, secret-scan{{#if governance}}, governance{{/if governance}}]
     if: always()
     steps:
       - name: Require all upstream jobs to succeed

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -105,7 +105,7 @@ lint:
 # no-op on a fresh scaffold with no .ts sources yet — tsc errors with TS18003
 # ("No inputs were found") instead of passing (the #592-adjacent day-one gap)
 typecheck:
-    sh -c 'if find . \( -name "*.ts" -o -name "*.tsx" \) -not -path "./node_modules/*" | grep -q .; then bunx tsc --noEmit; else echo "No TypeScript sources yet — nothing to type-check."; fi'
+    sh -c 'if find . \( -name "*.ts" -o -name "*.tsx" \) -not -path "*/node_modules/*" | grep -q .; then bunx tsc --noEmit; else echo "No TypeScript sources yet — nothing to type-check."; fi'
 
 # auto-format project code (Biome is the formatter; eslint owns the gates)
 format:

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -13,9 +13,12 @@ lint:
     find .claude -name '*.sh' -exec shfmt -d -i 2 {} +
 
 # static type check (strict mode per mypy.ini; add mypy with `uv add --dev mypy`)
-# no-op on a fresh scaffold with no src/ yet — mypy errors on a missing path
+# no-op on a fresh scaffold with no src/ yet — mypy errors on a missing path.
+# --install-types fetches missing dependency stubs (types-PyYAML etc.) so
+# untyped deps don't fail the strict gate with import-untyped (#592); it
+# shells out to pip, which uv-managed environments omit — hence --with pip.
 typecheck:
-    if [ -d src ]; then uv run --with "mypy>=1.10" mypy src/; else echo "No src/ directory yet — nothing to type-check."; fi
+    if [ -d src ]; then uv run --with "mypy>=1.10" --with pip mypy --install-types --non-interactive src/; else echo "No src/ directory yet — nothing to type-check."; fi
 
 # auto-format project code
 format:

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -2,9 +2,12 @@
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
 
-# install/sync dev dependencies (PEP 735 dependency-group; add tools with `uv add --dev`)
+# install/sync dev dependencies (PEP 735 dependency-group; add tools with `uv add --dev`).
+# A fresh scaffold has no pyproject.toml (or one without [dependency-groups])
+# yet — `uv sync --group dev` hard-fails on both, which would break CI's first
+# step before the day-one guards in typecheck/test-cov can even run.
 setup:
-    uv sync --group dev
+    sh -c 'if [ ! -f pyproject.toml ]; then echo "No pyproject.toml yet — nothing to sync."; elif grep -q "^\[dependency-groups\]" pyproject.toml; then uv sync --group dev; else uv sync; fi'
 
 # lint project code (docstring + complexity gates per ruff.toml)
 lint:
@@ -99,8 +102,10 @@ lint:
     find .claude -name '*.sh' -exec shfmt -d -i 2 {} +
 
 # static type check (strict mode per tsconfig.base.json)
+# no-op on a fresh scaffold with no .ts sources yet — tsc errors with TS18003
+# ("No inputs were found") instead of passing (the #592-adjacent day-one gap)
 typecheck:
-    bunx tsc --noEmit
+    sh -c 'if find . \( -name "*.ts" -o -name "*.tsx" \) -not -path "./node_modules/*" | grep -q .; then bunx tsc --noEmit; else echo "No TypeScript sources yet — nothing to type-check."; fi'
 
 # auto-format project code (Biome is the formatter; eslint owns the gates)
 format:
@@ -165,10 +170,13 @@ test:
     go test ./...
 
 # tests with the coverage gate (CI always runs this, not `test` — PI-569).
-# tune the "70" threshold to your project's baseline.
+# tune the "70" threshold to your project's baseline. Skips cleanly before any
+# Go source exists (`go test ./...` errors on a fresh module, like license/
+# fuzz). The awk END gate is fail-closed: a missing/unreadable coverage.out
+# yields zero input lines and fails the recipe instead of silently passing
+# (a bare `... | awk '{...}'` returned awk's 0 exit when the cover tool failed).
 test-cov:
-    go test -coverprofile=coverage.out ./...
-    go tool cover -func=coverage.out | tail -n 1 | awk '{ pct = $3; sub("%", "", pct); if (pct + 0 < 70) { print "Coverage " pct "% is below the 70% gate"; exit 1 } else { print "Coverage " pct "% meets the 70% gate" } }'
+    sh -c 'set -e; if ! find . -name "*.go" | grep -q .; then echo "No Go sources yet — nothing to test."; exit 0; fi; go test -coverprofile=coverage.out ./...; go tool cover -func=coverage.out | awk '\''END { if (NR == 0 || $1 != "total:") { print "Coverage gate: could not read coverage totals"; exit 1 } pct = $3; sub("%", "", pct); if (pct + 0 < 70) { print "Coverage " pct "% is below the 70% gate"; exit 1 } else { print "Coverage " pct "% meets the 70% gate" } }'\'''
 
 # docs: nothing to build — pkg.go.dev renders doc comments
 docs:

--- a/templates/lifecycle/dot_claude/scripts/create_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/create_issue.sh
@@ -374,7 +374,9 @@ write_bullets() {
   echo
   echo "## Acceptance criteria"
   echo
-  write_list "Define acceptance criteria before implementation" "${ACCEPTANCE[@]}"
+  # ${arr[@]+...} guard: expanding an empty array under `set -u` is fatal on
+  # bash < 4.4 (macOS ships 3.2), so a run without --acceptance would die here.
+  write_list "Define acceptance criteria before implementation" ${ACCEPTANCE[@]+"${ACCEPTANCE[@]}"}
   echo
   echo "## Definition of Ready"
   echo
@@ -429,7 +431,10 @@ if [ -n "$MILESTONE" ]; then
   CREATE_ARGS+=(--milestone "$MILESTONE")
 fi
 
-ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" "${LABEL_ARGS[@]}")
+# LABEL_ARGS stays empty when the label is missing and cannot be created (the
+# documented continue-without-label fallback) — guard the expansion so that
+# path survives `set -u` on bash < 4.4 (macOS ships 3.2).
+ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}" ${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
 # ---------------------------------------------------------------------------

--- a/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
@@ -46,7 +46,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PY="$SCRIPT_DIR/../hooks/_py.sh"
 
 PR_NUMBER="${1:-}"
-MODE="${2:-}"
+MODE=""
 REVIEW_CYCLE=0
 MAX_REVIEW_CYCLES=2
 NO_REVIEW=0
@@ -57,17 +57,16 @@ if [ -z "$PR_NUMBER" ]; then
   exit 1
 fi
 
-if [ -n "$MODE" ] && [ "$MODE" != "--merge" ]; then
-  echo "Unknown option: $MODE" >&2
-  exit 2
-fi
-
-# Parse remaining flags (order-independent after position 2).
-# Shift past <pr-number> and optional --merge; remaining args are flags.
-shift 1                            # drop PR_NUMBER
-[ "$MODE" = "--merge" ] && shift 1 # drop --merge if present
+# Parse flags (order-independent). --merge is just another flag: the usage
+# line presents every flag as independent, so `monitor_pr.sh 12 --no-review`
+# must not be rejected for lacking --merge in position 2.
+shift 1 # drop PR_NUMBER
 while [ $# -gt 0 ]; do
   case "$1" in
+  --merge)
+    MODE="--merge"
+    shift
+    ;;
   --review-cycle)
     REVIEW_CYCLE="${2:-0}"
     shift 2

--- a/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
@@ -90,6 +90,16 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# --admin, --no-review and --review-cycle only take effect while merging. Warn
+# loudly if they were passed without --merge (e.g. `monitor_pr.sh 12 --admin`)
+# so the flag isn't silently a no-op — the script would otherwise just monitor
+# and exit 0, looking like a successful merge that never happened.
+if [ "$MODE" != "--merge" ]; then
+  if [ "$ALLOW_ADMIN" -eq 1 ] || [ "$NO_REVIEW" -eq 1 ] || [ "$REVIEW_CYCLE" -ne 0 ]; then
+    echo "WARNING: --admin/--no-review/--review-cycle only apply with --merge; ignoring (monitor-only run)." >&2
+  fi
+fi
+
 _count_pending() {
   echo "$1" | "$PY" -c "
 import json, sys

--- a/templates/lifecycle/dot_claude/scripts/start_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/start_issue.sh
@@ -17,8 +17,14 @@ command -v gh >/dev/null 2>&1 || {
   exit 1
 }
 
+# Anchor sibling-script and config lookups on this script's location, not the
+# caller's cwd — invoked from a subdirectory, a cwd-relative path would derive
+# the wrong project key and then die at the push_branch.sh call, stranding the
+# repo on a fresh unpushed branch with no PR.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Resolve the base branch (ADR-014) from the promotion chain via gh_host.sh.
-source "$(dirname "$0")/gh_host.sh"
+source "$SCRIPT_DIR/gh_host.sh"
 
 VALID_TYPES="feat fix chore docs test"
 
@@ -61,7 +67,7 @@ derive_project_key() {
   fi
 
   local configured=""
-  configured=$(grep '^[[:space:]]*project_key:' .claude/config.yaml 2>/dev/null |
+  configured=$(grep '^[[:space:]]*project_key:' "$SCRIPT_DIR/../config.yaml" 2>/dev/null |
     head -n 1 |
     cut -d: -f2- |
     sed 's/#.*$//' |
@@ -159,7 +165,7 @@ if [ -z "$(git rev-list "${BASE_BRANCH}..HEAD" 2>/dev/null || true)" ]; then
 fi
 
 # --- Push and set upstream (retry + remote-SHA verification) ---
-.claude/scripts/push_branch.sh "$BRANCH"
+"$SCRIPT_DIR/push_branch.sh" "$BRANCH"
 
 # --- Open draft PR ---
 # Conventional Commits with issue key as scope (ADR-006)

--- a/tests/contracts/test_governance_overlay.py
+++ b/tests/contracts/test_governance_overlay.py
@@ -79,6 +79,26 @@ class TestGovernanceOn:
         assert "governance-as-code" in text
         assert "NIST AI RMF" in text
 
+    @staticmethod
+    def _gate_needs(target: Path) -> str:
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        gate_start = ci.index("ci-gate:")
+        return next(
+            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
+        )
+
+    def test_governance_job_blocks_via_ci_gate(self, tmp_path: Path):
+        # The job's comment calls it "the enforcement boundary" — only true if
+        # ci-gate (the single required status check) actually needs it.
+        target = _scaffold(tmp_path / "p", governance=True)
+        assert "governance" in self._gate_needs(target)
+
+    def test_gate_needs_clean_without_governance(self, tmp_path: Path):
+        # With the overlay off there is no governance job — a leftover entry in
+        # ci-gate's needs would leave the gate permanently pending/failed.
+        target = _scaffold(tmp_path / "p", governance=False)
+        assert "governance" not in self._gate_needs(target)
+
 
 class TestUsageTrackDocs:
     """#411: the policy layer scaffolds with its load-bearing content."""

--- a/tests/contracts/test_governance_product.py
+++ b/tests/contracts/test_governance_product.py
@@ -151,6 +151,30 @@ class TestAIBOM:
         aibom = (target / _GOV / "ai-bom.generated.md").read_text(encoding="utf-8")
         assert "my-custom-model" in aibom
 
+    def test_add_multi_model_populates_aibom_routes(self, tmp_path: Path):
+        # `add multi-model` on a governance project: the live project has no CCR
+        # config yet mid-add (it's the file being installed), so detection must
+        # fall back to the freshly-rendered staging config rather than emitting
+        # an empty routes table. Detecting the *absent* live config would leave
+        # the AIBOM saying "no routes" while the config.json being added has them.
+        from project_init.concerns import apply_concern
+        from project_init.upgrade import write_scaffold_record
+
+        target = tmp_path / "p"
+        preset = load_preset("obsidian-only")
+        extra = overlay_layers("claude", no_plugin=False, governance=True)
+        preset = {**preset, "layers": list(preset["layers"]) + extra}
+        variables = make_variables(governance="true")
+        created = scaffold(target, preset, variables, strict=True)
+        write_scaffold_record(target, "obsidian-only", variables, created)
+        assert not (target / ".claude" / "multi-model" / "config.json").exists()
+
+        assert apply_concern(target, "multi-model", enable=True, apply=True) == 0
+        assert (target / ".claude" / "multi-model" / "config.json").is_file()
+        aibom = (target / _GOV / "ai-bom.generated.md").read_text(encoding="utf-8")
+        assert "Detected CCR routes" in aibom
+        assert "deepseek" in aibom, "AIBOM must show the routes just added, not an empty table"
+
 
 # --------------------------------------------------------------------------- #
 # Declarations lifecycle (seed-once + preserve)

--- a/tests/contracts/test_governance_product.py
+++ b/tests/contracts/test_governance_product.py
@@ -126,6 +126,31 @@ class TestAIBOM:
         target = _scaffold(tmp_path / "p", governance=False)
         assert not (target / _GOV / "ai-bom.generated.md").exists()
 
+    def test_upgrade_detects_routes_from_project_not_staging(self, tmp_path: Path):
+        # Upgrade re-renders into a staging dir whose CCR config.json is the
+        # pristine template copy. Route detection must read the *project's*
+        # live config — detecting against staging would make `upgrade --apply`
+        # overwrite the AIBOM's real routes with template defaults.
+        from project_init.__main__ import main
+        from project_init.upgrade import write_scaffold_record
+
+        target = tmp_path / "p"
+        preset = load_preset("obsidian-only")
+        extra = overlay_layers("claude", no_plugin=False, multi_model=True, governance=True)
+        preset = {**preset, "layers": list(preset["layers"]) + extra}
+        variables = make_variables(governance="true", multi_model="true")
+        created = scaffold(target, preset, variables, strict=True)
+        write_scaffold_record(target, "obsidian-only", variables, created)
+
+        ccr = target / ".claude" / "multi-model" / "config.json"
+        data = json.loads(ccr.read_text(encoding="utf-8"))
+        data["Router"]["think"] = "myprov,my-custom-model"
+        ccr.write_text(json.dumps(data), encoding="utf-8")
+
+        assert main(["upgrade", str(target), "--apply", "--accept-new", "all"]) == 0
+        aibom = (target / _GOV / "ai-bom.generated.md").read_text(encoding="utf-8")
+        assert "my-custom-model" in aibom
+
 
 # --------------------------------------------------------------------------- #
 # Declarations lifecycle (seed-once + preserve)

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -111,6 +111,11 @@ class TestJustfilePerLanguage:
         body = _recipe_body((target / "justfile").read_text(), "typecheck")
         assert "tsc --noEmit" in body
         assert "No TypeScript sources yet" in body
+        # Prune node_modules at any depth (monorepos vendor .ts under nested
+        # node_modules) — a top-level-only "./node_modules/*" would falsely
+        # detect vendored sources and run tsc (PR #594 review).
+        assert "*/node_modules/*" in body
+        assert '"./node_modules/*"' not in body
 
     def test_python_setup_tolerates_missing_pyproject(self, tmp_path: Path):
         """`uv sync --group dev` hard-fails with no pyproject.toml (fresh

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -104,6 +104,33 @@ class TestJustfilePerLanguage:
         assert "--non-interactive" in body
         assert "--with pip" in body, "mypy --install-types needs pip in the uv environment"
 
+    def test_node_typecheck_tolerates_missing_sources(self, tmp_path: Path):
+        """The #592-adjacent day-one gap: `tsc --noEmit` fails with TS18003
+        ("No inputs were found"), not a pass, when no .ts sources exist yet."""
+        target = _scaffold_language(tmp_path / "n", "node")
+        body = _recipe_body((target / "justfile").read_text(), "typecheck")
+        assert "tsc --noEmit" in body
+        assert "No TypeScript sources yet" in body
+
+    def test_python_setup_tolerates_missing_pyproject(self, tmp_path: Path):
+        """`uv sync --group dev` hard-fails with no pyproject.toml (fresh
+        scaffold) or no [dependency-groups] table — CI's first step must not
+        die before the day-one guards in typecheck/test-cov can run."""
+        target = _scaffold_language(tmp_path / "p", "python")
+        body = _recipe_body((target / "justfile").read_text(), "setup")
+        assert "pyproject.toml" in body
+        assert "uv sync --group dev" in body
+
+    def test_go_test_cov_guards_fresh_module_and_fails_closed(self, tmp_path: Path):
+        """`go test ./...` errors on a module with no .go files (like the
+        guarded license/fuzz recipes), and the coverage gate must be
+        fail-closed: zero awk input (cover tool failed) fails the recipe
+        instead of returning awk's 0."""
+        target = _scaffold_language(tmp_path / "g", "go")
+        body = _recipe_body((target / "justfile").read_text(), "test-cov")
+        assert "No Go sources yet" in body
+        assert "NR == 0" in body, "coverage gate must fail on empty cover output"
+
     def test_python_coverage_recipe(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "p", "python")
         text = (target / "justfile").read_text()

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -90,7 +90,19 @@ class TestJustfilePerLanguage:
         target = _scaffold_language(tmp_path / "p", "python")
         body = _recipe_body((target / "justfile").read_text(), "typecheck")
         assert "if [ -d src ]" in body
-        assert "mypy src/" in body
+        assert "mypy" in body and "src/" in body
+
+    def test_python_typecheck_installs_dependency_stubs(self, tmp_path: Path):
+        """#592: `uv run --with mypy` supplies runtime deps but not their stub
+        packages, so any untyped dep (PyYAML → types-PyYAML) fails the strict
+        gate with import-untyped on a fresh scaffold. The recipe must let mypy
+        fetch stubs itself — and must pull in pip, which mypy's
+        --install-types shells out to but uv-managed environments omit."""
+        target = _scaffold_language(tmp_path / "p", "python")
+        body = _recipe_body((target / "justfile").read_text(), "typecheck")
+        assert "--install-types" in body
+        assert "--non-interactive" in body
+        assert "--with pip" in body, "mypy --install-types needs pip in the uv environment"
 
     def test_python_coverage_recipe(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "p", "python")

--- a/tests/contracts/test_parity_bundle.py
+++ b/tests/contracts/test_parity_bundle.py
@@ -41,7 +41,9 @@ class TestParityBundlePresent:
         py = _service(tmp_path / "py", "python")
         assert "python:3.13-slim" in (py / "Dockerfile").read_text()
         go = _service(tmp_path / "go", "go")
-        assert "golang:1.23" in (go / "Dockerfile").read_text()
+        # 1.24 to match mise.toml's `go` pin — a go.mod created under a newer
+        # toolchain than the build image fails with "go.mod requires go >= X".
+        assert "golang:1.24" in (go / "Dockerfile").read_text()
         rust = _service(tmp_path / "rust", "rust")
         assert "rust:1-slim-bookworm" in (rust / "Dockerfile").read_text()
 

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -144,6 +144,14 @@ class TestNodeToolchain:
         ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
         assert "just typecheck" in ci
 
+    def test_ci_install_falls_back_to_just_setup(self):
+        """A fresh node scaffold has no package.json — `bun install` errors
+        without one. CI must fall back to `just setup`, which seeds the lint
+        toolchain eslint.config.mjs imports, so the first CI run passes."""
+        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "just setup" in ci, "node CI must fall back to just setup when no package.json"
+        assert "package.json" in ci
+
     def test_typedoc_config_rendered_and_parseable(self):
         raw = (self.target / "typedoc.json").read_text()
         uncommented = re.sub(r"^\s*//.*$", "", raw, flags=re.MULTILINE)
@@ -201,6 +209,14 @@ class TestGoToolchain:
         assert "max-complexity: 10" in content, (
             "cyclop cap must mirror ruff's mccabe max-complexity = 10"
         )
+
+    def test_ci_uses_golangci_action_v8_or_newer(self):
+        """golangci-lint-action must be v8+ to run the shipped v2 config —
+        v6 caps the tool at v1.64.8, which rejects `version: "2"`."""
+        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
+        m = re.search(r"golangci/golangci-lint-action@v(\d+)", ci)
+        assert m, "golangci-lint-action must be referenced in Go CI"
+        assert int(m.group(1)) >= 8, "must be v8+ for golangci-lint v2 config"
 
     def test_no_docs_workflow(self):
         """Go needs no docs site — pkg.go.dev renders doc comments."""

--- a/tests/contracts/test_scorecard.py
+++ b/tests/contracts/test_scorecard.py
@@ -8,6 +8,7 @@ must upload SARIF to code scanning for in-repo visibility.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -31,7 +32,9 @@ class TestScorecardJob:
     def test_job_present_for_every_language(self, tmp_path: Path, language: str):
         ci = _ci(_scaffold_language(tmp_path / "p", language))
         assert "scorecard:" in ci
-        assert "ossf/scorecard-action" in ci
+        # Full X.Y.Z pin: ossf/scorecard-action publishes no floating `v2`
+        # major tag, so a bare `@v2` fails to resolve on every scheduled run.
+        assert re.search(r"ossf/scorecard-action@v\d+\.\d+\.\d+", ci)
 
     def test_scheduled_not_per_pr(self, tmp_path: Path):
         ci = _ci(_scaffold_language(tmp_path / "p", "python"))

--- a/tests/integration/test_concern_add_remove.py
+++ b/tests/integration/test_concern_add_remove.py
@@ -216,6 +216,28 @@ class TestPurgeExport:
         assert rc == 1
         assert "apply to `remove`" in capsys.readouterr().err
 
+    def test_purge_is_scoped_to_the_toggled_concern(self, tmp_path: Path, capsys):
+        # `remove docs --purge` must not sweep vault/memory notes — they belong
+        # to the memory concern, not docs. An unscoped orphan sweep deleted the
+        # user's entire vault on any remove+purge. docs owns no preserved source
+        # data at all, so the flags are rejected before anything is touched.
+        target = tmp_path / "p"
+        note = self._mem_project(target, content="irreplaceable")
+        rc = apply_concern(target, "docs", enable=False, apply=True, purge=True)
+        assert rc == 1
+        assert "owns no preserved source data" in capsys.readouterr().err
+        assert note.is_file()
+        assert note.read_text() == "irreplaceable"
+
+    def test_purge_memory_leaves_governance_source_data(self, tmp_path: Path):
+        # Purging one source-owning concern must not cross into another's data.
+        target = _scaffold(tmp_path / "p", memory_stack="obsidian-only", governance=True)
+        gov_file = target / ".claude/governance/ai-declarations.md"
+        assert gov_file.is_file()
+        apply_concern(target, "memory", enable=False, apply=True, purge=True)
+        assert not (target / ".claude/vault").exists()
+        assert gov_file.is_file()
+
     def test_purge_cleans_leftovers_after_plain_remove(self, tmp_path: Path):
         # A preserved governance user file survives a plain remove; a later --purge
         # must still clean it even though the concern flag is already off (no change).

--- a/tests/integration/test_memory_backends.py
+++ b/tests/integration/test_memory_backends.py
@@ -160,7 +160,13 @@ class TestPreservedPathExclusion:
         target = tmp_path / "p"
         _scaffold(target, "--preset", "obsidian-only")
         _preset, _vars, manifest, _migrated = read_scaffold_record(target)
-        assert not any(k.startswith((".claude/memory", ".claude/vault")) for k in manifest)
+        # READMEs are the one exception: template-owned (_ALWAYS_OVERWRITE),
+        # so they are recorded/refreshed even inside preserved dirs.
+        assert not any(
+            k.startswith((".claude/memory", ".claude/vault")) and not k.endswith("README.md")
+            for k in manifest
+        )
+        assert ".claude/vault/README.md" in manifest
 
         # A user-authored vault note is never reported as drift or an addition.
         note = target / ".claude" / "vault" / "knowledge" / "my-note.md"

--- a/tests/integration/test_memory_starters.py
+++ b/tests/integration/test_memory_starters.py
@@ -222,6 +222,36 @@ class TestLintMemoryScript:
         assert result.returncode == 1
         assert "user_role.md" in result.stderr
 
+    def test_orphan_check_matches_wikilinks_exactly(self):
+        """The orphan-note report must match note names to wikilink targets as
+        exact fixed strings, not unanchored regexes: a metacharacter name must
+        not misfire, and a name that is a substring of another's link must not
+        count as linked."""
+        subprocess.run(["git", "init", str(self.target)], capture_output=True, check=True)
+        vault = self.target / ".claude" / "vault"
+        # Metachar name, linked by another note — a regex match would error or
+        # mismatch and wrongly flag it as an orphan.
+        (vault / "plan(v2).md").write_text("# plan v2\n")
+        (vault / "roadmap.md").write_text("See [[plan(v2)]].\n")
+        # Substring trap: nothing links to `foo`, but `[[foobar]]` exists — a
+        # substring match would wrongly treat `foo` as linked.
+        (vault / "foo.md").write_text("# foo\n")
+        (vault / "bar.md").write_text("Link to [[foobar]].\n")
+        (vault / "foobar.md").write_text("# foobar\n")
+
+        script = self.target / ".claude" / "scripts" / "lint_memory.sh"
+        result = subprocess.run(
+            ["bash", str(script)], cwd=str(self.target), capture_output=True, text=True
+        )
+        # Orphan reporting is warn-only — it never fails the lint.
+        assert result.returncode == 0, result.stderr
+        assert "plan(v2).md: no inbound wikilinks" not in result.stderr, (
+            "a metacharacter note name linked by another note is not an orphan"
+        )
+        assert "foo.md: no inbound wikilinks" in result.stderr, (
+            "`foo` is an orphan — being a substring of [[foobar]] must not count as a link"
+        )
+
     def test_lint_warns_on_dangling_path_reference(self):
         """A fact naming a `path/like.ext` that doesn't exist warns but does NOT
         fail (#497, ADR-024 staleness): deterministic, advisory."""

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -420,9 +420,12 @@ class TestUpgradeApply:
     def test_preserved_dirs_untouched(self, tmp_path: Path, capsys):
         target = tmp_path / "p"
         _scaffold(target)
-        memory_files = list((target / ".claude" / "memory").glob("*.md"))
-        assert memory_files, "fixture needs a scaffolded memory file"
-        probe = memory_files[0]
+        # A user-authored memory note — NOT README.md, which is template-owned
+        # (_ALWAYS_OVERWRITE) and refreshed even inside preserved dirs (see
+        # test_vault_readme_is_managed_and_refreshed). Globbing memory/*.md and
+        # taking [0] was order-dependent and could land on the now-managed
+        # README, so probe an explicit user file instead.
+        probe = target / ".claude" / "memory" / "my-note.md"
         probe.write_text("hand-written agent memory\n")
 
         rc = main(["upgrade", str(target), "--apply"])

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -238,9 +238,13 @@ class TestScaffoldRecord:
         assert variables["language"] == "python"
         assert not migrated
         assert "justfile" in manifest
-        # The record never tracks user-owned paths.
+        # The record never tracks user-owned paths. (READMEs are template-owned
+        # — _ALWAYS_OVERWRITE — so they ARE tracked even inside preserved dirs.)
         assert _CONFIG_REL.as_posix() not in manifest
-        assert not any(k.startswith((".claude/memory", ".claude/vault")) for k in manifest)
+        assert not any(
+            k.startswith((".claude/memory", ".claude/vault")) and not k.endswith("README.md")
+            for k in manifest
+        )
 
     def test_missing_config_errors(self, tmp_path: Path, capsys):
         rc = main(["upgrade", str(tmp_path / "nope")])
@@ -337,6 +341,35 @@ class TestUpgradeApply:
         assert "changed" in capsys.readouterr().out
         assert justfile.read_bytes() == rendered_now
         assert not (target / "justfile.new").exists()
+
+    def test_vault_readme_is_managed_and_refreshed(self, tmp_path: Path):
+        """READMEs are template-owned even inside preserved dirs (they are in
+        _ALWAYS_OVERWRITE): they must be recorded in the manifest and refreshed
+        like any managed file. Before, write_scaffold_record skipped everything
+        under memory/vault, so a re-run found no recorded hash, assumed the
+        user owned the README, and parked every template-side refresh as a
+        `.new` sibling plus a spurious conflict — the refresh rule was dead."""
+        target = tmp_path / "p"
+        _scaffold(target)
+        rel = ".claude/vault/README.md"
+        readme = target / rel
+        assert readme.is_file()
+        _, _, manifest, _ = read_scaffold_record(target)
+        assert rel in manifest, "vault README must be a managed (recorded) file"
+
+        rendered_now = readme.read_bytes()
+        # Simulate an old render: different content, hash recorded as such.
+        old_render = b"# old vault readme\n"
+        readme.write_bytes(old_render)
+        _patch_manifest(
+            target,
+            lambda m: m.__setitem__(rel, hashlib.sha256(old_render).hexdigest()),
+        )
+
+        rc = main(["upgrade", str(target), "--apply"])
+        assert rc == 0
+        assert readme.read_bytes() == rendered_now, "stale README must refresh"
+        assert not (target / f"{rel}.new").exists()
 
     def test_user_edit_with_no_upstream_change_is_kept(self, tmp_path: Path):
         """User edited a file but upstream did not change it: the 3-way merge has

--- a/tests/unit/test_presets_inheritance.py
+++ b/tests/unit/test_presets_inheritance.py
@@ -89,6 +89,17 @@ class TestCompatMarker:
         )
         assert sc.load_preset("ok")["name"] == "ok"
 
+    def test_malformed_marker_raises(self, presets_dir: Path):
+        # A hand-authored two-component marker would otherwise parse as (0,0,0)
+        # and silently disable the compat gate the preset author asked for.
+        _write(
+            presets_dir,
+            "bad",
+            'name="bad"\ndescription="b"\nlayers=[]\nmin_project_init_version="99.0"\n',
+        )
+        with pytest.raises(ValueError, match="unparseable"):
+            sc.load_preset("bad")
+
 
 class TestGenerate:
     def test_generate_and_load(self, presets_dir: Path):


### PR DESCRIPTION
## What & why

Fixes the registered bug (#592) plus a set of related failures found while auditing the scaffolder source and the templates it emits into other projects. Four themed commits:

**1. Registered bug (#592) — typecheck omits dependency stubs**
The Python `typecheck` recipe ran `uv run --with mypy mypy src/`, which supplies runtime deps but not their stub packages, so any untyped dependency (PyYAML → `types-PyYAML`) failed the strict gate with `import-untyped` on a fresh scaffold's first CI run. The recipe now runs `mypy --install-types --non-interactive`. The issue's suggested one-liner alone doesn't actually work under uv — uv's ephemeral environments ship no `pip`, and mypy shells out to `pip` to install stubs — so the recipe also adds `--with pip`. Reproduced the original failure and verified the fix goes green from both a fresh and a stale mypy cache. The 0.6.0 migration note now also warns upgraders that `just ci` gained a blocking strict-mypy gate.

**2. Scaffolded lifecycle scripts — portability & correctness**
- `create_issue.sh` / `setup_env_protection.sh.tmpl`: guard empty-array expansions (`ACCEPTANCE`, `LABEL_ARGS`, `parts`) — under `set -u` on bash < 4.4 (macOS ships 3.2) expanding an empty array is fatal, so a plain `create_issue.sh feat "desc"` died before creating the issue, and the documented missing-label / unresolved-reviewer fallbacks crashed.
- `gh_host.sh`: `gh_profile()` anchored on the caller's cwd resolved to the `individual` default from any subdirectory, letting `monitor_pr.sh` admin-merge past org branch protection and `setup_github.sh` skip the org ruleset. Now anchored on the script's own location (as is `start_issue.sh`'s `push_branch.sh` call and project-key lookup).
- `monitor_pr.sh`: accept `--review-cycle`/`--no-review`/`--admin` without `--merge`, as the usage line documents.
- `lint_memory.sh`: match orphan-note wikilinks as exact fixed strings (was an unanchored regex — metacharacter note names misfired, substring hits masked real orphans).

**3. Engine correctness**
- `concerns.py`: scope `remove --purge/--export` to the toggled concern's own source data — the orphan sweep targeted every preserved file absent from the fresh render, i.e. the user's entire `.claude/vault`, so `remove docs --purge` permanently deleted user notes.
- `governance.py` / `upgrade.py` / `scaffold.py`: AIBOM CCR-route detection now reads the real project's config on upgrade/add/remove (new `detect_root` threading) instead of the staging render's pristine template copy, which made `upgrade --apply` clobber detected routes with template defaults.
- `upgrade.py`: record READMEs in the manifest even inside preserved dirs (mirroring scaffold's `_ALWAYS_OVERWRITE`), so the "READMEs always refresh" rule actually fires instead of parking every refresh as a spurious `.new` conflict.
- `scaffold.py`: reject an unparseable preset `min_project_init_version` instead of letting it sort as `(0,0,0)` and silently disable the compat gate.

**4. Scaffolded CI / config templates**
- `golangci-lint-action` v6 → v8 (v6 caps the tool at v1.64.8, which rejects the shipped `version: "2"` config); pin `ossf/scorecard-action@v2.4.3` (no floating `v2` tag exists upstream); Go Dockerfile builds the root package and matches mise's `go = "1.24"` pin; `go`/`node`/`python` recipes and node CI now survive a fresh scaffold with no sources yet; the Go coverage gate is fail-closed; the governance job is wired into `ci-gate` when the overlay is on.

Every fix has a new or updated test; the full suite passes (1858 passed, 2 skipped) and `just lint` is clean.

## Related issue

Closes #592

## Checklist

- [x] `just ci` passes locally (lint + full test suite)
- [x] Changes under `templates/` have a matching test in `tests/<layer>/test_*.py`
- [x] Docs / README updated if behavior or flags changed (0.6.0 migration note extended)
- [x] PR title follows Conventional Commits (`type(PI-N): description`, or `type: description` with no issue)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcbaMzawBmqCHgs5DwfayV)_