### PR TITLE
feat(PI-655): Attribute tool_result context volume per tool in usage_report

### DIFF
--- a/templates/observability/dot_agents/observability/usage_report.py
+++ b/templates/observability/dot_agents/observability/usage_report.py
@@ -160,10 +160,14 @@ def _content_chars(content: object) -> int:
     if isinstance(content, str):
         return len(content)
     if isinstance(content, list):
+        # A malformed block (non-string "text") counts 0 instead of aborting
+        # the whole report — same resilience posture as _safe_int.
         return sum(
-            len(b.get("text") or "")
+            len(text)
             for b in content
             if isinstance(b, dict) and b.get("type") == "text"
+            for text in (b.get("text"),)
+            if isinstance(text, str)
         )
     return 0
 

--- a/templates/observability/dot_agents/observability/usage_report.py
+++ b/templates/observability/dot_agents/observability/usage_report.py
@@ -491,6 +491,9 @@ def _bars(d: dict[str, int]) -> str:
 
 def render_html(report: dict, transcript: Path) -> str:
     a, c, p, r = (report[k] for k in ("adoption", "cost", "productivity", "reliability"))
+    contributors = dict(
+        sorted(c.get("context_contributors", {}).items(), key=lambda kv: (-kv[1], kv[0]))[:10]
+    )
     rows = "".join(
         f"<tr><td>{escape(row['model'])}</td><td>{row['messages']}</td>"
         f"<td>{row['input']:,}</td><td>{row['output']:,}</td>"
@@ -536,6 +539,8 @@ def render_html(report: dict, transcript: Path) -> str:
 <h2>Cost by model</h2>
 <table><tr><th>Model</th><th>Msgs</th><th>Input</th><th>Output</th><th>Cache read</th><th>Cost</th></tr>
 {rows}</table>
+<h2>Top context contributors (tool_result chars)</h2>{_bars(contributors)}
+<p class="muted">Summed tool_result size per tool — every char is re-sent each later turn (PI-655).</p>
 <h2>Reliability — errors by tool</h2>{_bars(r["errors_by_tool"])}
 <p class="muted">Accept/reject and exact active-time are OTEL-only and not captured here.</p>
 </body></html>

--- a/templates/observability/dot_agents/observability/usage_report.py
+++ b/templates/observability/dot_agents/observability/usage_report.py
@@ -151,6 +151,23 @@ def _count_lines(text: object) -> int:
     return text.count("\n") + 1
 
 
+def _content_chars(content: object) -> int:
+    """Size of a tool_result content payload in characters, content discarded.
+
+    tool_result content is either a plain string or a list of typed blocks
+    (text/image/...); only text sizes are counted, nothing is retained.
+    """
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        return sum(
+            len(b.get("text") or "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return 0
+
+
 def _safe_int(value: object) -> int:
     """Best-effort int cast — a malformed (non-numeric) token field yields 0.
 
@@ -173,6 +190,7 @@ def parse_transcript(path: Path) -> dict:
     models: dict[str, dict[str, int]] = {}
     tool_use_names: dict[str, str] = {}  # tool_use_id -> tool name (for reliability)
     tool_errors: dict[str, int] = {}
+    tool_result_chars: dict[str, int] = {}  # tool name -> summed result size (PI-655)
     tool_calls = 0
     tool_results = 0
     loc_added = 0
@@ -231,10 +249,17 @@ def parse_transcript(path: Path) -> dict:
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "tool_result":
                         tool_results += 1
+                        tid = block.get("tool_use_id")
+                        name = tool_use_names.get(tid, "?") if isinstance(tid, str) else "?"
                         if block.get("is_error"):
-                            tid = block.get("tool_use_id")
-                            name = tool_use_names.get(tid, "?") if isinstance(tid, str) else "?"
                             tool_errors[name] = tool_errors.get(name, 0) + 1
+                        # Context-volume attribution (PI-655, epic #641): every
+                        # result char is re-sent each subsequent turn, so per-tool
+                        # volume shows where the session's context went. Sizes
+                        # only — the text itself is discarded (privacy rule).
+                        chars = _content_chars(block.get("content"))
+                        if chars:
+                            tool_result_chars[name] = tool_result_chars.get(name, 0) + chars
 
     return {
         "skills": skills,
@@ -245,6 +270,7 @@ def parse_transcript(path: Path) -> dict:
         "tool_calls": tool_calls,
         "tool_results": tool_results,
         "tool_errors": tool_errors,
+        "tool_result_chars": tool_result_chars,
         "loc_added": loc_added,
         "edits": edits,
         "writes": writes,
@@ -352,6 +378,10 @@ def analyze(raw: dict, hooks: dict[str, int], git: dict) -> dict:
             "total_tokens": total_tokens,
             "cache_read_ratio": round(cache_ratio, 4),
             "approximate": True,
+            # Where the transcript's context volume came from (PI-655): summed
+            # tool_result chars per tool. Chars, not tokens — exact from the
+            # transcript; ≈tokens at 4 chars/token is applied at render time.
+            "context_contributors": raw.get("tool_result_chars", {}),
         },
         "productivity": {
             "loc_added_approx": raw["loc_added"],
@@ -411,6 +441,17 @@ def render_text(report: dict, transcript: Path) -> str:
             for row in c["models"]
         ]
     )
+    contributors = sorted(
+        c.get("context_contributors", {}).items(), key=lambda kv: (-kv[1], kv[0])
+    )[:10]
+    lines += ["", "== Top context contributors (tool_result volume) =="]
+    if contributors:
+        lines.extend(
+            f"    {name}: {chars:,} chars (≈{chars // 4:,} tokens)"
+            for name, chars in contributors
+        )
+    else:
+        lines.append("    (none)")
     lines += [
         "",
         "== Productivity ==",

--- a/tests/contracts/test_observability_report.py
+++ b/tests/contracts/test_observability_report.py
@@ -80,9 +80,11 @@ def _write_transcript(path: Path) -> None:
             "message": {
                 "content": [
                     # List-form content (typed blocks) — exercises the block path
-                    # of the context-volume counter (PI-655).
+                    # of the context-volume counter (PI-655). The malformed
+                    # non-string "text" block must count 0, not crash the report.
                     {"type": "tool_result", "tool_use_id": "t1", "is_error": False,
-                     "content": [{"type": "text", "text": "ok"}]},
+                     "content": [{"type": "text", "text": "ok"},
+                                 {"type": "text", "text": 123}]},
                     {"type": "tool_result", "tool_use_id": "t3", "is_error": True, "content": "boom"},
                 ]
             },

--- a/tests/contracts/test_observability_report.py
+++ b/tests/contracts/test_observability_report.py
@@ -79,7 +79,10 @@ def _write_transcript(path: Path) -> None:
             "type": "user",
             "message": {
                 "content": [
-                    {"type": "tool_result", "tool_use_id": "t1", "is_error": False, "content": "ok"},
+                    # List-form content (typed blocks) — exercises the block path
+                    # of the context-volume counter (PI-655).
+                    {"type": "tool_result", "tool_use_id": "t1", "is_error": False,
+                     "content": [{"type": "text", "text": "ok"}]},
                     {"type": "tool_result", "tool_use_id": "t3", "is_error": True, "content": "boom"},
                 ]
             },
@@ -126,6 +129,13 @@ class TestBuckets:
         assert cost["total_cost_usd"] > 0
         assert 0 < cost["cache_read_ratio"] <= 1
         assert cost["approximate"] is True
+        # Context-volume attribution (PI-655): summed tool_result chars per
+        # tool — "ok" (2, list-form) for Skill, "boom" (4, string) for Bash.
+        assert cost["context_contributors"] == {"Skill": 2, "Bash": 4}
+        text = mod.render_text(report, tx)
+        assert "Top context contributors" in text
+        html = mod.render_html(report, tx)
+        assert "Top context contributors" in html
 
         prod = report["productivity"]
         assert prod["loc_added_approx"] == 5  # 3-line Write + 2-line Edit


### PR DESCRIPTION
Closes #655

WS6 of epic #641 — the measurement piece that lets WS1/WS4/WS5 be verified against real sessions.

- `parse_transcript` now sums `tool_result` content size (chars) per tool name during the existing single pass, via the existing `tool_use_id → name` map. Handles both string and typed-block content forms. **Aggregate sizes only — no content kept** (existing privacy rule).
- New "Top context contributors" section in both text (`chars` + ≈tokens at 4 chars/token) and HTML (bar chart, top 10) renders, under the Cost bucket (`context_contributors`).
- Per-hook attribution deliberately out of scope: `usage.jsonl` already counts hook firings and payloads are static.
- Tests: fixture transcript extended with a typed-block tool_result; asserts exact per-tool char attribution and section presence in both renders.

`just lint` green; full suite 2023 passed / 8 skipped.