### PR TITLE
feat(PI-665): diagram skill — collaborative Mermaid-first diagramming

### DIFF
--- a/plugins/project-init-workflow/.agents-plugin/plugin.json
+++ b/plugins/project-init-workflow/.agents-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
-    "name": "Vytautas Čepas",
+    "name": "Vytautas \u010cepas",
     "url": "https://github.com/VytCepas"
   },
   "repository": "https://github.com/VytCepas/project-init",

--- a/plugins/project-init-workflow/skills/diagram/SKILL.md
+++ b/plugins/project-init-workflow/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.0.1"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.agents-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.2.1"
+__plugin_version__ = "0.3.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/amp/dot_agents/skills/diagram/SKILL.md
+++ b/templates/amp/dot_agents/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/templates/antigravity/dot_agents/skills/diagram/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/templates/base/dot_agents/project-init.md.tmpl
+++ b/templates/base/dot_agents/project-init.md.tmpl
@@ -35,6 +35,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 {{/if obsidian}}| Skill | `report_upstream_issue` | report a bug — routes tooling bugs upstream to project-init, keeps project bugs local |
 | Skill | `token_efficiency` | token-frugal working habits for long coding/debugging sessions |
 | Skill | `checkpoint` | checkpoint-and-clear session handoff (gitignored) |
+| Skill | `diagram` | draw/iterate diagrams (Mermaid-first, committed source) |
 | Skill | `add_hook` | add a new deterministic hook |
 | Skill | `add_command` | add a new slash command |
 {{#if lifecycle}}| Skill | `audit` | full project health scan, creates issue with findings |

--- a/templates/base/dot_agents/skills/README.md.tmpl
+++ b/templates/base/dot_agents/skills/README.md.tmpl
@@ -12,6 +12,7 @@ Each skill is a directory `.agents/skills/<name>/SKILL.md`. See [`INDEX.md`](IND
 {{/if lifecycle}}| `report_upstream_issue` | Report a bug — routes tooling/scaffolding bugs upstream to project-init, keeps project bugs local |
 | `token_efficiency` | Long coding/debugging session — token-frugal habits for tool output, reads, and responses |
 | `checkpoint` | Long session — write a gitignored handoff, /clear, resume cheap |
+| `diagram` | Draw architecture/code/idea diagrams as version-controlled Mermaid source |
 | `add_hook` | When you need a new deterministic hook (safety, lint, logging) |
 | `add_command` | When you need a new slash command for a recurring workflow |
 {{/if no_plugin}}{{#if plugin_mode}}

--- a/templates/codex/dot_agents/skills/diagram/SKILL.md
+++ b/templates/codex/dot_agents/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/templates/fallback/dot_agents/skills/INDEX.md.tmpl
+++ b/templates/fallback/dot_agents/skills/INDEX.md.tmpl
@@ -15,6 +15,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 {{/if obsidian}}{{#if memory}}| Save something to project memory | `.agents/skills/save_memory/SKILL.md` |
 {{/if memory}}| Work token-efficiently in a long session | `.agents/skills/token_efficiency/SKILL.md` |
 | Checkpoint a long session (save state, /clear, resume) | `.agents/skills/checkpoint/SKILL.md` |
+| Draw/iterate on architecture, code, or idea diagrams | `.agents/skills/diagram/SKILL.md` |
 | Record an architectural decision (ADR) | `.agents/skills/add_adr/SKILL.md` |
 | Report / file a bug or issue | `.agents/skills/report_upstream_issue/SKILL.md` |
 | Add a hook | `.agents/skills/add_hook/SKILL.md` |

--- a/templates/fallback/dot_agents/skills/diagram/SKILL.md
+++ b/templates/fallback/dot_agents/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/templates/junie/dot_junie/skills/diagram/SKILL.md
+++ b/templates/junie/dot_junie/skills/diagram/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagram
+description: Draw and iterate on diagrams with the user — system architecture, code structure, data models, flows, or idea sketches — as version-controlled Mermaid/DOT/Excalidraw source with live previews
+when_to_use: Use when the user says "draw", "diagram", "sketch", "visualize the architecture", "schema", "flowchart", "sequence diagram", "ERD", "mindmap", or wants to see how components/ideas relate.
+user-invocable: true
+---
+
+# Diagram — draw it together, keep the source
+
+Diagrams here are **source files first** (Mermaid by default): diffable,
+regenerable, and reviewable like code. Renders are previews; the committed
+source is the artifact.
+
+## 1. Pick the notation by diagram type
+
+| The user wants to see… | Use |
+|---|---|
+| Components/flow/dependencies | Mermaid `flowchart` (`LR` for pipelines, `TB` for hierarchies); add `layout: elk` frontmatter when >15 nodes |
+| Interactions over time | Mermaid `sequenceDiagram` |
+| Lifecycle / states | Mermaid `stateDiagram-v2` |
+| Data model / tables | Mermaid `erDiagram` |
+| Modules / classes | Mermaid `classDiagram` |
+| Brainstorm / idea map | Mermaid `mindmap` |
+| Timeline / plan | Mermaid `gantt` |
+
+**Escalations (only when Mermaid genuinely fails the job):**
+- Dense graph that Mermaid tangles even with `layout: elk` → Graphviz **DOT
+  source**. Render only if `dot` is installed (`command -v dot`); otherwise
+  ship the source and say plainly that no local renderer is available.
+- Free-form idea sketch with spatial meaning → **Excalidraw JSON** (open and
+  edit at excalidraw.com). No local render — say so; don't pretend.
+
+## 2. Ground before drawing
+
+- **Code/architecture mode:** derive nodes and edges from reality — read
+  `CODE_MAP.md` (if present), imports, and directory structure. Never invent
+  a component; if a box isn't backed by a file/module/service you can name,
+  it doesn't go on the diagram.
+- **Idea mode:** one interview round first — what are the entities, what
+  relations matter, what question should the diagram answer?
+
+## 3. The iteration loop
+
+1. Write source to `docs/diagrams/<slug>.mmd` — or `.agents/vault/design/`
+   when the project has an Obsidian vault (its existing home for "diagrams,
+   spec drafts").
+2. Preview:
+   - On Claude Code, send the `.mmd` file to the user with inline render —
+     the side panel renders Mermaid natively, no tooling needed.
+   - For a picture file (or non-Claude surfaces):
+     `bunx @mermaid-js/mermaid-cli -i <slug>.mmd -o <slug>.svg` and send the
+     SVG.
+3. Ask **one** targeted question per round — "right boxes?", "right
+   arrows?", "right grouping?" — not "any feedback?".
+4. Apply feedback as **small edits, never wholesale regeneration**. Keep
+   node IDs stable across rounds so the source diff shows exactly what
+   changed.
+
+## 4. Quality rules
+
+- **≤ ~25 nodes per view.** Past that, split: one overview diagram plus
+  drill-down diagrams per area. A mega-graph answers no question.
+- `subgraph` blocks for layers and boundaries (UI / core / infra;
+  trusted / untrusted).
+- Label every edge whose relation isn't obvious from the endpoints.
+- Title the diagram; add a legend when shapes/styles carry meaning.
+- Never encode meaning in color alone (accessibility; renders vary).
+
+## 5. Finalize
+
+- Commit the **source**. Optionally export the SVG next to it (same
+  `bunx @mermaid-js/mermaid-cli` command) when a rendered file is needed.
+- Embedding:
+  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+    inline the source in docs/README where useful.
+  - mkdocs needs one-time config; offer to add it:
+
+    ```yaml
+    markdown_extensions:
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
+    ```
+
+- A diagram that drifted from the code is worse than none: when the
+  underlying structure changes, update the source in the same PR — that is
+  why the source, not the picture, is the committed artifact.

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -151,6 +151,9 @@ _ADDED_SINCE_BASELINE = {
     # INDEX/README/project-init.md rows already excluded above. The .gitignore
     # edit (.agents/tmp/) was re-pinned in the fixtures, not excluded.
     ".agents/skills/checkpoint/SKILL.md",
+    # PI-665: diagram skill (collaborative Mermaid-first diagramming);
+    # INDEX/README/project-init.md rows already excluded above
+    ".agents/skills/diagram/SKILL.md",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -135,6 +135,9 @@ _ADDED_SINCE_BASELINE = {
     # INDEX/README/project-init.md rows already excluded above. The .gitignore
     # edit (.agents/tmp/) was re-pinned in the fixtures, not excluded.
     ".agents/skills/checkpoint/SKILL.md",
+    # PI-665: diagram skill (collaborative Mermaid-first diagramming);
+    # INDEX/README/project-init.md rows already excluded above
+    ".agents/skills/diagram/SKILL.md",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/integration/test_diagram_skill.py
+++ b/tests/integration/test_diagram_skill.py
@@ -39,7 +39,7 @@ class TestDiagramSkill:
         assert "docs/diagrams/" in content
         assert ".agents/vault/design/" in content
         assert "bunx @mermaid-js/mermaid-cli" in content
-        assert "node IDs stable" in content.lower() or "Keep\n   node IDs stable" in content
+        assert "node ids stable" in content.lower()
         # Quality rules.
         assert "25 nodes" in content
         assert "subgraph" in content

--- a/tests/integration/test_diagram_skill.py
+++ b/tests/integration/test_diagram_skill.py
@@ -1,0 +1,59 @@
+"""PI-665: the diagram skill — collaborative Mermaid-first diagramming.
+
+Diagrams are version-controlled source files (Mermaid by default, DOT /
+Excalidraw escalations), grounded in repo reality for code diagrams, iterated
+in small stable-ID diffs with one targeted question per round.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+
+class TestDiagramSkill:
+    def test_present_and_default_on_no_plugin(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (
+            tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md"
+        ).read_text()
+        assert "name: diagram" in content
+        assert "user-invocable: true" in content
+        assert len(content.splitlines()) < 500
+
+    def test_body_covers_the_method(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (
+            tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md"
+        ).read_text()
+        # Notation table with the mermaid diagram types + dense-graph escape.
+        assert "erDiagram" in content
+        assert "sequenceDiagram" in content
+        assert "layout: elk" in content
+        # Grounding: code diagrams derive from reality, never invented.
+        assert "CODE_MAP.md" in content
+        assert "Never invent" in content
+        # Iteration loop: committed source, targeted feedback, stable IDs.
+        assert "docs/diagrams/" in content
+        assert ".agents/vault/design/" in content
+        assert "bunx @mermaid-js/mermaid-cli" in content
+        assert "node IDs stable" in content.lower() or "Keep\n   node IDs stable" in content
+        # Quality rules.
+        assert "25 nodes" in content
+        assert "subgraph" in content
+        # Embedding: GitHub-native fences + the mkdocs enablement snippet.
+        assert "pymdownx.superfences" in content
+        # Honest degradation for escalation formats.
+        assert "excalidraw.com" in content
+        assert "command -v dot" in content
+
+    def test_listed_in_skill_tables(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        for rel in (
+            ".agents/skills/INDEX.md",
+            ".agents/skills/README.md",
+            ".agents/project-init.md",
+        ):
+            assert "diagram" in (tmp_target / rel).read_text(), rel


### PR DESCRIPTION
Closes #665

A `/diagram` skill for iteratively drawing architecture, code, data-model, and idea diagrams with the agent — **source files first** (diffable, regenerable), renders as previews.

- **Notation-by-type table**: flowchart/sequence/state/ER/class/mindmap/gantt in Mermaid (`layout: elk` for dense graphs); honest escalations — DOT source (renders only if `dot` exists), Excalidraw JSON for spatial idea sketches (no local render, says so).
- **Ground before drawing**: code diagrams derive from CODE_MAP/imports/structure — a box not backed by a nameable file/module doesn't go on the diagram; idea mode interviews for entities/relations first.
- **Iteration loop**: source under `docs/diagrams/` (or the vault's `design/` — its existing convention), side-panel Mermaid preview on Claude Code / `bunx @mermaid-js/mermaid-cli` SVG elsewhere, ONE targeted question per round, stable node IDs so diffs stay reviewable.
- **Quality rules**: ≤25 nodes per view (overview + drill-downs), subgraphs for boundaries, labeled edges, no color-only meaning.
- **Embedding**: GitHub renders fences natively; mkdocs superfences snippet offered on demand (not a template default — keeps this PR skill-only).

**Live-smoked before push**: rendered a real diagram of project-init's scaffold pipeline via `bunx @mermaid-js/mermaid-cli` (cached Puppeteer Chrome — no downloads beyond the JS package) and previewed the `.mmd` in the Claude side panel. Also installed user-level and invoked in-session.

Ships via ADR-010 (plugin + fallback + codex/antigravity/amp/junie). Byte-identity: SKILL.md added to exclusions in both modules; no fixture re-pins. Tests: `test_diagram_skill.py` (frontmatter, method markers, three discoverability tables, <500-line cap).

`just lint` green; full serial suite (CI-equivalent) 2049 passed / 8 skipped.