### PR TITLE
fix: unbreak fresh-scaffold lint gate (shfmt + ruff S on emitted scripts)

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: "3.12"
 
+      # shellcheck ships preinstalled on ubuntu-24.04; shfmt does not. The
+      # scaffolded-output lint guard (test_shell_lint_gate.py) skips when its
+      # tool is absent, so without this step the shfmt guard would silently
+      # no-op in CI — a green check that tested nothing. Pinned + checksum-
+      # verified, mirroring the install the scaffolded ci.yml.tmpl ships.
+      - name: Install shfmt
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tmp="$(mktemp -d)"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
+          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
+          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
+          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Sync dev dependencies
         run: uv sync --group dev --locked
 

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
+++ b/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
@@ -30,9 +30,26 @@ WAIT_MIN=5
 REVIEWERS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --reviewer) [ $# -ge 2 ] || { echo "Missing value for --reviewer" >&2; exit 1; }; REVIEWERS+=("$2"); shift 2 ;;
-    --wait) [ $# -ge 2 ] || { echo "Missing value for --wait" >&2; exit 1; }; WAIT_MIN="$2"; shift 2 ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  --reviewer)
+    [ $# -ge 2 ] || {
+      echo "Missing value for --reviewer" >&2
+      exit 1
+    }
+    REVIEWERS+=("$2")
+    shift 2
+    ;;
+  --wait)
+    [ $# -ge 2 ] || {
+      echo "Missing value for --wait" >&2
+      exit 1
+    }
+    WAIT_MIN="$2"
+    shift 2
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
   esac
 done
 
@@ -83,7 +100,10 @@ if [ "$PROFILE" = "org" ]; then
     # parts can be empty when every --reviewer failed to resolve; the ${arr[*]+}
     # guard keeps that path on bash < 4.4 (macOS 3.2), where expanding an empty
     # array under `set -u` is fatal, so it reaches the UNCHANGED warning below.
-    reviewers_json="[$(IFS=,; echo ${parts[*]+"${parts[*]}"})]"
+    reviewers_json="[$(
+      IFS=,
+      echo ${parts[*]+"${parts[*]}"}
+    )]"
   fi
   if [ "$reviewers_json" = "[]" ]; then
     # Do NOT PUT an empty-reviewers payload — that would WIPE any reviewers already
@@ -93,14 +113,14 @@ if [ "$PROFILE" = "org" ]; then
     echo "    setup_env_protection.sh --reviewer @your-org/your-team" >&2
     SKIP_PROD=1
   else
-    cat > "$BODY" <<JSON
+    cat >"$BODY" <<JSON
 { "prevent_self_review": true, "can_admins_bypass": false, "reviewers": $reviewers_json,
   "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
 JSON
     GATE_DESC="required reviewers + prevent-self-review + no admin bypass (hard human gate)"
   fi
 else
-  cat > "$BODY" <<JSON
+  cat >"$BODY" <<JSON
 { "wait_timer": $WAIT_MIN,
   "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
 JSON
@@ -108,12 +128,12 @@ JSON
 fi
 
 if [ "$SKIP_PROD" = 1 ]; then
-  :  # production left untouched (see warning above)
+  : # production left untouched (see warning above)
 elif gh api "repos/$OWNER/$NAME/environments/production" -X PUT --input "$BODY" >/dev/null 2>&1; then
   echo "Environment 'production' ensured: $GATE_DESC"
   # Restrict production deploys to the base branch.
   if gh api "repos/$OWNER/$NAME/environments/production/deployment-branch-policies" \
-       -X POST -f name="$BASE" >/dev/null 2>&1; then
+    -X POST -f name="$BASE" >/dev/null 2>&1; then
     echo "  production deploys restricted to '$BASE'"
   else
     echo "  (branch policy for '$BASE' may already exist)"

--- a/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
+++ b/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
@@ -26,7 +26,8 @@ ENVS_FILE="$(cd "$SCRIPT_DIR/../.." && pwd)/deploy/environments.yaml"
 ENVS=()
 if [ -f "$ENVS_FILE" ]; then
   while IFS= read -r e; do ENVS+=("$e"); done < <(
-    sed -n 's/^  \([a-z][a-z0-9_-]*\):$/\1/p' "$ENVS_FILE")
+    sed -n 's/^  \([a-z][a-z0-9_-]*\):$/\1/p' "$ENVS_FILE"
+  )
 fi
 [ "${#ENVS[@]}" -eq 0 ] && ENVS=(staging production)
 
@@ -36,7 +37,7 @@ any=0
 for env in "${ENVS[@]}"; do
   line=$(gh api "repos/$OWNER/$NAME/deployments?environment=$env&per_page=1" \
     -q '.[0] | "\(.id // "")\t\(.sha[0:7] // "?")\t\(.created_at // "?")"' 2>/dev/null || true)
-  IFS=$'\t' read -r id sha when <<< "$line"
+  IFS=$'\t' read -r id sha when <<<"$line"
   if [ -z "${id:-}" ]; then
     printf '%-14s %-12s %-10s %s\n' "$env" "—" "—" "(no GitHub deployment)"
     continue

--- a/templates/lifecycle/dot_claude/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_claude/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -49,6 +49,13 @@ normalization + GraphQL-merge rule + interpreter-heredoc scanning),
 (rm split-flag detection), `commit-msg` (corrected install comment), and the
 fallback hooks `pre_commit_gate.sh` / `post_edit_lint.sh` (cd to repo root so a
 subdirectory session lints the right paths).
+
+Exception (init-lint fix): `dag_workflow.py` gained three `# noqa: S603`
+directives on its `subprocess.run` calls — the scaffolded `ruff.toml` selects
+`S` and lints `.claude/**`, so a fresh lifecycle-on project's `just lint` failed
+on those argv-list (never shell-string) calls, mirroring the `# noqa: S310`
+package_guard.py already carries. Only the `.claude/hooks/dag_workflow.py` hash
+was re-pinned across all four combos, after verifying every other file matched.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/integration/test_quality_gate_lint.py
+++ b/tests/integration/test_quality_gate_lint.py
@@ -3,6 +3,14 @@
 A fresh project must start green — ruff (with the scaffolded ruff.toml,
 including docstring and complexity gates) has to accept everything
 project-init itself puts in the target directory.
+
+The lifecycle-on case is a distinct guard: the default scaffold enables the
+GitHub lifecycle overlay, which ships ``.claude/hooks/dag_workflow.py`` — a file
+the base/obsidian-only case never emits. Since the scaffolded ``ruff.toml``
+selects ``S`` (bandit) and lints ``.claude/**``, that hook's ``subprocess.run``
+calls tripped ``S603`` and turned a fresh project's ``just lint`` red on the
+first push until the calls were annotated. Lint the config the CLI actually
+produces, not just the barest preset.
 """
 
 from __future__ import annotations
@@ -12,26 +20,21 @@ from pathlib import Path
 
 import pytest
 
-from project_init.scaffold import load_preset, scaffold
+from project_init.scaffold import load_preset, overlay_layers, scaffold
 from tests.helpers import find_uv, make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-@pytest.mark.skipif(find_uv() is None, reason="uv not available")
-def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
-    scaffold(
-        tmp_target,
-        load_preset("obsidian-only"),
-        make_variables(language="python", python="true", node="", go=""),
-    )
-    assert (tmp_target / "ruff.toml").is_file()
+def _ruff_check(target: Path) -> subprocess.CompletedProcess:
+    """Run the scaffolded ruff gate against *target* exactly as ``just lint`` does.
 
-    # --config pins the scaffolded ruff.toml so this repo's config can't leak
-    # in; cwd must be the target because ruff resolves relative
-    # per-file-ignores globs (".claude/**") against the working directory.
-    # `--project` keeps uv resolving this repo's environment for the ruff bin.
-    result = subprocess.run(
+    ``--config`` pins the scaffolded ruff.toml so this repo's config can't leak
+    in; cwd must be the target because ruff resolves relative per-file-ignores
+    globs (``.claude/**``) against the working directory. ``--project`` keeps uv
+    resolving this repo's environment for the ruff bin.
+    """
+    return subprocess.run(
         [
             find_uv(),
             "run",
@@ -43,10 +46,49 @@ def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
             "ruff.toml",
             ".",
         ],
-        cwd=tmp_target,
+        cwd=target,
         capture_output=True,
         text=True,
     )
+
+
+@pytest.mark.skipif(find_uv() is None, reason="uv not available")
+def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
+    scaffold(
+        tmp_target,
+        load_preset("obsidian-only"),
+        make_variables(language="python", python="true", node="", go=""),
+    )
+    assert (tmp_target / "ruff.toml").is_file()
+
+    result = _ruff_check(tmp_target)
     assert result.returncode == 0, (
         f"scaffolded project does not pass its own lint gate:\n{result.stdout}{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(find_uv() is None, reason="uv not available")
+def test_ruff_passes_with_lifecycle_hooks(tmp_target: Path):
+    """The default lifecycle-on scaffold must also start green.
+
+    Reproduces the CLI's layer assembly (preset + lifecycle overlay) so
+    ``.claude/hooks/dag_workflow.py`` is emitted and actually linted — the file
+    the obsidian-only-only guard above never covers.
+    """
+    preset = load_preset("obsidian-only")
+    stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")
+    extra = overlay_layers([], no_plugin=False, memory_stack=stack, lifecycle=True)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    scaffold(
+        tmp_target,
+        preset,
+        make_variables(language="python", python="true", node="", go="", lifecycle="true"),
+    )
+    assert (tmp_target / ".claude" / "hooks" / "dag_workflow.py").is_file(), (
+        "lifecycle overlay did not emit dag_workflow.py — test no longer guards the S603 path"
+    )
+
+    result = _ruff_check(tmp_target)
+    assert result.returncode == 0, (
+        f"lifecycle-on scaffold does not pass its own lint gate:\n{result.stdout}{result.stderr}"
     )

--- a/tests/integration/test_quality_gate_lint.py
+++ b/tests/integration/test_quality_gate_lint.py
@@ -73,7 +73,7 @@ def test_ruff_passes_with_lifecycle_hooks(tmp_target: Path):
 
     Reproduces the CLI's layer assembly (preset + lifecycle overlay) so
     ``.claude/hooks/dag_workflow.py`` is emitted and actually linted — the file
-    the obsidian-only-only guard above never covers.
+    the obsidian-only guard above never covers.
     """
     preset = load_preset("obsidian-only")
     stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -96,6 +96,6 @@ def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
         )
         if result.returncode != 0:
             failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
-    assert not failures, "emitted .claude scripts fail `shellcheck -S error`:\n" + "\n".join(
+    assert not failures, "emitted .claude scripts fail `shellcheck -S error -x`:\n" + "\n".join(
         failures
     )

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -1,0 +1,101 @@
+"""The scaffolded shell scripts must pass the `just lint` shell gate on a fresh
+project.
+
+`just lint` (and the CI `Lint` step) runs `shellcheck -S error -x` and
+`shfmt -d -i 2` over every `.claude/**/*.sh` a scaffold emits. Those tools are
+installed unconditionally in CI, so a single un-formatted emitted script turns a
+brand-new project red on its first push — regardless of language or whether the
+user has added a pyproject yet.
+
+The failure that motivated this guard: `setup_env_protection.sh` and
+`whats_deployed.sh` (emitted only for a service + deploy-target scaffold, a combo
+no other lint test exercised) shipped un-`shfmt`-formatted. Contract tests that
+merely assert the justfile *contains* the `shfmt` string never ran the tool on
+the emitted output. This one does.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, overlay_layers, scaffold
+from tests.helpers import make_variables
+
+_SHFMT = shutil.which("shfmt")
+_SHELLCHECK = shutil.which("shellcheck")
+
+
+def _service_deploy_lifecycle(target: Path) -> Path:
+    """A service + deploy + lifecycle scaffold — the widest emitted-script set.
+
+    deploy!=none adds setup_env_protection.sh + whats_deployed.sh; the lifecycle
+    overlay adds the DAG guard/workflow scripts. Together they cover the scripts
+    the narrower per-feature tests each miss.
+    """
+    preset = load_preset("obsidian-only")
+    stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")
+    extra = overlay_layers([], no_plugin=False, memory_stack=stack, lifecycle=True)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    scaffold(
+        target,
+        preset,
+        make_variables(
+            language="python",
+            python="true",
+            node="",
+            go="",
+            lifecycle="true",
+            delivery="service",
+            delivery_service="true",
+            deploy_target="cloud-run",
+            deploy_enabled="true",
+            deploy_container="true",
+            deploy_cloud_run="true",
+        ),
+    )
+    return target
+
+
+def _claude_scripts(target: Path) -> list[Path]:
+    return sorted((target / ".claude").rglob("*.sh"))
+
+
+@pytest.mark.skipif(_SHFMT is None, reason="shfmt not available")
+def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
+    _service_deploy_lifecycle(tmp_target)
+    scripts = _claude_scripts(tmp_target)
+    # Guard against the scaffold silently emitting nothing and the test passing
+    # vacuously — the deploy-gated scripts must be present to be checked.
+    names = {p.name for p in scripts}
+    assert {"setup_env_protection.sh", "whats_deployed.sh"} <= names, names
+
+    dirty = []
+    for p in scripts:
+        result = subprocess.run(
+            [_SHFMT, "-d", "-i", "2", str(p)], capture_output=True, text=True
+        )
+        if result.stdout.strip() or result.returncode != 0:
+            dirty.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
+    assert not dirty, "emitted .claude scripts fail `shfmt -d -i 2`:\n" + "\n".join(dirty)
+
+
+@pytest.mark.skipif(_SHELLCHECK is None, reason="shellcheck not available")
+def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
+    _service_deploy_lifecycle(tmp_target)
+    scripts = _claude_scripts(tmp_target)
+    assert scripts, "no .claude/**/*.sh emitted — test guards nothing"
+
+    failures = []
+    for p in scripts:
+        result = subprocess.run(
+            [_SHELLCHECK, "-S", "error", "-x", str(p)], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
+    assert not failures, "emitted .claude scripts fail `shellcheck -S error`:\n" + "\n".join(
+        failures
+    )

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -16,6 +16,7 @@ the emitted output. This one does.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -27,6 +28,23 @@ from tests.helpers import make_variables
 
 _SHFMT = shutil.which("shfmt")
 _SHELLCHECK = shutil.which("shellcheck")
+
+
+def _require(tool: str | None, name: str) -> str:
+    """Return the tool path, or fail in CI / skip locally when it is absent.
+
+    A plain ``skipif`` would let this guard silently no-op wherever the tool
+    isn't installed — including CI if its install step is ever dropped, turning
+    a green check into one that tested nothing (the exact failure mode this
+    module exists to prevent). Under ``CI`` a missing tool is a hard error so
+    the gap is loud; locally it degrades to a skip so `just test` still runs.
+    """
+    if tool:
+        return tool
+    msg = f"{name} not on PATH"
+    if os.environ.get("CI"):
+        pytest.fail(f"{msg} — required in CI so the {name} scaffold-lint gate can't silently skip")
+    pytest.skip(msg)
 
 
 def _service_deploy_lifecycle(target: Path) -> Path:
@@ -64,8 +82,8 @@ def _claude_scripts(target: Path) -> list[Path]:
     return sorted((target / ".claude").rglob("*.sh"))
 
 
-@pytest.mark.skipif(_SHFMT is None, reason="shfmt not available")
 def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
+    shfmt = _require(_SHFMT, "shfmt")
     _service_deploy_lifecycle(tmp_target)
     scripts = _claude_scripts(tmp_target)
     # Guard against the scaffold silently emitting nothing and the test passing
@@ -76,15 +94,15 @@ def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
     dirty = []
     for p in scripts:
         result = subprocess.run(
-            [_SHFMT, "-d", "-i", "2", str(p)], capture_output=True, text=True
+            [shfmt, "-d", "-i", "2", str(p)], capture_output=True, text=True
         )
         if result.stdout.strip() or result.returncode != 0:
             dirty.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
     assert not dirty, "emitted .claude scripts fail `shfmt -d -i 2`:\n" + "\n".join(dirty)
 
 
-@pytest.mark.skipif(_SHELLCHECK is None, reason="shellcheck not available")
 def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
+    shellcheck = _require(_SHELLCHECK, "shellcheck")
     _service_deploy_lifecycle(tmp_target)
     scripts = _claude_scripts(tmp_target)
     assert scripts, "no .claude/**/*.sh emitted — test guards nothing"
@@ -92,7 +110,7 @@ def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
     failures = []
     for p in scripts:
         result = subprocess.run(
-            [_SHELLCHECK, "-S", "error", "-x", str(p)], capture_output=True, text=True
+            [shellcheck, "-S", "error", "-x", str(p)], capture_output=True, text=True
         )
         if result.returncode != 0:
             failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")


### PR DESCRIPTION
## What & why

A freshly scaffolded project's `just lint` (and the CI `Lint` step) failed on the **first push** — no user code involved, the emitted files themselves were red. Two independent defects:

**1. `shfmt` — service + deploy scaffolds.** `.claude/scripts/setup_env_protection.sh` and `whats_deployed.sh` (emitted for `--delivery service --deploy …`) shipped un-`shfmt`-formatted. They live under `.claude/`, which `just lint` runs `shfmt -d -i 2` over, so the gate failed. Reformatted the templates; a stray EOF blank line (the trailing newline after `{{/if}}`) is dropped by closing the conditional with no trailing newline — the `codex/hooks.json.tmpl` / `Dockerfile.tmpl` convention. Semantics unchanged (`bash -n` + the deploy-overlay contract still pass).

**2. `ruff S603` — every lifecycle-on Python project (the default).** The scaffolded `ruff.toml` selects `S` (bandit) and lints `.claude/**`, but `.claude/hooks/dag_workflow.py`'s three `subprocess.run` calls (argv lists, never shell strings) were never annotated, so the ruff step failed. Added `# noqa: S603` with justifications, mirroring the `# noqa: S310` `package_guard.py` already carries.

**Why it slipped through:** the ruff gate test only scaffolded a lifecycle-**off** preset (no `dag_workflow.py`), and no test ran `shfmt`/`shellcheck` on emitted scripts at all (the contract only asserted the justfile *contained* the `shfmt` string). Both gaps are now closed:
- `test_quality_gate_lint.py` also lints a lifecycle-on scaffold.
- new `test_shell_lint_gate.py` runs the real `shfmt -d -i 2` + `shellcheck -S error -x` gate over a service+deploy+lifecycle scaffold's `.claude` scripts.

Both new tests fail against the pre-fix templates and pass after. Re-pinned the `dag_workflow.py` hash in the 8 lifecycle/memory byte-identity baselines (only that key drifted) and re-synced the lifecycle plugin payload.

## Related issue

<!-- Minor fix, no tracking issue. -->

## Checklist

- [x] `just ci` passes locally (lint + full test suite — 1865 passed, 2 skipped)
- [x] Changes under `templates/` have a matching test in `tests/<layer>/test_*.py`
- [ ] Docs / README updated if behavior or flags changed (no behavior/flag change)
- [x] PR title follows Conventional Commits (`type: description`, no issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_012WXwBMpWF9jumzV8j3qyPg)_