### PR TITLE
feat(PI-661): Ship zero-token statusline context meter in scaffolded settings

### DIFF
--- a/templates/base/dot_agents/hooks/statusline.sh
+++ b/templates/base/dot_agents/hooks/statusline.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# statusline.sh — zero-token context meter (PI-661, epic #641).
+# Claude Code statusLine command: receives session JSON on stdin, prints one
+# line rendered in the terminal footer. Statusline output NEVER enters the
+# transcript, so this surfaces context-window % and cache-hit rate at zero
+# token cost. Fail-open: any parse error prints a minimal placeholder.
+
+set -u
+
+# Resolve the Python interpreter through the canonical helper (PI-361).
+PY="$(dirname "$0")/_py.sh"
+
+"$PY" -c '
+import json
+import sys
+
+try:
+    d = json.load(sys.stdin)
+    model = (d.get("model") or {}).get("display_name") or "?"
+    cw = d.get("context_window") or {}
+    pct = cw.get("used_percentage")
+    usage = cw.get("current_usage") or {}
+    reads = usage.get("cache_read_input_tokens") or 0
+    total_in = (
+        (usage.get("input_tokens") or 0)
+        + (usage.get("cache_creation_input_tokens") or 0)
+        + reads
+    )
+    parts = [f"[{model}]"]
+    if pct is not None:
+        pct = int(pct)
+        filled = min(10, pct // 10)
+        bar = "#" * filled + "-" * (10 - filled)
+        parts.append(f"ctx {bar} {pct}%")
+        if pct >= 60:
+            parts.append("(consider /compact)")
+    else:
+        parts.append("ctx: warming up")
+    if total_in:
+        parts.append(f"cache {100 * reads // total_in}%")
+    print(" ".join(parts))
+except Exception:
+    print("ctx: n/a")
+' 2>/dev/null || echo "ctx: n/a"

--- a/templates/base/dot_agents/settings.json.tmpl
+++ b/templates/base/dot_agents/settings.json.tmpl
@@ -3,6 +3,10 @@
   "env": {
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "\"$CLAUDE_PROJECT_DIR\"/.agents/hooks/statusline.sh"
+  },
   "extraKnownMarketplaces": {
     {{#if egress_ok}}"claude-plugins-official": {
       "source": {

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -144,6 +144,9 @@ _ADDED_SINCE_BASELINE = {
     ".agents/skills/token_efficiency/SKILL.md",
     # PI-657: guard/per-surface mechanics moved out of always-loaded AGENTS.md
     ".agents/docs/guides/enforcement.md",
+    # PI-661: zero-token statusline context meter (wired in settings.json,
+    # which is already excluded above)
+    ".agents/hooks/statusline.sh",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -128,6 +128,9 @@ _ADDED_SINCE_BASELINE = {
     ".agents/skills/token_efficiency/SKILL.md",
     # PI-657: guard/per-surface mechanics moved out of always-loaded AGENTS.md
     ".agents/docs/guides/enforcement.md",
+    # PI-661: zero-token statusline context meter (wired in settings.json,
+    # which is already excluded above)
+    ".agents/hooks/statusline.sh",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/contracts/test_statusline.py
+++ b/tests/contracts/test_statusline.py
@@ -1,0 +1,66 @@
+"""PI-661 (epic #641): zero-token statusline context meter.
+
+The statusline renders in the terminal and never enters the transcript — a
+free surface for context-window % and cache-hit rate. Fail-open by contract:
+malformed stdin prints a placeholder, never crashes the footer.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+
+def _run(script: Path, payload: str) -> str:
+    result = subprocess.run(
+        ["bash", str(script)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+class TestStatusline:
+    def test_wired_in_settings(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        settings = json.loads((tmp_target / ".agents" / "settings.json").read_text())
+        assert settings["statusLine"]["type"] == "command"
+        assert "statusline.sh" in settings["statusLine"]["command"]
+
+    def test_renders_context_and_cache(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        script = tmp_target / ".agents" / "hooks" / "statusline.sh"
+        assert script.stat().st_mode & 0o111, "statusline.sh must be executable"
+        payload = json.dumps(
+            {
+                "model": {"display_name": "Fable 5"},
+                "context_window": {
+                    "used_percentage": 72.4,
+                    "current_usage": {
+                        "input_tokens": 3571,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 96000,
+                    },
+                },
+            }
+        )
+        out = _run(script, payload)
+        assert "72%" in out
+        assert "cache 96%" in out
+        assert "/compact" in out  # nudge appears at >=60%
+
+    def test_early_session_and_garbage_fail_open(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        script = tmp_target / ".agents" / "hooks" / "statusline.sh"
+        # used_percentage null early in session (documented behavior).
+        out = _run(script, json.dumps({"context_window": {}}))
+        assert "warming up" in out
+        # Garbage stdin never crashes the footer.
+        assert _run(script, "not json") == "ctx: n/a"


### PR DESCRIPTION
Closes #661

WS10 of epic #641. No template shipped a `statusLine` before; statusline output renders in the terminal and **never enters the transcript** — zero token cost for permanent visibility of the two numbers that drive the compact/clear decision.

- New `templates/base/dot_agents/hooks/statusline.sh` (bash + `_py.sh` stdlib Python): renders `[Model] ctx ####------ 42% cache 96%` from the statusline stdin JSON (`context_window.used_percentage`, `current_usage` cache split — schema verified against current code.claude.com docs). At ≥60% context it appends a `(consider /compact)` nudge, matching the scaffold's `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=70` headroom.
- **Fail-open by contract:** null `used_percentage` early in session → "warming up"; garbage stdin → `ctx: n/a`; the footer can never crash.
- Wired via `statusLine` in `settings.json.tmpl` (`$CLAUDE_PROJECT_DIR` pattern, same as hooks).
- Tests (`test_statusline.py`): settings wiring, executable bit, rendered meter + cache% + nudge, both fail-open paths.

`just lint` green; full suite 2043 passed / 8 skipped.