### PR TITLE
feat(PI-619): Scaffold .agents/AGENTS.md for Antigravity

### DIFF
--- a/templates/antigravity/dot_agents/AGENTS.md.tmpl
+++ b/templates/antigravity/dot_agents/AGENTS.md.tmpl
@@ -1,0 +1,9 @@
+# Antigravity Rules
+
+Canonical instructions for this repository live in [AGENTS.md](../AGENTS.md).
+
+Read [AGENTS.md](../AGENTS.md) before working in this codebase. It is the source of truth for repo conventions, testing rules, GitHub workflow, and branch naming.
+
+## Language Rules
+
+Before writing code, check the language-specific rules in [rules/](rules/) and follow them.

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -206,6 +206,13 @@ class TestAntigravityOverlay:
         assert not (target / ".agents" / "scripts" / "setup_gemini.sh").exists()
 
 
+    def test_scaffolds_agents_md(self, tmp_path: Path):
+        target = _scaffold_agents(tmp_path / "p", "antigravity")
+        agents_md = target / ".agents" / "AGENTS.md"
+        assert agents_md.exists(), ".agents/AGENTS.md must be scaffolded for Antigravity"
+        assert "[AGENTS.md](../AGENTS.md)" in agents_md.read_text()
+
+
 class TestOllamaTier:
     def test_instructions_level_only(self, tmp_path: Path):
         """Ollama adds documentation, never agent-specific wiring."""


### PR DESCRIPTION
Closes #619. This creates the expected .agents/AGENTS.md file for Antigravity which links to the canonical AGENTS.md in the root directory.