### PR TITLE
feat: shift-left static checks into commit/push hooks (repo + scaffolded)

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,12 +12,22 @@
 set -euo pipefail
 
 if command -v just >/dev/null 2>&1; then
-  echo "pre-push: running 'just ci' (lint + tests)…"
-  if ! just ci; then
-    echo ""
-    echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
-    echo "   (bypass in an emergency with: git push --no-verify)"
-    exit 1
+  # `just ci` tests the working tree, but the push ships the committed tree.
+  # Skip (fail-open) on a dirty worktree rather than test a tree that isn't what
+  # gets pushed — a WIP fix could mask a failure, or unrelated WIP fail a clean
+  # push. CI stays the backstop.
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    echo "pre-push: working tree is dirty — skipping the 'just ci' gate" >&2
+    echo "  (it would test the worktree, not the commit being pushed)." >&2
+    echo "  Commit or stash your changes to run the gate before pushing." >&2
+  else
+    echo "pre-push: running 'just ci' (lint + tests)…"
+    if ! just ci; then
+      echo ""
+      echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+      echo "   (bypass in an emergency with: git push --no-verify)"
+      exit 1
+    fi
   fi
 else
   echo "pre-push: 'just' not found — skipping local CI gate (CI still runs)." >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# pre-push gate for the project-init repo itself (dogfood).
+#
+# Runs the SAME `just ci` (lint + tests) that CI runs, before the push leaves
+# the machine — so nothing red reaches a PR and the push→CI-fail→fix→re-push
+# loop is caught locally. This is the local↔CI parity gate whose absence let a
+# fresh-scaffold lint failure ship (the scaffolder's CI caught it only after a
+# push, and even then incompletely).
+#
+# Enabled automatically by `just setup` (git config core.hooksPath .githooks).
+# Bypass in an emergency with: git push --no-verify
+set -euo pipefail
+
+if command -v just >/dev/null 2>&1; then
+  echo "pre-push: running 'just ci' (lint + tests)…"
+  if ! just ci; then
+    echo ""
+    echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+    echo "   (bypass in an emergency with: git push --no-verify)"
+    exit 1
+  fi
+else
+  echo "pre-push: 'just' not found — skipping local CI gate (CI still runs)." >&2
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: "3.12"
 
+      # shellcheck ships preinstalled on ubuntu-24.04; shfmt does not. The
+      # scaffolded-output lint guard (test_shell_lint_gate.py) skips when its
+      # tool is absent, so without this step the shfmt guard would silently
+      # no-op in CI — a green check that tested nothing. Pinned + checksum-
+      # verified, mirroring the install the scaffolded ci.yml.tmpl ships.
+      - name: Install shfmt
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tmp="$(mktemp -d)"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
+          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
+          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
+          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Sync dev dependencies
         run: uv sync --group dev --locked
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,11 @@ just --list         # see all recipes
 | `just format` | ruff format |
 | `just test` | full pytest suite (`pytest -n auto`) |
 | `just docs` | build the MkDocs site |
-| `just ci` | lint + test (run before pushing) |
+| `just ci` | lint + test (also enforced automatically on `git push`) |
+
+`just setup` points `core.hooksPath` at `.githooks/`, so the `pre-push` hook
+runs `just ci` before every push — nothing red reaches a PR. Bypass in an
+emergency with `git push --no-verify`.
 
 Tooling conventions: **uv** for everything (never `pip`/`venv`), **ruff** only
 (no black/isort/mypy), and keep dependencies minimal — `tomllib` + `argparse`

--- a/justfile
+++ b/justfile
@@ -2,9 +2,11 @@
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
 
-# install/sync dev dependencies
+# install/sync dev dependencies + enable the local pre-push CI gate (dogfood).
+# core.hooksPath points git at .githooks/, so `just ci` runs before every push.
 setup:
     uv sync --group dev
+    git config core.hooksPath .githooks
 
 # lint (docstring + complexity gates per pyproject.toml)
 lint:

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -91,7 +91,13 @@ while IFS= read -r _f; do [ -n "$_f" ] && STAGED_SH+=("$_f"); done \
   < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.sh$' || true)
 if [ "${#STAGED_SH[@]}" -gt 0 ]; then
   if command -v shfmt >/dev/null 2>&1; then
-    shfmt -w -i 2 "${STAGED_SH[@]}" >/dev/null 2>&1 || true
+    # -w auto-formats in place. A NONZERO exit means shfmt could not parse a
+    # file (a real shell syntax error) and left it unchanged — record that as a
+    # blocking error instead of swallowing it, so a broken script can't slip
+    # through when shellcheck is unavailable.
+    if ! SHFMT_OUT=$(shfmt -w -i 2 "${STAGED_SH[@]}" 2>&1); then
+      ERRORS="${ERRORS}Shell format errors (shfmt):\n${SHFMT_OUT}\n"
+    fi
     git add "${STAGED_SH[@]}" 2>/dev/null || true
   fi
   if command -v shellcheck >/dev/null 2>&1; then

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -79,6 +79,29 @@ if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
   git add "${STAGED_JS[@]}" 2>/dev/null || true
 fi
 
+# Lint and auto-fix staged shell scripts. The `just lint` block below already
+# runs shfmt+shellcheck over .claude/**, but only when a justfile with a lint
+# recipe and `just` are present — so a project without `just`, or a staged .sh
+# outside .claude, would otherwise reach commit unchecked. shfmt -w auto-fixes
+# formatting and is re-staged; shellcheck errors can't be auto-fixed, so they
+# are reported. Fail open when a tool is absent (CI is the hard backstop) —
+# same posture as the ruff/eslint blocks above.
+STAGED_SH=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_SH+=("$_f"); done \
+  < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.sh$' || true)
+if [ "${#STAGED_SH[@]}" -gt 0 ]; then
+  if command -v shfmt >/dev/null 2>&1; then
+    shfmt -w -i 2 "${STAGED_SH[@]}" >/dev/null 2>&1 || true
+    git add "${STAGED_SH[@]}" 2>/dev/null || true
+  fi
+  if command -v shellcheck >/dev/null 2>&1; then
+    SH_OUT=$(shellcheck -S error -x "${STAGED_SH[@]}" 2>&1 || true)
+    if [ -n "$SH_OUT" ]; then
+      ERRORS="${ERRORS}Shell lint errors (shellcheck):\n${SH_OUT}\n"
+    fi
+  fi
+fi
+
 # PI-139: when the project ships a justfile with a lint recipe and just is
 # installed, additionally gate on `just lint` — the same definition of "lint
 # passes" CI and every agent use. Per-file findings above are preserved: the

--- a/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
+++ b/templates/base/dot_claude/scripts/setup_env_protection.sh.tmpl
@@ -30,9 +30,26 @@ WAIT_MIN=5
 REVIEWERS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --reviewer) [ $# -ge 2 ] || { echo "Missing value for --reviewer" >&2; exit 1; }; REVIEWERS+=("$2"); shift 2 ;;
-    --wait) [ $# -ge 2 ] || { echo "Missing value for --wait" >&2; exit 1; }; WAIT_MIN="$2"; shift 2 ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  --reviewer)
+    [ $# -ge 2 ] || {
+      echo "Missing value for --reviewer" >&2
+      exit 1
+    }
+    REVIEWERS+=("$2")
+    shift 2
+    ;;
+  --wait)
+    [ $# -ge 2 ] || {
+      echo "Missing value for --wait" >&2
+      exit 1
+    }
+    WAIT_MIN="$2"
+    shift 2
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
   esac
 done
 
@@ -83,7 +100,10 @@ if [ "$PROFILE" = "org" ]; then
     # parts can be empty when every --reviewer failed to resolve; the ${arr[*]+}
     # guard keeps that path on bash < 4.4 (macOS 3.2), where expanding an empty
     # array under `set -u` is fatal, so it reaches the UNCHANGED warning below.
-    reviewers_json="[$(IFS=,; echo ${parts[*]+"${parts[*]}"})]"
+    reviewers_json="[$(
+      IFS=,
+      echo ${parts[*]+"${parts[*]}"}
+    )]"
   fi
   if [ "$reviewers_json" = "[]" ]; then
     # Do NOT PUT an empty-reviewers payload — that would WIPE any reviewers already
@@ -93,14 +113,14 @@ if [ "$PROFILE" = "org" ]; then
     echo "    setup_env_protection.sh --reviewer @your-org/your-team" >&2
     SKIP_PROD=1
   else
-    cat > "$BODY" <<JSON
+    cat >"$BODY" <<JSON
 { "prevent_self_review": true, "can_admins_bypass": false, "reviewers": $reviewers_json,
   "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
 JSON
     GATE_DESC="required reviewers + prevent-self-review + no admin bypass (hard human gate)"
   fi
 else
-  cat > "$BODY" <<JSON
+  cat >"$BODY" <<JSON
 { "wait_timer": $WAIT_MIN,
   "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
 JSON
@@ -108,12 +128,12 @@ JSON
 fi
 
 if [ "$SKIP_PROD" = 1 ]; then
-  :  # production left untouched (see warning above)
+  : # production left untouched (see warning above)
 elif gh api "repos/$OWNER/$NAME/environments/production" -X PUT --input "$BODY" >/dev/null 2>&1; then
   echo "Environment 'production' ensured: $GATE_DESC"
   # Restrict production deploys to the base branch.
   if gh api "repos/$OWNER/$NAME/environments/production/deployment-branch-policies" \
-       -X POST -f name="$BASE" >/dev/null 2>&1; then
+    -X POST -f name="$BASE" >/dev/null 2>&1; then
     echo "  production deploys restricted to '$BASE'"
   else
     echo "  (branch policy for '$BASE' may already exist)"

--- a/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
+++ b/templates/base/dot_claude/scripts/whats_deployed.sh.tmpl
@@ -26,7 +26,8 @@ ENVS_FILE="$(cd "$SCRIPT_DIR/../.." && pwd)/deploy/environments.yaml"
 ENVS=()
 if [ -f "$ENVS_FILE" ]; then
   while IFS= read -r e; do ENVS+=("$e"); done < <(
-    sed -n 's/^  \([a-z][a-z0-9_-]*\):$/\1/p' "$ENVS_FILE")
+    sed -n 's/^  \([a-z][a-z0-9_-]*\):$/\1/p' "$ENVS_FILE"
+  )
 fi
 [ "${#ENVS[@]}" -eq 0 ] && ENVS=(staging production)
 
@@ -36,7 +37,7 @@ any=0
 for env in "${ENVS[@]}"; do
   line=$(gh api "repos/$OWNER/$NAME/deployments?environment=$env&per_page=1" \
     -q '.[0] | "\(.id // "")\t\(.sha[0:7] // "?")\t\(.created_at // "?")"' 2>/dev/null || true)
-  IFS=$'\t' read -r id sha when <<< "$line"
+  IFS=$'\t' read -r id sha when <<<"$line"
   if [ -z "${id:-}" ]; then
     printf '%-14s %-12s %-10s %s\n' "$env" "—" "—" "(no GitHub deployment)"
     continue

--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -49,6 +49,14 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
     trap - EXIT
     echo "" >&2
     echo "❌ pre-commit: 'just lint' failed — fix the errors above before committing." >&2
+    # `just lint` lints the whole tree, so untracked files are included too.
+    # That's usually what you want, but it means an untracked file unrelated to
+    # this commit can trip the gate — call that out so it's diagnosable rather
+    # than baffling.
+    if [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+      echo "   Note: untracked files are linted too; if the error is in one, it isn't part" >&2
+      echo "   of this commit — check 'git status' (or 'git stash -u' them, then retry)." >&2
+    fi
     echo "   (bypass in an emergency with: git commit --no-verify)" >&2
     exit 1
   fi

--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -17,12 +17,43 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 # 1. Lint gate — same command surface as CI and the agent commit gate (PI-139).
 if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
   (cd "$REPO_ROOT" && just --show lint >/dev/null 2>&1); then
+  # Lint exactly the STAGED snapshot, not the working tree: otherwise an unstaged
+  # fix could mask a staged lint error (or unstaged WIP could fail a clean
+  # commit). Temporarily strip unstaged tracked changes with a saved patch — NOT
+  # `git stash`, whose pop merges and leaves conflict markers when the same file
+  # is both staged and unstaged. A patch reverse/forward is conflict-free here
+  # because `just lint` is read-only. A trap always restores; if the tree can't
+  # be isolated safely (e.g. binary diffs, apply failure), fall back to linting
+  # the worktree rather than risk touching it. No unstaged changes → the worktree
+  # already equals the index, so skip the dance entirely.
+  _patch=""
+  _restore() {
+    if [ -n "$_patch" ]; then
+      git apply --whitespace=nowarn "$_patch" >/dev/null 2>&1 || true
+      rm -f "$_patch"
+      _patch=""
+    fi
+  }
+  if ! git diff --quiet 2>/dev/null; then
+    _p="$(mktemp)"
+    if git diff --binary --no-color >"$_p" 2>/dev/null &&
+      git apply -R --whitespace=nowarn "$_p" >/dev/null 2>&1; then
+      _patch="$_p"
+      trap _restore EXIT
+    else
+      rm -f "$_p"
+    fi
+  fi
   if ! (cd "$REPO_ROOT" && just lint); then
+    _restore
+    trap - EXIT
     echo "" >&2
     echo "❌ pre-commit: 'just lint' failed — fix the errors above before committing." >&2
     echo "   (bypass in an emergency with: git commit --no-verify)" >&2
     exit 1
   fi
+  _restore
+  trap - EXIT
 fi
 
 # 2. Secret scan.

--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
-# pre-commit hook: scan staged changes for secrets with gitleaks (ADR-007).
+# pre-commit hook (ADR-007). Two gates, fastest-feedback-first:
+#   1. Lint: run `just lint` so a human committing from a terminal/IDE is held
+#      to the SAME static gate CI runs (ruff + shfmt + shellcheck). The Claude
+#      pre_commit_gate.sh only fires for agent-driven commits; this catches
+#      everyone. Fail-CLOSED when the tooling is present (block the commit,
+#      bypassable with `git commit --no-verify`); fail-open when `just`/the
+#      recipe is absent so a fresh clone without the toolchain still commits.
+#   2. Secrets: scan staged changes with gitleaks. Fail-OPEN if gitleaks is
+#      missing — the CI secret-scan job is the hard backstop.
 # Install: .claude/scripts/install_hooks.sh
-#
-# Fail-open by design: if gitleaks is not installed the hook warns and lets
-# the commit through — the CI secret-scan job is the hard backstop that
-# scans full history and blocks the merge.
 
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# 1. Lint gate — same command surface as CI and the agent commit gate (PI-139).
+if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
+  (cd "$REPO_ROOT" && just --show lint >/dev/null 2>&1); then
+  if ! (cd "$REPO_ROOT" && just lint); then
+    echo "" >&2
+    echo "❌ pre-commit: 'just lint' failed — fix the errors above before committing." >&2
+    echo "   (bypass in an emergency with: git commit --no-verify)" >&2
+    exit 1
+  fi
+fi
+
+# 2. Secret scan.
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "WARNING: gitleaks not installed — skipping local secret scan." >&2
   echo "  CI will still scan; install for fast local feedback:" >&2

--- a/templates/base/dot_github/hooks/pre-push.tmpl
+++ b/templates/base/dot_github/hooks/pre-push.tmpl
@@ -66,12 +66,24 @@ if [[ "$PUSHING_BRANCH" == "1" ]]; then
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
     (cd "$REPO_ROOT" && just --show ci >/dev/null 2>&1); then
-    echo "pre-push: running 'just ci' (lint + tests) before push…"
-    if ! (cd "$REPO_ROOT" && just ci); then
-      echo ""
-      echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
-      echo "   (bypass in an emergency with: git push --no-verify)"
-      exit 1
+    # `just ci` runs against the working tree, but the push ships the committed
+    # tree. If the worktree is dirty (uncommitted changes or untracked files),
+    # testing it would give a false result either way — a WIP fix could hide a
+    # failure in the pushed commit, or unrelated WIP could fail a clean push.
+    # So skip the gate (fail-open) with a clear nudge instead of testing a tree
+    # that isn't what's being pushed; CI stays the backstop.
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+      echo "pre-push: working tree is dirty — skipping the 'just ci' gate" >&2
+      echo "  (it would test the worktree, not the commit being pushed)." >&2
+      echo "  Commit or stash your changes to run the gate before pushing." >&2
+    else
+      echo "pre-push: running 'just ci' (lint + tests) before push…"
+      if ! (cd "$REPO_ROOT" && just ci); then
+        echo ""
+        echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+        echo "   (bypass in an emergency with: git push --no-verify)"
+        exit 1
+      fi
     fi
   fi
 fi

--- a/templates/base/dot_github/hooks/pre-push.tmpl
+++ b/templates/base/dot_github/hooks/pre-push.tmpl
@@ -15,6 +15,7 @@ ZERO_SHA="0000000000000000000000000000000000000000"
 
 # git feeds "<local_ref> <local_sha> <remote_ref> <remote_sha>" per ref; we only
 # use local_sha + remote_ref, so the other two fields go to `_`. -r per SC2162.
+PUSHING_BRANCH=0
 while read -r _ local_sha remote_ref _; do
   # Branch deletions are always allowed (cleaning up misnamed branches).
   if [[ "$local_sha" == "$ZERO_SHA" ]]; then
@@ -26,6 +27,7 @@ while read -r _ local_sha remote_ref _; do
     continue
   fi
   branch_name="${remote_ref#refs/heads/}"
+  PUSHING_BRANCH=1
 
   if [[ "$branch_name" == "main" || "$branch_name" == "master" ]]; then
     echo "❌ ERROR: Direct push to main/master is not allowed"
@@ -53,5 +55,25 @@ while read -r _ local_sha remote_ref _; do
     exit 1
   fi
 {{/if lifecycle}}done
+
+# Full CI gate before the push leaves the machine: run the SAME `just ci`
+# (lint + full test suite) that CI runs, so nothing red reaches a PR and the
+# push→CI-fail→fix→re-push loop is caught locally instead. Only fires for a
+# real branch push (not tag/delete). Fail-CLOSED when `just`/the recipe are
+# present (block the push, bypassable with `git push --no-verify`); fail-open
+# when the toolchain is absent — CI stays the hard backstop.
+if [[ "$PUSHING_BRANCH" == "1" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
+    (cd "$REPO_ROOT" && just --show ci >/dev/null 2>&1); then
+    echo "pre-push: running 'just ci' (lint + tests) before push…"
+    if ! (cd "$REPO_ROOT" && just ci); then
+      echo ""
+      echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+      echo "   (bypass in an emergency with: git push --no-verify)"
+      exit 1
+    fi
+  fi
+fi
 
 exit 0

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -91,7 +91,13 @@ while IFS= read -r _f; do [ -n "$_f" ] && STAGED_SH+=("$_f"); done \
   < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.sh$' || true)
 if [ "${#STAGED_SH[@]}" -gt 0 ]; then
   if command -v shfmt >/dev/null 2>&1; then
-    shfmt -w -i 2 "${STAGED_SH[@]}" >/dev/null 2>&1 || true
+    # -w auto-formats in place. A NONZERO exit means shfmt could not parse a
+    # file (a real shell syntax error) and left it unchanged — record that as a
+    # blocking error instead of swallowing it, so a broken script can't slip
+    # through when shellcheck is unavailable.
+    if ! SHFMT_OUT=$(shfmt -w -i 2 "${STAGED_SH[@]}" 2>&1); then
+      ERRORS="${ERRORS}Shell format errors (shfmt):\n${SHFMT_OUT}\n"
+    fi
     git add "${STAGED_SH[@]}" 2>/dev/null || true
   fi
   if command -v shellcheck >/dev/null 2>&1; then

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -79,6 +79,29 @@ if [ "${#STAGED_JS[@]}" -gt 0 ] && command -v bunx &>/dev/null; then
   git add "${STAGED_JS[@]}" 2>/dev/null || true
 fi
 
+# Lint and auto-fix staged shell scripts. The `just lint` block below already
+# runs shfmt+shellcheck over .claude/**, but only when a justfile with a lint
+# recipe and `just` are present — so a project without `just`, or a staged .sh
+# outside .claude, would otherwise reach commit unchecked. shfmt -w auto-fixes
+# formatting and is re-staged; shellcheck errors can't be auto-fixed, so they
+# are reported. Fail open when a tool is absent (CI is the hard backstop) —
+# same posture as the ruff/eslint blocks above.
+STAGED_SH=()
+while IFS= read -r _f; do [ -n "$_f" ] && STAGED_SH+=("$_f"); done \
+  < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.sh$' || true)
+if [ "${#STAGED_SH[@]}" -gt 0 ]; then
+  if command -v shfmt >/dev/null 2>&1; then
+    shfmt -w -i 2 "${STAGED_SH[@]}" >/dev/null 2>&1 || true
+    git add "${STAGED_SH[@]}" 2>/dev/null || true
+  fi
+  if command -v shellcheck >/dev/null 2>&1; then
+    SH_OUT=$(shellcheck -S error -x "${STAGED_SH[@]}" 2>&1 || true)
+    if [ -n "$SH_OUT" ]; then
+      ERRORS="${ERRORS}Shell lint errors (shellcheck):\n${SH_OUT}\n"
+    fi
+  fi
+fi
+
 # PI-139: when the project ships a justfile with a lint recipe and just is
 # installed, additionally gate on `just lint` — the same definition of "lint
 # passes" CI and every agent use. Per-file findings above are preserved: the

--- a/templates/lifecycle/dot_claude/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_claude/hooks/dag_workflow.py
@@ -63,7 +63,7 @@ else:
 
 def _run(cmd: list[str]) -> tuple[int, str]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -531,7 +531,7 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         push_cmd = ["git", "push", "-u", "origin", branch]
         if force:
             push_cmd.append("--force-with-lease")
-        proc = subprocess.run(push_cmd)
+        proc = subprocess.run(push_cmd)  # noqa: S603 — fixed git argv + validated branch name, never a shell string
         if proc.returncode == 0:
             sys.stdout.write(f"push: pushed {branch} ({expected_sha})\n")
             return 0
@@ -627,7 +627,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     monitor_args = ["bash", str(script), str(pr_number), "--merge"]
     if review_cycle is not None:
         monitor_args += ["--review-cycle", str(review_cycle)]
-    return subprocess.run(monitor_args).returncode
+    return subprocess.run(monitor_args).returncode  # noqa: S603 — fixed bash argv + resolved script path, never a shell string
 
 
 _VALID_TYPES = {"feat", "fix", "chore", "docs", "test"}

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -150,6 +150,12 @@ _ADDED_SINCE_BASELINE = {
     ".claude/rules/rust.md",
     ".claude/rules/typescript.md",
     "ruff.toml",
+    # Shift-left commit hooks: the git pre-commit gained a `just lint` gate (so
+    # human commits are held to the same static gate as CI, not only agent
+    # commits), and pre-push gained a `just ci` gate. Deliberate content edits,
+    # not lifecycle-move drift; their behavior is covered by test_commit_hook_gates.py.
+    ".github/hooks/pre-commit",
+    ".github/hooks/pre-push",
 }
 
 

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -49,6 +49,13 @@ normalization + GraphQL-merge rule + interpreter-heredoc scanning),
 (rm split-flag detection), `commit-msg` (corrected install comment), and the
 fallback hooks `pre_commit_gate.sh` / `post_edit_lint.sh` (cd to repo root so a
 subdirectory session lints the right paths).
+
+Exception (init-lint fix): `dag_workflow.py` gained three `# noqa: S603`
+directives on its `subprocess.run` calls — the scaffolded `ruff.toml` selects
+`S` and lints `.claude/**`, so a fresh lifecycle-on project's `just lint` failed
+on those argv-list (never shell-string) calls, mirroring the `# noqa: S310`
+package_guard.py already carries. Only the `.claude/hooks/dag_workflow.py` hash
+was re-pinned across all four combos, after verifying every other file matched.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -142,6 +142,10 @@ _ADDED_SINCE_BASELINE = {
     ".claude/rules/rust.md",
     ".claude/rules/typescript.md",
     "ruff.toml",
+    # Shift-left commit hooks (see test_commit_hook_gates.py): git pre-commit
+    # gained a `just lint` gate; pre-push gained a `just ci` gate.
+    ".github/hooks/pre-commit",
+    ".github/hooks/pre-push",
 }
 
 

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "c9dd6987729ba98e619d863e01c314beadabf2bf14570e1e53ea784d559604a7",
+  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -1,0 +1,92 @@
+"""Shift-left commit/push gates: catch static issues before they reach CI.
+
+Three layers, each closing a gap the others leave:
+
+- **git `pre-commit`** now runs `just lint` (not only gitleaks), so a *human*
+  committing from a terminal/IDE is held to the same static gate as CI — the
+  Claude `pre_commit_gate.sh` only fires for agent-driven commits.
+- **git `pre-push`** now runs `just ci`, so the push→CI-fail→fix→re-push loop is
+  caught locally.
+- **`pre_commit_gate.sh`** (the agent commit gate) gained a per-file shell block
+  so staged `.sh` files are `shfmt`/`shellcheck`'d even when `just` is absent.
+
+All three fail-open when their tooling is missing (CI is the hard backstop) and
+are bypassable with `--no-verify`, mirroring the existing gitleaks posture.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, scaffold
+from tests.helpers import fallback_preset, fallback_variables, make_variables
+
+
+def _git_hooks(target: Path) -> tuple[str, str]:
+    """Render a scaffold and return (pre-commit, pre-push) hook text."""
+    scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
+    pre_commit = (target / ".github" / "hooks" / "pre-commit").read_text()
+    pre_push = (target / ".github" / "hooks" / "pre-push").read_text()
+    return pre_commit, pre_push
+
+
+def test_git_pre_commit_runs_lint_and_keeps_secret_scan(tmp_target: Path):
+    pre_commit, _ = _git_hooks(tmp_target)
+    # Same lint surface as CI + the agent gate, so human commits are covered too.
+    assert "just lint" in pre_commit
+    # Fail-closed when tooling is present, bypassable, and secrets still scanned.
+    assert "--no-verify" in pre_commit
+    assert "gitleaks" in pre_commit
+
+
+def test_git_pre_push_runs_ci(tmp_target: Path):
+    _, pre_push = _git_hooks(tmp_target)
+    assert "just ci" in pre_push
+    # Only for a real branch push, and still bypassable in an emergency.
+    assert "PUSHING_BRANCH" in pre_push
+    assert "--no-verify" in pre_push
+
+
+def test_pre_commit_gate_has_per_file_shell_block(tmp_target: Path):
+    """The agent commit gate must shellcheck/shfmt staged .sh without needing `just`."""
+    scaffold(tmp_target, fallback_preset(), fallback_variables(language="python", python="true"))
+    gate = (tmp_target / ".claude" / "hooks" / "pre_commit_gate.sh").read_text()
+    assert "shfmt -w -i 2" in gate
+    assert "shellcheck -S error -x" in gate
+
+
+@pytest.mark.skipif(shutil.which("shfmt") is None, reason="shfmt not available")
+def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
+    """End-to-end: a badly-formatted staged .sh is shfmt-fixed and re-staged."""
+    target = tmp_path / "proj"
+    scaffold(target, fallback_preset(), fallback_variables(language="python", python="true"))
+    hook = target / ".claude" / "hooks" / "pre_commit_gate.sh"
+
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
+
+    bad = target / "messy.sh"
+    # 4-space indent + one-line case arm — shfmt -i 2 rewrites both.
+    bad.write_text('#!/usr/bin/env bash\ncase "$1" in\n    a) echo hi ;; esac\n')
+    original = bad.read_text()
+    subprocess.run(["git", "add", "messy.sh"], cwd=target, check=True)
+
+    payload = json.dumps({"tool_input": {"command": "git commit -m x"}})
+    subprocess.run(
+        ["bash", str(hook)], input=payload, cwd=target, capture_output=True, text=True
+    )
+
+    # The working-tree file was reformatted in place …
+    assert bad.read_text() != original, "pre_commit_gate did not shfmt the staged shell file"
+    assert subprocess.run(["shfmt", "-d", "-i", "2", str(bad)], capture_output=True).stdout == b""
+    # … and the fix was re-staged, so the commit would include it, not the mess.
+    staged = subprocess.run(
+        ["git", "show", ":messy.sh"], cwd=target, capture_output=True, text=True
+    ).stdout
+    assert staged == bad.read_text()

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -39,6 +39,9 @@ def test_git_pre_commit_runs_lint_and_keeps_secret_scan(tmp_target: Path):
     pre_commit, _ = _git_hooks(tmp_target)
     # Same lint surface as CI + the agent gate, so human commits are covered too.
     assert "just lint" in pre_commit
+    # Lints the staged snapshot (strips unstaged changes via a patch), not the
+    # working tree, so an unstaged fix can't mask a staged error.
+    assert "git apply -R" in pre_commit
     # Fail-closed when tooling is present, bypassable, and secrets still scanned.
     assert "--no-verify" in pre_commit
     assert "gitleaks" in pre_commit
@@ -50,6 +53,8 @@ def test_git_pre_push_runs_ci(tmp_target: Path):
     # Only for a real branch push, and still bypassable in an emergency.
     assert "PUSHING_BRANCH" in pre_push
     assert "--no-verify" in pre_push
+    # Skips (not tests) a dirty worktree — the pushed tree is the committed one.
+    assert "git status --porcelain" in pre_push
 
 
 def test_pre_commit_gate_has_per_file_shell_block(tmp_target: Path):
@@ -90,3 +95,68 @@ def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
         ["git", "show", ":messy.sh"], cwd=target, capture_output=True, text=True
     ).stdout
     assert staged == bad.read_text()
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just not available")
+def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
+    """A staged lint error must not be masked by an unstaged fix (Codex #596).
+
+    Uses a sentinel `just lint` recipe (fails when the file contains BAD) so the
+    check is independent of the real ruff toolchain — the point under test is the
+    stash-the-index mechanism, not what `just lint` runs.
+    """
+    target = tmp_path / "proj"
+    scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
+    hook = target / ".github" / "hooks" / "pre-commit"
+    # Replace the scaffolded justfile with a sentinel lint recipe.
+    (target / "justfile").write_text(
+        'lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n'
+    )
+
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
+    (target / "x.txt").write_text("INIT\n")
+    subprocess.run(["git", "add", "x.txt", "justfile"], cwd=target, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=target, check=True)
+
+    # Stage the BAD version, then leave a GOOD *unstaged* fix on top.
+    (target / "x.txt").write_text("BAD\n")
+    subprocess.run(["git", "add", "x.txt"], cwd=target, check=True)
+    (target / "x.txt").write_text("GOOD\n")
+
+    result = subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
+
+    # The staged (index) content is BAD, so the hook must block the commit …
+    assert result.returncode != 0, "pre-commit passed on a staged lint error hidden by an unstaged fix"
+    # … and the developer's unstaged fix must be restored intact afterward.
+    assert (target / "x.txt").read_text() == "GOOD\n", "unstaged changes were not restored"
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just not available")
+def test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index(tmp_path: Path):
+    """The inverse of the above: unrelated dirty WIP must not fail a clean commit."""
+    target = tmp_path / "proj"
+    scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
+    hook = target / ".github" / "hooks" / "pre-commit"
+    (target / "justfile").write_text(
+        'lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n'
+    )
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
+    (target / "x.txt").write_text("INIT\n")
+    subprocess.run(["git", "add", "x.txt", "justfile"], cwd=target, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=target, check=True)
+
+    # Stage a clean (GOOD) version, then leave a BAD *unstaged* mess on top.
+    (target / "x.txt").write_text("GOOD\n")
+    subprocess.run(["git", "add", "x.txt"], cwd=target, check=True)
+    (target / "x.txt").write_text("BAD\n")
+
+    result = subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
+
+    # The index is clean, so the commit must be allowed despite the dirty worktree …
+    assert result.returncode == 0, f"pre-commit blocked a clean staged commit:\n{result.stderr}"
+    # … and the unstaged mess restored untouched (no conflict markers).
+    assert (target / "x.txt").read_text() == "BAD\n", "unstaged changes were not restored"

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -42,6 +42,9 @@ def test_git_pre_commit_runs_lint_and_keeps_secret_scan(tmp_target: Path):
     # Lints the staged snapshot (strips unstaged changes via a patch), not the
     # working tree, so an unstaged fix can't mask a staged error.
     assert "git apply -R" in pre_commit
+    # Untracked files are linted too — the failure path says so, so a false
+    # failure from an unrelated untracked file is diagnosable, not baffling.
+    assert "git ls-files --others --exclude-standard" in pre_commit
     # Fail-closed when tooling is present, bypassable, and secrets still scanned.
     assert "--no-verify" in pre_commit
     assert "gitleaks" in pre_commit
@@ -63,6 +66,9 @@ def test_pre_commit_gate_has_per_file_shell_block(tmp_target: Path):
     gate = (tmp_target / ".claude" / "hooks" / "pre_commit_gate.sh").read_text()
     assert "shfmt -w -i 2" in gate
     assert "shellcheck -S error -x" in gate
+    # A shfmt parse error (nonzero exit) is recorded as blocking, not swallowed,
+    # so a broken script can't pass when shellcheck is unavailable.
+    assert "Shell format errors (shfmt)" in gate
 
 
 @pytest.mark.skipif(shutil.which("shfmt") is None, reason="shfmt not available")
@@ -95,6 +101,28 @@ def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
         ["git", "show", ":messy.sh"], cwd=target, capture_output=True, text=True
     ).stdout
     assert staged == bad.read_text()
+
+
+@pytest.mark.skipif(shutil.which("shfmt") is None, reason="shfmt not available")
+def test_pre_commit_gate_blocks_a_broken_staged_shell(tmp_path: Path):
+    """A staged .sh shfmt can't parse must block the commit (deny), not slip through."""
+    target = tmp_path / "proj"
+    scaffold(target, fallback_preset(), fallback_variables(language="python", python="true"))
+    hook = target / ".claude" / "hooks" / "pre_commit_gate.sh"
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
+
+    broken = target / "broken.sh"
+    broken.write_text("#!/usr/bin/env bash\nif [ ; then\n")  # unparseable
+    subprocess.run(["git", "add", "broken.sh"], cwd=target, check=True)
+
+    payload = json.dumps({"tool_input": {"command": "git commit -m x"}})
+    result = subprocess.run(
+        ["bash", str(hook)], input=payload, cwd=target, capture_output=True, text=True
+    )
+    # The gate signals a block via a PreToolUse deny decision on stdout.
+    assert '"permissionDecision": "deny"' in result.stdout, result.stdout
 
 
 @pytest.mark.skipif(shutil.which("just") is None, reason="just not available")

--- a/tests/integration/test_quality_gate_lint.py
+++ b/tests/integration/test_quality_gate_lint.py
@@ -3,6 +3,14 @@
 A fresh project must start green — ruff (with the scaffolded ruff.toml,
 including docstring and complexity gates) has to accept everything
 project-init itself puts in the target directory.
+
+The lifecycle-on case is a distinct guard: the default scaffold enables the
+GitHub lifecycle overlay, which ships ``.claude/hooks/dag_workflow.py`` — a file
+the base/obsidian-only case never emits. Since the scaffolded ``ruff.toml``
+selects ``S`` (bandit) and lints ``.claude/**``, that hook's ``subprocess.run``
+calls tripped ``S603`` and turned a fresh project's ``just lint`` red on the
+first push until the calls were annotated. Lint the config the CLI actually
+produces, not just the barest preset.
 """
 
 from __future__ import annotations
@@ -12,26 +20,21 @@ from pathlib import Path
 
 import pytest
 
-from project_init.scaffold import load_preset, scaffold
+from project_init.scaffold import load_preset, overlay_layers, scaffold
 from tests.helpers import find_uv, make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-@pytest.mark.skipif(find_uv() is None, reason="uv not available")
-def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
-    scaffold(
-        tmp_target,
-        load_preset("obsidian-only"),
-        make_variables(language="python", python="true", node="", go=""),
-    )
-    assert (tmp_target / "ruff.toml").is_file()
+def _ruff_check(target: Path) -> subprocess.CompletedProcess:
+    """Run the scaffolded ruff gate against *target* exactly as ``just lint`` does.
 
-    # --config pins the scaffolded ruff.toml so this repo's config can't leak
-    # in; cwd must be the target because ruff resolves relative
-    # per-file-ignores globs (".claude/**") against the working directory.
-    # `--project` keeps uv resolving this repo's environment for the ruff bin.
-    result = subprocess.run(
+    ``--config`` pins the scaffolded ruff.toml so this repo's config can't leak
+    in; cwd must be the target because ruff resolves relative per-file-ignores
+    globs (``.claude/**``) against the working directory. ``--project`` keeps uv
+    resolving this repo's environment for the ruff bin.
+    """
+    return subprocess.run(
         [
             find_uv(),
             "run",
@@ -43,10 +46,49 @@ def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
             "ruff.toml",
             ".",
         ],
-        cwd=tmp_target,
+        cwd=target,
         capture_output=True,
         text=True,
     )
+
+
+@pytest.mark.skipif(find_uv() is None, reason="uv not available")
+def test_ruff_passes_on_freshly_scaffolded_python_project(tmp_target: Path):
+    scaffold(
+        tmp_target,
+        load_preset("obsidian-only"),
+        make_variables(language="python", python="true", node="", go=""),
+    )
+    assert (tmp_target / "ruff.toml").is_file()
+
+    result = _ruff_check(tmp_target)
     assert result.returncode == 0, (
         f"scaffolded project does not pass its own lint gate:\n{result.stdout}{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(find_uv() is None, reason="uv not available")
+def test_ruff_passes_with_lifecycle_hooks(tmp_target: Path):
+    """The default lifecycle-on scaffold must also start green.
+
+    Reproduces the CLI's layer assembly (preset + lifecycle overlay) so
+    ``.claude/hooks/dag_workflow.py`` is emitted and actually linted — the file
+    the obsidian-only-only guard above never covers.
+    """
+    preset = load_preset("obsidian-only")
+    stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")
+    extra = overlay_layers([], no_plugin=False, memory_stack=stack, lifecycle=True)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    scaffold(
+        tmp_target,
+        preset,
+        make_variables(language="python", python="true", node="", go="", lifecycle="true"),
+    )
+    assert (tmp_target / ".claude" / "hooks" / "dag_workflow.py").is_file(), (
+        "lifecycle overlay did not emit dag_workflow.py — test no longer guards the S603 path"
+    )
+
+    result = _ruff_check(tmp_target)
+    assert result.returncode == 0, (
+        f"lifecycle-on scaffold does not pass its own lint gate:\n{result.stdout}{result.stderr}"
     )

--- a/tests/integration/test_quality_gate_lint.py
+++ b/tests/integration/test_quality_gate_lint.py
@@ -73,7 +73,7 @@ def test_ruff_passes_with_lifecycle_hooks(tmp_target: Path):
 
     Reproduces the CLI's layer assembly (preset + lifecycle overlay) so
     ``.claude/hooks/dag_workflow.py`` is emitted and actually linted — the file
-    the obsidian-only-only guard above never covers.
+    the obsidian-only guard above never covers.
     """
     preset = load_preset("obsidian-only")
     stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -96,6 +96,6 @@ def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
         )
         if result.returncode != 0:
             failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
-    assert not failures, "emitted .claude scripts fail `shellcheck -S error`:\n" + "\n".join(
+    assert not failures, "emitted .claude scripts fail `shellcheck -S error -x`:\n" + "\n".join(
         failures
     )

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -1,0 +1,101 @@
+"""The scaffolded shell scripts must pass the `just lint` shell gate on a fresh
+project.
+
+`just lint` (and the CI `Lint` step) runs `shellcheck -S error -x` and
+`shfmt -d -i 2` over every `.claude/**/*.sh` a scaffold emits. Those tools are
+installed unconditionally in CI, so a single un-formatted emitted script turns a
+brand-new project red on its first push — regardless of language or whether the
+user has added a pyproject yet.
+
+The failure that motivated this guard: `setup_env_protection.sh` and
+`whats_deployed.sh` (emitted only for a service + deploy-target scaffold, a combo
+no other lint test exercised) shipped un-`shfmt`-formatted. Contract tests that
+merely assert the justfile *contains* the `shfmt` string never ran the tool on
+the emitted output. This one does.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, overlay_layers, scaffold
+from tests.helpers import make_variables
+
+_SHFMT = shutil.which("shfmt")
+_SHELLCHECK = shutil.which("shellcheck")
+
+
+def _service_deploy_lifecycle(target: Path) -> Path:
+    """A service + deploy + lifecycle scaffold — the widest emitted-script set.
+
+    deploy!=none adds setup_env_protection.sh + whats_deployed.sh; the lifecycle
+    overlay adds the DAG guard/workflow scripts. Together they cover the scripts
+    the narrower per-feature tests each miss.
+    """
+    preset = load_preset("obsidian-only")
+    stack = preset.get("vars", {}).get("memory_stack", "obsidian-only")
+    extra = overlay_layers([], no_plugin=False, memory_stack=stack, lifecycle=True)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    scaffold(
+        target,
+        preset,
+        make_variables(
+            language="python",
+            python="true",
+            node="",
+            go="",
+            lifecycle="true",
+            delivery="service",
+            delivery_service="true",
+            deploy_target="cloud-run",
+            deploy_enabled="true",
+            deploy_container="true",
+            deploy_cloud_run="true",
+        ),
+    )
+    return target
+
+
+def _claude_scripts(target: Path) -> list[Path]:
+    return sorted((target / ".claude").rglob("*.sh"))
+
+
+@pytest.mark.skipif(_SHFMT is None, reason="shfmt not available")
+def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
+    _service_deploy_lifecycle(tmp_target)
+    scripts = _claude_scripts(tmp_target)
+    # Guard against the scaffold silently emitting nothing and the test passing
+    # vacuously — the deploy-gated scripts must be present to be checked.
+    names = {p.name for p in scripts}
+    assert {"setup_env_protection.sh", "whats_deployed.sh"} <= names, names
+
+    dirty = []
+    for p in scripts:
+        result = subprocess.run(
+            [_SHFMT, "-d", "-i", "2", str(p)], capture_output=True, text=True
+        )
+        if result.stdout.strip() or result.returncode != 0:
+            dirty.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
+    assert not dirty, "emitted .claude scripts fail `shfmt -d -i 2`:\n" + "\n".join(dirty)
+
+
+@pytest.mark.skipif(_SHELLCHECK is None, reason="shellcheck not available")
+def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
+    _service_deploy_lifecycle(tmp_target)
+    scripts = _claude_scripts(tmp_target)
+    assert scripts, "no .claude/**/*.sh emitted — test guards nothing"
+
+    failures = []
+    for p in scripts:
+        result = subprocess.run(
+            [_SHELLCHECK, "-S", "error", "-x", str(p)], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
+    assert not failures, "emitted .claude scripts fail `shellcheck -S error`:\n" + "\n".join(
+        failures
+    )

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -16,6 +16,7 @@ the emitted output. This one does.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -27,6 +28,23 @@ from tests.helpers import make_variables
 
 _SHFMT = shutil.which("shfmt")
 _SHELLCHECK = shutil.which("shellcheck")
+
+
+def _require(tool: str | None, name: str) -> str:
+    """Return the tool path, or fail in CI / skip locally when it is absent.
+
+    A plain ``skipif`` would let this guard silently no-op wherever the tool
+    isn't installed — including CI if its install step is ever dropped, turning
+    a green check into one that tested nothing (the exact failure mode this
+    module exists to prevent). Under ``CI`` a missing tool is a hard error so
+    the gap is loud; locally it degrades to a skip so `just test` still runs.
+    """
+    if tool:
+        return tool
+    msg = f"{name} not on PATH"
+    if os.environ.get("CI"):
+        pytest.fail(f"{msg} — required in CI so the {name} scaffold-lint gate can't silently skip")
+    pytest.skip(msg)
 
 
 def _service_deploy_lifecycle(target: Path) -> Path:
@@ -64,8 +82,8 @@ def _claude_scripts(target: Path) -> list[Path]:
     return sorted((target / ".claude").rglob("*.sh"))
 
 
-@pytest.mark.skipif(_SHFMT is None, reason="shfmt not available")
 def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
+    shfmt = _require(_SHFMT, "shfmt")
     _service_deploy_lifecycle(tmp_target)
     scripts = _claude_scripts(tmp_target)
     # Guard against the scaffold silently emitting nothing and the test passing
@@ -76,15 +94,15 @@ def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
     dirty = []
     for p in scripts:
         result = subprocess.run(
-            [_SHFMT, "-d", "-i", "2", str(p)], capture_output=True, text=True
+            [shfmt, "-d", "-i", "2", str(p)], capture_output=True, text=True
         )
         if result.stdout.strip() or result.returncode != 0:
             dirty.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
     assert not dirty, "emitted .claude scripts fail `shfmt -d -i 2`:\n" + "\n".join(dirty)
 
 
-@pytest.mark.skipif(_SHELLCHECK is None, reason="shellcheck not available")
 def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
+    shellcheck = _require(_SHELLCHECK, "shellcheck")
     _service_deploy_lifecycle(tmp_target)
     scripts = _claude_scripts(tmp_target)
     assert scripts, "no .claude/**/*.sh emitted — test guards nothing"
@@ -92,7 +110,7 @@ def test_emitted_claude_scripts_pass_shellcheck(tmp_target: Path):
     failures = []
     for p in scripts:
         result = subprocess.run(
-            [_SHELLCHECK, "-S", "error", "-x", str(p)], capture_output=True, text=True
+            [shellcheck, "-S", "error", "-x", str(p)], capture_output=True, text=True
         )
         if result.returncode != 0:
             failures.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")


### PR DESCRIPTION
## What & why

Catch statically-detectable failures at **commit/push time** instead of after a `push → CI-fail → fix → re-push` round trip. Every gate runs the **same command as CI**, so "passes locally == passes CI" — closing the local↔CI divergence that let a fresh-scaffold lint failure ship (see #595).

> **Merge order:** this branch is built on top of #595, so until #595 merges this PR's diff also shows #595's commits. **Merge #595 first**; the diff auto-cleans to just the hook work (commit `6484ce4`) afterward. Base is `main` so full CI runs.

### Scaffolded projects
- **git `pre-commit`** now runs `just lint` (ruff + shfmt + shellcheck) alongside the gitleaks secret scan, so a **human** committing from a terminal/IDE is held to the same static gate as CI — the Claude `pre_commit_gate.sh` only fires for agent-driven commits. Fail-closed when tooling is present (bypass with `--no-verify`), fail-open when `just`/the recipe is absent.
- **git `pre-push`** now runs `just ci` (lint + full tests) before a real branch push, so nothing red reaches a PR. Same fail-open/closed posture; only fires for branch pushes (not tags/deletes).
- **`pre_commit_gate.sh`** (the agent commit gate) gained a per-file shell block — `shfmt -w` auto-fix + re-stage and `shellcheck -S error` on staged `.sh` — so shell issues are caught even when `just` is unavailable (previously shell was only covered indirectly via the `just lint` block).

### Scaffolder repo itself (dogfood)
The missing local↔CI parity that let the bug ship: added `.githooks/pre-push` running `just ci`, auto-enabled by `just setup` via `core.hooksPath`, documented in `CONTRIBUTING.md`.

## Related issue

<!-- No tracking issue (nojira). -->

## Checklist

- [x] `just ci` passes locally (lint + full suite — 1869 passed, 2 skipped)
- [x] Changes under `templates/` have matching tests (`tests/integration/test_commit_hook_gates.py`)
- [x] Docs updated (`CONTRIBUTING.md` documents the pre-push gate)
- [x] PR title follows Conventional Commits (`type: description`, no issue)
