### PR TITLE
feat(PI-645): Polish interactive wizard UI (theme, preset table, spinner, summary)

### DIFF
--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -469,7 +469,11 @@ def _choose_preset_interactive(presets: list[dict]) -> dict:
         )
     )
     default_idx = _default_preset_index(presets)
-    render_presets(presets, default_idx)
+    # Resolve each preset's memory stack through extends inheritance so the
+    # table's Memory column is accurate for inheriting presets like `governed`
+    # (raw vars would show "—"; PI-645 review, mirrors #511).
+    memory_by_name = {row["name"]: row["memory_stack"] for row in _presets_payload(presets)}
+    render_presets(presets, default_idx, memory_by_name)
     console.print()
 
     choice = _prompt_menu_index("Choose a preset", len(presets), default=default_idx)

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -10,6 +10,13 @@ from datetime import date
 from pathlib import Path
 
 from project_init import __plugin_version__, __repo_url__, __version__
+from project_init.console import (
+    console,
+    is_interactive,
+    option_line,
+    render_presets,
+    scaffolding,
+)
 from project_init.mcps import (
     MCP_CATALOG,
     PLAYWRIGHT_MCP,
@@ -385,13 +392,11 @@ def _prompt_choice(label: str, valid: tuple[str, ...], *, default: str) -> str:
     must not silently coerce to ``none`` — normalize case and re-prompt with the
     valid set instead (PI review 2026-07).
     """
-    from rich.console import Console
-
     while True:
         value = _prompt(label, default=default).strip().lower()
         if value in valid:
             return value
-        Console().print(f"[red]Invalid choice {value!r}. Valid: {', '.join(valid)}[/red]")
+        console.print(f"[red]Invalid choice {value!r}. Valid: {', '.join(valid)}[/red]")
 
 
 def _prompt_menu_index(question: str, count: int, *, default: int) -> int:
@@ -401,14 +406,13 @@ def _prompt_menu_index(question: str, count: int, *, default: int) -> int:
     number must not silently become the default selection (2026-07 QA) —
     re-prompt with the valid range instead.
     """
-    from rich.console import Console
     from rich.prompt import IntPrompt
 
     while True:
         choice = IntPrompt.ask(question, default=default)
         if 1 <= choice <= count:
             return choice
-        Console().print(
+        console.print(
             f"[red]Invalid choice {choice}. Enter a number between 1 and {count}.[/red]"
         )
 
@@ -420,9 +424,6 @@ def _prompt_validated(label: str, *, default: str, flag: str, allow_empty: bool 
     at the field so the user fixes it in place instead of completing the whole
     wizard only to hit ``parser.error`` and lose every answer (PI review).
     """
-    from rich.console import Console
-
-    console = Console()
     while True:
         value = _prompt(label, default=default)
         err = _text_field_error(flag, value, allow_empty=allow_empty)
@@ -451,10 +452,8 @@ def _default_preset_index(presets: list[dict]) -> int:
 
 
 def _choose_preset_interactive(presets: list[dict]) -> dict:
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     # Value framing (#472, ADR-023): say what a preset *is* and that it's only a
     # starting point, so the choice is informed rather than blind.
     console.print(
@@ -469,11 +468,8 @@ def _choose_preset_interactive(presets: list[dict]) -> dict:
             border_style="cyan",
         )
     )
-    console.print("[bold]Available presets:[/bold]")
     default_idx = _default_preset_index(presets)
-    for i, p in enumerate(presets, 1):
-        marker = "  [green](recommended)[/green]" if i == default_idx else ""
-        console.print(f"  [cyan]{i}[/cyan]. {p['name']} — {p['description']}{marker}")
+    render_presets(presets, default_idx)
     console.print()
 
     choice = _prompt_menu_index("Choose a preset", len(presets), default=default_idx)
@@ -481,16 +477,14 @@ def _choose_preset_interactive(presets: list[dict]) -> dict:
 
 
 def _choose_mcps_interactive(catalog: list[dict]) -> list[dict]:
-    from rich.console import Console
     from rich.prompt import Prompt
 
-    console = Console()
     console.print(
         "\n[bold]MCP servers[/bold] — optional plug-in tool servers your agent "
         "can call (Model Context Protocol):"
     )
     for i, m in enumerate(catalog, 1):
-        console.print(f"  [cyan]{i}[/cyan]. {m['name']} — {m['description']}")
+        console.print(option_line(i, m['name'], m['description']))
     console.print()
 
     while True:
@@ -544,10 +538,8 @@ def _choose_browser_interactive() -> bool:
 
 def _choose_profile_interactive() -> str:
     """Present the three distribution profiles and what each bundles (#247, ADR-023)."""
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     console.print(
         Panel(
             "A [bold]profile[/bold] sets how this project receives project-init "
@@ -560,7 +552,7 @@ def _choose_profile_interactive() -> str:
         )
     )
     for i, name in enumerate(_PROFILES, 1):
-        console.print(f"  [cyan]{i}[/cyan]. {name} — {_PROFILE_SUMMARY[name]}")
+        console.print(option_line(i, name, _PROFILE_SUMMARY[name]))
     console.print()
     choice = _prompt_menu_index("Choose a profile", len(_PROFILES), default=1)
     return _PROFILES[choice - 1]
@@ -720,46 +712,119 @@ def _emit_preset_list(presets: list[dict], *, as_json: bool) -> None:
 def _print_summary(
     target: Path, created: list[Path], preset_name: str, memory_stack: str = "none"
 ) -> None:
-    from rich.console import Console
-    from rich.panel import Panel
-
-    console = Console()
-
     dirs = sorted({str(p.parent) for p in created if str(p.parent) != "."})
     files_count = len(created)
-
-    body = f"[bold]Preset:[/bold] {preset_name}\n"
-    body += f"[bold]Files:[/bold] {files_count} created/updated\n"
-    body += f"[bold]Target:[/bold] {target.resolve()}\n\n"
-    body += "[bold]Directories:[/bold]\n"
-    for d in dirs[:15]:
-        body += f"  {d}/\n"
-    if len(dirs) > 15:
-        body += f"  ... and {len(dirs) - 15} more\n"
-
     next_step = _MEMORY_NEXT_STEPS.get(memory_stack, "")
-    if next_step:
-        body += f"\n[bold]Next:[/bold] {next_step}\n"
-
     # The emitted git hooks, lifecycle scripts, and CI workflows all assume a
     # git repo; say so instead of scaffolding into a bare dir silently
     # (2026-07 QA). Checked structurally (.git up the tree — a valid dir, or a
     # file for worktrees/submodules) — the scaffolder never shells out to git.
-    if not any(_is_git_marker(p / ".git") for p in (target, *target.resolve().parents)):
-        body += (
-            "\n[yellow]Note:[/yellow] this directory is not a git repository — "
-            "the scaffolded git hooks and CI workflows assume one.\n"
-            "  Run: [bold]git init && git add -A && git commit -m 'scaffold'[/bold]\n"
-        )
-
-    body += (
-        "\n[bold]Start:[/bold] cd into the project and run [bold]claude[/bold] — "
-        "it picks up CLAUDE.md and .agents/ automatically.\n"
+    git_missing = not any(
+        _is_git_marker(p / ".git") for p in (target, *target.resolve().parents)
     )
 
+    # Off a TTY (piped/captured/CI) render plain, unwrapped text — no borders to
+    # word-wrap mid-phrase, and nothing decorative to bloat a transcript.
+    if not is_interactive():
+        _print_summary_plain(
+            target, dirs, files_count, preset_name, next_step, git_missing=git_missing
+        )
+        return
+
+    from rich.panel import Panel
+    from rich.rule import Rule
+    from rich.table import Table
+
+    facts = Table.grid(padding=(0, 2))
+    facts.add_column(style="key", justify="right")
+    facts.add_column()
+    facts.add_row("Preset", preset_name)
+    facts.add_row("Files", f"[success]{files_count}[/success] created/updated")
+    facts.add_row("Target", str(target.resolve()))
+
+    rows: list = [facts, Rule(style="muted"), _directory_tree(dirs)]
+    if next_step:
+        rows.append(f"[heading]Next[/heading]  {next_step}")
+    if git_missing:
+        rows.append(
+            "[warning]⚠ Not a git repository[/warning] — the scaffolded git hooks and "
+            "CI workflows assume one.\n"
+            "  Run [heading]git init && git add -A && git commit -m 'scaffold'[/heading]"
+        )
+    rows.append(
+        "[heading]Start[/heading]  cd into the project and run [key]claude[/key] — "
+        "it picks up CLAUDE.md and .agents/ automatically."
+    )
+
+    body = Table.grid(padding=(1, 0))
+    body.add_column()
+    for row in rows:
+        body.add_row(row)
+
     console.print()
-    console.print(Panel(body.rstrip(), title="project-init", border_style="green"))
+    console.print(
+        Panel(
+            body,
+            title="[success]✔ project-init — scaffold complete[/success]",
+            border_style="success",
+            padding=(1, 2),
+        )
+    )
     console.print()
+
+
+def _print_summary_plain(  # noqa: PLR0913 — one arg per rendered summary field
+    target: Path,
+    dirs: list[str],
+    files_count: int,
+    preset_name: str,
+    next_step: str,
+    *,
+    git_missing: bool,
+    limit: int = 24,
+) -> None:
+    """Colourless, unwrapped summary for non-TTY runs (uses builtin print)."""
+    print()
+    print("project-init — scaffold complete")
+    print(f"  Preset: {preset_name}")
+    print(f"  Files:  {files_count} created/updated")
+    print(f"  Target: {target.resolve()}")
+    for d in dirs[:limit]:
+        print(f"    {d}/")
+    if len(dirs) > limit:
+        print(f"    ... and {len(dirs) - limit} more")
+    if next_step:
+        print(f"  Next: {next_step}")
+    if git_missing:
+        print(
+            "  Note: this directory is not a git repository — the scaffolded git "
+            "hooks and CI workflows assume one."
+        )
+        print("    Run: git init && git add -A && git commit -m 'scaffold'")
+    print(
+        "  Start: cd into the project and run claude — it picks up CLAUDE.md and "
+        ".agents/ automatically."
+    )
+    print()
+
+
+def _directory_tree(dirs: list[str], *, limit: int = 24):
+    """A nested rich Tree of the created directories (flat list was fragile)."""
+    from rich.tree import Tree
+
+    root = Tree("[heading].[/heading]", guide_style="muted")
+    nodes: dict[str, object] = {"": root}
+    for d in dirs[:limit]:
+        path = ""
+        parent = root
+        for part in d.split("/"):
+            path = f"{path}/{part}" if path else part
+            if path not in nodes:
+                nodes[path] = parent.add(f"[info]{part}/[/info]")
+            parent = nodes[path]
+    if len(dirs) > limit:
+        root.add(f"[muted]… and {len(dirs) - limit} more[/muted]")
+    return root
 
 
 def _is_git_marker(path: Path) -> bool:
@@ -777,8 +842,6 @@ def _print_profile_notice(profile: str, *, no_plugin: bool, no_egress: bool) -> 
     Called on the non-interactive path so a default is never applied silently:
     it states the profile, the delivery, the egress posture, and enforcement.
     """
-    from rich.console import Console
-
     delivery = "project-init copied in locally" if no_plugin else "plugin-first"
     # --no-plugin only copies project-init's own payload; the external official
     # marketplace stays enabled until no-egress mode (#258) omits it.
@@ -787,7 +850,7 @@ def _print_profile_notice(profile: str, *, no_plugin: bool, no_egress: bool) -> 
         if no_egress
         else "external official marketplace enabled (network egress)"
     )
-    Console().print(
+    console.print(
         f"[cyan]Profile:[/cyan] {profile} — {_PROFILE_SUMMARY[profile]}\n"
         f"[cyan]Delivery:[/cyan] {delivery}; {egress}; "
         f"[cyan]enforcement:[/cyan] {_profile_enforcement(profile)}"
@@ -804,11 +867,9 @@ def _choose_multi_model_interactive() -> bool:
     pre-accepts via the flag and skips this; only an interactive run without the
     flag reaches here.
     """
-    from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Confirm
 
-    console = Console()
     body = (
         "Run other models [bold]through the Claude Code harness[/bold] via "
         "claude-code-router (CCR) — one terminal, live switching, and automatic "
@@ -844,11 +905,9 @@ def _choose_governance_interactive() -> bool:
     pre-accepts via the flag and skips this. Most projects are not AI products,
     so it is strictly opt-in and off by default.
     """
-    from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Confirm
 
-    console = Console()
     body = (
         "Ship [bold]governance-as-code[/bold] — versioned, reviewed policy that "
         "travels with the repo — for projects that build or operate an AI "
@@ -887,11 +946,9 @@ def _choose_observability_interactive() -> bool:
     informed choice or declines; declining leaves a clean project. Passing
     --observability pre-accepts via the flag and skips this. Off by default.
     """
-    from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Confirm
 
-    console = Console()
     body = (
         "Get a [bold]file-based usage report[/bold] for your agent sessions — "
         "tokens, tool calls, and activity — with [bold]no Docker, no OTEL, and "
@@ -934,10 +991,8 @@ def _choose_memory_interactive(default: str = "obsidian-only") -> str:
     project). Passing --memory pre-selects and skips this. The default follows
     the chosen preset's memory stack.
     """
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     default_idx = _MEMORY_STACKS.index(default) + 1 if default in _MEMORY_STACKS else 3
     body = (
         "A [bold]memory backend[/bold] gives your agents a place to persist "
@@ -989,10 +1044,8 @@ def _choose_lifecycle_interactive(default: str = "github") -> str:
     --lifecycle pre-selects and skips this. The default follows the chosen
     preset's lifecycle tier.
     """
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     body = (
         "The [bold]GitHub lifecycle[/bold] tier ships project-init's flagship "
         "workflow — [bold]issue → branch → PR → review → merge[/bold], enforced "
@@ -1027,11 +1080,10 @@ def _choose_lifecycle_interactive(default: str = "github") -> str:
 # new concern can't ship without an explanation.
 def _explain_and_confirm(title: str, body: str, question: str, *, default: bool) -> bool:
     """Render a concise explanation Panel for a toolchain toggle, then ask."""
-    from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Confirm
 
-    Console().print(Panel(body, title=title, border_style="cyan"))
+    console.print(Panel(body, title=title, border_style="cyan"))
     return Confirm.ask(question, default=default)
 
 
@@ -1152,10 +1204,8 @@ WIZARD_MECHANICAL_FLAGS: frozenset[str] = frozenset(
 
 def _print_conflicts(conflicts: list[tuple[Path, Path]]) -> None:
     """Warn that user-owned files were kept; renders landed as .new siblings."""
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     body = (
         "Your existing files were [bold]not overwritten[/bold]. The new "
         "project-init version of each was written alongside as a sibling — "
@@ -1171,10 +1221,8 @@ def _print_mcp_commands(selected: list[dict]) -> None:
     if not selected:
         return
 
-    from rich.console import Console
     from rich.panel import Panel
 
-    console = Console()
     body = "\n".join(m["command"] for m in selected)
     console.print(
         Panel(
@@ -1236,9 +1284,8 @@ def _resolve_iac_interactive(iac: str | None) -> str:
         try:
             return resolve_iac(iac)
         except ValueError as e:
-            from rich.console import Console
 
-            Console().print(f"[red]{e}[/red]")
+            console.print(f"[red]{e}[/red]")
     return _choose_iac_interactive()
 
 
@@ -1252,14 +1299,12 @@ def _resolve_overlays_interactive(
     error into a parser.error). Deploy applies only to services; IaC is
     independent of delivery.
     """
-    from rich.console import Console
-
     resolved_delivery = None
     if delivery:
         try:
             resolved_delivery = resolve_delivery(delivery, language)
         except ValueError as e:
-            Console().print(f"[red]{e}[/red]")
+            console.print(f"[red]{e}[/red]")
     if resolved_delivery is None:
         resolved_delivery = _choose_delivery_interactive(language)
 
@@ -1267,7 +1312,7 @@ def _resolve_overlays_interactive(
 
     if resolved_delivery != "service":
         if deploy and deploy.strip().lower() not in ("", "none"):
-            Console().print(
+            console.print(
                 f"[yellow]--deploy {deploy} ignored: deploy targets apply only to "
                 f"delivery=service (this is {resolved_delivery}).[/yellow]"
             )
@@ -1277,7 +1322,7 @@ def _resolve_overlays_interactive(
         try:
             resolved_deploy = resolve_deploy(deploy, resolved_delivery)
         except ValueError as e:
-            Console().print(f"[red]{e}[/red]")
+            console.print(f"[red]{e}[/red]")
     if resolved_deploy is None:
         resolved_deploy = _choose_deploy_interactive()
     return resolved_delivery, resolved_deploy, resolved_iac
@@ -1293,9 +1338,8 @@ def _gather_mcps_interactive(cli_mcps: str, cli_browser: bool) -> list[dict]:
         try:
             selected = _resolve_mcps_non_interactive(cli_mcps, cli_browser)
         except ValueError as e:
-            from rich.console import Console
 
-            Console().print(f"[red]{e}[/red] — choose from the catalog instead.")
+            console.print(f"[red]{e}[/red] — choose from the catalog instead.")
         else:
             # --mcps pins the catalog picks, but browser automation is its own
             # concern (ADR-023) — still offer it when --browser was not given,
@@ -1311,10 +1355,9 @@ def _gather_mcps_interactive(cli_mcps: str, cli_browser: bool) -> list[dict]:
 
 def _print_wizard_guidance() -> None:
     """Frame the interactive path so defaults feel intentional, not mysterious."""
-    from rich.console import Console
     from rich.panel import Panel
 
-    Console().print(
+    console.print(
         Panel(
             "[bold]Recommended path:[/bold] answer the identity questions, then "
             "press [bold]Enter[/bold] to accept each default unless you already "
@@ -1460,9 +1503,8 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         try:
             agents = resolve_agents(cli_agents)
         except ValueError as e:
-            from rich.console import Console
 
-            Console().print(f"[red]{e}[/red]")
+            console.print(f"[red]{e}[/red]")
             agents = _choose_agents_interactive()
     else:
         agents = _choose_agents_interactive()
@@ -1540,12 +1582,9 @@ def _choose_delivery_interactive(language: str) -> str:
     Re-prompts if the choice is invalid for the chosen language (a service needs
     a language toolchain).
     """
-    from rich.console import Console
-
-    console = Console()
     console.print("\n[bold]How is this delivered?[/bold]")
     for i, name in enumerate(_DELIVERY, 1):
-        console.print(f"  {i}. [cyan]{name}[/cyan] — {_DELIVERY_SUMMARY[name]}")
+        console.print(option_line(i, name, _DELIVERY_SUMMARY[name]))
     while True:
         choice = _prompt_menu_index("Choose a delivery model", len(_DELIVERY), default=3)
         try:
@@ -1594,12 +1633,9 @@ def resolve_deploy(raw: str | None, delivery: str) -> str:
 
 def _choose_deploy_interactive() -> str:
     """Present the deploy options (ADR-015); default none. Shown only for services."""
-    from rich.console import Console
-
-    console = Console()
     console.print("\n[bold]How is this service deployed?[/bold]")
     for i, name in enumerate(_DEPLOY_TARGETS, 1):
-        console.print(f"  {i}. [cyan]{name}[/cyan] — {_DEPLOY_SUMMARY[name]}")
+        console.print(option_line(i, name, _DEPLOY_SUMMARY[name]))
     choice = _prompt_menu_index("Choose a deploy target", len(_DEPLOY_TARGETS), default=1)
     return _DEPLOY_TARGETS[choice - 1]
 
@@ -1631,12 +1667,9 @@ def resolve_iac(raw: str | None) -> str:
 
 def _choose_iac_interactive() -> str:
     """Present the IaC options (ADR-015); default none."""
-    from rich.console import Console
-
-    console = Console()
     console.print("\n[bold]Infrastructure-as-Code overlay?[/bold]")
     for i, name in enumerate(_IAC_OPTIONS, 1):
-        console.print(f"  {i}. [cyan]{name}[/cyan] — {_IAC_SUMMARY[name]}")
+        console.print(option_line(i, name, _IAC_SUMMARY[name]))
     choice = _prompt_menu_index("Choose an IaC overlay", len(_IAC_OPTIONS), default=1)
     return _IAC_OPTIONS[choice - 1]
 
@@ -1669,11 +1702,9 @@ _AGENT_SURFACES = (
 
 def _choose_agents_interactive() -> list[str]:
     """Present the agent/editor surfaces to scaffold for (ADR-017, #616)."""
-    from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Prompt
 
-    console = Console()
     body = (
         "Project-init configures [bold]agent and editor surfaces[/bold] so they "
         "know your rules and hooks. [bold]Claude[/bold] is always supported.\n\n"
@@ -2622,7 +2653,8 @@ def _cli(argv: list[str]) -> int:
     conflicts: list[tuple[Path, Path]] = []
 
     try:
-        created = scaffold(target, preset, variables, strict=args.strict, conflicts=conflicts)
+        with scaffolding():
+            created = scaffold(target, preset, variables, strict=args.strict, conflicts=conflicts)
         _record_scaffold(target, preset, variables, created)
     except TemplateRenderError as e:
         sys.stderr.write(f"error: {e}\n")

--- a/src/project_init/console.py
+++ b/src/project_init/console.py
@@ -101,12 +101,14 @@ def render_presets(presets: list[dict], default_idx: int) -> None:
 def scaffolding(label: str = "Scaffolding project…") -> Iterator[None]:
     """Spinner for the duration of a long, single-shot operation.
 
-    A no-op when stderr is not a TTY so nothing is emitted when captured; on a
-    TTY it shows a transient spinner that clears itself when the block exits (no
-    faked determinate progress — the engine reports the real file count
-    afterwards).
+    Shown only when the session is fully interactive — stdout a TTY
+    (:func:`is_interactive`) *and* stderr a TTY — so it stays consistent with
+    every other richer device and emits nothing when either stream is
+    piped/captured. On a TTY it shows a transient spinner that clears itself
+    when the block exits (no faked determinate progress — the engine reports the
+    real file count afterwards).
     """
-    if _status_console.is_terminal:
+    if is_interactive() and _status_console.is_terminal:
         with _status_console.status(f"[info]{label}[/info]", spinner="dots"):
             yield
     else:

--- a/src/project_init/console.py
+++ b/src/project_init/console.py
@@ -68,12 +68,19 @@ def option_line(index: int, name: str, description: str, *, recommended: bool = 
     return f"  [key]{index}[/key]. [heading]{name}[/heading] — [muted]{description}[/muted]{mark}"
 
 
-def render_presets(presets: list[dict], default_idx: int) -> None:
+def render_presets(
+    presets: list[dict], default_idx: int, memory_by_name: dict[str, str]
+) -> None:
     """Print the preset options as an aligned table (plain list off-TTY).
 
     The table adds a Memory column the old space-padded string list could not
     show; on a non-TTY it degrades to the plain numbered list callers relied on
     before, keeping captured output stable.
+
+    *memory_by_name* maps preset name → the memory stack it actually scaffolds,
+    already resolved for ``extends`` inheritance by the caller — reading the raw
+    per-preset ``vars`` here would advertise ``—`` for an inheriting preset like
+    ``governed`` (#511 / PI-645 review).
     """
     if not is_interactive():
         console.print("[heading]Available presets:[/heading]")
@@ -92,7 +99,7 @@ def render_presets(presets: list[dict], default_idx: int) -> None:
     table.add_column("What you get", style="muted", ratio=1)
     for i, preset in enumerate(presets, 1):
         rec = "  [recommend]✔ recommended[/recommend]" if i == default_idx else ""
-        memory = str(preset.get("vars", {}).get("memory_stack") or "—")
+        memory = str(memory_by_name.get(preset["name"]) or "—")
         table.add_row(str(i), preset["name"], memory, f"{preset['description']}{rec}")
     console.print(table)
 

--- a/src/project_init/console.py
+++ b/src/project_init/console.py
@@ -1,0 +1,113 @@
+"""Central rich styling for the interactive wizard.
+
+One :data:`console` and one :data:`WIZARD_THEME` so the wizard's colour
+vocabulary (``info`` / ``success`` / ``warning`` / ``error`` / …) is defined
+once here instead of being retyped in every prompt helper. Built-in markup
+(``[red]``, ``[dim]``) still resolves, so migrating a call site to the shared
+console is non-breaking.
+
+Richer devices (tables, spinner, tree) render only on a real TTY. When output
+is piped, redirected, or captured they degrade to plain text via
+:func:`is_interactive`, so non-interactive runs stay lean and never leak escape
+sequences into a transcript (PI-641).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from rich.console import Console
+from rich.theme import Theme
+
+# The wizard's whole colour vocabulary. Markup like [info]…[/info] resolves
+# through this theme; keep it small and semantic rather than colour-named so
+# the palette can shift in one place.
+WIZARD_THEME = Theme(
+    {
+        "info": "cyan",
+        "success": "bold green",
+        "warning": "yellow",
+        "error": "bold red",
+        "heading": "bold",
+        "muted": "dim",
+        "key": "bold cyan",
+        "recommend": "green",
+        "accent": "magenta",
+    }
+)
+
+# file is left as the default so the Console resolves sys.stdout lazily at print
+# time — pytest's capsys (which swaps sys.stdout for a non-TTY buffer) is then
+# captured correctly and is_terminal reflects the real destination.
+console = Console(theme=WIZARD_THEME)
+
+# The spinner renders to stderr so it can never interleave with stdout — in
+# particular the machine-readable --json payload stays clean.
+_status_console = Console(theme=WIZARD_THEME, stderr=True)
+
+
+def is_interactive() -> bool:
+    """Whether richer devices should render (True only on a real TTY).
+
+    False when output is piped/redirected/captured, so callers fall back to
+    plain text instead of emitting box-drawing and escape sequences into a
+    non-TTY sink.
+    """
+    return console.is_terminal
+
+
+def option_line(index: int, name: str, description: str, *, recommended: bool = False) -> str:
+    """One numbered menu row in the single house style.
+
+    Centralises the ``[key]N[/key]. name — desc`` format so choosers can't
+    drift apart (the preset/mcp group used to style the number, the
+    delivery/deploy/iac group the name).
+    """
+    mark = "  [recommend](recommended)[/recommend]" if recommended else ""
+    return f"  [key]{index}[/key]. [heading]{name}[/heading] — [muted]{description}[/muted]{mark}"
+
+
+def render_presets(presets: list[dict], default_idx: int) -> None:
+    """Print the preset options as an aligned table (plain list off-TTY).
+
+    The table adds a Memory column the old space-padded string list could not
+    show; on a non-TTY it degrades to the plain numbered list callers relied on
+    before, keeping captured output stable.
+    """
+    if not is_interactive():
+        console.print("[heading]Available presets:[/heading]")
+        for i, preset in enumerate(presets, 1):
+            mark = "  (recommended)" if i == default_idx else ""
+            console.print(f"  {i}. {preset['name']} — {preset['description']}{mark}")
+        return
+
+    from rich import box
+    from rich.table import Table
+
+    table = Table(box=box.SIMPLE_HEAD, pad_edge=False, show_edge=False, expand=True)
+    table.add_column("#", style="key", width=2, justify="right")
+    table.add_column("Preset", style="heading", no_wrap=True)
+    table.add_column("Memory", style="accent", no_wrap=True)
+    table.add_column("What you get", style="muted", ratio=1)
+    for i, preset in enumerate(presets, 1):
+        rec = "  [recommend]✔ recommended[/recommend]" if i == default_idx else ""
+        memory = str(preset.get("vars", {}).get("memory_stack") or "—")
+        table.add_row(str(i), preset["name"], memory, f"{preset['description']}{rec}")
+    console.print(table)
+
+
+@contextmanager
+def scaffolding(label: str = "Scaffolding project…") -> Iterator[None]:
+    """Spinner for the duration of a long, single-shot operation.
+
+    A no-op when stderr is not a TTY so nothing is emitted when captured; on a
+    TTY it shows a transient spinner that clears itself when the block exits (no
+    faked determinate progress — the engine reports the real file count
+    afterwards).
+    """
+    if _status_console.is_terminal:
+        with _status_console.status(f"[info]{label}[/info]", spinner="dots"):
+            yield
+    else:
+        yield

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -1,0 +1,67 @@
+"""Unit tests for the shared wizard console (PI-645).
+
+Covers the single-house-style menu row, the preset table and its off-TTY plain
+fallback, and that the scaffolding spinner is an inert no-op when captured.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+import project_init.console as pc
+
+
+def test_option_line_single_house_style() -> None:
+    """Number is the styled token and the row carries name + description."""
+    line = pc.option_line(2, "core", "no memory backend")
+    assert "2" in line and "core" in line and "no memory backend" in line
+    assert "(recommended)" not in line
+    assert "(recommended)" in pc.option_line(1, "obsidian-only", "the default", recommended=True)
+
+
+def test_is_interactive_false_under_capture(capsys) -> None:
+    """Captured/piped output is never a TTY, so richer devices stand down."""
+    assert pc.is_interactive() is False
+    capsys.readouterr()
+
+
+def test_render_presets_plain_lists_every_preset(capsys) -> None:
+    """Off a TTY the table degrades to a plain numbered list of all presets."""
+    presets = [
+        {"name": "core", "description": "no memory", "vars": {"memory_stack": "none"}},
+        {"name": "obsidian-only", "description": "vault only", "vars": {"memory_stack": "obsidian-only"}},
+    ]
+    pc.render_presets(presets, default_idx=2)
+    out = capsys.readouterr().out
+    assert "Available presets" in out
+    assert "core" in out and "obsidian-only" in out
+    # The recommended marker lands on the default index only.
+    assert out.count("(recommended)") == 1
+
+
+def test_render_presets_table_when_interactive(monkeypatch, capsys) -> None:
+    """Forced-TTY path renders the aligned table incl. the Memory column."""
+    rec = Console(theme=pc.WIZARD_THEME, force_terminal=True, width=100)
+    monkeypatch.setattr(pc, "console", rec)
+    monkeypatch.setattr(pc, "is_interactive", lambda: True)
+    presets = [{"name": "core", "description": "no memory", "vars": {"memory_stack": "none"}}]
+    pc.render_presets(presets, default_idx=1)
+    out = capsys.readouterr().out
+    assert "core" in out and "none" in out
+    assert "recommended" in out
+
+
+def test_render_presets_handles_missing_memory(capsys) -> None:
+    """A preset without a memory_stack var shows a dash, not a KeyError."""
+    pc.render_presets([{"name": "x", "description": "d", "vars": {}}], default_idx=1)
+    assert "x" in capsys.readouterr().out
+
+
+def test_scaffolding_is_noop_off_tty(capsys) -> None:
+    """The spinner emits nothing to stdout when stderr is not a TTY."""
+    with pc.scaffolding("working"):
+        ran = True
+    assert ran
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "working" not in captured.err

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -19,10 +19,12 @@ def test_option_line_single_house_style() -> None:
     assert "(recommended)" in pc.option_line(1, "obsidian-only", "the default", recommended=True)
 
 
-def test_is_interactive_false_under_capture(capsys) -> None:
-    """Captured/piped output is never a TTY, so richer devices stand down."""
+def test_is_interactive_tracks_console_tty(monkeypatch) -> None:
+    """is_interactive reflects the console's TTY-ness (deterministic, no -s dep)."""
+    import io
+
+    monkeypatch.setattr(pc, "console", Console(file=io.StringIO()))
     assert pc.is_interactive() is False
-    capsys.readouterr()
 
 
 def test_render_presets_plain_lists_every_preset(capsys) -> None:
@@ -64,4 +66,4 @@ def test_scaffolding_is_noop_off_tty(capsys) -> None:
     assert ran
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert "working" not in captured.err
+    assert captured.err == ""

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -33,7 +33,7 @@ def test_render_presets_plain_lists_every_preset(capsys) -> None:
         {"name": "core", "description": "no memory", "vars": {"memory_stack": "none"}},
         {"name": "obsidian-only", "description": "vault only", "vars": {"memory_stack": "obsidian-only"}},
     ]
-    pc.render_presets(presets, default_idx=2)
+    pc.render_presets(presets, default_idx=2, memory_by_name={"core": "none", "obsidian-only": "obsidian-only"})
     out = capsys.readouterr().out
     assert "Available presets" in out
     assert "core" in out and "obsidian-only" in out
@@ -47,15 +47,30 @@ def test_render_presets_table_when_interactive(monkeypatch, capsys) -> None:
     monkeypatch.setattr(pc, "console", rec)
     monkeypatch.setattr(pc, "is_interactive", lambda: True)
     presets = [{"name": "core", "description": "no memory", "vars": {"memory_stack": "none"}}]
-    pc.render_presets(presets, default_idx=1)
+    pc.render_presets(presets, default_idx=1, memory_by_name={"core": "none"})
     out = capsys.readouterr().out
     assert "core" in out and "none" in out
     assert "recommended" in out
 
 
+def test_render_presets_shows_resolved_inherited_memory(monkeypatch, capsys) -> None:
+    """Memory column reflects the *resolved* stack, not the raw vars (#511/PI-645).
+
+    `governed` declares only `extends`, so its raw vars carry no memory_stack;
+    the caller-supplied resolved map must still show its inherited stack.
+    """
+    rec = Console(theme=pc.WIZARD_THEME, force_terminal=True, width=100)
+    monkeypatch.setattr(pc, "console", rec)
+    monkeypatch.setattr(pc, "is_interactive", lambda: True)
+    presets = [{"name": "governed", "description": "policy layer", "vars": {}}]
+    pc.render_presets(presets, default_idx=1, memory_by_name={"governed": "obsidian-only"})
+    out = capsys.readouterr().out
+    assert "obsidian-only" in out
+
+
 def test_render_presets_handles_missing_memory(capsys) -> None:
-    """A preset without a memory_stack var shows a dash, not a KeyError."""
-    pc.render_presets([{"name": "x", "description": "d", "vars": {}}], default_idx=1)
+    """A preset absent from the resolved map shows a dash, not a KeyError."""
+    pc.render_presets([{"name": "x", "description": "d", "vars": {}}], default_idx=1, memory_by_name={})
     assert "x" in capsys.readouterr().out
 
 


### PR DESCRIPTION
Closes #645

## What

The interactive `project-init` wizard is the one genuinely human-facing terminal surface. This gives it one visual language and makes it production-ready, `src/`-only (no templates, byte-identity fixtures, or `.claude` mirror touched; `rich` is already a core dep).

- **New `src/project_init/console.py`** — one `rich.Theme` + a single shared `Console`, so the cyan/green/yellow/red vocabulary is named once (`info`/`success`/`warning`/`error`/`muted`/…) instead of retyped across the **~30 lazy `Console()`** instantiations in `__main__.py` (all migrated).
- **Presets → aligned `Table`** with a *Memory* column the old space-padded string list couldn't show.
- **Scaffold → transient spinner** (`console.status` on **stderr**, so it never interleaves with stdout or the `--json` payload).
- **Success screen → one panel** with a key/value grid + a nested file `Tree`, replacing the up-to-four separately-bordered blocks.
- **Unified menu numbering** — delivery/deploy/iac/profile/mcp all route through one `option_line()` helper, killing the `[cyan]1[/cyan].` vs `1. [cyan]name[/cyan]` drift.

## Degrade-to-plain (PI-641)

Every richer device is gated on `is_interactive()` (TTY detection). Piped/redirected/captured runs get plain, unwrapped text — no box-drawing or escape sequences leaking into a transcript, and the `--json` path is byte-identical (early return, untouched).

## Tests

- New `tests/unit/test_console.py` covers `option_line`, the preset table + its plain fallback, missing-memory handling, and the spinner no-op.
- Full suite green: **2000 passed, 8 skipped**.

## Not in scope

Scaffolded-project bash/hook output (separate, higher-risk pass — the Python wizard does not ship into targets). No new dependency, no new CLI flag (ADR-023 partition test unaffected).