### PR TITLE
feat(PI-651): Cap failure-path hook output at 40 lines

### DIFF
--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -109,7 +109,7 @@ file, errors = sys.argv[1], sys.argv[2]
 lines = errors.splitlines()
 if len(lines) > 40:
     errors = '\n'.join(lines[:40]) + (
-        f'\n… output truncated ({len(lines)} lines total) — re-run the linter on the file for the full report.'
+        f'\n… output truncated ({len(lines)} lines total) — run \`just lint\` for the full report.'
     )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -103,6 +103,14 @@ if [ -n "$ERRORS" ]; then
   "$PY" -c "
 import json, sys
 file, errors = sys.argv[1], sys.argv[2]
+# Token-efficiency (PI-651, epic #641): injected context persists in the
+# transcript and is re-sent every turn — cap the error text; the first lines
+# carry the actionable findings and the linter has the full report.
+lines = errors.splitlines()
+if len(lines) > 40:
+    errors = '\n'.join(lines[:40]) + (
+        f'\n… output truncated ({len(lines)} lines total) — re-run the linter on the file for the full report.'
+    )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
 " "$FILE" "$ERRORS"

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -100,9 +100,13 @@ case "$FILE" in
 esac
 
 if [ -n "$ERRORS" ]; then
-  "$PY" -c "
+  # $ERRORS travels via stdin, not argv: a single argv entry is capped by the
+  # OS (~128KB on Linux), so exactly the hugest reports — the ones the cap
+  # exists for — would fail the exec with E2BIG and emit nothing (Codex review).
+  printf '%s' "$ERRORS" | "$PY" -c "
 import json, sys
-file, errors = sys.argv[1], sys.argv[2]
+file = sys.argv[1]
+errors = sys.stdin.read()
 # Token-efficiency (PI-651, epic #641): injected context persists in the
 # transcript and is re-sent every turn — cap the error text; the first lines
 # carry the actionable findings and the linter has the full report.
@@ -113,7 +117,7 @@ if len(lines) > 40:
     )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
-" "$FILE" "$ERRORS"
+" "$FILE"
 fi
 
 exit 0

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -145,9 +145,12 @@ if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ] &&
 fi
 
 if [ -n "$ERRORS" ]; then
-  "$PY" -c "
+  # $ERRORS travels via stdin, not argv: a single argv entry is capped by the
+  # OS (~128KB on Linux), so a huge lint report would fail the exec with E2BIG
+  # and the deny would never be emitted — a gate bypass (Codex review).
+  printf '%s' "$ERRORS" | "$PY" -c "
 import json, sys
-errors = sys.argv[1].replace('\\\\n', '\n')
+errors = sys.stdin.read().replace('\\\\n', '\n')
 # Token-efficiency (PI-651, epic #641): the deny reason persists in the
 # transcript and is re-sent every turn — cap the error text; the deny
 # decision itself is unchanged and 'just lint' has the full report.
@@ -158,7 +161,7 @@ if len(lines) > 40:
     )
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
-" "$ERRORS"
+"
 fi
 
 exit 0

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -148,6 +148,14 @@ if [ -n "$ERRORS" ]; then
   "$PY" -c "
 import json, sys
 errors = sys.argv[1].replace('\\\\n', '\n')
+# Token-efficiency (PI-651, epic #641): the deny reason persists in the
+# transcript and is re-sent every turn — cap the error text; the deny
+# decision itself is unchanged and 'just lint' has the full report.
+lines = errors.splitlines()
+if len(lines) > 40:
+    errors = '\n'.join(lines[:40]) + (
+        f'\n… output truncated ({len(lines)} lines total) — run \`just lint\` for the full report.'
+    )
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
 " "$ERRORS"

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -109,7 +109,7 @@ file, errors = sys.argv[1], sys.argv[2]
 lines = errors.splitlines()
 if len(lines) > 40:
     errors = '\n'.join(lines[:40]) + (
-        f'\n… output truncated ({len(lines)} lines total) — re-run the linter on the file for the full report.'
+        f'\n… output truncated ({len(lines)} lines total) — run \`just lint\` for the full report.'
     )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -103,6 +103,14 @@ if [ -n "$ERRORS" ]; then
   "$PY" -c "
 import json, sys
 file, errors = sys.argv[1], sys.argv[2]
+# Token-efficiency (PI-651, epic #641): injected context persists in the
+# transcript and is re-sent every turn — cap the error text; the first lines
+# carry the actionable findings and the linter has the full report.
+lines = errors.splitlines()
+if len(lines) > 40:
+    errors = '\n'.join(lines[:40]) + (
+        f'\n… output truncated ({len(lines)} lines total) — re-run the linter on the file for the full report.'
+    )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
 " "$FILE" "$ERRORS"

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -100,9 +100,13 @@ case "$FILE" in
 esac
 
 if [ -n "$ERRORS" ]; then
-  "$PY" -c "
+  # $ERRORS travels via stdin, not argv: a single argv entry is capped by the
+  # OS (~128KB on Linux), so exactly the hugest reports — the ones the cap
+  # exists for — would fail the exec with E2BIG and emit nothing (Codex review).
+  printf '%s' "$ERRORS" | "$PY" -c "
 import json, sys
-file, errors = sys.argv[1], sys.argv[2]
+file = sys.argv[1]
+errors = sys.stdin.read()
 # Token-efficiency (PI-651, epic #641): injected context persists in the
 # transcript and is re-sent every turn — cap the error text; the first lines
 # carry the actionable findings and the linter has the full report.
@@ -113,7 +117,7 @@ if len(lines) > 40:
     )
 ctx = f'Lint errors in {file} (after auto-fix attempt) — please fix before continuing:\n{errors}'
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': ctx}}))
-" "$FILE" "$ERRORS"
+" "$FILE"
 fi
 
 exit 0

--- a/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
@@ -145,9 +145,12 @@ if command -v just >/dev/null 2>&1 && [ -f "$ROOT/justfile" ] &&
 fi
 
 if [ -n "$ERRORS" ]; then
-  "$PY" -c "
+  # $ERRORS travels via stdin, not argv: a single argv entry is capped by the
+  # OS (~128KB on Linux), so a huge lint report would fail the exec with E2BIG
+  # and the deny would never be emitted — a gate bypass (Codex review).
+  printf '%s' "$ERRORS" | "$PY" -c "
 import json, sys
-errors = sys.argv[1].replace('\\\\n', '\n')
+errors = sys.stdin.read().replace('\\\\n', '\n')
 # Token-efficiency (PI-651, epic #641): the deny reason persists in the
 # transcript and is re-sent every turn — cap the error text; the deny
 # decision itself is unchanged and 'just lint' has the full report.
@@ -158,7 +161,7 @@ if len(lines) > 40:
     )
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
-" "$ERRORS"
+"
 fi
 
 exit 0

--- a/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
@@ -148,6 +148,14 @@ if [ -n "$ERRORS" ]; then
   "$PY" -c "
 import json, sys
 errors = sys.argv[1].replace('\\\\n', '\n')
+# Token-efficiency (PI-651, epic #641): the deny reason persists in the
+# transcript and is re-sent every turn — cap the error text; the deny
+# decision itself is unchanged and 'just lint' has the full report.
+lines = errors.splitlines()
+if len(lines) > 40:
+    errors = '\n'.join(lines[:40]) + (
+        f'\n… output truncated ({len(lines)} lines total) — run \`just lint\` for the full report.'
+    )
 msg = 'Pre-commit lint check failed. Fix these errors before committing:\n\n' + errors
 print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': msg}}))
 " "$ERRORS"

--- a/tests/integration/test_hook_output_caps.py
+++ b/tests/integration/test_hook_output_caps.py
@@ -82,6 +82,7 @@ class TestPostEditLintCap:
         ctx = self._run(work, bad)
         assert "Lint errors in" in ctx
         assert "output truncated" in ctx
+        assert "just lint" in ctx  # the trailer's pointer to the full report
         # 40 capped lines + header + trailer, with generous slack — never the
         # full 60-error dump (ruff emits several lines per finding).
         assert len(ctx.splitlines()) < 50

--- a/tests/integration/test_hook_output_caps.py
+++ b/tests/integration/test_hook_output_caps.py
@@ -112,6 +112,20 @@ class TestPreCommitGateCap:
         assert result.returncode == 0, result.stderr
         return json.loads(result.stdout)["hookSpecificOutput"]
 
+    def test_huge_report_exceeding_arg_limit_still_denies(self, tmp_path: Path):
+        """A report larger than the OS single-argv cap (~128KB on Linux) must
+        still produce the capped deny — passing $ERRORS as argv used to fail
+        the exec with E2BIG and silently skip the deny (gate bypass; Codex
+        review on PI-651). $ERRORS now travels via stdin."""
+        work = _make_workdir(tmp_path, "pre_commit_gate.sh")
+        subprocess.run(["git", "init", "-q"], cwd=work, check=True, capture_output=True)
+        bad = work / "bad.py"
+        _noisy_py(bad, 3000)  # ruff report comfortably exceeds 128KB
+        subprocess.run(["git", "add", "bad.py"], cwd=work, check=True, capture_output=True)
+        out = self._run_gate(work)
+        assert out["permissionDecision"] == "deny"
+        assert "output truncated" in out["permissionDecisionReason"]
+
     def test_oversized_deny_reason_is_capped_but_still_denies(self, tmp_path: Path):
         work = _make_workdir(tmp_path, "pre_commit_gate.sh")
         subprocess.run(["git", "init", "-q"], cwd=work, check=True, capture_output=True)

--- a/tests/integration/test_hook_output_caps.py
+++ b/tests/integration/test_hook_output_caps.py
@@ -1,0 +1,126 @@
+"""PI-651 (epic #641): failure-path hook output is capped before injection.
+
+`post_edit_lint.sh` (PostToolUse additionalContext) and `pre_commit_gate.sh`
+(PreToolUse deny reason) persist their text in the transcript, re-sent every
+turn — so the injected error report is capped at 40 lines with a trailer
+pointing at the full report. The deny/allow decisions themselves are
+unchanged: a failing gate still denies, whatever the output size.
+
+The hooks are exercised from a bare (non-uv) temp repo with the repo venv's
+ruff on PATH, so the system-ruff branch runs deterministically offline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOKS_SRC = _REPO_ROOT / "templates" / "fallback" / "dot_agents" / "hooks"
+_VENV_BIN = Path(sys.executable).parent
+
+pytestmark = pytest.mark.skipif(
+    not (_VENV_BIN / "ruff").exists() and shutil.which("ruff") is None,
+    reason="ruff not available",
+)
+
+
+def _hook_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{_VENV_BIN}:{env['PATH']}"
+    return env
+
+
+def _make_workdir(tmp_path: Path, *hooks: str) -> Path:
+    """A bare working dir (no pyproject/uv.lock → system-ruff branch)."""
+    work = tmp_path / "work"
+    hooks_dir = work / ".agents" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    for name in (*hooks, "_usage_log.sh"):
+        shutil.copy(_HOOKS_SRC / name, hooks_dir / name)
+    # _py.sh lives in the base layer (always copied by the scaffolder).
+    shutil.copy(
+        _REPO_ROOT / "templates" / "base" / "dot_agents" / "hooks" / "_py.sh",
+        hooks_dir / "_py.sh",
+    )
+    return work
+
+
+def _noisy_py(path: Path, errors: int) -> None:
+    # F821 (undefined name) is default-on and NOT auto-fixable → each line
+    # survives the --fix pass and lands in the reported errors.
+    path.write_text("".join(f"print(undefined_name_{i})\n" for i in range(errors)))
+
+
+class TestPostEditLintCap:
+    def _run(self, work: Path, file_path: Path) -> str:
+        payload = json.dumps({"tool_input": {"file_path": str(file_path)}})
+        result = subprocess.run(
+            ["bash", str(work / ".agents" / "hooks" / "post_edit_lint.sh")],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=work,
+            env=_hook_env(),
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        if not result.stdout.strip():
+            return ""
+        return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+    def test_oversized_lint_output_is_capped_with_trailer(self, tmp_path: Path):
+        work = _make_workdir(tmp_path, "post_edit_lint.sh")
+        bad = work / "bad.py"
+        _noisy_py(bad, 60)
+        ctx = self._run(work, bad)
+        assert "Lint errors in" in ctx
+        assert "output truncated" in ctx
+        # 40 capped lines + header + trailer, with generous slack — never the
+        # full 60-error dump (ruff emits several lines per finding).
+        assert len(ctx.splitlines()) < 50
+        assert "undefined_name_0" in ctx  # the first findings survive
+
+    def test_small_lint_output_is_not_truncated(self, tmp_path: Path):
+        work = _make_workdir(tmp_path, "post_edit_lint.sh")
+        bad = work / "bad.py"
+        _noisy_py(bad, 2)
+        ctx = self._run(work, bad)
+        assert "Lint errors in" in ctx
+        assert "output truncated" not in ctx
+
+
+class TestPreCommitGateCap:
+    def _run_gate(self, work: Path) -> dict:
+        payload = json.dumps({"tool_input": {"command": "git commit -m x"}})
+        result = subprocess.run(
+            ["bash", str(work / ".agents" / "hooks" / "pre_commit_gate.sh")],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=work,
+            env=_hook_env(),
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)["hookSpecificOutput"]
+
+    def test_oversized_deny_reason_is_capped_but_still_denies(self, tmp_path: Path):
+        work = _make_workdir(tmp_path, "pre_commit_gate.sh")
+        subprocess.run(["git", "init", "-q"], cwd=work, check=True, capture_output=True)
+        bad = work / "bad.py"
+        _noisy_py(bad, 60)
+        subprocess.run(["git", "add", "bad.py"], cwd=work, check=True, capture_output=True)
+        out = self._run_gate(work)
+        # Quality guardrail: the decision is untouched — only the text is capped.
+        assert out["permissionDecision"] == "deny"
+        reason = out["permissionDecisionReason"]
+        assert "output truncated" in reason
+        assert "just lint" in reason
+        assert len(reason.splitlines()) < 50


### PR DESCRIPTION
Closes #651

WS4 of epic #641. `post_edit_lint.sh` (PostToolUse `additionalContext`) and `pre_commit_gate.sh` (PreToolUse deny reason) piped raw linter output into context on failure — text that persists in the transcript and is re-sent every turn.

- Injected error text is now capped at **40 lines** inside each hook's Python emitter, with a trailer: "… output truncated (N lines total) — run `just lint` for the full report."
- **Decisions unchanged**: a failing gate still denies; only the reason/context text is capped. The first 40 lines carry the actionable findings.
- Plugin copies re-synced via `tools/sync_plugin.py` (this repo itself doesn't ship these two hooks).
- 3 behavioral tests (`tests/integration/test_hook_output_caps.py`): oversized output capped with trailer (both hooks), small output untouched, deny decision preserved — exercised offline via a bare non-uv temp repo with the venv's ruff.

`just lint` green; full suite 2026 passed / 8 skipped.