### PR TITLE
chore(PI-659): Dedupe project-init.md format table and compaction list

### DIFF
--- a/templates/base/dot_agents/project-init.md.tmpl
+++ b/templates/base/dot_agents/project-init.md.tmpl
@@ -108,9 +108,9 @@ This project is **single-trunk**: feature PRs target `main` and merge by squash.
 ### Commit and PR format
 
 Commit messages, PR titles, and branch names follow the quick-ref in
-[AGENTS.md](../AGENTS.md) (single source: `type(KEY-N): description`, branch
-`<type>/<KEY>-<n>-<slug>`, body includes `Closes #<n>`). Commit messages use
-the same format as PR titles. Types: `feat` · `fix` · `chore` · `docs` · `test`
+[AGENTS.md](../AGENTS.md) — the single source for those formats. Commit
+messages use the same format as PR titles.
+Types: `feat` · `fix` · `chore` · `docs` · `test`
 
 For minor work without an issue, use `.agents/scripts/create_nojira_pr.sh <type> "description"`.
 It creates or reuses a typed `nojira` branch, pushes through `push_branch.sh`,

--- a/templates/base/dot_agents/project-init.md.tmpl
+++ b/templates/base/dot_agents/project-init.md.tmpl
@@ -107,15 +107,10 @@ This project is **single-trunk**: feature PRs target `main` and merge by squash.
 
 ### Commit and PR format
 
-| What | Format | Example |
-|------|--------|---------|
-| Commit message | `<type>(KEY-<n>): description` | `feat(PI-42): Add OAuth login` |
-| PR title | `<type>(KEY-<n>): description` | `feat(PI-42): Add OAuth login` |
-| No-issue PR | `<type>: description` (no scope) | `fix: Fix typo` |
-| PR body | must include `Closes #<n>` | triggers auto-close on merge |
-| Branch | `<type>/<KEY>-<n>-<slug>` | `feat/PI-42-add-oauth-login` |
-
-Types: `feat` · `fix` · `chore` · `docs` · `test`
+Commit messages, PR titles, and branch names follow the quick-ref in
+[AGENTS.md](../AGENTS.md) (single source: `type(KEY-N): description`, branch
+`<type>/<KEY>-<n>-<slug>`, body includes `Closes #<n>`). Commit messages use
+the same format as PR titles. Types: `feat` · `fix` · `chore` · `docs` · `test`
 
 For minor work without an issue, use `.agents/scripts/create_nojira_pr.sh <type> "description"`.
 It creates or reuses a typed `nojira` branch, pushes through `push_branch.sh`,
@@ -172,9 +167,5 @@ gh pr list                                            # open PRs
 
 ## Compact Instructions
 
-When compacting, preserve:
-- GitHub Issue number being worked on
-- Files modified this session
-- Test results (pass/fail count, failing test names)
-- Unresolved errors or lint failures
-- Decisions not yet committed to `.agents/docs/adr/`
+Compaction is a Claude Code mechanism; the canonical preserve-list lives in
+[CLAUDE.md](../CLAUDE.md) (single source — do not duplicate it here).

--- a/tests/contracts/test_project_init_md_dedupe.py
+++ b/tests/contracts/test_project_init_md_dedupe.py
@@ -10,6 +10,7 @@ surfaces).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from project_init.scaffold import scaffold
@@ -38,8 +39,17 @@ class TestProjectInitMdDedupe:
         assert "CLAUDE.md" in project_init  # pointer present
 
     def test_pointer_links_resolve(self, tmp_target: Path):
-        """project-init.md lives in .agents/, so its ../ hrefs must resolve."""
+        """project-init.md lives in .agents/, so the ACTUAL hrefs in the
+        rendered file must resolve from there (a link to plain `AGENTS.md`
+        instead of `../AGENTS.md` would be broken)."""
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        base = tmp_target / ".agents"
-        assert (base / ".." / "AGENTS.md").resolve().exists()
-        assert (base / ".." / "CLAUDE.md").resolve().exists()
+        source = tmp_target / ".agents" / "project-init.md"
+        content = source.read_text()
+        hrefs = re.findall(r"\]\(([^)#]+)\)", content)
+        pointer_hrefs = [h for h in hrefs if h.endswith(("AGENTS.md", "CLAUDE.md"))]
+        # Both dedup pointers are present as real links...
+        assert any(h.endswith("AGENTS.md") for h in pointer_hrefs)
+        assert any(h.endswith("CLAUDE.md") for h in pointer_hrefs)
+        # ...and every one of them resolves relative to the file's location.
+        for href in pointer_hrefs:
+            assert (source.parent / href).resolve().exists(), f"broken href {href!r}"

--- a/tests/contracts/test_project_init_md_dedupe.py
+++ b/tests/contracts/test_project_init_md_dedupe.py
@@ -1,0 +1,45 @@
+"""PI-659 (epic #641): project-init.md defers to single sources, no duplication.
+
+The Commit-and-PR format table (canonical: AGENTS.md quick-ref + the
+github_workflow skill) and the compaction preserve-list (canonical: CLAUDE.md)
+were duplicated verbatim in project-init.md — three drifting copies of the
+same rules. The file now points at the single source; the rest of the
+GitHub-tracking section stays (it is the lifecycle doc for skill-less
+surfaces).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+
+class TestProjectInitMdDedupe:
+    def test_format_table_replaced_by_pointer(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (tmp_target / ".agents" / "project-init.md").read_text()
+        # Pointer to the single source, types list retained inline.
+        assert "quick-ref" in content
+        assert "feat` · `fix` · `chore` · `docs` · `test" in content
+        # The duplicated table rows are gone.
+        assert "| Commit message |" not in content
+        # nojira flow (not duplicated elsewhere at this detail) stays.
+        assert "create_nojira_pr.sh" in content
+
+    def test_compact_preserve_list_lives_only_in_claude_md(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        project_init = (tmp_target / ".agents" / "project-init.md").read_text()
+        claude_md = (tmp_target / "CLAUDE.md").read_text()
+        marker = "Unresolved errors or lint failures"
+        assert marker in claude_md  # canonical copy intact
+        assert marker not in project_init  # duplicate removed
+        assert "CLAUDE.md" in project_init  # pointer present
+
+    def test_pointer_links_resolve(self, tmp_target: Path):
+        """project-init.md lives in .agents/, so its ../ hrefs must resolve."""
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        base = tmp_target / ".agents"
+        assert (base / ".." / "AGENTS.md").resolve().exists()
+        assert (base / ".." / "CLAUDE.md").resolve().exists()


### PR DESCRIPTION
Closes #659

WS11 of epic #641 (conservative scope). Two verbatim duplications removed from `project-init.md.tmpl` — three drifting copies of the same rules become one source each:

- **Commit-and-PR format table** → pointer to the AGENTS.md quick-ref (single source); types list and the nojira flow stay inline (not duplicated elsewhere at that detail).
- **Compaction preserve-list** → pointer to CLAUDE.md (compaction is a Claude-only mechanism; the canonical list lives there).

**Scope guardrail:** the rest of the GitHub-tracking section deliberately STAYS — it is the lifecycle documentation for skill-less surfaces (Cursor, VS Code, Ollama agents); removing it would be a quality loss.

Tests: `test_project_init_md_dedupe.py` (pointer present, duplicates gone, canonical copies intact, links resolve). `just lint` green; full suite 2035 passed / 8 skipped.