### PR TITLE
docs: release v1.0.0 — docs/wizard-copy audit fixes + version bump

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 0.6.1
+version: 1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Before doing any GitHub issue, branch, push, PR, review, CI, or merge work, read
 ├── tools/                  # sync_plugin.py, third-party update checker, benchmark
 ├── templates/
 │   ├── base/               # always copied into target projects
-│   ├── auto/               # always-on emitted artifacts (agent memory files)
+│   ├── auto/               # agent memory files (memory tiers auto and higher)
 │   ├── fallback/           # shared hooks/skills — rendered only with --no-plugin (ADR-010)
 │   ├── lifecycle/          # GitHub lifecycle enforcement (default; --lifecycle none opts out)
 │   ├── lifecycle_fallback/ # lifecycle guard hooks + skills for --no-plugin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ just --list         # see all recipes
 
 | Recipe | What it does |
 |---|---|
-| `just lint` | ruff check + format check (the gate hooks/CI enforce) |
+| `just lint` | ruff check (the gate hooks/CI enforce) |
 | `just format` | ruff format |
 | `just test` | full pytest suite (`pytest -n auto`) |
-| `just docs` | build the MkDocs site |
+| `just docs` | serve the MkDocs site locally |
 | `just ci` | lint + test (also enforced automatically on `git push`) |
 
 `just setup` points `core.hooksPath` at `.githooks/`, so the `pre-push` hook

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ This installs [`uv`](https://docs.astral.sh/uv/) if missing, clones the repo to 
 Pin a specific version, or opt into the unreleased development head:
 
 ```bash
-PROJECT_INIT_REF=v0.5.1 bash -c "$(curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh)"
+PROJECT_INIT_REF=v1.0.0 bash -c "$(curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh)"
 PROJECT_INIT_REF=main   bash -c "$(curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh)"
 ```
 
 Direct tool install without the slash command (any pinned tag):
 
 ```bash
-uv tool install git+https://github.com/VytCepas/project-init@v0.5.1
+uv tool install git+https://github.com/VytCepas/project-init@v1.0.0
 ```
 
 Distribution rationale: [ADR-008](https://github.com/VytCepas/project-init/blob/main/docs/adr/adr-008-distribution-channel.md) (git channel), [ADR-011](https://github.com/VytCepas/project-init/blob/main/docs/adr/adr-011-pypi-trusted-publishing.md) (PyPI via trusted publishing).
@@ -182,11 +182,11 @@ The wizard asks (interactive mode only):
 - Multi-model switching (`--multi-model`) — opt-in overlay (ADR-016) that scaffolds a [claude-code-router](https://github.com/musistudio/claude-code-router) config + a `setup_models.sh` installer, so you can run DeepSeek/Kimi/Ollama **through the Claude Code harness** with live `/model` switching and background **cost-routing** — your hooks, CI gates, and standards stay identical (they run below the model). OpenAI/Codex is better in its native `--agents` harness. CCR is **pinned**, machine-level, and the scaffolder never runs it (ADR-001). Clean by default.
 - AI governance (`--governance`) — opt-in overlay (ADR-018) that ships **governance-as-code** for projects that build or operate an AI system: a **policy layer** (AI usage policy, approved-tools / data-handling / code-provenance docs, NIST RMF crosswalk), a **system card** template carrying a flat-scalar governance manifest, a two-file **AIBOM** (generated MCP + detected-CCR-route inventory, plus a user-owned declarations file), and a **presence-triggered CI gate** that validates every real system card (required fields, allowed values, the `prohibited`+`allowed:true` illegal combo, declarations completeness, `last_reviewed` staleness) — failing the build, not producing a PDF. Adopts NIST AI RMF / ISO 42001 / EU AI Act / OWASP conventions (referenced, not re-authored). A freshly scaffolded project ships only an example/template, so the gate passes until a team deliberately writes a card. Most projects are not AI products — strictly opt-in, off by default. The `governed` preset enables it.
 - Observability (`--observability`) — opt-in overlay (ADR-019) that scaffolds a **file-based usage report**: a stdlib analyzer over the Claude Code transcript JSONL plus a guarded, stdin-safe hook self-log, rendered to an HTML report with one command. **No Docker, no OTEL, no egress** — everything stays on disk. Lets you see what your agents actually do (tokens, tool calls, activity) without a telemetry backend. Strictly opt-in, off by default.
-- Memory backend (`--memory none|auto|obsidian|obsidian-graphify|obsidian-graphify-rag`) — a **superset ladder** (ADR-024): **none** (vault-free; the `core` preset), **auto** (flat agent-memory files in `.claude/memory/`, no vault — pure files, installs nothing), **Obsidian-only** (auto **plus** a human markdown vault), **Obsidian + Graphify** (obsidian **plus** a derived code knowledge graph; recommended for code-heavy projects), or **+ RAG** (`obsidian-graphify-rag`, tier 3 — a semantic recall *seam*: docs + a user-run `setup_rag.sh` stub + the `rag_endpoint` descriptor, **engine not bundled**; worth it only at multi-project/monorepo scale, parked in #495). Each rung adds a retrieval surface without relocating the anchors. The flag overrides the preset's default; the wizard explains each backend and its install cost before asking (#466, #497, ADR-024).
+- Memory backend (`--memory none|auto|obsidian-only|obsidian-graphify|obsidian-graphify-rag`; `obsidian` is accepted as an alias for `obsidian-only`) — a **superset ladder** (ADR-024): **none** (vault-free; the `core` preset), **auto** (flat agent-memory files in `.claude/memory/`, no vault — pure files, installs nothing), **Obsidian-only** (auto **plus** a human markdown vault), **Obsidian + Graphify** (obsidian **plus** a derived code knowledge graph; recommended for code-heavy projects), or **+ RAG** (`obsidian-graphify-rag`, tier 3 — a semantic recall *seam*: docs + a user-run `setup_rag.sh` stub + the `rag_endpoint` descriptor, **engine not bundled**; worth it only at multi-project/monorepo scale, parked in #495). Each rung adds a retrieval surface without relocating the anchors. The flag overrides the preset's default; the wizard explains each backend and its install cost before asking (#466, #497, ADR-024).
 - GitHub lifecycle (`--lifecycle github|none`) — **github** (default) ships the issue → branch → PR → review → merge automation: DAG guard hooks, lifecycle scripts (`start_issue`/`finish_pr`/…), board/PR-validation workflows, issue/PR templates, the `create_issue`/`start_task`/`github_workflow` skills, and — in plugin mode — the `project-init-lifecycle` plugin. **none** declines it for a forge-agnostic or minimalist scaffold (the `core` preset's audience). The forge-portable quality hooks (commit-msg, gitleaks secret scan, lint/format gate, prod-safety) stay either way. The flag overrides the preset's default; the wizard explains it before asking (#476, ADR-021).
-- Core MCPs (Context7)
-- Database MCP — none / Postgres / SQLite
+- Core MCPs (Context7, stdio or hosted-HTTP) — database MCPs are intentionally not offered: the reference Postgres/SQLite servers were archived upstream with unpatched CVEs (PI-387); use the agent's native `psql`/`sqlite3` access instead
 - Browser automation — Playwright (yes/no)
+- Distribution profile (`--profile individual|standalone|org`) — how the project receives project-init updates and how strictly rules are enforced (ADR-013): **individual** (default — plugin-first, updates tracked from upstream, advisory enforcement), **standalone** (everything copied into the repo, no plugin dependency, you apply updates), **org** (your organization's fork is the source of truth, server-side enforcement). Org mode can add `--no-egress` to omit the external official plugin marketplace from scaffolded settings (#258)
 - Owner/team (`--owner`) — default CODEOWNERS owner, SECURITY contact, and LICENSE copyright holder (e.g. `@org/team`)
 - License (`--license mit|apache-2.0|proprietary|none`) — renders a LICENSE with the current year and the owner (or project name); `none` skips the file
 - No-plugin fallback (`--no-plugin`) — copies the shared hooks/skills into `.claude/` and wires them in `settings.json` instead of relying on the `project-init-workflow` plugin (offline / no-trust environments)
@@ -244,7 +244,8 @@ The test suite validates this command works correctly — see `TestREADMEExample
 
 ## Update
 
-Re-run the installer — it moves the clone to the latest tagged release:
+PyPI install: `uv tool upgrade project-init`. Git install: re-run the
+installer — it moves the clone to the latest tagged release:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
@@ -360,6 +361,9 @@ directory yourself.
 ## Uninstall
 
 ```bash
+# PyPI install:
+uv tool uninstall project-init
+# git install (installer path):
 rm -rf ~/.local/share/project-init ~/.claude/commands/project-init.md
 ```
 
@@ -384,7 +388,7 @@ The hooks need `python3` on `PATH` (replaces the previous `jq` dependency). They
 Edit and commit from inside WSL (`wsl` then `cd ~/projects/...`). Editing WSL files from Git Bash on Windows mangles executable bits and line endings.
 
 **`Unknown preset 'foo'`**
-Run `project-init --help` and pick from `core` (vault-free), `auto` (memory files, no vault), `obsidian-only`, `obsidian-graphify` (ADR-009), or `governed`. Custom presets go in `templates/presets/<name>.toml`.
+Run `project-init --list-presets` and pick from `core` (vault-free), `auto` (memory files, no vault), `obsidian-only`, `obsidian-graphify` (ADR-009), or `governed`. Custom presets go in `templates/presets/<name>.toml` — author one with `project-init preset new <name> --extends <base>` (#252).
 
 ## Positioning in the ecosystem
 
@@ -450,7 +454,7 @@ project-init/
 
 ## Status
 
-Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v0.6.1). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
+Actively developed and published to [PyPI](https://pypi.org/project/project-init/) (current release: v1.0.0). Contributions welcome — track and propose work in [GitHub Issues](https://github.com/VytCepas/project-init/issues), and use [GitHub Discussions](https://github.com/VytCepas/project-init/discussions) for questions, ideas, and feedback. Forks and pull requests are encouraged.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,31 @@
-# docs — project-init internal knowledge base
+# project-init documentation
 
-Architecture decisions, development guides, and references for contributors and AI agents.
+**project-init** scaffolds agentic-development infrastructure: one command
+drops a `.claude/` layout (memory, docs, hooks, skills, curated MCPs, a
+GitHub lifecycle) into any project so Claude Code — and other agents — are
+productive and governed from the first prompt.
 
-## Contents
+```bash
+uv tool install project-init   # or one-off: uvx project-init .
+```
+
+New here? Start with:
+
+- **[Using project-init](guides/using-project-init.md)** — install, wizard, day-to-day usage
+- **[Positioning](positioning.md)** — how it compares to other scaffolders and plugins
+- **[README on GitHub](https://github.com/VytCepas/project-init#readme)** — full flag reference and agent-support tiers
+
+## For contributors and AI agents
 
 | Path | Purpose |
 |---|---|
-| [`positioning.md`](positioning.md) | Where project-init sits in the ecosystem — comparison table + moat |
-| [`adr/`](adr/) | Architecture Decision Records — why decisions were made |
-| [`development/`](development/) | Standards, testing, template system |
-| [`guides/`](guides/) | How-to guides for users and contributors |
+| [`adr/`](adr/adr-001-scaffolder-design.md) | Architecture Decision Records — why decisions were made |
+| [`development/`](development/contributing.md) | Contributing, standards, testing, template system |
+| [`guides/`](guides/using-project-init.md) | How-to guides for users and contributors |
 
-## Agent instruction
-
-For active agent workflow rules, start with `CLAUDE.md`. `AGENTS.md` redirects there. Use `.github/copilot-instructions.md` for GitHub Issues, PR titles, PR bodies, and board behavior.
+For active agent workflow rules, start with `CLAUDE.md` in the repo (AGENTS.md
+redirects there); `.github/copilot-instructions.md` covers GitHub Issues, PR
+titles, PR bodies, and board behavior.
 
 ## Adding an ADR
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,35 +1,23 @@
 # Contributing
 
-## Setup
+The canonical, always-current guide lives in the repo root:
+**[CONTRIBUTING.md](https://github.com/VytCepas/project-init/blob/main/CONTRIBUTING.md)**.
+This page is intentionally a stub so the two can never drift apart.
+
+The 30-second version:
 
 ```bash
 git clone https://github.com/VytCepas/project-init.git
 cd project-init
-uv sync --extra dev
+just setup     # uv sync + dev deps + pre-push CI gate
+just ci        # lint + full test suite — must be green before a PR
 ```
 
-## Workflow
-
-1. `gh issue list` — pick or create an issue
-2. Create a branch for the issue work using `<issue_type>/PI-<issue-number>-<branch-short-description>`
-3. Write failing tests first (TDD)
-4. Implement until tests pass
-5. `uv run ruff check . && uv run ruff format .` — lint and format
-6. `uv run pytest` — all tests pass
-7. Open a PR following `.github/copilot-instructions.md`
-
-## PR checklist
-
-- [ ] Title: `[PI-IssueNumber][type] description`
-- [ ] Body includes `Closes #<number>`
-- [ ] New template files have a corresponding test
-- [ ] No unrendered `{{...}}` placeholders in template output
-- [ ] `uv run ruff check .` passes
-- [ ] `uv run pytest` passes
-
-## Principles
-
-- Keep the scaffolder small — no new dependencies unless unavoidable
-- Deterministic — scaffold output must be identical for the same inputs
-- No LLM calls from the scaffolder itself
-- `uv` everywhere — never `pip install` or `python -m venv`
+- The `justfile` is the command surface (`just --list`); `uv` for everything,
+  `ruff` only.
+- Branches: `type/PI-<n>-slug` for issue-linked work; PR titles use
+  Conventional Commits (`type(PI-N): description`, or `type: description`
+  with no issue).
+- Any change under `templates/` needs a matching test in the focused
+  `tests/<layer>/test_*.py` module — templates are tested by scaffolding
+  into a temp dir.

--- a/docs/development/template-system.md
+++ b/docs/development/template-system.md
@@ -9,7 +9,7 @@ Templates live in `templates/` and are copied into target projects by the scaffo
 ```
 templates/
 ├── base/               # always copied into target projects
-├── auto/               # always-on emitted artifacts (agent memory files)
+├── auto/               # agent memory files (memory tiers `auto` and higher)
 ├── fallback/           # shared hooks/skills — rendered only with --no-plugin (ADR-010)
 ├── lifecycle/          # GitHub lifecycle enforcement (default; --lifecycle none opts out)
 ├── lifecycle_fallback/ # lifecycle guard hooks + skills for --no-plugin
@@ -19,7 +19,10 @@ templates/
 ├── multi_model/        # CCR model-switching overlay (--multi-model)
 ├── governance/         # AI governance overlay (--governance)
 ├── observability/      # transcript metrics overlay (--observability)
-├── codex/ antigravity/ amp/ junie/  # per-surface wiring overlays (--agents)
+├── codex/              # per-surface wiring overlay (--agents codex)
+├── antigravity/        # per-surface wiring overlay (--agents antigravity)
+├── amp/                # per-surface wiring overlay (--agents amp)
+├── junie/              # per-surface wiring overlay (--agents junie)
 └── presets/            # TOML preset definitions
 ```
 

--- a/docs/development/template-system.md
+++ b/docs/development/template-system.md
@@ -8,10 +8,19 @@ Templates live in `templates/` and are copied into target projects by the scaffo
 
 ```
 templates/
-├── base/           # Always copied (every preset)
-├── obsidian/       # Overlay for both Obsidian presets
-├── graphify/       # Overlay for the obsidian-graphify preset
-└── presets/        # TOML preset definitions
+├── base/               # always copied into target projects
+├── auto/               # always-on emitted artifacts (agent memory files)
+├── fallback/           # shared hooks/skills — rendered only with --no-plugin (ADR-010)
+├── lifecycle/          # GitHub lifecycle enforcement (default; --lifecycle none opts out)
+├── lifecycle_fallback/ # lifecycle guard hooks + skills for --no-plugin
+├── obsidian/           # vault overlay for both Obsidian-* presets
+├── graphify/           # Graphify overlay (implies obsidian)
+├── rag/                # tier-3 RAG memory overlay
+├── multi_model/        # CCR model-switching overlay (--multi-model)
+├── governance/         # AI governance overlay (--governance)
+├── observability/      # transcript metrics overlay (--observability)
+├── codex/ antigravity/ amp/ junie/  # per-surface wiring overlays (--agents)
+└── presets/            # TOML preset definitions
 ```
 
 Layers are applied in order defined by the preset's `layers` list. Later layers overwrite earlier ones for the same relative path.

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -39,26 +39,42 @@ uvx --from ~/.local/share/project-init project-init . \
   --mcps context7
 ```
 
-Available flags:
+The most-used flags:
 
 | Flag | Values | Default |
 |------|--------|---------|
-| `--preset` | `obsidian-only`, `obsidian-graphify` | (asked interactively) |
-| `--language` | `python`, `node`, `go`, `none` | `none` |
-| `--mcps` | `context7` (comma-separated) | none |
+| `--preset` | `core`, `auto`, `obsidian-only`, `obsidian-graphify`, `governed` (see `--list-presets`) | (asked interactively) |
+| `--language` | `python`, `node`, `go`, `rust`, `none` | `none` |
+| `--memory` | `none`, `auto`, `obsidian-only`, `obsidian-graphify`, `obsidian-graphify-rag` | the preset's tier |
+| `--lifecycle` | `github`, `none` | `github` |
+| `--mcps` | `context7`, `context7-http` (comma-separated) | none |
 | `--browser` | flag (Playwright MCP) | off |
 | `--strict` | flag (fail on unrendered placeholders) | off |
+
+The full surface (delivery/deploy/IaC overlays, governance, observability,
+multi-model, agents, license, profile, …) is documented by `project-init --help`
+and the [README](https://github.com/VytCepas/project-init#readme); machine-readable
+preset discovery via `project-init --list-presets --json`.
 
 ---
 
 ## 3. Choosing a Preset
 
+A preset is just a starting bundle — every piece can still be declined or
+added individually at the prompts (or later, see §7).
+
 | Preset | When to use |
 |--------|-------------|
-| **obsidian-only** | Small to medium projects. Plain markdown vault, no external APIs needed. Human-friendly and agent-readable. |
+| **core** | Leanest: the agentic base layer with **no memory backend** and no vault. |
+| **auto** | Flat agent-memory files in `.claude/memory/` — no Obsidian vault. |
+| **obsidian-only** | Small to medium projects. Plain markdown vault, no external APIs needed. Human-friendly and agent-readable. **Recommended default.** |
 | **obsidian-graphify** | Code-heavy projects. Adds a Graphify code knowledge graph agents query before grepping. No API keys for IDE use (ADR-009). |
+| **governed** | obsidian-only plus the AI-governance policy layer (for projects that build/operate an AI system). |
 
-Start with `obsidian-only` when in doubt. Upgrade later by re-running with `--preset obsidian-graphify` — it merges without overwriting your existing memory or vault content.
+Start with `obsidian-only` when in doubt. Move up or down the memory ladder
+later with `project-init add memory <tier> --target . --apply` (or
+`remove memory`) — it merges without overwriting your existing memory or
+vault content.
 
 ---
 
@@ -181,7 +197,17 @@ The graph rebuilds incrementally per commit; agents query `graphify-out/graph.js
 
 **Add a slash command**: run `/add_command`. Creates a `SKILL.md` in `.claude/skills/<name>/`. Register it in `.claude/skills/INDEX.md`.
 
-**Re-run to update**: `/project-init` is safe to re-run anytime. It never overwrites `memory/` or `vault/` content.
+**Upgrade to current templates**: `project-init upgrade .` reports drift between
+your project and the current templates (nothing is touched); `project-init
+upgrade . --apply` re-renders, 3-way-merging files you edited and parking real
+conflicts as `<file>.new` siblings. Re-running the wizard itself is also safe
+anytime — it never overwrites `memory/` or `vault/` content.
+
+**Plugin vs `--no-plugin`**: by default a scaffold is *plugin-first* — its
+`settings.json` references the `project-init-workflow` / `project-init-lifecycle`
+plugins, so hook/skill updates arrive through the plugin marketplace. Pass
+`--no-plugin` to copy everything into `.claude/` instead (offline or
+no-marketplace-trust environments).
 
 **Add or remove a whole concern later**: to opt into a tier you declined at init —
 or drop one you no longer want — use `add` / `remove` instead of re-running the

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -72,7 +72,8 @@ added individually at the prompts (or later, see §7).
 | **governed** | obsidian-only plus the AI-governance policy layer (for projects that build/operate an AI system). |
 
 Start with `obsidian-only` when in doubt. Move up or down the memory ladder
-later with `project-init add memory <tier> --target . --apply` (or
+later with `project-init add memory <stack> --target . --apply` (a stack name:
+`auto`, `obsidian-only`, `obsidian-graphify`, `obsidian-graphify-rag`; or
 `remove memory`) — it merges without overwriting your existing memory or
 vault content.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,9 @@ nav:
   - Guide:
     - Using project-init: guides/using-project-init.md
     - Org fork lifecycle (runbook): guides/org-fork-lifecycle.md
+    - Phone / remote access: development/mobile-remote-access.md
   - Architecture Decisions:
-    - Overview: adr/adr-001-scaffolder-design.md
+    - Scaffolder design: adr/adr-001-scaffolder-design.md
     - dot_ prefix convention: adr/adr-002-dotglob-template-convention.md
     - GitHub-native workflow: adr/adr-003-github-native-workflow.md
     - Obsidian + docs integration: adr/adr-004-obsidian-docs-integration.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "0.6.1"
+version = "1.0.0"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Vytautas Čepas", email = "vyt.cepas.ve@gmail.com" }]
 keywords = ["claude-code", "agents", "scaffolding", "obsidian", "graphify"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "0.6.1"
+__version__ = "1.0.0"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -453,18 +453,19 @@ def _choose_preset_interactive(presets: list[dict]) -> dict:
             "overlays (memory, lifecycle, toolchain).\n\n"
             "[cyan]Helps:[/cyan] pick the closest fit, then the prompts below let "
             "you still decline or add individual pieces.\n"
-            "[dim]Default: the recommended Obsidian-only preset. `core` is the "
+            "[dim]Default: the recommended obsidian-only preset. \"core\" is the "
             "leanest (no memory backend).[/dim]",
             title="Preset",
             border_style="cyan",
         )
     )
     console.print("[bold]Available presets:[/bold]")
+    default_idx = _default_preset_index(presets)
     for i, p in enumerate(presets, 1):
-        console.print(f"  [cyan]{i}[/cyan]. {p['name']} — {p['description']}")
+        marker = "  [green](recommended)[/green]" if i == default_idx else ""
+        console.print(f"  [cyan]{i}[/cyan]. {p['name']} — {p['description']}{marker}")
     console.print()
 
-    default_idx = _default_preset_index(presets)
     choice = _prompt_menu_index("Choose a preset", len(presets), default=default_idx)
     return presets[choice - 1]
 
@@ -474,7 +475,10 @@ def _choose_mcps_interactive(catalog: list[dict]) -> list[dict]:
     from rich.prompt import Prompt
 
     console = Console()
-    console.print("\n[bold]MCPs to install:[/bold]")
+    console.print(
+        "\n[bold]MCP servers[/bold] — optional plug-in tool servers your agent "
+        "can call (Model Context Protocol):"
+    )
     for i, m in enumerate(catalog, 1):
         console.print(f"  [cyan]{i}[/cyan]. {m['name']} — {m['description']}")
     console.print()
@@ -529,11 +533,22 @@ def _choose_browser_interactive() -> bool:
 
 
 def _choose_profile_interactive() -> str:
-    """Present the three distribution profiles and what each bundles (#247)."""
+    """Present the three distribution profiles and what each bundles (#247, ADR-023)."""
     from rich.console import Console
+    from rich.panel import Panel
 
     console = Console()
-    console.print("\n[bold]Distribution profile[/bold] (ADR-013):")
+    console.print(
+        Panel(
+            "A [bold]profile[/bold] sets how this project receives project-init "
+            "updates and how strictly its rules are enforced.\n\n"
+            "[cyan]Helps:[/cyan] match the scaffold to who maintains it — a "
+            "personal project, a self-contained repo, or an org fleet.\n"
+            "[dim]Default: individual — right for a personal project.[/dim]",
+            title="Distribution profile",
+            border_style="cyan",
+        )
+    )
     for i, name in enumerate(_PROFILES, 1):
         console.print(f"  [cyan]{i}[/cyan]. {name} — {_PROFILE_SUMMARY[name]}")
     console.print()
@@ -727,6 +742,11 @@ def _print_summary(
             "  Run: [bold]git init && git add -A && git commit -m 'scaffold'[/bold]\n"
         )
 
+    body += (
+        "\n[bold]Start:[/bold] cd into the project and run [bold]claude[/bold] — "
+        "it picks up CLAUDE.md and .claude/ automatically.\n"
+    )
+
     console.print()
     console.print(Panel(body.rstrip(), title="project-init", border_style="green"))
     console.print()
@@ -771,25 +791,23 @@ def _choose_multi_model_interactive() -> bool:
 
     console = Console()
     body = (
-        "Run other models [bold]through the Claude Code harness[/bold] — one "
-        "terminal, live switching, and automatic [bold]cost-routing[/bold] "
-        "(background work goes to a cheap model). Your hooks, CI gates, and "
-        "standards stay identical — they run below the model.\n\n"
-        "  [dim]claude[/dim]                          [dim]# opens as usual[/dim]\n"
+        "Run other models [bold]through the Claude Code harness[/bold] via "
+        "claude-code-router (CCR) — one terminal, live switching, and automatic "
+        "[bold]cost-routing[/bold] (background work goes to a cheap model). Your "
+        "hooks, CI gates, and standards stay identical — they run below the "
+        "model.\n\n"
+        "  [dim]claude[/dim]                            [dim]# opens as usual[/dim]\n"
         "  [dim]/model deepseek,deepseek-v4-flash[/dim] [dim]# switch mid-session, context kept[/dim]\n"
-        "  [dim]/model ollama,qwen3-coder:30b[/dim]      [dim]# or qwen3-coder-next (newer)[/dim]\n"
-        "  [dim]/model anthropic,claude-opus-4-8[/dim] [dim]# back to Claude[/dim]\n\n"
+        "  [dim]/model ollama,qwen3-coder:30b[/dim]     [dim]# local model[/dim]\n\n"
         "[cyan]Helps:[/cyan] control cost / test models without leaving the terminal.\n"
-        "[cyan]Alternatives:[/cyan]\n"
+        "[cyan]Alternatives:[/cyan] [bold]skip this if you only use Claude.[/bold]\n"
         "  • [bold]OpenAI/Codex[/bold] has a native harness "
         "([dim]--agents codex[/dim]) — better quality there; route it through CCR "
         "only for one-terminal convenience.\n"
         "  • [bold]Ollama[/bold] models also run natively/locally.\n"
         "  • Say yes and the scaffolded [dim]setup_models.sh[/dim] installs CCR "
-        "(pinned), seeds the config, and can pull local models for you.\n\n"
-        "[cyan]Updates:[/cyan] the pinned CCR version flows from project-init via "
-        "upgrade-as-PR; set up another way and you update it yourself.\n"
-        "Clean by default — decline and nothing is added."
+        "(pinned), seeds the config, and can pull local models for you.\n"
+        "[dim]Default: off — decline and nothing is added.[/dim]"
     )
     console.print(
         Panel(body, title="Multi-model switching (claude-code-router)", border_style="cyan")
@@ -817,13 +835,15 @@ def _choose_governance_interactive() -> bool:
         "travels with the repo — for projects that build or operate an AI "
         "system.\n\n"
         "[bold]Scaffolds today:[/bold]\n"
-        "  [dim]AI_USAGE_POLICY.md[/dim]      [dim]# 1-page AUP (NIST-aligned)[/dim]\n"
+        "  [dim]AI_USAGE_POLICY.md[/dim]      [dim]# 1-page acceptable-use policy "
+        "(NIST-aligned)[/dim]\n"
         "  [dim]approved-tools.md[/dim]       [dim]# allow/deny models, endpoints, data[/dim]\n"
         "  [dim]data-handling.md[/dim]        [dim]# what data may reach AI tools[/dim]\n"
         "  [dim]ai-code-provenance.md[/dim]   [dim]# attribution + licence checks[/dim]\n"
         "  [dim]NIST_RMF_CROSSWALK.md[/dim]   [dim]# maps to Govern/Map/Measure/Manage[/dim]\n"
         "  [dim]examples/SYSTEM_CARD[/dim]    [dim]# system-card template + filled example[/dim]\n"
-        "  [dim]ai-bom.generated.md[/dim]     [dim]# AIBOM, regenerated each run[/dim]\n"
+        "  [dim]ai-bom.generated.md[/dim]     [dim]# AI bill of materials (AIBOM), "
+        "regenerated each run[/dim]\n"
         "  [dim]governance_gate.py[/dim]      [dim]# presence-triggered CI gate (in the merge gate)[/dim]\n\n"
         "[cyan]Helps:[/cyan] answer \"what AI runs here, on what data, under whose "
         "sign-off\" for reviewers, customers, and regulators.\n"
@@ -833,7 +853,7 @@ def _choose_governance_interactive() -> bool:
         "placeholder fields — inert until you write a card.\n"
         "[cyan]Note:[/cyan] most projects are not AI products — keep this off unless "
         "yours calls an LLM API over data.\n"
-        "Clean by default — decline and nothing is added."
+        "[dim]Default: off — decline and nothing is added.[/dim]"
     )
     console.print(Panel(body, title="AI governance (governance-as-code)", border_style="cyan"))
     return Confirm.ask("Set up the AI-governance overlay?", default=False)
@@ -862,7 +882,7 @@ def _choose_observability_interactive() -> bool:
         "  [dim]observability.sh[/dim]   [dim]# one command → an HTML report[/dim]\n"
         "  [dim]hook self-log[/dim]      [dim]# guarded, stdin-safe activity log[/dim]\n\n"
         "[cyan]Helps:[/cyan] see what your agents actually do without a backend.\n"
-        "Clean by default — decline and nothing is added."
+        "[dim]Default: off — decline and nothing is added.[/dim]"
     )
     console.print(Panel(body, title="Observability (file-based usage report)", border_style="cyan"))
     return Confirm.ask("Set up the observability overlay?", default=False)
@@ -899,11 +919,12 @@ def _choose_memory_interactive(default: str = "obsidian-only") -> str:
     from rich.panel import Panel
 
     console = Console()
+    default_idx = _MEMORY_STACKS.index(default) + 1 if default in _MEMORY_STACKS else 3
     body = (
         "A [bold]memory backend[/bold] gives your agents a place to persist "
         "decisions, conventions, and session notes [bold]across conversations[/bold] "
         "— so context survives beyond a single chat. Everything stays on disk. "
-        "Each rung is a [bold]superset[/bold] of the one above (ADR-024).\n\n"
+        "Each rung is a [bold]superset[/bold] of the one above.\n\n"
         "[bold]1. none[/bold]      [dim]no memory — leanest; bring your own docs[/dim]\n"
         "            [dim]Installs now: nothing · You run later: nothing[/dim]\n"
         "[bold]2. auto[/bold]      [dim].claude/memory (flat agent facts) — no vault[/dim]\n"
@@ -915,19 +936,20 @@ def _choose_memory_interactive(default: str = "obsidian-only") -> str:
         "            [dim]graph agents can query (Graphify)[/dim]\n"
         "            [dim]Installs now: files only · You run later:[/dim]\n"
         "            [dim]uv tool install graphifyy && .claude/scripts/setup_graphify.sh[/dim]\n"
-        "[bold]5. obsidian-graphify-rag[/bold]  [dim]graphify PLUS a semantic /[/dim]\n"
-        "            [dim]vector recall surface over the whole corpus (RAG)[/dim]\n"
+        "            [dim](the package name really has two y's)[/dim]\n"
+        "[bold]5. obsidian-graphify-rag[/bold]  [dim]graphify PLUS search-by-meaning[/dim]\n"
+        "            [dim]over all notes+code, not just exact words (RAG)[/dim]\n"
         "            [dim]Installs now: files only · You run later:[/dim]\n"
         "            [dim].claude/scripts/setup_rag.sh (cocoindex-code —[/dim]\n"
         "            [dim]keyless, on-device; no container, no API key)[/dim]\n\n"
         "[cyan]Helps:[/cyan] agents recall why a decision was made weeks later;\n"
-        "the RAG rung (option 5, tier 3) adds cross-corpus semantic search worth\n"
-        "it only at [bold]multi-project / monorepo[/bold] scale — for one small/medium\n"
-        "repo, vault + the graph + grep already win, so [bold]skip it[/bold] (default off).\n"
-        "Clean by default — pick [bold]none[/bold] and no memory is added."
+        "the RAG rung (option 5) is worth it only at [bold]multi-project /\n"
+        "monorepo[/bold] scale — for one small/medium repo, vault + the graph +\n"
+        "grep already win, so [bold]skip it[/bold].\n"
+        f"[dim]Default: option {default_idx} ({default}) — your preset's stack. "
+        "Choose 1 (none) and no memory is added at all.[/dim]"
     )
     console.print(Panel(body, title="Memory backend", border_style="cyan"))
-    default_idx = _MEMORY_STACKS.index(default) + 1 if default in _MEMORY_STACKS else 3
     choice = _prompt_menu_index("Choose a memory backend", len(_MEMORY_STACKS), default=default_idx)
     return _MEMORY_STACKS[choice - 1]
 
@@ -957,20 +979,21 @@ def _choose_lifecycle_interactive(default: str = "github") -> str:
         "workflow — [bold]issue → branch → PR → review → merge[/bold], enforced "
         "by deterministic guard hooks so the steps can't be skipped or "
         "mis-ordered.\n\n"
-        "[bold]1. github[/bold]  [dim]DAG guard hooks, lifecycle scripts "
-        "(start_issue/finish_pr/…),[/dim]\n"
-        "          [dim]board+wiki+PR-validation workflows, issue/PR templates,[/dim]\n"
-        "          [dim]and the create_issue/start_task/github_workflow skills[/dim]\n"
-        "[bold]2. none[/bold]    [dim]decline it — forge-agnostic / minimalist; "
-        "bring your own flow[/dim]\n\n"
+        "[bold]1. github[/bold]  [dim]guard hooks that enforce the step order, "
+        "lifecycle scripts[/dim]\n"
+        "          [dim](start_issue/finish_pr/…), board+wiki+PR-validation "
+        "workflows,[/dim]\n"
+        "          [dim]issue/PR templates, and the matching skills[/dim]\n"
+        "[bold]2. none[/bold]    [dim]not tied to GitHub, or you prefer your own "
+        "flow — minimal[/dim]\n\n"
         "[cyan]Helps:[/cyan] every change is traceable to an issue and a "
         "reviewed PR; no accidental pushes to main.\n"
-        "[dim]Forge-portable quality hooks (commit-msg, gitleaks secret scan, "
+        "[dim]Default: github. Quality hooks (commit-msg, gitleaks secret scan, "
         "lint/format gate, prod-safety) stay either way.[/dim]"
     )
     console.print(Panel(body, title="GitHub lifecycle (issue → PR → merge)", border_style="cyan"))
     default_idx = _LIFECYCLE_TIERS.index(default) + 1 if default in _LIFECYCLE_TIERS else 1
-    choice = _prompt_menu_index("Ship the GitHub lifecycle?", len(_LIFECYCLE_TIERS), default=default_idx)
+    choice = _prompt_menu_index("Choose a lifecycle tier", len(_LIFECYCLE_TIERS), default=default_idx)
     return _LIFECYCLE_TIERS[choice - 1]
 
 
@@ -1036,8 +1059,7 @@ def _choose_docs_interactive(language: str) -> bool:
         f"A [bold]{tool}[/bold] config for a local documentation preview "
         f"({'mkdocs serve' if language == 'python' else 'typedoc'}).\n\n"
         "[cyan]Helps:[/cyan] browsable docs from your markdown/docstrings.\n"
-        "[dim]Local-only — no publish workflow ships (PI-343). On by default; "
-        "decline with --no-docs.[/dim]",
+        "[dim]Local-only — no publish workflow is included. Default: on.[/dim]",
         f"Include the local docs-preview config ({tool})?",
         default=True,
     )
@@ -1387,7 +1409,8 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     resolved_lifecycle = lifecycle_flag or _choose_lifecycle_interactive(default=preset_lifecycle)
     while True:
         agents_raw = _prompt(
-            "Agents/surfaces (claude always; add codex/ollama/cursor/antigravity/vscode, comma-separated)",
+            "Agents/surfaces (claude always; add codex/ollama/cursor/antigravity/"
+            "vscode/amp/junie, comma-separated)",
             default=cli_agents or "claude",
         )
         try:
@@ -1437,8 +1460,11 @@ _DELIVERY_ALIASES = {
 
 _DELIVERY_SUMMARY = {
     "library": "a package/library published to a registry (PyPI/npm/crate)",
-    "service": "a deployed service or app — gets the container parity bundle",
-    "prototype": "a prototype / not sure yet — single trunk, nothing env-specific",
+    "service": (
+        "a deployed service or app — adds a Dockerfile + CI that builds the "
+        "same container locally and in CI"
+    ),
+    "prototype": "just exploring / not sure yet — minimal setup, no deploy extras (default)",
 }
 
 
@@ -1493,10 +1519,12 @@ _DEPLOY_OIDC = ("cloud-run",)
 
 _DEPLOY_SUMMARY = {
     "none": "my platform/PaaS deploys it, or not deployed via Actions yet (default)",
-    "cloud-run": "Google Cloud Run (build-once, promote the digest)",
-    "fly": "Fly.io (build-once, promote the digest)",
-    "k8s": "Kubernetes (kubectl/helm set image to the digest)",
-    "registry": "publish the image to GHCR only — not a deployment",
+    "cloud-run": "Google Cloud Run (build one image, ship that exact image to prod)",
+    "fly": "Fly.io (build one image, ship that exact image to prod)",
+    "k8s": "Kubernetes (kubectl/helm set image to the built image)",
+    "registry": (
+        "publish the image to GitHub Container Registry (GHCR) only — not a deployment"
+    ),
     "custom": "container deploy with a TODO ship step you fill in",
 }
 
@@ -1534,8 +1562,11 @@ def _choose_deploy_interactive() -> str:
 _IAC_OPTIONS = ("none", "opentofu")
 _IAC_ALIASES = {"tofu": "opentofu", "terraform": "opentofu"}
 _IAC_SUMMARY = {
-    "none": "no infrastructure-as-code scaffolding",
-    "opentofu": "OpenTofu (HCL) skeleton + plan-on-PR workflow; apply manual/gated",
+    "none": "no infrastructure-as-code scaffolding (default)",
+    "opentofu": (
+        "OpenTofu (open-source Terraform) starter under infra/ + a plan preview "
+        "on each PR; applying stays manual"
+    ),
 }
 
 
@@ -1604,15 +1635,17 @@ _PROFILES = ("individual", "standalone", "org")
 # the non-interactive notice so the choice is never silent (ADR-013, #247).
 _PROFILE_SUMMARY = {
     "individual": (
-        "plugin-first (project-init + external official plugins), track upstream, "
-        "advisory enforcement — today's default"
+        "you maintain it — updates arrive through the project-init plugin, "
+        "rules are advisory (default)"
     ),
     "standalone": (
-        "project-init payload copied in locally, owner-driven pinned updates, "
-        "advisory enforcement (external official marketplace still enabled — "
-        "full no-egress is the org mode, #258)"
+        "everything copied into the repo, no plugin dependency — you apply "
+        "updates yourself, rules stay advisory"
     ),
-    "org": ("fork as source-of-truth, host-adaptive delivery, hard (server-side) enforcement"),
+    "org": (
+        "your organization runs a project-init fork and controls updates — "
+        "rules are enforced server-side"
+    ),
 }
 
 

--- a/src/project_init/mcps.py
+++ b/src/project_init/mcps.py
@@ -26,8 +26,9 @@ MCP_CATALOG: list[dict] = [
     {
         "id": "context7-http",
         "name": "Context7 (hosted HTTP)",
-        "description": "Live library docs over Streamable HTTP — the transport that "
-        "works on Claude web/mobile/Cowork (stdio servers are invisible there)",
+        "description": "Same docs lookup, hosted — choose this (or both) if you "
+        "also use Claude in the browser or on mobile, where locally-run servers "
+        "are unavailable",
         # HTTP/remote server (PI-397): rendered with type:http for Claude/VS Code,
         # url-only for Amp/Junie/Codex. Never SSE (deprecated in the MCP spec).
         # Register under the same name as the rendered config key (the id) so the

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,30 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "1.0.0": {
+        "summary": (
+            "First stable release, following a full QA sweep (~180 scaffolder "
+            "invocations across presets, languages, overlays, hostile input, "
+            "and subcommand lifecycles — zero crashes). Fixes: `--strict` no "
+            "longer rejects user text containing literal `{{...}}`; wizard "
+            "menus re-prompt on a mistyped number instead of silently using "
+            "the default, and invalid MCP selections re-ask; `add`/`remove` "
+            "reject a positional path with a `--target` hint (including `add "
+            "memory <path>`); clearer errors for empty `--name`/`--description` "
+            "and a bare trailing subcommand word; failing runs print nothing "
+            "on stdout. Scaffolded fixes: CI's integration and nightly-mutation "
+            "jobs skip cleanly before a pyproject.toml exists; deploy.yml ship "
+            "stubs name your project (new `{{project_slug}}` variable) instead "
+            "of `my-service`; AGENTS.md support-tier notes now cover "
+            "Cursor/Amp/Junie. Wizard explainers were rewritten for newcomers "
+            "(profile panel, glossed MCP/RAG/OpenTofu/GHCR jargon, accurate "
+            "default lines)."
+        ),
+        "action_required": (
+            "Re-run `project-init upgrade` to pick up the CI-guard, deploy-stub, "
+            "and AGENTS.md fixes. No breaking changes."
+        ),
+    },
     "0.6.1": {
         "summary": (
             "Bug-fix pass from a full code review. Scaffolder: `upgrade --apply` "

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "0.6.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## What & why

Release prep for **v1.0.0 — the first stable release** — combining a first-time-user documentation audit, an ADR-023 wizard-copy audit, and the version bump.

**Documentation** (audited against `--help` and the code):
- README: removed the phantom "Database MCP" wizard bullet (feature removed in PI-387), documented `--profile`/`--no-egress`, troubleshooting now points at `--list-presets`, mentions `preset new`, notes the `obsidian` alias, adds `uv tool upgrade`/`uninstall` paths, bumps pin examples and the release line
- `docs/development/contributing.md`: the stale duplicate (wrong `uv sync --extra dev`, pre-ADR-006 PR-title format) is now a stub pointing at root CONTRIBUTING.md so the two can't drift
- `docs/guides/using-project-init.md`: flags table matches `--help` (all 5 presets, rust, memory/lifecycle), preset guidance covers all 5 presets with the `add memory <tier>` upgrade path, new "Upgrading" and "plugin vs `--no-plugin`" notes
- `docs/README.md` is now a user-facing landing page; template-system tree lists all layers; CONTRIBUTING recipe table matches the justfile; mkdocs nav gains the phone/remote guide

**Wizard copy** (every explainer checked against ADR-023 + a novice reader):
- profile chooser gains its missing explainer panel; plain-language option summaries
- "MCP" glossed at the prompt; memory panel's closing line now states the *actual* Enter default (it previously claimed "none" while defaulting to obsidian-only); agents prompt lists `amp`/`junie`; lifecycle prompt reads "Choose a lifecycle tier" with an explicit default; multi-model panel trimmed with "skip this if you only use Claude"; AUP/AIBOM/OpenTofu/GHCR expanded; internal ADR/ticket refs removed from user-facing copy; the preset list marks the recommended row; the summary panel ends with a "Start: run claude" step

**Release**: version 1.0.0 in pyproject/`__init__`/CITATION.cff, new migration note. After merge, the release is cut by dispatching `tag-release.yml` with `v1.0.0` (ADR-011 trusted publishing).

## Checklist

- [x] `just ci` passes locally (lint + full test suite — 1933 passed, 8 skipped)
- [x] Changes under `templates/` have a matching test (no template changes in this PR)
- [x] Docs / README updated if behavior or flags changed (this PR *is* the docs update)
- [x] PR title follows Conventional Commits (`type: description`, no linked issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1YtHS9AYHA3qKsiD7Ty1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1YtHS9AYHA3qKsiD7Ty1a)_