### PR TITLE
feat(PI-653): Quiet monitor_pr review-wait frames to state changes only

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Wait for all CI checks on a PR, then optionally merge.
-# Prints CI failures and the final pass line; the review-wait loop also logs
-# periodic progress (every ~30s) so a long wait isn't silent.
+# Prints CI failures and the final pass line; the review-wait loop logs a
+# frame only when reviewDecision changes (PI-653) — no per-poll noise.
 # Requires: gh, python3 (stdlib only — no jq dependency).
 #
 # Usage:
@@ -224,11 +224,18 @@ fi
 if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; then
   echo "Waiting for reviewer (up to ${REVIEW_TIMEOUT}s, polling every 30s) — reviewDecision: ${REVIEW_DECISION}"
 fi
+# Token-efficiency (PI-653, epic #641): the poll loop echoes a frame only when
+# reviewDecision CHANGES — identical repeated frames persist in the agent's
+# transcript and are re-sent every turn. Terminal summaries are unchanged.
+LAST_DECISION="$REVIEW_DECISION"
 while { [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; } && [ "$REVIEW_ELAPSED" -lt "$REVIEW_TIMEOUT" ]; do
   sleep 30
   REVIEW_ELAPSED=$((REVIEW_ELAPSED + 30))
   REVIEW_DECISION=$(_get_review_decision)
-  echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+  if [ "$REVIEW_DECISION" != "$LAST_DECISION" ]; then
+    echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+    LAST_DECISION="$REVIEW_DECISION"
+  fi
   # Early exit: if any review activity exists (even COMMENTED), stop waiting.
   # Bot reviewers like Codex post comments without changing reviewDecision.
   if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] && _has_review_activity; then

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Wait for all CI checks on a PR, then optionally merge.
-# Prints CI failures and the final pass line; the review-wait loop also logs
-# periodic progress (every ~30s) so a long wait isn't silent.
+# Prints CI failures and the final pass line; the review-wait loop logs a
+# frame only when reviewDecision changes (PI-653) — no per-poll noise.
 # Requires: gh, python3 (stdlib only — no jq dependency).
 #
 # Usage:
@@ -224,11 +224,18 @@ fi
 if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; then
   echo "Waiting for reviewer (up to ${REVIEW_TIMEOUT}s, polling every 30s) — reviewDecision: ${REVIEW_DECISION}"
 fi
+# Token-efficiency (PI-653, epic #641): the poll loop echoes a frame only when
+# reviewDecision CHANGES — identical repeated frames persist in the agent's
+# transcript and are re-sent every turn. Terminal summaries are unchanged.
+LAST_DECISION="$REVIEW_DECISION"
 while { [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; } && [ "$REVIEW_ELAPSED" -lt "$REVIEW_TIMEOUT" ]; do
   sleep 30
   REVIEW_ELAPSED=$((REVIEW_ELAPSED + 30))
   REVIEW_DECISION=$(_get_review_decision)
-  echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+  if [ "$REVIEW_DECISION" != "$LAST_DECISION" ]; then
+    echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+    LAST_DECISION="$REVIEW_DECISION"
+  fi
   # Early exit: if any review activity exists (even COMMENTED), stop waiting.
   # Bot reviewers like Codex post comments without changing reviewDecision.
   if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] && _has_review_activity; then

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -270,11 +270,18 @@ fi
 if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; then
   echo "Waiting for reviewer (up to ${REVIEW_TIMEOUT}s, polling every 30s) — reviewDecision: ${REVIEW_DECISION}"
 fi
+# Token-efficiency (PI-653, epic #641): the poll loop echoes a frame only when
+# reviewDecision CHANGES — identical repeated frames persist in the agent's
+# transcript and are re-sent every turn. Terminal summaries are unchanged.
+LAST_DECISION="$REVIEW_DECISION"
 while { [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] || [ "$REVIEW_DECISION" = "UNKNOWN" ]; } && [ "$REVIEW_ELAPSED" -lt "$REVIEW_TIMEOUT" ]; do
   sleep 30
   REVIEW_ELAPSED=$((REVIEW_ELAPSED + 30))
   REVIEW_DECISION=$(_get_review_decision)
-  echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+  if [ "$REVIEW_DECISION" != "$LAST_DECISION" ]; then
+    echo "  [${REVIEW_ELAPSED}s/${REVIEW_TIMEOUT}s] reviewDecision: ${REVIEW_DECISION:-none}"
+    LAST_DECISION="$REVIEW_DECISION"
+  fi
   # Early exit: if any review activity exists (even COMMENTED), stop waiting.
   # Bot reviewers like Codex post comments without changing reviewDecision.
   if [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ] && _has_review_activity; then

--- a/tests/integration/test_monitor_pr_quiet_frames.py
+++ b/tests/integration/test_monitor_pr_quiet_frames.py
@@ -1,0 +1,86 @@
+"""PI-653 (epic #641): monitor_pr.sh review-wait frames only on state change.
+
+The review-wait poll loop previously echoed an identical
+`[Ns/360s] reviewDecision: REVIEW_REQUIRED` frame every 30s into the agent's
+transcript. It now echoes a frame only when reviewDecision changes; the
+initial wait line and all terminal summaries are unchanged.
+
+Exercised with stubbed `gh` (scripted decision sequence) and a no-op `sleep`
+so the loop runs its iterations instantly and offline.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_GH_STUB = """#!/bin/bash
+# Scripted gh: reviewDecision is REVIEW_REQUIRED for the first 4 reads, then
+# APPROVED. Everything else returns minimal happy-path answers.
+STATE_DIR="${GH_STUB_DIR:?}"
+case "$*" in
+*"pr checks"*)
+  echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]'
+  ;;
+*"--json reviewDecision"*)
+  n=$(cat "$STATE_DIR/count" 2>/dev/null || echo 0)
+  echo $((n + 1)) >"$STATE_DIR/count"
+  if [ "$n" -lt 4 ]; then echo "REVIEW_REQUIRED"; else echo "APPROVED"; fi
+  ;;
+*"--json reviews"*)
+  echo 0
+  ;;
+*"--json url"*)
+  echo "https://example.invalid/pr/1"
+  ;;
+*)
+  exit 0
+  ;;
+esac
+"""
+
+
+def test_review_wait_frames_only_on_decision_change(tmp_target: Path, tmp_path: Path):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    script = tmp_target / ".agents" / "scripts" / "monitor_pr.sh"
+    assert script.is_file()
+
+    stub_bin = tmp_path / "stub-bin"
+    stub_bin.mkdir()
+    gh = stub_bin / "gh"
+    gh.write_text(_GH_STUB)
+    gh.chmod(0o755)
+    slp = stub_bin / "sleep"
+    slp.write_text("#!/bin/sh\nexit 0\n")
+    slp.chmod(0o755)
+
+    state = tmp_path / "state"
+    state.mkdir()
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}:{env['PATH']}"
+    env["GH_STUB_DIR"] = str(state)
+
+    result = subprocess.run(
+        ["bash", str(script), "1"],  # monitor-only, no --merge
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    out = result.stdout
+    assert result.returncode == 0, result.stderr + out
+
+    # Initial wait line present; poll iterations with an UNCHANGED decision
+    # are silent — the only frame is the transition to APPROVED.
+    assert "Waiting for reviewer" in out
+    frames = [ln for ln in out.splitlines() if "] reviewDecision:" in ln]
+    assert len(frames) == 1, out
+    assert "APPROVED" in frames[0]
+    # Terminal summary unchanged.
+    assert "passed" in out


### PR DESCRIPTION
Closes #653

WS5 of epic #641. The review-wait poll loop echoed an identical `[Ns/360s] reviewDecision: REVIEW_REQUIRED` frame every 30s into the agent transcript (up to 12 lines per run, repeated across review cycles, re-sent every turn).

- Frames now print **only when `reviewDecision` changes**; the initial "Waiting for reviewer…" line and all terminal summaries are unchanged. No timing or decision logic touched.
- Both copies patched: `templates/lifecycle/dot_agents/scripts/monitor_pr.sh` and this repo's `.agents/scripts/monitor_pr.sh` (+ `.claude` mirror via sync-claude); stale header comment in the repo copy corrected.
- Behavioral test (`tests/integration/test_monitor_pr_quiet_frames.py`): stubbed `gh` scripts a 4×REVIEW_REQUIRED→APPROVED sequence with no-op `sleep`; asserts exactly one frame (the transition) and intact terminal summary.

`just lint` green; full suite 2024 passed / 8 skipped.