### PR TITLE
fix: resolve full-codebase review findings and release v0.6.1

### DIFF
--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -62,8 +62,11 @@ else:
 
 
 def _run(cmd: list[str]) -> tuple[int, str]:
+    # Per-call timeout must stay well below the hook budget (settings.json
+    # "timeout": 60): a PreToolUse hook that exceeds its budget is killed and
+    # FAILS OPEN, so one hung gh call must never eat the whole allowance.
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -304,15 +307,20 @@ _HEREDOC_RE = re.compile(
 # push`, `git -c k=v push`). Left unnormalized they defeat every `git push`
 # rule, including the direct-push-to-main block (2026-07 review). Options that
 # consume a value are listed with their value; boolean options stand alone.
+# An option value is one shell word INCLUDING quoted runs — `-c foo='a b'`
+# must normalize away too: a bare \S+ stops at the space inside the quotes
+# and the mangled residue defeats every git rule (mirrors the quoted-value
+# matcher in pre_commit_gate.sh).
+_GIT_OPT_VAL = r"(?:[^\s'\"]|'[^']*'|\"[^\"]*\")+"
 _GIT_GLOBAL_OPT = (
     r"(?:"
-    r"-C[ \t]+\S+"  # -C <path>
-    r"|-c[ \t]+\S+"  # -c <name=value>
-    r"|--git-dir(?:=\S+|[ \t]+\S+)"
-    r"|--work-tree(?:=\S+|[ \t]+\S+)"
-    r"|--namespace(?:=\S+|[ \t]+\S+)"
-    r"|--config-env(?:=\S+|[ \t]+\S+)"
-    r"|--exec-path(?:=\S+)?"
+    rf"-C[ \t]+{_GIT_OPT_VAL}"  # -C <path>
+    rf"|-c[ \t]+{_GIT_OPT_VAL}"  # -c <name=value>
+    rf"|--git-dir(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--work-tree(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--namespace(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--config-env(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--exec-path(?:={_GIT_OPT_VAL})?"
     r"|--no-pager|--paginate|-p|-P|--bare"
     r"|--no-replace-objects|--literal-pathspecs|--no-optional-locks|--icase-pathspecs"
     r")"
@@ -688,10 +696,18 @@ def cmd_create_pr_nojira(
     if rc != 0:
         return rc
 
-    code, url = _gh(["pr", "view", "--json", "url", "-q", ".url"])
-    if code == 0 and url.strip():
-        sys.stdout.write(f"Draft PR already exists: {url.strip()}\n")
-        return 0
+    # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
+    # PR for the branch — reusing a branch name after a merge must open a new
+    # PR, not report the merged one as "already exists" (matches check_pr_opened).
+    code, out = _gh(["pr", "view", "--json", "url,state"])
+    if code == 0:
+        try:
+            data = json.loads(out or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("state") == "OPEN" and data.get("url"):
+            sys.stdout.write(f"Draft PR already exists: {data['url']}\n")
+            return 0
 
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -4,9 +4,13 @@
 # Requires: gh, python3 (stdlib only — no jq dependency).
 #
 # Usage:
-#   .claude/scripts/monitor_pr.sh <pr-number> [--merge] [--review-cycle N] [--no-review]
+#   .claude/scripts/monitor_pr.sh <pr-number> [--merge] [--review-cycle N] [--no-review] [--admin]
 #
 # --merge: squash-merge and delete branch automatically when all checks pass.
+# --admin: allow an admin override when the PR is BLOCKED by branch protection
+#   AFTER the review gate passed (e.g. an unresolved conversation). Without it,
+#   a post-review BLOCKED state fails with guidance instead of silently
+#   overriding the protection setup_github.sh provisioned (2026-07 review).
 # --review-cycle N: current review fix cycle count (0-based, default 0).
 #   When N >= MAX_REVIEW_CYCLES and review/decision is still failing or pending,
 #   force-merges with --admin.
@@ -29,33 +33,39 @@
 set -euo pipefail
 
 PR_NUMBER="${1:-}"
-MODE="${2:-}"
+MODE=""
 REVIEW_CYCLE=0
 MAX_REVIEW_CYCLES=2
 NO_REVIEW=0
+ALLOW_ADMIN=0
 
 if [ -z "$PR_NUMBER" ]; then
-  echo "Usage: monitor_pr.sh <pr-number> [--merge] [--review-cycle N] [--no-review]" >&2
+  echo "Usage: monitor_pr.sh <pr-number> [--merge] [--review-cycle N] [--no-review] [--admin]" >&2
   exit 1
 fi
 
-if [ -n "$MODE" ] && [ "$MODE" != "--merge" ]; then
-  echo "Unknown option: $MODE" >&2
-  exit 2
-fi
-
-# Parse remaining flags (order-independent after position 2).
-# Shift past <pr-number> and optional --merge; remaining args are flags.
+# Parse flags (order-independent). --merge is just another flag: the usage
+# line presents every flag as independent, so `monitor_pr.sh 12 --no-review`
+# must not be rejected for lacking --merge in position 2.
 shift 1  # drop PR_NUMBER
-[ "$MODE" = "--merge" ] && shift 1  # drop --merge if present
 while [ $# -gt 0 ]; do
   case "$1" in
+    --merge)          MODE="--merge"; shift ;;
     --review-cycle)   REVIEW_CYCLE="${2:-0}"; shift 2 ;;
     --review-cycle=*) REVIEW_CYCLE="${1#*=}"; shift ;;
     --no-review)      NO_REVIEW=1; shift ;;
+    --admin)          ALLOW_ADMIN=1; shift ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;
   esac
 done
+
+# --admin, --no-review and --review-cycle only take effect while merging. Warn
+# loudly if they were passed without --merge so the flag isn't silently a no-op.
+if [ "$MODE" != "--merge" ]; then
+  if [ "$ALLOW_ADMIN" -eq 1 ] || [ "$NO_REVIEW" -eq 1 ] || [ "$REVIEW_CYCLE" -ne 0 ]; then
+    echo "WARNING: --admin/--no-review/--review-cycle only apply with --merge; ignoring (monitor-only run)." >&2
+  fi
+fi
 
 _count_pending() {
   echo "$1" | python3 -c "
@@ -212,6 +222,7 @@ while { [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UN
   # Bot reviewers like Codex post comments without changing reviewDecision.
   if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] && _has_review_activity; then
     echo "  Review comments detected — proceeding without waiting for formal approval."
+    REVIEW_ACTIVITY=1
     break
   fi
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
@@ -241,8 +252,15 @@ if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
 fi
 
 if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ]; then
-  echo "PR #$PR_NUMBER: review/decision still pending after ${REVIEW_TIMEOUT}s — no reviewer has acted."
-  echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
+  if [ "${REVIEW_ACTIVITY:-0}" -eq 1 ]; then
+    # The wait loop broke early because reviews were posted (e.g. a bot's
+    # COMMENTED review) — surface them instead of claiming nobody acted.
+    echo "PR #$PR_NUMBER: review comments posted, but no formal approval yet:"
+    _print_review_comments
+  else
+    echo "PR #$PR_NUMBER: review/decision still pending after ${REVIEW_TIMEOUT}s — no reviewer has acted."
+    echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
+  fi
 
   if [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then
@@ -272,8 +290,21 @@ if [ "$MODE" = "--merge" ]; then
       exit 1
     fi
   elif [ "$MERGE_STATE" = "BLOCKED" ]; then
-    echo "PR is blocked by review protection — merging with admin override."
-    _admin_merge
+    # The review gate already passed to reach here, so BLOCKED means a DIFFERENT
+    # branch-protection rule is unmet — most often an unresolved review thread.
+    # Auto-admin-merging past it on cycle 0 silently defeats the protection this
+    # very tool set up, so it requires an explicit --admin opt-in (2026-07
+    # review; backported from the template copy).
+    if [ "$ALLOW_ADMIN" -eq 1 ]; then
+      echo "PR is blocked by branch protection — merging with admin override (--admin)."
+      _admin_merge
+    else
+      echo "ERROR: PR #$PR_NUMBER is BLOCKED by branch protection after the review gate" >&2
+      echo "  passed — typically an unresolved review conversation, or a required" >&2
+      echo "  check that has not reported. Resolve the blocker, or re-run with --admin" >&2
+      echo "  to override." >&2
+      exit 1
+    fi
   else
     if ! _run_gh pr merge "$PR_NUMBER" --squash --delete-branch; then
       if ! _run_gh pr merge "$PR_NUMBER" --squash --delete-branch --auto; then

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -51,13 +51,23 @@ shift 1  # drop PR_NUMBER
 while [ $# -gt 0 ]; do
   case "$1" in
     --merge)          MODE="--merge"; shift ;;
-    --review-cycle)   REVIEW_CYCLE="${2:-0}"; shift 2 ;;
+    --review-cycle)
+      # Validate before `shift 2`: with no value, the shift fails under set -e
+      # and aborts with no message (Copilot review).
+      if [ $# -lt 2 ]; then
+        echo "--review-cycle requires a numeric value" >&2
+        exit 2
+      fi
+      REVIEW_CYCLE="$2"; shift 2 ;;
     --review-cycle=*) REVIEW_CYCLE="${1#*=}"; shift ;;
     --no-review)      NO_REVIEW=1; shift ;;
     --admin)          ALLOW_ADMIN=1; shift ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;
   esac
 done
+case "$REVIEW_CYCLE" in
+  '' | *[!0-9]*) echo "--review-cycle must be a non-negative integer (got '$REVIEW_CYCLE')" >&2; exit 2 ;;
+esac
 
 # --admin, --no-review and --review-cycle only take effect while merging. Warn
 # loudly if they were passed without --merge so the flag isn't silently a no-op.

--- a/.claude/scripts/push_wiki.sh
+++ b/.claude/scripts/push_wiki.sh
@@ -41,8 +41,13 @@ git clone "https://github.com/${REPO_SLUG}.wiki.git" "$WIKI_DIR"
 cp "$SOURCE_FILE" "$WIKI_DIR/Home.md"
 
 cd "$WIKI_DIR"
-for page in "${PRUNE_PAGES[@]}"; do
-  [[ -f "$page" ]] && git rm -q "$page" && echo "Pruned $page"
+# ${arr[@]+...} guard: expanding an empty array under `set -u` is a fatal
+# "unbound variable" on bash 3.2-4.3 (stock macOS), aborting before the commit.
+for page in ${PRUNE_PAGES[@]+"${PRUNE_PAGES[@]}"}; do
+  if [[ -f "$page" ]]; then
+    git rm -q "$page"
+    echo "Pruned $page"
+  fi
 done
 git add Home.md
 if git diff --cached --quiet; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/github_command_guard.sh",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 0.6.0
+version: 0.6.1

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ project-init/
 
 ## Status
 
-Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v0.6.0). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
+Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v0.6.1). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
 
 ## License
 

--- a/plugins/project-init-lifecycle/.claude-plugin/plugin.json
+++ b/plugins/project-init-lifecycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-lifecycle",
   "displayName": "project-init GitHub Lifecycle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GitHub lifecycle automation from project-init (#476, ADR-021): the issue->branch->PR->review->merge DAG guard + workflow-state hooks and the create_issue/start_task/github_workflow/request_review/audit skills. Enabled only when the lifecycle tier is on; the forge-agnostic quality/safety hooks live in project-init-workflow.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -62,8 +62,11 @@ else:
 
 
 def _run(cmd: list[str]) -> tuple[int, str]:
+    # Per-call timeout must stay well below the hook budget (settings.json
+    # "timeout": 60): a PreToolUse hook that exceeds its budget is killed and
+    # FAILS OPEN, so one hung gh call must never eat the whole allowance.
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -304,15 +307,20 @@ _HEREDOC_RE = re.compile(
 # push`, `git -c k=v push`). Left unnormalized they defeat every `git push`
 # rule, including the direct-push-to-main block (2026-07 review). Options that
 # consume a value are listed with their value; boolean options stand alone.
+# An option value is one shell word INCLUDING quoted runs — `-c foo='a b'`
+# must normalize away too: a bare \S+ stops at the space inside the quotes
+# and the mangled residue defeats every git rule (mirrors the quoted-value
+# matcher in pre_commit_gate.sh).
+_GIT_OPT_VAL = r"(?:[^\s'\"]|'[^']*'|\"[^\"]*\")+"
 _GIT_GLOBAL_OPT = (
     r"(?:"
-    r"-C[ \t]+\S+"  # -C <path>
-    r"|-c[ \t]+\S+"  # -c <name=value>
-    r"|--git-dir(?:=\S+|[ \t]+\S+)"
-    r"|--work-tree(?:=\S+|[ \t]+\S+)"
-    r"|--namespace(?:=\S+|[ \t]+\S+)"
-    r"|--config-env(?:=\S+|[ \t]+\S+)"
-    r"|--exec-path(?:=\S+)?"
+    rf"-C[ \t]+{_GIT_OPT_VAL}"  # -C <path>
+    rf"|-c[ \t]+{_GIT_OPT_VAL}"  # -c <name=value>
+    rf"|--git-dir(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--work-tree(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--namespace(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--config-env(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--exec-path(?:={_GIT_OPT_VAL})?"
     r"|--no-pager|--paginate|-p|-P|--bare"
     r"|--no-replace-objects|--literal-pathspecs|--no-optional-locks|--icase-pathspecs"
     r")"
@@ -688,10 +696,18 @@ def cmd_create_pr_nojira(
     if rc != 0:
         return rc
 
-    code, url = _gh(["pr", "view", "--json", "url", "-q", ".url"])
-    if code == 0 and url.strip():
-        sys.stdout.write(f"Draft PR already exists: {url.strip()}\n")
-        return 0
+    # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
+    # PR for the branch — reusing a branch name after a merge must open a new
+    # PR, not report the merged one as "already exists" (matches check_pr_opened).
+    code, out = _gh(["pr", "view", "--json", "url,state"])
+    if code == 0:
+        try:
+            data = json.loads(out or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("state") == "OPEN" and data.get("url"):
+            sys.stdout.write(f"Draft PR already exists: {data['url']}\n")
+            return 0
 
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"

--- a/plugins/project-init-lifecycle/hooks/hooks.json
+++ b/plugins/project-init-lifecycle/hooks/hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "shell": "bash",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/github_command_guard.sh",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -70,7 +70,12 @@ while IFS= read -r _f; do [ -n "$_f" ] && STAGED_PY+=("$_f"); done \
   < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
 if [ "${#STAGED_PY[@]}" -gt 0 ]; then
   LINT_OUT=""
-  if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
+  # The `uv run ruff --version` probe keeps this branch fail-open: in a uv
+  # project that doesn't ship ruff, `uv run ruff check` emits a "Failed to
+  # spawn" error that would otherwise be captured as bogus "Python lint
+  # errors" and block the commit. Probe first; fall through to system ruff.
+  if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null &&
+    uv run ruff --version >/dev/null 2>&1; then
     uv run ruff check --fix --quiet "${STAGED_PY[@]}" >/dev/null 2>&1 || true
     uv run ruff format --quiet "${STAGED_PY[@]}" >/dev/null 2>&1 || true
     LINT_OUT=$(uv run ruff check --quiet "${STAGED_PY[@]}" 2>&1 || true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.6.0"
+version = "0.6.1"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,8 +1,8 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.2.0"
+__plugin_version__ = "0.2.1"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -369,6 +369,22 @@ def _prompt(label: str, default: str = "") -> str:
     return Prompt.ask(label, default=default) or default
 
 
+def _prompt_choice(label: str, valid: tuple[str, ...], *, default: str) -> str:
+    """Prompt for one of *valid*, case-insensitively, re-asking on a bad answer.
+
+    Interactive counterpart to argparse ``choices``: typing ``Python`` or ``MIT``
+    must not silently coerce to ``none`` — normalize case and re-prompt with the
+    valid set instead (PI review 2026-07).
+    """
+    from rich.console import Console
+
+    while True:
+        value = _prompt(label, default=default).strip().lower()
+        if value in valid:
+            return value
+        Console().print(f"[red]Invalid choice {value!r}. Valid: {', '.join(valid)}[/red]")
+
+
 def _prompt_validated(label: str, *, default: str, flag: str, allow_empty: bool = False) -> str:
     """Prompt, re-asking until the value would not corrupt config.yaml.
 
@@ -1185,11 +1201,18 @@ def _gather_mcps_interactive(cli_mcps: str, cli_browser: bool) -> list[dict]:
     """
     if cli_mcps.strip():
         try:
-            return _resolve_mcps_non_interactive(cli_mcps, cli_browser)
+            selected = _resolve_mcps_non_interactive(cli_mcps, cli_browser)
         except ValueError as e:
             from rich.console import Console
 
             Console().print(f"[red]{e}[/red] — choose from the catalog instead.")
+        else:
+            # --mcps pins the catalog picks, but browser automation is its own
+            # concern (ADR-023) — still offer it when --browser was not given,
+            # matching how devcontainer/mise/vscode still prompt in the same run.
+            if not cli_browser and _choose_browser_interactive():
+                selected = selected + [PLAYWRIGHT_MCP]
+            return selected
     selected = _choose_mcps_interactive(MCP_CATALOG)
     if cli_browser or _choose_browser_interactive():
         selected = selected + [PLAYWRIGHT_MCP]
@@ -1226,6 +1249,7 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     cli_devcontainer: bool = False,
     cli_mise: bool = False,
     cli_vscode: bool = False,
+    cli_agents: str = "claude",
 ) -> ScaffoldInputs:
     """Prompt for the profile, project basics, MCPs, governance, and overlays.
 
@@ -1248,9 +1272,11 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     project_description = _prompt_validated(
         "Description", default=cli_description or "", flag="description"
     )
-    language = _prompt("Language (python/node/go/rust/none)", default=cli_language or "none")
-    if language not in {"python", "node", "go", "rust", "none"}:
-        language = "none"
+    language = _prompt_choice(
+        "Language (python/node/go/rust/none)",
+        ("python", "node", "go", "rust", "none"),
+        default=cli_language or "none",
+    )
     (
         delivery_flag,
         deploy_flag,
@@ -1273,11 +1299,11 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         flag="owner",
         allow_empty=True,
     )
-    license_choice = _prompt(
-        "License (mit/apache-2.0/proprietary/none)", default=cli_license or "none"
+    license_choice = _prompt_choice(
+        "License (mit/apache-2.0/proprietary/none)",
+        ("mit", "apache-2.0", "proprietary", "none"),
+        default=cli_license or "none",
     )
-    if license_choice not in {"mit", "apache-2.0", "proprietary", "none"}:
-        license_choice = "none"
 
     # Toolchain toggles — each explains its value before asking (#472, ADR-023).
     # A store_true CLI flag pre-accepts the toggle and skips its prompt.
@@ -1314,7 +1340,7 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     while True:
         agents_raw = _prompt(
             "Agents/surfaces (claude always; add codex/ollama/cursor/antigravity/vscode, comma-separated)",
-            default="claude",
+            default=cli_agents or "claude",
         )
         try:
             agents = resolve_agents(agents_raw)
@@ -2153,6 +2179,24 @@ def _resolve_preset_memory(preset: dict, parser: argparse.ArgumentParser) -> str
     return resolved
 
 
+def _resolve_preset_lifecycle(preset: dict, parser: argparse.ArgumentParser) -> str:
+    """Validate a preset's ``lifecycle`` tier (#476).
+
+    Only the exact string ``"none"`` disables the lifecycle downstream
+    (``inputs.lifecycle != "none"``), so an off-meaning value — a TOML boolean
+    ``false``, ``"off"``, a typo'd ``"None"`` — would silently ship the full
+    lifecycle overlay, the opposite of the preset author's intent. Reject it up
+    front instead (mirrors _resolve_preset_memory).
+    """
+    raw = preset.get("vars", {}).get("lifecycle", "github")
+    if raw not in _LIFECYCLE_TIERS:
+        parser.error(
+            f"preset {preset['name']!r} declares an invalid lifecycle "
+            f"{raw!r}; valid: {', '.join(_LIFECYCLE_TIERS)}"
+        )
+    return raw
+
+
 def _cli(argv: list[str]) -> int:
     """Dispatch a fully-formed argv to the scaffold CLI or a subcommand."""
     _subcommands = {
@@ -2197,7 +2241,7 @@ def _cli(argv: list[str]) -> int:
     preset_memory = _resolve_preset_memory(preset, parser)
     # Lifecycle-tier fallback when --lifecycle is absent (#476): the preset's
     # tier (a preset may set lifecycle = "none" to be minimal), default "github".
-    preset_lifecycle = preset.get("vars", {}).get("lifecycle", "github")
+    preset_lifecycle = _resolve_preset_lifecycle(preset, parser)
 
     # Validate non-interactive args / gather interactive input BEFORE creating
     # the target directory (PI-20, PI-199: a bad flag OR a Ctrl-C at an
@@ -2240,6 +2284,7 @@ def _cli(argv: list[str]) -> int:
             cli_devcontainer=args.devcontainer,
             cli_mise=args.mise,
             cli_vscode=args.vscode,
+            cli_agents=args.agents,
         )
     _validate_text_inputs(inputs, parser)
     _validate_existing_config(target, parser)

--- a/src/project_init/capabilities.py
+++ b/src/project_init/capabilities.py
@@ -245,8 +245,16 @@ def render(variables: dict[str, str]) -> str:
         ]
     lines += ["", f"## MCP servers ({len(servers)})", ""]
     if servers:
+        # HTTP-transport servers (e.g. context7-http) carry a url instead of
+        # command+args — surface it rather than an empty Invocation cell
+        # (mirrors governance._server_transport).
         rows = [
-            (name, " ".join([spec.get("command", "")] + spec.get("args", [])).strip())
+            (
+                name,
+                spec.get("url", "")
+                if spec.get("type") == "http" or spec.get("url")
+                else " ".join([spec.get("command", "")] + spec.get("args", [])).strip(),
+            )
             for name, spec in sorted(servers.items())
         ]
         lines += _table(("Server", "Invocation"), rows)

--- a/src/project_init/concerns.py
+++ b/src/project_init/concerns.py
@@ -48,6 +48,10 @@ class ConcernError(Exception):
 
 
 def _set_memory(v: dict, stack: str) -> None:
+    # Accept the friendly `obsidian` alias the main CLI's --memory takes (#466)
+    # so `project-init add memory obsidian` matches the documented flag surface.
+    if stack == "obsidian":
+        stack = "obsidian-only"
     if stack not in MEMORY_STACKS:
         raise ConcernError(
             f"unknown memory stack {stack!r}; choose one of {', '.join(MEMORY_STACKS)}"

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,29 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "0.6.1": {
+        "summary": (
+            "Bug-fix pass from a full code review. Scaffolder: `upgrade --apply` "
+            "no longer resets a hand-set `memory.rag_endpoint`, preset control "
+            "vars (governance/lifecycle/memory_stack) no longer leak into the "
+            "template gates (so `remove governance` on a governed-preset project "
+            "now converges, and a preset's `lifecycle = \"none\"` renders "
+            "correctly), and the wizard honors `--agents`, re-prompts on a "
+            "mistyped language/license instead of silently coercing to `none`, "
+            "and still offers the browser concern when `--mcps` is passed. "
+            "Scaffolded fixes: the GitHub command-guard closes a quoted "
+            "global-option bypass (`git -c foo='a b' push`), its hook budget no "
+            "longer fails open on one slow gh call, start_issue.sh reports a "
+            "nonexistent issue instead of dying silently, monitor_pr.sh "
+            "surfaces bot review comments instead of a false timeout message, "
+            "and the commit gate no longer blocks commits in uv projects that "
+            "don't ship ruff."
+        ),
+        "action_required": (
+            "Re-run `project-init upgrade` to pick up the guard and script "
+            "fixes. No breaking changes."
+        ),
+    },
     "0.6.0": {
         "summary": (
             "Robustness + hardening pass (2026-07 review). Re-running the "

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -792,6 +792,11 @@ def _coerce_preset_var(value: object) -> str:
     return str(value)
 
 
+# Preset [vars] keys consumed by CLI/upgrade resolution (tier/flag selection),
+# not template variables — see the skip inside _apply_preset_vars.
+_PRESET_CONTROL_KEYS = frozenset({"memory_stack", "lifecycle", "governance"})
+
+
 def _apply_preset_vars(variables: dict[str, str], preset: dict) -> dict[str, str]:
     """Merge preset ``[vars]`` (#252) into the render variables.
 
@@ -814,6 +819,16 @@ def _apply_preset_vars(variables: dict[str, str], preset: dict) -> dict[str, str
     merged = dict(variables)
     owner_was_unset = not merged.get("project_owner")
     for key, value in preset_vars.items():
+        # Control keys (memory_stack/lifecycle/governance) configure the
+        # CLI/upgrade resolution itself and are already folded into the render
+        # variables upstream with the right precedence. Merging them here
+        # collides with the same-named gate variables: a `governed` preset's
+        # `governance = true` would refill the gate an explicit
+        # `remove governance` set to "" (never converging), and a preset's
+        # `lifecycle = "none"` — a tier name, not a gate — is a TRUTHY string
+        # that would turn every {{#if lifecycle}} block ON (2026-07 review).
+        if key in _PRESET_CONTROL_KEYS:
+            continue
         if not merged.get(key):
             merged[key] = _coerce_preset_var(value)
     # If the preset supplied the owner into an empty slot (no --owner) and did

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -927,6 +927,30 @@ def _memory_section(text: str) -> str:
     return m.group(0) if m else ""
 
 
+# The `rag_endpoint:` line inside the memory block: key, value (up to a
+# comment), optional trailing comment. The template always renders the value
+# EMPTY — setup_rag.sh instructs the user to hand-set it (ADR-026).
+_RAG_ENDPOINT_RE = re.compile(r"(?m)^(\s*rag_endpoint:)([^#\n]*)(#.*)?$")
+
+
+def _carry_rag_endpoint(old_mem: str, new_mem: str) -> str:
+    """Preserve a hand-set ``memory.rag_endpoint`` across the block splice.
+
+    The staged render always has an empty ``rag_endpoint:`` (it is not a
+    template variable), so splicing the block wholesale would silently reset
+    the endpoint the user recorded per setup_rag.sh — breaking the ADR-025
+    descriptor the field exists for (2026-07 review). Carry the old line over
+    when the user set a value and the fresh render left it empty.
+    """
+    old_m = _RAG_ENDPOINT_RE.search(old_mem)
+    new_m = _RAG_ENDPOINT_RE.search(new_mem)
+    if not old_m or not new_m:
+        return new_mem
+    if not old_m.group(2).strip() or new_m.group(2).strip():
+        return new_mem
+    return new_mem[: new_m.start()] + old_m.group(0) + new_mem[new_m.end() :]
+
+
 def _sync_memory_block(text: str, staging: Path) -> str:
     """Refresh the derived `memory:` descriptor from the freshly rendered config.
 
@@ -946,6 +970,10 @@ def _sync_memory_block(text: str, staging: Path) -> str:
     if old_mem == new_mem:
         return text
     if old_mem:  # change or remove (new_mem may be '')
+        if new_mem:
+            new_mem = _carry_rag_endpoint(old_mem, new_mem)
+            if old_mem == new_mem:
+                return text
         return text.replace(old_mem, new_mem, 1)
     # add: insert the block immediately before the `mcps:` key
     return re.sub(r"(?m)^mcps:", lambda _m: new_mem + "mcps:", text, count=1)
@@ -1579,7 +1607,12 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     # re-render never crashes (configs predating #247/#248).
     variables.setdefault("profile", "individual")
     variables.setdefault("enforcement", "advisory")
-    variables.setdefault("project_init_plugin_version", __plugin_version__)
+    # The plugin payload tracks the running scaffolder (ADR-010): bump it
+    # unconditionally, like project_init_version above. A setdefault is dead
+    # here — _backfill_variables has already seeded the migration default
+    # ("0.1.0"), which would stamp a stale plugin version into the visible
+    # project fields on --apply (2026-07 review).
+    variables["project_init_plugin_version"] = __plugin_version__
 
     staging_root = Path(tempfile.mkdtemp(prefix="project-init-upgrade-"))
     staging = staging_root / "render"

--- a/templates/base/dot_claude/settings.json.tmpl
+++ b/templates/base/dot_claude/settings.json.tmpl
@@ -49,7 +49,7 @@
             "type": "command",
             "shell": "bash",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/github_command_guard.sh",
-            "timeout": 10
+            "timeout": 60
           },
 {{/if lifecycle}}          {
             "type": "command",

--- a/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_claude/hooks/pre_commit_gate.sh
@@ -70,7 +70,12 @@ while IFS= read -r _f; do [ -n "$_f" ] && STAGED_PY+=("$_f"); done \
   < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep '\.py$' || true)
 if [ "${#STAGED_PY[@]}" -gt 0 ]; then
   LINT_OUT=""
-  if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
+  # The `uv run ruff --version` probe keeps this branch fail-open: in a uv
+  # project that doesn't ship ruff, `uv run ruff check` emits a "Failed to
+  # spawn" error that would otherwise be captured as bogus "Python lint
+  # errors" and block the commit. Probe first; fall through to system ruff.
+  if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null &&
+    uv run ruff --version >/dev/null 2>&1; then
     uv run ruff check --fix --quiet "${STAGED_PY[@]}" >/dev/null 2>&1 || true
     uv run ruff format --quiet "${STAGED_PY[@]}" >/dev/null 2>&1 || true
     LINT_OUT=$(uv run ruff check --quiet "${STAGED_PY[@]}" 2>&1 || true)

--- a/templates/lifecycle/dot_claude/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_claude/hooks/dag_workflow.py
@@ -62,8 +62,11 @@ else:
 
 
 def _run(cmd: list[str]) -> tuple[int, str]:
+    # Per-call timeout must stay well below the hook budget (settings.json
+    # "timeout": 60): a PreToolUse hook that exceeds its budget is killed and
+    # FAILS OPEN, so one hung gh call must never eat the whole allowance.
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)  # noqa: S603 — argv list built from internal literals/validated state, never a shell string
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 1, ""
     return proc.returncode, proc.stdout
@@ -304,15 +307,20 @@ _HEREDOC_RE = re.compile(
 # push`, `git -c k=v push`). Left unnormalized they defeat every `git push`
 # rule, including the direct-push-to-main block (2026-07 review). Options that
 # consume a value are listed with their value; boolean options stand alone.
+# An option value is one shell word INCLUDING quoted runs — `-c foo='a b'`
+# must normalize away too: a bare \S+ stops at the space inside the quotes
+# and the mangled residue defeats every git rule (mirrors the quoted-value
+# matcher in pre_commit_gate.sh).
+_GIT_OPT_VAL = r"(?:[^\s'\"]|'[^']*'|\"[^\"]*\")+"
 _GIT_GLOBAL_OPT = (
     r"(?:"
-    r"-C[ \t]+\S+"  # -C <path>
-    r"|-c[ \t]+\S+"  # -c <name=value>
-    r"|--git-dir(?:=\S+|[ \t]+\S+)"
-    r"|--work-tree(?:=\S+|[ \t]+\S+)"
-    r"|--namespace(?:=\S+|[ \t]+\S+)"
-    r"|--config-env(?:=\S+|[ \t]+\S+)"
-    r"|--exec-path(?:=\S+)?"
+    rf"-C[ \t]+{_GIT_OPT_VAL}"  # -C <path>
+    rf"|-c[ \t]+{_GIT_OPT_VAL}"  # -c <name=value>
+    rf"|--git-dir(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--work-tree(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--namespace(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--config-env(?:={_GIT_OPT_VAL}|[ \t]+{_GIT_OPT_VAL})"
+    rf"|--exec-path(?:={_GIT_OPT_VAL})?"
     r"|--no-pager|--paginate|-p|-P|--bare"
     r"|--no-replace-objects|--literal-pathspecs|--no-optional-locks|--icase-pathspecs"
     r")"
@@ -688,10 +696,18 @@ def cmd_create_pr_nojira(
     if rc != 0:
         return rc
 
-    code, url = _gh(["pr", "view", "--json", "url", "-q", ".url"])
-    if code == 0 and url.strip():
-        sys.stdout.write(f"Draft PR already exists: {url.strip()}\n")
-        return 0
+    # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
+    # PR for the branch — reusing a branch name after a merge must open a new
+    # PR, not report the merged one as "already exists" (matches check_pr_opened).
+    code, out = _gh(["pr", "view", "--json", "url,state"])
+    if code == 0:
+        try:
+            data = json.loads(out or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("state") == "OPEN" and data.get("url"):
+            sys.stdout.write(f"Draft PR already exists: {data['url']}\n")
+            return 0
 
     # Conventional Commits, no scope = no linked issue (ADR-006)
     pr_title = f"{type_}: {title}"

--- a/templates/lifecycle/dot_claude/scripts/create_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/create_issue.sh
@@ -534,6 +534,7 @@ PYEOF
   fi
 
   if [ -z "$item_id" ]; then
+    rm -f "$pdata_file"
     echo "Warning: could not add #$issue_num to project #$project_num — skipping field sync" >&2
     return 0
   fi

--- a/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
@@ -267,6 +267,7 @@ while { [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UN
   # Bot reviewers like Codex post comments without changing reviewDecision.
   if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] && _has_review_activity; then
     echo "  Review comments detected — proceeding without waiting for formal approval."
+    REVIEW_ACTIVITY=1
     break
   fi
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
@@ -297,8 +298,15 @@ if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
 fi
 
 if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ]; then
-  echo "PR #$PR_NUMBER: review/decision still pending after ${REVIEW_TIMEOUT}s — no reviewer has acted."
-  echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
+  if [ "${REVIEW_ACTIVITY:-0}" -eq 1 ]; then
+    # The wait loop broke early because reviews were posted (e.g. a bot's
+    # COMMENTED review) — surface them instead of claiming nobody acted.
+    echo "PR #$PR_NUMBER: review comments posted, but no formal approval yet:"
+    _print_review_comments
+  else
+    echo "PR #$PR_NUMBER: review/decision still pending after ${REVIEW_TIMEOUT}s — no reviewer has acted."
+    echo "  Full PR: $(gh pr view "$PR_NUMBER" --json url -q '.url' 2>/dev/null || true)"
+  fi
 
   if [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ]; then

--- a/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_claude/scripts/monitor_pr.sh
@@ -68,7 +68,13 @@ while [ $# -gt 0 ]; do
     shift
     ;;
   --review-cycle)
-    REVIEW_CYCLE="${2:-0}"
+    # Validate before `shift 2`: with no value, the shift fails under set -e
+    # and aborts with no message (Copilot review).
+    if [ $# -lt 2 ]; then
+      echo "--review-cycle requires a numeric value" >&2
+      exit 2
+    fi
+    REVIEW_CYCLE="$2"
     shift 2
     ;;
   --review-cycle=*)
@@ -89,6 +95,12 @@ while [ $# -gt 0 ]; do
     ;;
   esac
 done
+case "$REVIEW_CYCLE" in
+'' | *[!0-9]*)
+  echo "--review-cycle must be a non-negative integer (got '$REVIEW_CYCLE')" >&2
+  exit 2
+  ;;
+esac
 
 # --admin, --no-review and --review-cycle only take effect while merging. Warn
 # loudly if they were passed without --merge (e.g. `monitor_pr.sh 12 --admin`)

--- a/templates/lifecycle/dot_claude/scripts/start_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/start_issue.sh
@@ -104,14 +104,20 @@ if ! echo "$PROJECT_KEY" | grep -qE '^[A-Z][A-Z0-9]{1,9}$'; then
 fi
 
 # --- Fetch issue title ---
-# `|| true`: under set -e a nonexistent issue would kill the script at this
-# assignment with gh's stderr discarded — zero output, unreachable error
-# branch. Let the empty-check below report it instead.
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null || true)
+# `|| true`: under set -e a failing gh would kill the script at this assignment
+# before the error branch below could run. Capture stderr to a file (NOT 2>&1 —
+# that would mix gh's error text into ISSUE_TITLE and defeat the empty-check)
+# so an auth/network failure is reported as itself, not as "issue not found"
+# (Copilot review).
+GH_ERR=$(mktemp)
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>"$GH_ERR" || true)
 if [ -z "$ISSUE_TITLE" ]; then
-  echo "ERROR: issue #$ISSUE_NUMBER not found" >&2
+  echo "ERROR: could not fetch issue #$ISSUE_NUMBER — it may not exist, or gh failed:" >&2
+  sed 's/^/  /' "$GH_ERR" >&2
+  rm -f "$GH_ERR"
   exit 1
 fi
+rm -f "$GH_ERR"
 
 ISSUE_REF="${PROJECT_KEY}-${ISSUE_NUMBER}"
 

--- a/templates/lifecycle/dot_claude/scripts/start_issue.sh
+++ b/templates/lifecycle/dot_claude/scripts/start_issue.sh
@@ -104,7 +104,10 @@ if ! echo "$PROJECT_KEY" | grep -qE '^[A-Z][A-Z0-9]{1,9}$'; then
 fi
 
 # --- Fetch issue title ---
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null)
+# `|| true`: under set -e a nonexistent issue would kill the script at this
+# assignment with gh's stderr discarded — zero output, unreachable error
+# branch. Let the empty-check below report it instead.
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null || true)
 if [ -z "$ISSUE_TITLE" ]; then
   echo "ERROR: issue #$ISSUE_NUMBER not found" >&2
   exit 1

--- a/tests/contracts/test_capabilities.py
+++ b/tests/contracts/test_capabilities.py
@@ -83,6 +83,15 @@ def test_no_gui_hooks_section_without_gui_surfaces(tmp_path: Path):
     assert "### GUI surface hooks" not in (t / _REL).read_text()
 
 
+def test_http_mcp_server_shows_url_invocation(tmp_path: Path):
+    # HTTP-transport servers (context7-http) carry a url instead of
+    # command+args — the Invocation cell must surface it, not render empty
+    # (2026-07 review; mirrors governance._server_transport).
+    t = _scaffold(tmp_path / "p", agents="claude,codex", installed_mcps="context7-http")
+    text = (t / _REL).read_text()
+    assert "| context7-http | https://mcp.context7.com/mcp |" in text
+
+
 def test_mcp_section_empty_when_none(tmp_path: Path):
     t = _scaffold(tmp_path / "p", agents="claude", installed_mcps="none")
     text = (t / _REL).read_text()

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -56,6 +56,13 @@ directives on its `subprocess.run` calls — the scaffolded `ruff.toml` selects
 on those argv-list (never shell-string) calls, mirroring the `# noqa: S310`
 package_guard.py already carries. Only the `.claude/hooks/dag_workflow.py` hash
 was re-pinned across all four combos, after verifying every other file matched.
+
+Exception (2026-07 review, second pass): `dag_workflow.py` closed the
+quoted-global-option guard bypass (`git -c foo='a b' push …`), capped its
+per-subprocess timeout below the hook budget, and made the nojira "PR already
+exists" short-circuit check the PR is OPEN. Deliberate guard fixes, not
+move-drift — only the `.claude/hooks/dag_workflow.py` hash was re-pinned across
+all four combos, after verifying every other file still matched.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_lifecycle_script_hardening.py
+++ b/tests/contracts/test_lifecycle_script_hardening.py
@@ -1,0 +1,151 @@
+"""2026-07 code-review pass: content contracts on lifecycle scripts + hook wiring.
+
+Each assertion pins a specific defect fixed in the review:
+
+- ``start_issue.sh`` died silently on a nonexistent issue — under ``set -e``
+  the command-substitution assignment killed the script (gh stderr discarded)
+  before the "issue not found" branch could run.
+- ``create_issue.sh`` leaked its mktemp file on the could-not-add early return.
+- ``pre_commit_gate.sh`` fail-closed in uv projects that don't ship ruff: uv's
+  "Failed to spawn" error was captured as bogus "Python lint errors".
+- ``monitor_pr.sh`` printed "no reviewer has acted" (and hid the comments)
+  after breaking early on review activity; the ROOT copy also predated the
+  template's ``--admin`` opt-in for BLOCKED merges and the order-independent
+  flag parser.
+- The ``github_command_guard`` hook budget (10s) was smaller than one internal
+  subprocess timeout (15s); a PreToolUse hook that exceeds its budget is
+  killed and FAILS OPEN, so the guarded command executed unchecked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIFECYCLE_SCRIPTS = _REPO_ROOT / "templates/lifecycle/dot_claude/scripts"
+_ROOT_SCRIPTS = _REPO_ROOT / ".claude/scripts"
+
+
+class TestStartIssueErrorPath:
+    def test_issue_title_fetch_survives_set_e(self):
+        s = (_LIFECYCLE_SCRIPTS / "start_issue.sh").read_text()
+        m = re.search(r"^ISSUE_TITLE=\$\(gh issue view .*\)$", s, re.MULTILINE)
+        assert m, "issue-title fetch line not found"
+        assert "|| true" in m.group(0), (
+            "under set -e a failing gh exit kills the script at the assignment, "
+            "making the 'issue not found' branch unreachable"
+        )
+
+
+class TestCreateIssueTempFile:
+    def test_could_not_add_early_return_removes_temp_file(self):
+        s = (_LIFECYCLE_SCRIPTS / "create_issue.sh").read_text()
+        block = re.search(
+            r"\n(.*\n)?\s*echo \"Warning: could not add", s
+        )
+        assert block, "could-not-add warning not found"
+        assert 'rm -f "$pdata_file"' in block.group(0), (
+            "the could-not-add early return must clean up the mktemp file "
+            "like the project-not-found path does"
+        )
+
+
+class TestPreCommitGateFailOpen:
+    def test_uv_branch_probes_ruff_before_linting(self):
+        for rel in (
+            "templates/fallback/dot_claude/hooks/pre_commit_gate.sh",
+            "plugins/project-init-workflow/hooks/pre_commit_gate.sh",
+        ):
+            s = (_REPO_ROOT / rel).read_text()
+            assert "uv run ruff --version" in s, (
+                f"{rel}: without the probe, a uv project that doesn't ship ruff "
+                "captures uv's spawn error as bogus lint errors and blocks the commit"
+            )
+
+
+class TestMonitorPrReviewActivity:
+    def test_early_break_surfaces_comments_not_false_timeout(self):
+        for path in (
+            _LIFECYCLE_SCRIPTS / "monitor_pr.sh",
+            _ROOT_SCRIPTS / "monitor_pr.sh",
+        ):
+            s = path.read_text()
+            assert "REVIEW_ACTIVITY=1" in s, f"{path}: early-break flag missing"
+            assert "review comments posted" in s, (
+                f"{path}: the early review-activity break must surface the "
+                "comments instead of claiming no reviewer acted"
+            )
+
+
+class TestRootMonitorPrBackport:
+    """The root copy is this repo's own tool (invoked by `dag_workflow.py
+    finish`); the template fixes must not silently diverge from it again."""
+
+    def test_admin_gate_backported(self):
+        s = (_ROOT_SCRIPTS / "monitor_pr.sh").read_text()
+        assert "ALLOW_ADMIN" in s
+        assert '[ "$ALLOW_ADMIN" -eq 1 ]' in s, (
+            "a BLOCKED merge state must require the explicit --admin opt-in, "
+            "not auto-admin-merge past branch protection on cycle 0"
+        )
+
+    def test_flag_parser_is_order_independent(self):
+        s = (_ROOT_SCRIPTS / "monitor_pr.sh").read_text()
+        assert 'MODE="${2:-}"' not in s, (
+            "the positional parser rejected documented usage like "
+            "`monitor_pr.sh 12 --no-review` with 'Unknown option'"
+        )
+        assert "--admin)" in s
+        assert "--merge)" in s
+
+
+class TestGuardHookBudget:
+    """A PreToolUse hook killed at its timeout fails OPEN, so the guard's hook
+    budget must comfortably exceed its internal per-subprocess timeout."""
+
+    _SUBPROCESS_TIMEOUT_RE = re.compile(r"subprocess\.run\(.*timeout=(\d+)")
+
+    def _guard_timeout(self, hooks_cfg: dict) -> int:
+        for group in hooks_cfg["hooks"]["PreToolUse"]:
+            for hook in group["hooks"]:
+                if "github_command_guard" in hook["command"]:
+                    return hook["timeout"]
+        raise AssertionError("github_command_guard hook not wired")
+
+    def test_repo_settings_budget_exceeds_subprocess_timeout(self):
+        cfg = json.loads((_REPO_ROOT / ".claude/settings.json").read_text())
+        dag = (_REPO_ROOT / ".claude/hooks/dag_workflow.py").read_text()
+        m = self._SUBPROCESS_TIMEOUT_RE.search(dag)
+        assert m, "dag_workflow.py subprocess timeout not found"
+        assert self._guard_timeout(cfg) >= 4 * int(m.group(1)), (
+            "one hung gh call must never eat the whole hook budget — the "
+            "guard makes several sequential gh/git calls before denying"
+        )
+
+    def test_plugin_hooks_budget_matches(self):
+        cfg = json.loads(
+            (_REPO_ROOT / "plugins/project-init-lifecycle/hooks/hooks.json").read_text()
+        )
+        assert self._guard_timeout(cfg) == 60
+
+    def test_scaffolded_settings_template_budget_matches(self):
+        s = (_REPO_ROOT / "templates/base/dot_claude/settings.json.tmpl").read_text()
+        m = re.search(r'github_command_guard\.sh",\s*\n\s*"timeout": (\d+)', s)
+        assert m, "guard hook entry not found in settings.json.tmpl"
+        assert int(m.group(1)) == 60
+
+
+class TestNojiraPrStateCheck:
+    def test_existing_pr_short_circuit_checks_open_state(self):
+        # `gh pr view` with no selector also resolves the most recent
+        # CLOSED/MERGED PR for a reused branch name — the "already exists"
+        # short-circuit must check the state like check_pr_opened does.
+        for rel in (
+            ".claude/hooks/dag_workflow.py",
+            "templates/lifecycle/dot_claude/hooks/dag_workflow.py",
+            "plugins/project-init-lifecycle/hooks/dag_workflow.py",
+        ):
+            s = (_REPO_ROOT / rel).read_text()
+            assert '"url,state"' in s, f"{rel}: nojira PR reuse ignores PR state"

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -53,6 +53,12 @@ no other file drifted — `dag_workflow.py` (command-guard bypass fixes),
 `.gitignore` (no longer ignoring the committed `.codex/` wiring), `prod_guard.py`
 (rm split-flag detection), `commit-msg` (install comment), and the fallback
 hooks `pre_commit_gate.sh` / `post_edit_lint.sh` (cd to repo root).
+
+Exception (2026-07 review, second pass): `dag_workflow.py` closed the
+quoted-global-option guard bypass, capped its per-subprocess timeout below the
+hook budget, and made the nojira "PR already exists" short-circuit check the PR
+is OPEN. Only the `.claude/hooks/dag_workflow.py` hash was re-pinned across all
+four combos, after verifying every other file still matched.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
   ".claude/hooks/_usage_log.sh": "9684c3821fd3ac2cbac334a3f2ccb6de6c5792062b1bc30702001c02d19da5de",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/github_command_guard.sh": "14bcf3da720916a0fdaec22febb33401c60d79717cc0035880c7c84b2cd428f1",
   ".claude/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",
   ".claude/hooks/pre_commit_gate.sh": "67f7ba1545e8b94e66b61d806daa938a3826c2109ac48517d211859f27cd2077",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".claude/docs/guides/using-memory.md": "433598cd17ee0a7d98f2987100cae5426947ee8edb8e0b2dfa7c7786a7b94e1e",
   ".claude/hooks/README.md": "9a6533d1f8ad8cc667683ba58bbda5e524c230931f65c77cb2d477c72c080061",
   ".claude/hooks/_py.sh": "41c28f08f42df48131b052aa6a74f0b49b2baa17624e4c17e2f6ca4c289ad100",
-  ".claude/hooks/dag_workflow.py": "89fa3cb1a10b180bf36a87fdb7abcac80f590db3a71d659af14046a9a531f065",
+  ".claude/hooks/dag_workflow.py": "8703a77cc38a2a2fabf47a69db8991526f791ecc6d6d714a65e4aaa0997a8362",
   ".claude/hooks/prod_guard.py": "a61a50e02e536fca88335673fe9ccf52ab153fff8768c3f0d99ce665e54390cc",
   ".claude/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".claude/memory/README.md": "ff7e14d842d875f537d7d3a6cbe18df47e754088949804f94f348e300bbcbc5e",

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -293,6 +293,12 @@ class TestGuardSteering:
             "git --git-dir=/tmp/x/.git push origin main",
             "git --work-tree=/tmp/x -C /tmp/x push origin main",
             "git -p push origin main",
+            # Quoted option values containing spaces must normalize away too —
+            # a bare \S+ matcher stops inside the quotes and the mangled
+            # residue defeated every git rule (2026-07 review, second pass).
+            "git -c foo='a b' push origin main",
+            'git --git-dir="/a b/.git" push origin main',
+            "git -C '/tmp/some dir' push origin main",
         ],
     )
     def test_blocks_push_to_main_through_git_global_options(self, cmd: str, tmp_path: Path):

--- a/tests/unit/test_audit_fixes.py
+++ b/tests/unit/test_audit_fixes.py
@@ -11,7 +11,11 @@ import pytest
 
 from project_init import scaffold as sc
 from project_init.__main__ import _gather_mcps_interactive
-from project_init.upgrade import _backfill_variables, _memory_stack_from_flags
+from project_init.upgrade import (
+    _backfill_variables,
+    _carry_rag_endpoint,
+    _memory_stack_from_flags,
+)
 
 
 class TestMemoryStackBackfill:
@@ -77,10 +81,28 @@ class TestPresetVarsReachRender:
     def test_bool_false_does_not_enable_a_gate(self):
         # str(False) == "False" is truthy and would ENABLE the gate — a TOML
         # false must coerce to "" (off), true to "true".
-        preset = {"layers": ["base"], "vars": {"observability": False, "governance": True}}
-        merged = sc._apply_preset_vars({"observability": "", "governance": ""}, preset)
+        preset = {"layers": ["base"], "vars": {"observability": False, "multi_model": True}}
+        merged = sc._apply_preset_vars({"observability": "", "multi_model": ""}, preset)
         assert merged["observability"] == ""
-        assert merged["governance"] == "true"
+        assert merged["multi_model"] == "true"
+
+    def test_control_keys_never_refill_the_render_context(self):
+        # memory_stack/lifecycle/governance configure the CLI/upgrade resolution
+        # and are folded into the variables upstream. Merging them here breaks
+        # convergence: a `governed` preset's `governance = true` would re-enable
+        # the gate an explicit `remove governance` set to "", and a preset's
+        # `lifecycle = "none"` (a tier name) is a TRUTHY string that would turn
+        # every {{#if lifecycle}} block ON (2026-07 review).
+        preset = {
+            "layers": ["base"],
+            "vars": {"governance": True, "lifecycle": "none", "memory_stack": "obsidian-only"},
+        }
+        merged = sc._apply_preset_vars(
+            {"governance": "", "lifecycle": "", "memory_stack": "none"}, preset
+        )
+        assert merged["governance"] == ""  # explicit OFF survives the preset
+        assert merged["lifecycle"] == ""  # tier name never leaks into the gate
+        assert merged["memory_stack"] == "none"
 
     def test_owner_preset_keeps_license_holder_in_step(self):
         # Preset supplies project_owner, no --owner: LICENSE copyright must track
@@ -105,12 +127,65 @@ class TestPresetVarsReachRender:
         assert merged["license_holder"] == "mine"
 
 
+class TestCarryRagEndpoint:
+    """The memory-block splice on upgrade must not reset a hand-set
+    memory.rag_endpoint — the template always renders it empty and
+    setup_rag.sh explicitly instructs the user to set it (2026-07 review)."""
+
+    _OLD = (
+        "memory:\n"
+        "  tier: 3\n"
+        '  rag_endpoint: "ccc mcp"  # user-set per setup_rag.sh\n'
+        "\n"
+    )
+    _NEW = (
+        "memory:\n"
+        "  tier: 3\n"
+        "  rag_endpoint:        # tier 3: set after running setup_rag.sh\n"
+        "\n"
+    )
+
+    def test_user_value_survives_the_splice(self):
+        out = _carry_rag_endpoint(self._OLD, self._NEW)
+        assert '  rag_endpoint: "ccc mcp"  # user-set per setup_rag.sh' in out
+        assert "tier: 3" in out
+
+    def test_untouched_endpoint_takes_fresh_render(self):
+        out = _carry_rag_endpoint(self._NEW, self._NEW)
+        assert out == self._NEW
+
+    def test_template_supplied_value_wins_over_old(self):
+        rendered = self._NEW.replace("rag_endpoint:  ", "rag_endpoint: new-value")
+        assert _carry_rag_endpoint(self._OLD, rendered) == rendered
+
+    def test_no_endpoint_line_is_a_no_op(self):
+        no_rag = "memory:\n  tier: 2\n\n"
+        assert _carry_rag_endpoint(self._OLD, no_rag) == no_rag
+
+
 class TestWizardHonorsMcpsFlag:
     """--mcps passed without --non-interactive must be honored, not dropped."""
 
-    def test_cli_mcps_resolved_without_prompting(self):
+    def test_cli_mcps_resolved_without_catalog_prompt(self, monkeypatch):
+        # --mcps pins the catalog picks without the multi-select, but browser
+        # automation is its own selectable concern (ADR-023): it must still be
+        # OFFERED when --browser was not given, matching how devcontainer/mise/
+        # vscode still prompt in the same run (2026-07 review).
+        offered = []
+        monkeypatch.setattr(
+            "project_init.__main__._choose_browser_interactive",
+            lambda: offered.append(True) or False,
+        )
         selected = _gather_mcps_interactive("context7", False)
         assert [m["id"] for m in selected] == ["context7"]
+        assert offered, "browser concern must still be offered (ADR-023)"
+
+    def test_cli_mcps_browser_prompt_accept_adds_playwright(self, monkeypatch):
+        monkeypatch.setattr(
+            "project_init.__main__._choose_browser_interactive", lambda: True
+        )
+        selected = _gather_mcps_interactive("context7", False)
+        assert [m["id"] for m in selected] == ["context7", "playwright"]
 
     def test_cli_mcps_with_browser(self):
         selected = _gather_mcps_interactive("context7", True)

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## What & why

Full bug-hunt across the wizard CLI, scaffold/upgrade engine, and the lifecycle hooks/scripts (source + templates + plugin payloads), followed by a diff-level code review and an end-to-end persona simulation (14 distinct usage profiles: node service + deploy/IaC, go minimalist, rust library, JSON orchestrator, no-plugin, all agent surfaces, governed org, RAG tier, custom-preset authors, upgrade round-trips, edge paths) — all green.

**Scaffolder (src/):**
- `upgrade --apply` no longer resets a hand-set `memory.rag_endpoint` when splicing the derived `memory:` block (ADR-025/ADR-026)
- preset `[vars]` control keys (`governance`/`lifecycle`/`memory_stack`) no longer leak into the template-gate namespace: `remove governance` on a governed-preset project now converges (previously left a broken CI job and regenerated the AI-BOM forever), and a preset's `lifecycle = "none"` no longer renders every `{{#if lifecycle}}` block ON
- upgrade stamps the current plugin version instead of a dead `setdefault` shadowed by the `"0.1.0"` migration backfill
- wizard: `--agents` honored without `--non-interactive`; language/license prompts normalize case and re-prompt instead of silently coercing to `none`; `--mcps` no longer suppresses the browser concern prompt (ADR-023)
- a preset's `lifecycle` var is validated up front (a TOML `false` silently shipped the full lifecycle overlay)
- CAPABILITIES.md shows the url for HTTP-transport MCP servers; `add memory obsidian` accepts the documented alias

**Guard + lifecycle scripts (all copies in lockstep, plugin payload synced):**
- `dag_workflow.py`: quoted git global-option values (`git -c foo='a b' push origin main`) no longer bypass every git rule including the push-to-main block; per-call subprocess timeout capped below the hook budget (raised to 60s) so one hung `gh` call can't make the fail-open PreToolUse hook time out; the nojira "PR already exists" short-circuit requires the PR to be OPEN
- `start_issue.sh`: a nonexistent issue reports an error instead of dying silently under `set -e`
- `monitor_pr.sh`: root copy backports the `--admin` opt-in for BLOCKED merges and the order-independent flag parser; both copies surface bot review comments after an early activity break instead of a false timeout message
- `pre_commit_gate.sh`: probes `uv run ruff --version` so uv projects without ruff fail open instead of blocking commits with uv's spawn error
- `push_wiki.sh`: empty `--prune` array no longer aborts under `set -u` on bash 3.2–4.3; `create_issue.sh`: temp file cleaned on early return

**Release prep:** version 0.6.1 across `pyproject.toml` / `__init__.py` / `CITATION.cff` / README / `uv.lock`, a 0.6.1 migration note, plugin bumps (workflow 0.2.1, lifecycle 0.1.1).

## Related issue

No tracking issue (review-driven fix batch).

## Checklist

- [x] `uv run ruff check .` + `uv run pytest -n auto` pass locally (1911 passed, 8 skipped) — the recipes `just ci` wraps
- [x] Changes under `templates/` have matching tests (`tests/contracts/test_lifecycle_script_hardening.py`, extended `test_dag_workflow.py`, `test_capabilities.py`, `test_audit_fixes.py`; byte-identity baselines re-pinned per the documented exception procedure)
- [x] Docs / README updated (README release line, migration note)
- [x] PR title follows Conventional Commits (`fix: description`, no issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLXJGTrZdeFt9f69pVqX81

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLXJGTrZdeFt9f69pVqX81)_