### PR TITLE
feat(PI-649): Deduplicate and trim the workflow_state_reminder injection

### DIFF
--- a/.agents/hooks/workflow_state_reminder.sh
+++ b/.agents/hooks/workflow_state_reminder.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# workflow_state_reminder.sh — inject the full lifecycle rules when a prompt
+# workflow_state_reminder.sh — inject the lifecycle rules when a prompt
 # mentions GitHub workflow actions, plus the current DAG state if available.
 # UserPromptSubmit hook. Receives prompt JSON on stdin.
+#
+# Token-efficiency (PI-649, ADR-028): injected context persists in the
+# transcript and is re-sent every turn, so the static rules block is injected
+# ONCE per session (sentinel file keyed on the stdin session_id); later
+# triggers get only the dynamic DAG state. Fail-open: no session_id or an
+# unwritable tmp dir falls back to injecting the full block every time.
 
 set -euo pipefail
 
@@ -11,11 +17,14 @@ INPUT=$(cat)
 # Failures are non-fatal — the static rules are always injected.
 DAG_STATE=$(python3 "$(dirname "$0")/dag_workflow.py" nodes 2>/dev/null || true)
 
-printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" python3 -c '
+printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" \
+  PI_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" python3 -c '
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
 
 try:
     data = json.load(sys.stdin)
@@ -39,34 +48,62 @@ if not trigger:
     sys.exit(0)
 
 dag_state = os.environ.get("DAG_STATE", "").strip()
-state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
-context = (
-    "GitHub workflow rules (enforced by .agents/hooks/dag_workflow.py):\n"
-    "\n"
-    "Lifecycle order (DAG):\n"
-    "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
-    "                                                  \\-> ci.green -+\n"
-    "                                                  \\-> review.approved -+-> pr.merged\n"
-    "\n"
-    "Use these entrypoints. Do NOT call the raw command — the DAG hook will block:\n"
-    "  - start_task skill                     (issue + branch + draft PR, for issue-backed work)\n"
-    "  - .agents/scripts/create_nojira_pr.sh  (not: gh pr create, for no-issue work)\n"
-    "  - .agents/scripts/push_branch.sh       (not: git push)\n"
-    "  - .agents/scripts/promote_review.sh    (not: gh pr ready)\n"
-    "  - .agents/scripts/finish_pr.sh <pr>    (push, promote, then merge)\n"
-    "  - .agents/scripts/monitor_pr.sh <pr> --merge   (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
-    "\n"
-    "Naming:\n"
-    "  branch:     <type>/PI-<n>-<kebab-slug>     e.g. feat/PI-98-dag-workflow\n"
-    "  PR title:   type(PI-N): description        e.g. feat(PI-98): Add DAG enforcement\n"
-    "              (no scope = no linked issue, e.g. fix: Correct typo) — ADR-006\n"
-    "  PR body:    must include `Closes #N`\n"
-    "\n"
-    "Iterating before push: edit, test, debug freely. The DAG only fires on\n"
-    "guarded commands (push, PR create/ready/merge). Push only when ready.\n"
-    f"{state_block}"
-)
+# Session-scoped dedup (ADR-028): the static rules are injected once per
+# session. The sentinel is keyed on the session_id from the hook payload plus
+# a project-dir hash (parallel sessions in different repos must not collide).
+# Any failure here falls back to first_time=True — the full block is safe,
+# just token-costly.
+first_time = True
+session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
+if session_id:
+    proj = hashlib.sha256(
+        os.environ.get("PI_PROJECT_DIR", "").encode()
+    ).hexdigest()[:8]
+    sentinel = os.path.join(
+        tempfile.gettempdir(), f"pi_wsr_{proj}_{session_id}"
+    )
+    try:
+        if os.path.exists(sentinel):
+            first_time = False
+        else:
+            with open(sentinel, "w"):
+                pass
+    except OSError:
+        first_time = True
+
+state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
+
+if first_time:
+    context = (
+        "GitHub workflow rules (enforced by .agents/hooks/dag_workflow.py):\n"
+        "\n"
+        "Lifecycle order (DAG):\n"
+        "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
+        "                                                  \\-> ci.green -+\n"
+        "                                                  \\-> review.approved -+-> pr.merged\n"
+        "\n"
+        "Use these entrypoints — the DAG hook blocks the raw commands:\n"
+        "  start_task skill (issue + branch + draft PR) | create_nojira_pr.sh (not: gh pr create)\n"
+        "  push_branch.sh (not: git push) | promote_review.sh (not: gh pr ready)\n"
+        "  finish_pr.sh <pr> | monitor_pr.sh <pr> --merge (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
+        "  (scripts live in .agents/scripts/)\n"
+        "\n"
+        "Naming: branch <type>/PI-<n>-<kebab-slug> | "
+        "PR title type(PI-N): description (no scope = no linked issue, ADR-006) | "
+        "body includes `Closes #N`\n"
+        "Details (review cycles, iterating before push): load the github_workflow skill.\n"
+        f"{state_block}"
+    )
+elif state_block:
+    context = (
+        "Lifecycle reminder (full rules were injected earlier this session; "
+        "load the github_workflow skill for details).\n"
+        f"{state_block}"
+    )
+else:
+    # Rules already shown and no DAG state to report — nothing new to say.
+    sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/.agents/hooks/workflow_state_reminder.sh
+++ b/.agents/hooks/workflow_state_reminder.sh
@@ -50,11 +50,14 @@ if not trigger:
 dag_state = os.environ.get("DAG_STATE", "").strip()
 
 # Session-scoped dedup (ADR-028): the static rules are injected once per
-# session. The sentinel is keyed on the session_id from the hook payload plus
-# a project-dir hash (parallel sessions in different repos must not collide).
-# Any failure here falls back to first_time=True — the full block is safe,
-# just token-costly.
+# session, and the dynamic DAG state is re-injected only when it CHANGED
+# since the last injection (the sentinel stores its hash). The sentinel is
+# keyed on the session_id from the hook payload plus a project-dir hash
+# (parallel sessions in different repos must not collide). Any failure here
+# falls back to first_time=True — the full block is safe, just token-costly.
 first_time = True
+state_changed = True
+cur_hash = hashlib.sha256(dag_state.encode()).hexdigest()[:16]
 session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
 if session_id:
     proj = hashlib.sha256(
@@ -66,11 +69,14 @@ if session_id:
     try:
         if os.path.exists(sentinel):
             first_time = False
-        else:
-            with open(sentinel, "w"):
-                pass
+            with open(sentinel) as fh:
+                state_changed = fh.read().strip() != cur_hash
+        if first_time or state_changed:
+            with open(sentinel, "w") as fh:
+                fh.write(cur_hash)
     except OSError:
         first_time = True
+        state_changed = True
 
 state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
@@ -95,14 +101,15 @@ if first_time:
         "Details (review cycles, iterating before push): load the github_workflow skill.\n"
         f"{state_block}"
     )
-elif state_block:
+elif state_block and state_changed:
     context = (
         "Lifecycle reminder (full rules were injected earlier this session; "
         "load the github_workflow skill for details).\n"
         f"{state_block}"
     )
 else:
-    # Rules already shown and no DAG state to report — nothing new to say.
+    # Rules already shown and the DAG state is unchanged (or absent) —
+    # nothing new to say.
     sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))

--- a/.claude/hooks/workflow_state_reminder.sh
+++ b/.claude/hooks/workflow_state_reminder.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# workflow_state_reminder.sh — inject the full lifecycle rules when a prompt
+# workflow_state_reminder.sh — inject the lifecycle rules when a prompt
 # mentions GitHub workflow actions, plus the current DAG state if available.
 # UserPromptSubmit hook. Receives prompt JSON on stdin.
+#
+# Token-efficiency (PI-649, ADR-028): injected context persists in the
+# transcript and is re-sent every turn, so the static rules block is injected
+# ONCE per session (sentinel file keyed on the stdin session_id); later
+# triggers get only the dynamic DAG state. Fail-open: no session_id or an
+# unwritable tmp dir falls back to injecting the full block every time.
 
 set -euo pipefail
 
@@ -11,11 +17,14 @@ INPUT=$(cat)
 # Failures are non-fatal — the static rules are always injected.
 DAG_STATE=$(python3 "$(dirname "$0")/dag_workflow.py" nodes 2>/dev/null || true)
 
-printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" python3 -c '
+printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" \
+  PI_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" python3 -c '
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
 
 try:
     data = json.load(sys.stdin)
@@ -39,34 +48,62 @@ if not trigger:
     sys.exit(0)
 
 dag_state = os.environ.get("DAG_STATE", "").strip()
-state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
-context = (
-    "GitHub workflow rules (enforced by .agents/hooks/dag_workflow.py):\n"
-    "\n"
-    "Lifecycle order (DAG):\n"
-    "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
-    "                                                  \\-> ci.green -+\n"
-    "                                                  \\-> review.approved -+-> pr.merged\n"
-    "\n"
-    "Use these entrypoints. Do NOT call the raw command — the DAG hook will block:\n"
-    "  - start_task skill                     (issue + branch + draft PR, for issue-backed work)\n"
-    "  - .agents/scripts/create_nojira_pr.sh  (not: gh pr create, for no-issue work)\n"
-    "  - .agents/scripts/push_branch.sh       (not: git push)\n"
-    "  - .agents/scripts/promote_review.sh    (not: gh pr ready)\n"
-    "  - .agents/scripts/finish_pr.sh <pr>    (push, promote, then merge)\n"
-    "  - .agents/scripts/monitor_pr.sh <pr> --merge   (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
-    "\n"
-    "Naming:\n"
-    "  branch:     <type>/PI-<n>-<kebab-slug>     e.g. feat/PI-98-dag-workflow\n"
-    "  PR title:   type(PI-N): description        e.g. feat(PI-98): Add DAG enforcement\n"
-    "              (no scope = no linked issue, e.g. fix: Correct typo) — ADR-006\n"
-    "  PR body:    must include `Closes #N`\n"
-    "\n"
-    "Iterating before push: edit, test, debug freely. The DAG only fires on\n"
-    "guarded commands (push, PR create/ready/merge). Push only when ready.\n"
-    f"{state_block}"
-)
+# Session-scoped dedup (ADR-028): the static rules are injected once per
+# session. The sentinel is keyed on the session_id from the hook payload plus
+# a project-dir hash (parallel sessions in different repos must not collide).
+# Any failure here falls back to first_time=True — the full block is safe,
+# just token-costly.
+first_time = True
+session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
+if session_id:
+    proj = hashlib.sha256(
+        os.environ.get("PI_PROJECT_DIR", "").encode()
+    ).hexdigest()[:8]
+    sentinel = os.path.join(
+        tempfile.gettempdir(), f"pi_wsr_{proj}_{session_id}"
+    )
+    try:
+        if os.path.exists(sentinel):
+            first_time = False
+        else:
+            with open(sentinel, "w"):
+                pass
+    except OSError:
+        first_time = True
+
+state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
+
+if first_time:
+    context = (
+        "GitHub workflow rules (enforced by .agents/hooks/dag_workflow.py):\n"
+        "\n"
+        "Lifecycle order (DAG):\n"
+        "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
+        "                                                  \\-> ci.green -+\n"
+        "                                                  \\-> review.approved -+-> pr.merged\n"
+        "\n"
+        "Use these entrypoints — the DAG hook blocks the raw commands:\n"
+        "  start_task skill (issue + branch + draft PR) | create_nojira_pr.sh (not: gh pr create)\n"
+        "  push_branch.sh (not: git push) | promote_review.sh (not: gh pr ready)\n"
+        "  finish_pr.sh <pr> | monitor_pr.sh <pr> --merge (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
+        "  (scripts live in .agents/scripts/)\n"
+        "\n"
+        "Naming: branch <type>/PI-<n>-<kebab-slug> | "
+        "PR title type(PI-N): description (no scope = no linked issue, ADR-006) | "
+        "body includes `Closes #N`\n"
+        "Details (review cycles, iterating before push): load the github_workflow skill.\n"
+        f"{state_block}"
+    )
+elif state_block:
+    context = (
+        "Lifecycle reminder (full rules were injected earlier this session; "
+        "load the github_workflow skill for details).\n"
+        f"{state_block}"
+    )
+else:
+    # Rules already shown and no DAG state to report — nothing new to say.
+    sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/.claude/hooks/workflow_state_reminder.sh
+++ b/.claude/hooks/workflow_state_reminder.sh
@@ -50,11 +50,14 @@ if not trigger:
 dag_state = os.environ.get("DAG_STATE", "").strip()
 
 # Session-scoped dedup (ADR-028): the static rules are injected once per
-# session. The sentinel is keyed on the session_id from the hook payload plus
-# a project-dir hash (parallel sessions in different repos must not collide).
-# Any failure here falls back to first_time=True — the full block is safe,
-# just token-costly.
+# session, and the dynamic DAG state is re-injected only when it CHANGED
+# since the last injection (the sentinel stores its hash). The sentinel is
+# keyed on the session_id from the hook payload plus a project-dir hash
+# (parallel sessions in different repos must not collide). Any failure here
+# falls back to first_time=True — the full block is safe, just token-costly.
 first_time = True
+state_changed = True
+cur_hash = hashlib.sha256(dag_state.encode()).hexdigest()[:16]
 session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
 if session_id:
     proj = hashlib.sha256(
@@ -66,11 +69,14 @@ if session_id:
     try:
         if os.path.exists(sentinel):
             first_time = False
-        else:
-            with open(sentinel, "w"):
-                pass
+            with open(sentinel) as fh:
+                state_changed = fh.read().strip() != cur_hash
+        if first_time or state_changed:
+            with open(sentinel, "w") as fh:
+                fh.write(cur_hash)
     except OSError:
         first_time = True
+        state_changed = True
 
 state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
@@ -95,14 +101,15 @@ if first_time:
         "Details (review cycles, iterating before push): load the github_workflow skill.\n"
         f"{state_block}"
     )
-elif state_block:
+elif state_block and state_changed:
     context = (
         "Lifecycle reminder (full rules were injected earlier this session; "
         "load the github_workflow skill for details).\n"
         f"{state_block}"
     )
 else:
-    # Rules already shown and no DAG state to report — nothing new to say.
+    # Rules already shown and the DAG state is unchanged (or absent) —
+    # nothing new to say.
     sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))

--- a/docs/adr/adr-028-session-scoped-reminder-injection.md
+++ b/docs/adr/adr-028-session-scoped-reminder-injection.md
@@ -1,0 +1,71 @@
+# ADR-028: Session-scoped injection for the workflow-state reminder
+
+- Status: Accepted
+- Date: 2026-07-08
+- Implements: [#649](https://github.com/VytCepas/project-init/issues/649)
+  (WS1 of epic [#641](https://github.com/VytCepas/project-init/issues/641),
+  reduce redundant token consumption)
+- Relates to: ADR-007 (git-level lifecycle enforcement — the guard this
+  reminder is advisory UX for), ADR-010 (the plugin derived-copy pattern the
+  hook ships through)
+
+## Context
+
+`workflow_state_reminder.sh` (UserPromptSubmit hook, three synced copies:
+this repo's `.agents/hooks/`, `templates/lifecycle_fallback/`, and the
+`project-init-lifecycle` plugin) injected a **static** ~350-word (~470-token)
+lifecycle-rules block on *every* prompt matching a workflow keyword
+(`implement|push|merge|review|branch|ship|ticket|…`) — 10–20 times per
+working session, with only the `Current DAG nodes` tail ever changing.
+
+Verified Claude Code semantics (2026-07, code.claude.com/docs/en/hooks):
+UserPromptSubmit `additionalContext` **persists in the transcript and is
+re-sent to the model on every subsequent turn** (it is appended as
+conversation content, so it does not break the prompt-cache prefix — but it
+pays context occupancy and cache-read cost for the rest of the session).
+Re-injecting an unchanged block therefore adds near-zero information at
+recurring cost: the second and later injections duplicate text the model
+already has in context.
+
+Most of the block also duplicated always-loaded or on-demand sources: the
+AGENTS.md workflow quick-ref and the `github_workflow` skill.
+
+## Decision
+
+1. **Inject the static rules once per session.** The hook derives a sentinel
+   file path from the `session_id` in the hook's stdin JSON (sanitized,
+   64-char cap) plus an 8-char SHA-256 hash of the project directory
+   (parallel sessions in different repos must not collide):
+   `$TMPDIR/pi_wsr_<proj-hash>_<session_id>`. First trigger of a session
+   injects the rules block and touches the sentinel; later triggers inject
+   only the dynamic `Current DAG nodes` state plus a one-line pointer to the
+   `github_workflow` skill. If there is no DAG state to report, later
+   triggers inject nothing at all.
+2. **Trim the static block.** The wrapper-script map keeps every
+   banned-command → wrapper mapping but drops the tutorial prose; naming
+   rules collapse to one line; review-cycle/iteration details defer to the
+   `github_workflow` skill (on-demand). ~470 tokens → ~200.
+3. **Fail-open.** A missing/empty `session_id`, an unwritable temp dir, or
+   any sentinel I/O error falls back to the previous behavior (full block
+   every trigger). Wrong-but-safe beats silent under-informing.
+
+## Consequences
+
+- Saves roughly `470 × (triggers − 1)` tokens of context occupancy per
+  session (measured 10–20 triggers/session on this repo), multiplied by
+  every remaining turn of the session, in this repo and every scaffolded
+  project with the lifecycle tier.
+- **Enforcement is unchanged.** The reminder is advisory UX; blocking is done
+  by `github_command_guard.sh` → `dag_workflow.py guard` (ADR-007), which
+  this ADR does not touch. An agent that misses the rules gets a corrective
+  deny message from the guard at worst.
+- Compaction edge: if a session is compacted, the earlier injected block may
+  be summarized away while the sentinel says "already injected". Accepted:
+  the AGENTS.md quick-ref survives compaction, the guard still blocks raw
+  commands, and the skill is loadable on demand.
+- Stale sentinels accumulate in `$TMPDIR` (one tiny empty file per session);
+  OS temp cleanup handles them. `/clear` starts a new `session_id`, so a
+  cleared session correctly re-injects.
+- Non-Claude surfaces are unaffected (the hook is Claude-specific
+  UserPromptSubmit wiring; other surfaces rely on AGENTS.md + git/CI
+  enforcement, ADR-012).

--- a/docs/adr/adr-028-session-scoped-reminder-injection.md
+++ b/docs/adr/adr-028-session-scoped-reminder-injection.md
@@ -37,10 +37,11 @@ AGENTS.md workflow quick-ref and the `github_workflow` skill.
    64-char cap) plus an 8-char SHA-256 hash of the project directory
    (parallel sessions in different repos must not collide):
    `$TMPDIR/pi_wsr_<proj-hash>_<session_id>`. First trigger of a session
-   injects the rules block and touches the sentinel; later triggers inject
-   only the dynamic `Current DAG nodes` state plus a one-line pointer to the
-   `github_workflow` skill. If there is no DAG state to report, later
-   triggers inject nothing at all.
+   injects the rules block and writes a 16-char hash of the current DAG
+   state into the sentinel; later triggers inject the dynamic `Current DAG
+   nodes` state (plus a one-line pointer to the `github_workflow` skill)
+   **only when that state changed** since the last injection. Unchanged or
+   absent state — the common case mid-session — injects nothing at all.
 2. **Trim the static block.** The wrapper-script map keeps every
    banned-command → wrapper mapping but drops the tutorial prose; naming
    rules collapse to one line; review-cycle/iteration details defer to the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Agentic-OS root layer: adr/adr-025-agentic-os-root-layer.md
     - Tier-3 RAG engine (cocoindex): adr/adr-026-tier3-rag-engine-cocoindex.md
     - Claude config projection (.claude mirror): adr/adr-027-claude-config-projection.md
+    - Session-scoped reminder injection: adr/adr-028-session-scoped-reminder-injection.md
   - Development:
     - Template system: development/template-system.md
     - Memory descriptor: development/memory-descriptor.md

--- a/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
@@ -79,11 +79,14 @@ dag_state = os.environ.get("DAG_STATE", "").strip()
 key = os.environ.get("PROJECT_KEY", "").strip() or "<KEY>"
 
 # Session-scoped dedup (ADR-028): the static rules are injected once per
-# session. The sentinel is keyed on the session_id from the hook payload plus
-# a project-dir hash (parallel sessions in different repos must not collide).
-# Any failure here falls back to first_time=True — the full block is safe,
-# just token-costly.
+# session, and the dynamic DAG state is re-injected only when it CHANGED
+# since the last injection (the sentinel stores its hash). The sentinel is
+# keyed on the session_id from the hook payload plus a project-dir hash
+# (parallel sessions in different repos must not collide). Any failure here
+# falls back to first_time=True — the full block is safe, just token-costly.
 first_time = True
+state_changed = True
+cur_hash = hashlib.sha256(dag_state.encode()).hexdigest()[:16]
 session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
 if session_id:
     proj = hashlib.sha256(
@@ -95,11 +98,14 @@ if session_id:
     try:
         if os.path.exists(sentinel):
             first_time = False
-        else:
-            with open(sentinel, "w"):
-                pass
+            with open(sentinel) as fh:
+                state_changed = fh.read().strip() != cur_hash
+        if first_time or state_changed:
+            with open(sentinel, "w") as fh:
+                fh.write(cur_hash)
     except OSError:
         first_time = True
+        state_changed = True
 
 state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
@@ -124,14 +130,15 @@ if first_time:
         "github_workflow skill.\n"
         f"{state_block}"
     )
-elif state_block:
+elif state_block and state_changed:
     context = (
         "Lifecycle reminder (full rules were injected earlier this session; "
         "load the github_workflow skill for details).\n"
         f"{state_block}"
     )
 else:
-    # Rules already shown and no DAG state to report — nothing new to say.
+    # Rules already shown and the DAG state is unchanged (or absent) —
+    # nothing new to say.
     sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))

--- a/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# workflow_state_reminder.sh — inject the full lifecycle rules when a prompt
+# workflow_state_reminder.sh — inject the lifecycle rules when a prompt
 # mentions GitHub workflow actions, plus the current DAG state if available.
 # UserPromptSubmit hook. Receives prompt JSON on stdin.
+#
+# Token-efficiency (PI-649, ADR-028): injected context persists in the
+# transcript and is re-sent every turn, so the static rules block is injected
+# ONCE per session (sentinel file keyed on the stdin session_id); later
+# triggers get only the dynamic DAG state. Fail-open: no session_id or an
+# unwritable tmp dir falls back to injecting the full block every time.
 
 set -euo pipefail
 
@@ -39,11 +45,14 @@ PROJECT_KEY=$({ grep '^[[:space:]]*project_key:' "$_pi_config" 2>/dev/null || tr
   head -n1 | sed 's/#.*$//' | cut -d: -f2- | tr -d "[:space:]\"'" | tr '[:lower:]' '[:upper:]')
 [ -z "$PROJECT_KEY" ] && PROJECT_KEY="<KEY>"
 
-printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" PROJECT_KEY="$PROJECT_KEY" "$PY" -c '
+printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" PROJECT_KEY="$PROJECT_KEY" \
+  PI_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" "$PY" -c '
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
 
 try:
     data = json.load(sys.stdin)
@@ -67,35 +76,63 @@ if not trigger:
     sys.exit(0)
 
 dag_state = os.environ.get("DAG_STATE", "").strip()
-state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 key = os.environ.get("PROJECT_KEY", "").strip() or "<KEY>"
 
-context = (
-    "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
-    "\n"
-    "Lifecycle order (DAG):\n"
-    "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
-    "                                                  \\-> ci.green -+\n"
-    "                                                  \\-> review.approved -+-> pr.merged\n"
-    "\n"
-    "Use these scripts. Do NOT call the raw command — the DAG hook will block:\n"
-    "  - .agents/scripts/create_issue.sh    (not: gh issue create)\n"
-    "  - .agents/scripts/start_issue.sh     (not: gh pr create, for issue-backed)\n"
-    "  - .agents/scripts/create_nojira_pr.sh (not: gh pr create, for no-issue work)\n"
-    "  - .agents/scripts/push_branch.sh     (not: git push)\n"
-    "  - .agents/scripts/promote_review.sh  (not: gh pr ready)\n"
-    "  - .agents/scripts/monitor_pr.sh <pr> --merge   (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
-    "\n"
-    "Naming:\n"
-    f"  branch:     <type>/{key}-<n>-<kebab-slug>     e.g. feat/{key}-98-dag-workflow\n"
-    f"  PR title:   type({key}-N): description        e.g. feat({key}-98): Add DAG enforcement\n"
-    "              (no scope = no linked issue, e.g. fix: Correct typo) — ADR-006\n"
-    "  PR body:    must include `Closes #N`\n"
-    "\n"
-    "Iterating before push: edit, test, debug freely. The DAG only fires on\n"
-    "guarded commands (push, PR create/ready/merge). Push only when ready.\n"
-    f"{state_block}"
-)
+# Session-scoped dedup (ADR-028): the static rules are injected once per
+# session. The sentinel is keyed on the session_id from the hook payload plus
+# a project-dir hash (parallel sessions in different repos must not collide).
+# Any failure here falls back to first_time=True — the full block is safe,
+# just token-costly.
+first_time = True
+session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
+if session_id:
+    proj = hashlib.sha256(
+        os.environ.get("PI_PROJECT_DIR", "").encode()
+    ).hexdigest()[:8]
+    sentinel = os.path.join(
+        tempfile.gettempdir(), f"pi_wsr_{proj}_{session_id}"
+    )
+    try:
+        if os.path.exists(sentinel):
+            first_time = False
+        else:
+            with open(sentinel, "w"):
+                pass
+    except OSError:
+        first_time = True
+
+state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
+
+if first_time:
+    context = (
+        "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
+        "\n"
+        "Lifecycle order (DAG):\n"
+        "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
+        "                                                  \\-> ci.green -+\n"
+        "                                                  \\-> review.approved -+-> pr.merged\n"
+        "\n"
+        "Use the wrapper scripts in .agents/scripts/ — the guard blocks the raw commands:\n"
+        "  create_issue.sh (not: gh issue create) | start_issue.sh / create_nojira_pr.sh (not: gh pr create)\n"
+        "  push_branch.sh (not: git push) | promote_review.sh (not: gh pr ready)\n"
+        "  monitor_pr.sh <pr> --merge (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
+        "\n"
+        f"Naming: branch <type>/{key}-<n>-<kebab-slug> | "
+        f"PR title type({key}-N): description (no scope = no linked issue) | "
+        "body includes `Closes #N`\n"
+        "Details (review cycles, no-issue PRs, iterating before push): load the "
+        "github_workflow skill.\n"
+        f"{state_block}"
+    )
+elif state_block:
+    context = (
+        "Lifecycle reminder (full rules were injected earlier this session; "
+        "load the github_workflow skill for details).\n"
+        f"{state_block}"
+    )
+else:
+    # Rules already shown and no DAG state to report — nothing new to say.
+    sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
+++ b/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
@@ -79,11 +79,14 @@ dag_state = os.environ.get("DAG_STATE", "").strip()
 key = os.environ.get("PROJECT_KEY", "").strip() or "<KEY>"
 
 # Session-scoped dedup (ADR-028): the static rules are injected once per
-# session. The sentinel is keyed on the session_id from the hook payload plus
-# a project-dir hash (parallel sessions in different repos must not collide).
-# Any failure here falls back to first_time=True — the full block is safe,
-# just token-costly.
+# session, and the dynamic DAG state is re-injected only when it CHANGED
+# since the last injection (the sentinel stores its hash). The sentinel is
+# keyed on the session_id from the hook payload plus a project-dir hash
+# (parallel sessions in different repos must not collide). Any failure here
+# falls back to first_time=True — the full block is safe, just token-costly.
 first_time = True
+state_changed = True
+cur_hash = hashlib.sha256(dag_state.encode()).hexdigest()[:16]
 session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
 if session_id:
     proj = hashlib.sha256(
@@ -95,11 +98,14 @@ if session_id:
     try:
         if os.path.exists(sentinel):
             first_time = False
-        else:
-            with open(sentinel, "w"):
-                pass
+            with open(sentinel) as fh:
+                state_changed = fh.read().strip() != cur_hash
+        if first_time or state_changed:
+            with open(sentinel, "w") as fh:
+                fh.write(cur_hash)
     except OSError:
         first_time = True
+        state_changed = True
 
 state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 
@@ -124,14 +130,15 @@ if first_time:
         "github_workflow skill.\n"
         f"{state_block}"
     )
-elif state_block:
+elif state_block and state_changed:
     context = (
         "Lifecycle reminder (full rules were injected earlier this session; "
         "load the github_workflow skill for details).\n"
         f"{state_block}"
     )
 else:
-    # Rules already shown and no DAG state to report — nothing new to say.
+    # Rules already shown and the DAG state is unchanged (or absent) —
+    # nothing new to say.
     sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))

--- a/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
+++ b/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# workflow_state_reminder.sh — inject the full lifecycle rules when a prompt
+# workflow_state_reminder.sh — inject the lifecycle rules when a prompt
 # mentions GitHub workflow actions, plus the current DAG state if available.
 # UserPromptSubmit hook. Receives prompt JSON on stdin.
+#
+# Token-efficiency (PI-649, ADR-028): injected context persists in the
+# transcript and is re-sent every turn, so the static rules block is injected
+# ONCE per session (sentinel file keyed on the stdin session_id); later
+# triggers get only the dynamic DAG state. Fail-open: no session_id or an
+# unwritable tmp dir falls back to injecting the full block every time.
 
 set -euo pipefail
 
@@ -39,11 +45,14 @@ PROJECT_KEY=$({ grep '^[[:space:]]*project_key:' "$_pi_config" 2>/dev/null || tr
   head -n1 | sed 's/#.*$//' | cut -d: -f2- | tr -d "[:space:]\"'" | tr '[:lower:]' '[:upper:]')
 [ -z "$PROJECT_KEY" ] && PROJECT_KEY="<KEY>"
 
-printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" PROJECT_KEY="$PROJECT_KEY" "$PY" -c '
+printf '%s' "$INPUT" | DAG_STATE="$DAG_STATE" PROJECT_KEY="$PROJECT_KEY" \
+  PI_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}" "$PY" -c '
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
 
 try:
     data = json.load(sys.stdin)
@@ -67,35 +76,63 @@ if not trigger:
     sys.exit(0)
 
 dag_state = os.environ.get("DAG_STATE", "").strip()
-state_block = f"\n\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
 key = os.environ.get("PROJECT_KEY", "").strip() or "<KEY>"
 
-context = (
-    "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
-    "\n"
-    "Lifecycle order (DAG):\n"
-    "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
-    "                                                  \\-> ci.green -+\n"
-    "                                                  \\-> review.approved -+-> pr.merged\n"
-    "\n"
-    "Use these scripts. Do NOT call the raw command — the DAG hook will block:\n"
-    "  - .agents/scripts/create_issue.sh    (not: gh issue create)\n"
-    "  - .agents/scripts/start_issue.sh     (not: gh pr create, for issue-backed)\n"
-    "  - .agents/scripts/create_nojira_pr.sh (not: gh pr create, for no-issue work)\n"
-    "  - .agents/scripts/push_branch.sh     (not: git push)\n"
-    "  - .agents/scripts/promote_review.sh  (not: gh pr ready)\n"
-    "  - .agents/scripts/monitor_pr.sh <pr> --merge   (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
-    "\n"
-    "Naming:\n"
-    f"  branch:     <type>/{key}-<n>-<kebab-slug>     e.g. feat/{key}-98-dag-workflow\n"
-    f"  PR title:   type({key}-N): description        e.g. feat({key}-98): Add DAG enforcement\n"
-    "              (no scope = no linked issue, e.g. fix: Correct typo) — ADR-006\n"
-    "  PR body:    must include `Closes #N`\n"
-    "\n"
-    "Iterating before push: edit, test, debug freely. The DAG only fires on\n"
-    "guarded commands (push, PR create/ready/merge). Push only when ready.\n"
-    f"{state_block}"
-)
+# Session-scoped dedup (ADR-028): the static rules are injected once per
+# session. The sentinel is keyed on the session_id from the hook payload plus
+# a project-dir hash (parallel sessions in different repos must not collide).
+# Any failure here falls back to first_time=True — the full block is safe,
+# just token-costly.
+first_time = True
+session_id = re.sub(r"[^A-Za-z0-9_-]", "", str(data.get("session_id") or ""))[:64]
+if session_id:
+    proj = hashlib.sha256(
+        os.environ.get("PI_PROJECT_DIR", "").encode()
+    ).hexdigest()[:8]
+    sentinel = os.path.join(
+        tempfile.gettempdir(), f"pi_wsr_{proj}_{session_id}"
+    )
+    try:
+        if os.path.exists(sentinel):
+            first_time = False
+        else:
+            with open(sentinel, "w"):
+                pass
+    except OSError:
+        first_time = True
+
+state_block = f"\nCurrent DAG nodes:\n{dag_state}\n" if dag_state else ""
+
+if first_time:
+    context = (
+        "GitHub workflow rules (enforced by the dag_workflow.py guard hook):\n"
+        "\n"
+        "Lifecycle order (DAG):\n"
+        "  issue.created -> branch.created -> branch.pushed -> pr.opened\n"
+        "                                                  \\-> ci.green -+\n"
+        "                                                  \\-> review.approved -+-> pr.merged\n"
+        "\n"
+        "Use the wrapper scripts in .agents/scripts/ — the guard blocks the raw commands:\n"
+        "  create_issue.sh (not: gh issue create) | start_issue.sh / create_nojira_pr.sh (not: gh pr create)\n"
+        "  push_branch.sh (not: git push) | promote_review.sh (not: gh pr ready)\n"
+        "  monitor_pr.sh <pr> --merge (not: gh pr merge / gh api .../merge / gh pr checks --watch)\n"
+        "\n"
+        f"Naming: branch <type>/{key}-<n>-<kebab-slug> | "
+        f"PR title type({key}-N): description (no scope = no linked issue) | "
+        "body includes `Closes #N`\n"
+        "Details (review cycles, no-issue PRs, iterating before push): load the "
+        "github_workflow skill.\n"
+        f"{state_block}"
+    )
+elif state_block:
+    context = (
+        "Lifecycle reminder (full rules were injected earlier this session; "
+        "load the github_workflow skill for details).\n"
+        f"{state_block}"
+    )
+else:
+    # Rules already shown and no DAG state to report — nothing new to say.
+    sys.exit(0)
 
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": context}}))
 '

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -159,17 +159,30 @@ class TestPrePushLifecycleGate:
     """ADR-007: pre-push enforces branch naming with the same rule as dag_workflow.py."""
 
     @pytest.fixture(autouse=True)
-    def _scaffold(self, tmp_target: Path):
+    def _scaffold(self, tmp_target: Path, tmp_path: Path):
         self.target = tmp_target
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         self.hook = self.target / ".github" / "hooks" / "pre-push"
+        # Neutralize the hook's `just ci` gate: the hook runs from pytest's
+        # cwd (this repo), so with a real `just` on PATH and a CLEAN worktree
+        # the gate would run THIS repo's full suite — which re-runs this test,
+        # recursively, forever (PI-649 discovery; only the branch-naming rules
+        # are under test here). A stub `just` that exits nonzero makes the
+        # gate's `just --show ci` probe fail → deterministic fail-open.
+        stub_bin = tmp_path / "stub-bin"
+        stub_bin.mkdir(exist_ok=True)
+        stub = stub_bin / "just"
+        stub.write_text("#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+        self._gate_env = os.environ.copy()
+        self._gate_env["PATH"] = f"{stub_bin}:{self._gate_env['PATH']}"
 
     SHA = "a" * 40
     ZERO = "0" * 40
 
     def _push(self, remote_ref: str, local_sha: str | None = None):
         line = f"refs/heads/x {local_sha or self.SHA} {remote_ref} {self.ZERO}\n"
-        return _run_hook(self.hook, stdin=line)
+        return _run_hook(self.hook, stdin=line, env=self._gate_env)
 
     def test_blocks_push_to_main(self):
         result = self._push("refs/heads/main")

--- a/tests/integration/test_workflow_state_reminder.py
+++ b/tests/integration/test_workflow_state_reminder.py
@@ -102,7 +102,11 @@ class TestSessionScopedInjection:
         malicious = "../../../../etc/passwd"
         context = _run_hook(self.hook, "implement it", malicious, tmp_path)
         assert _STATIC_MARKER in context
-        assert not (tmp_path / ".." / ".." / "etc").exists()
+        # The sentinel landed INSIDE $TMPDIR, named with the sanitized id
+        # ("/" and "." stripped) — the strong form of the no-escape assertion.
+        sentinels = list(tmp_path.glob("pi_wsr_*"))
+        assert len(sentinels) == 1
+        assert sentinels[0].name.endswith("_etcpasswd")
         # The stripped id still dedups on repeat (silent: state unchanged).
         second = _run_hook(self.hook, "implement it", malicious, tmp_path)
         assert _STATIC_MARKER not in second

--- a/tests/integration/test_workflow_state_reminder.py
+++ b/tests/integration/test_workflow_state_reminder.py
@@ -1,0 +1,97 @@
+"""PI-649 (ADR-028): session-scoped injection for the workflow-state reminder.
+
+UserPromptSubmit context persists in the transcript and is re-sent every turn,
+so the static lifecycle-rules block is injected once per session (sentinel file
+keyed on session_id + project-dir hash); later triggers get only the dynamic
+DAG state. Fail-open: no session_id → full block every time. Enforcement
+(github_command_guard / dag_workflow.py guard) is untouched by this mechanism.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_STATIC_MARKER = "Lifecycle order (DAG):"
+_REPEAT_MARKER = "injected earlier this session"
+
+
+def _run_hook(hook: Path, prompt: str, session_id: str | None, tmpdir: Path) -> str:
+    """Run the hook with a synthetic UserPromptSubmit payload; return context."""
+    payload: dict = {"prompt": prompt, "hook_event_name": "UserPromptSubmit"}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmpdir)  # isolate sentinels per test
+    env["CLAUDE_PROJECT_DIR"] = str(hook.parents[2])
+    result = subprocess.run(
+        ["bash", str(hook)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    if not result.stdout.strip():
+        return ""
+    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+class TestSessionScopedInjection:
+    @pytest.fixture(autouse=True)
+    def _scaffold(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        self.hook = tmp_target / ".agents" / "hooks" / "workflow_state_reminder.sh"
+        assert self.hook.is_file()
+
+    def test_first_trigger_injects_full_rules(self, tmp_path: Path):
+        context = _run_hook(self.hook, "let's implement the feature", "sess-a", tmp_path)
+        assert _STATIC_MARKER in context
+        # The banned-command → wrapper map survives the trim.
+        assert "push_branch.sh" in context
+        assert "git push" in context
+        assert "Closes #N" in context
+        # Details defer to the on-demand skill instead of inlined prose.
+        assert "github_workflow skill" in context
+
+    def test_second_trigger_same_session_skips_static_block(self, tmp_path: Path):
+        _run_hook(self.hook, "implement it", "sess-b", tmp_path)
+        second = _run_hook(self.hook, "now push the branch", "sess-b", tmp_path)
+        assert _STATIC_MARKER not in second
+        # Either dynamic-state-only (with pointer) or fully silent — never the
+        # static block again.
+        if second:
+            assert _REPEAT_MARKER in second
+
+    def test_new_session_reinjects_full_rules(self, tmp_path: Path):
+        _run_hook(self.hook, "implement it", "sess-c", tmp_path)
+        fresh = _run_hook(self.hook, "implement it", "sess-d", tmp_path)
+        assert _STATIC_MARKER in fresh
+
+    def test_missing_session_id_fails_open_to_full_block(self, tmp_path: Path):
+        first = _run_hook(self.hook, "implement it", None, tmp_path)
+        again = _run_hook(self.hook, "implement it", None, tmp_path)
+        assert _STATIC_MARKER in first
+        assert _STATIC_MARKER in again
+
+    def test_non_workflow_prompt_stays_silent(self, tmp_path: Path):
+        assert _run_hook(self.hook, "explain this function", "sess-e", tmp_path) == ""
+
+    def test_session_id_is_sanitized_for_the_sentinel_path(self, tmp_path: Path):
+        """Path-traversal characters in session_id must not escape the temp dir
+        (and must not crash the hook)."""
+        malicious = "../../../../etc/passwd"
+        context = _run_hook(self.hook, "implement it", malicious, tmp_path)
+        assert _STATIC_MARKER in context
+        assert not (tmp_path / ".." / ".." / "etc").exists()
+        # The stripped id still dedups on repeat.
+        second = _run_hook(self.hook, "implement it", malicious, tmp_path)
+        assert _STATIC_MARKER not in second

--- a/tests/integration/test_workflow_state_reminder.py
+++ b/tests/integration/test_workflow_state_reminder.py
@@ -66,10 +66,21 @@ class TestSessionScopedInjection:
         _run_hook(self.hook, "implement it", "sess-b", tmp_path)
         second = _run_hook(self.hook, "now push the branch", "sess-b", tmp_path)
         assert _STATIC_MARKER not in second
-        # Either dynamic-state-only (with pointer) or fully silent — never the
-        # static block again.
-        if second:
-            assert _REPEAT_MARKER in second
+        # The DAG state is unchanged between the two triggers, so the repeat
+        # is fully silent (the sentinel stores the state hash).
+        assert second == ""
+
+    def test_changed_dag_state_reinjects_dynamic_block_only(self, tmp_path: Path):
+        first = _run_hook(self.hook, "implement it", "sess-b2", tmp_path)
+        assert _STATIC_MARKER in first
+        # Simulate a DAG-state change by poking the stored hash.
+        sentinels = list(tmp_path.glob("pi_wsr_*"))
+        assert len(sentinels) == 1
+        sentinels[0].write_text("stale-hash")
+        second = _run_hook(self.hook, "now push the branch", "sess-b2", tmp_path)
+        assert _STATIC_MARKER not in second
+        assert _REPEAT_MARKER in second
+        assert "Current DAG nodes:" in second
 
     def test_new_session_reinjects_full_rules(self, tmp_path: Path):
         _run_hook(self.hook, "implement it", "sess-c", tmp_path)
@@ -92,6 +103,7 @@ class TestSessionScopedInjection:
         context = _run_hook(self.hook, "implement it", malicious, tmp_path)
         assert _STATIC_MARKER in context
         assert not (tmp_path / ".." / ".." / "etc").exists()
-        # The stripped id still dedups on repeat.
+        # The stripped id still dedups on repeat (silent: state unchanged).
         second = _run_hook(self.hook, "implement it", malicious, tmp_path)
         assert _STATIC_MARKER not in second
+        assert second == ""


### PR DESCRIPTION
Closes #649

WS1 of epic #641 — the biggest measured token drain (~470 tokens re-injected 10–20×/session).

- **Session-scoped dedup (ADR-028):** sentinel file keyed on sanitized stdin `session_id` + project-dir hash. First trigger injects a **trimmed** rules block (~470 → ~200 tokens: every banned-command → wrapper mapping kept, tutorial prose deferred to the `github_workflow` skill). The sentinel stores a 16-char hash of the DAG state, so repeat triggers are **fully silent unless the state changed** — and inject only the dynamic block when it did.
- **Fail-open:** missing `session_id`, unwritable tmp, or any sentinel I/O error → previous full-injection behavior. Path-traversal in `session_id` is sanitized (tested).
- **Three hook copies in sync:** `.agents/hooks/` (+ `.claude` mirror via sync-claude), `templates/lifecycle_fallback/`, `project-init-lifecycle` plugin (sync_plugin).
- **Enforcement untouched:** the reminder is advisory UX; `github_command_guard.sh` → `dag_workflow.py guard` blocking is unchanged.
- 7 behavioral tests (`tests/integration/test_workflow_state_reminder.py`).

**Also fixes a latent test-infra bug discovered en route:** `TestPrePushLifecycleGate` ran the scaffolded pre-push from pytest's cwd; with `just` installed and a **clean** worktree its `just ci` gate re-ran this repo's suite recursively (forever). Masked locally by dirty trees and in CI by `just` being absent. Fixed with a stub `just` on PATH so the gate deterministically fail-opens.

`just lint` green; full suite 2027 passed / 8 skipped in 10s.