### PR TITLE
feat(PI-666): CI_RUNS_ON self-hosted-runner escape hatch for scaffolded ci.yml

### DIFF
--- a/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
+++ b/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
@@ -1,0 +1,78 @@
+# Self-hosted CI runner — the Actions-minutes escape hatch (PI-666)
+
+When a **private** repo exhausts its GitHub Actions minutes (or hits a
+spending-limit/payment problem), every workflow job fails at start:
+*"The job was not started because recent account payments have failed or your
+spending limit needs to be increased."* Self-hosted runners bill **zero**
+minutes on private repos, and checks keep reporting to GitHub — branch
+protection and the merge gate stay intact.
+
+The scaffolded `ci.yml` reads `vars.CI_RUNS_ON` on its compute jobs; one repo
+variable routes them to your machine. Nothing else changes.
+
+## Diagnose first
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle   # billing lockout shows startup_failure
+gh api /users/{username}/settings/billing/actions      # included vs used minutes (org repos: /orgs/{org}/...)
+```
+
+Meanwhile, verification never stops: `just ci` runs the exact same gate
+locally (the recipes are what CI runs), and the pre-push git hook already
+enforces it.
+
+## Set up the runner (once)
+
+1. Repo → **Settings → Actions → Runners → New self-hosted runner**, or:
+
+   ```bash
+   gh api -X POST repos/{owner}/{repo}/actions/runners/registration-token --jq .token
+   ```
+
+2. On the machine that will run CI (Linux x64 shown):
+
+   ```bash
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   # download + extract the runner package per the Settings page instructions
+   ./config.sh --url https://github.com/{owner}/{repo} --token <TOKEN> --ephemeral
+   ./run.sh   # or install as a service: sudo ./svc.sh install && sudo ./svc.sh start
+   ```
+
+   **Prefer `--ephemeral`** — the runner takes one job and unregisters, so a
+   compromised job can't persist on the machine. Re-register per job via a
+   small loop or the service.
+
+3. The runner needs your project's toolchain (`uv`/`bun`, `just`, docker if
+   the image jobs are enabled). The first run tells you what's missing.
+
+## Switch CI over
+
+```bash
+just ci-local-on     # gh variable set CI_RUNS_ON --body self-hosted
+just ci-local-off    # back to GitHub-hosted
+```
+
+**Only set the variable when a runner is actually registered and online** —
+otherwise jobs queue forever, which is harder to notice than the billing
+error.
+
+## Trust model — read before enabling
+
+- Use this only on **private repos with trusted collaborators**. A
+  self-hosted runner executes whatever the workflow (and the PR) tells it to,
+  on your machine.
+- Never process public-fork PRs on a self-hosted runner.
+- Secret/PAT-bearing workflows{{#if lifecycle}} (`board-automation`, `validate-pr`,
+  `issue-validation`, `project-init-upgrade`){{/if lifecycle}} — including any
+  release/deploy/registry-publish workflows you enable — are **deliberately
+  pinned** to GitHub-hosted ephemeral runners so tokens never materialize on
+  your machine. They cost seconds and fit the free tier once `ci.yml` moves
+  off. Do not point them at `CI_RUNS_ON`.
+- The `scorecard` job stays GitHub-hosted (an OSSF requirement).
+
+## Alternatives
+
+Make the repo public (Actions is free), raise the spending limit, or wait for
+the monthly reset. `act` (nektos/act, needs Docker) can run workflows ad hoc,
+but image drift from real runners makes it a debugging project of its own —
+prefer the runner.

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -1,5 +1,13 @@
 name: CI
 
+# Compute jobs read `vars.CI_RUNS_ON` (PI-666): set the repo variable to
+# `self-hosted` to run CI on your own runner — the escape hatch when a private
+# repo exhausts its GitHub Actions minutes. Toggle with `just ci-local-on` /
+# `ci-local-off`; setup guide: .agents/docs/guides/self-hosted-ci-runner.md.
+# Secret/PAT-bearing workflows{{#if lifecycle}} (board-automation, validate-pr,
+# issue-validation, …){{/if lifecycle}} deliberately stay on GitHub-hosted
+# ephemeral runners.
+
 on:
   push:
     branches: [{{base_branch}}]
@@ -31,7 +39,7 @@ jobs:
   # a new CPython is released. The floor is always taken from requires-python.
   python-matrix:
     name: Resolve Python matrix
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       versions: ${{ steps.resolve.outputs.versions }}
     steps:
@@ -91,7 +99,7 @@ jobs:
 
   lint-and-test:
     name: Lint and test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
 {{#if python}}
     needs: python-matrix
     strategy:
@@ -343,7 +351,7 @@ jobs:
   # integration suite is stable enough to gate merges.
   integration-tests:
     name: Integration tests
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     needs: lint-and-test
     # Optional: Only run on main branch or when tests change significantly
     # if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.files[*].name, 'tests/')
@@ -394,7 +402,7 @@ jobs:
   # not a standalone file like ruff.toml/mypy.ini.
   mutation-tests:
     name: Mutation tests (mutmut)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -446,7 +454,7 @@ jobs:
   # vulnerable image to block merges.
   build-image:
     name: Build image (build-once)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     needs: lint-and-test
     permissions:
       contents: read
@@ -504,7 +512,7 @@ jobs:
   # no Dockerfile is scaffolded for other delivery modes.
   dockerfile-lint:
     name: Lint Dockerfile (hadolint)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Lint Dockerfile (hadolint)
@@ -517,7 +525,7 @@ jobs:
   # gives fast local feedback but is fail-open; this job is the hard gate.
   secret-scan:
     name: Secret scan (gitleaks)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -540,7 +548,7 @@ jobs:
   # visible. Promote to ci-gate's needs once calibrated.
   semgrep:
     name: Semgrep (semantic security scan)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -571,7 +579,7 @@ jobs:
   # lives in the justfile's `license` recipe (or deny.toml for Rust).
   license-scan:
     name: Dependency license scan
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -633,7 +641,7 @@ jobs:
   # targets worth gating on.
   fuzz:
     name: Go fuzz (seed corpus replay)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -662,7 +670,7 @@ jobs:
   # granted so the OIDC upload to the public dashboard works).
   scorecard:
     name: OpenSSF Scorecard
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04  # pinned: OSSF scorecard-action requires GitHub-hosted runners
     if: github.event_name == 'schedule'
     permissions:
       security-events: write   # upload the SARIF result to code scanning
@@ -705,7 +713,7 @@ jobs:
   # failing gate actually blocks the merge.
   ci-gate:
     name: CI gate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04  # pinned: seconds-long aggregator; stays on GitHub-hosted
     needs: [lint-and-test, secret-scan{{#if governance}}, governance{{/if governance}}]
     if: always()
     steps:
@@ -730,7 +738,7 @@ jobs:
   # best-effort); the gate is stdlib-only, so no language toolchain is needed.
   governance:
     name: AI governance gate
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Validate system cards

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -713,7 +713,7 @@ jobs:
   # failing gate actually blocks the merge.
   ci-gate:
     name: CI gate
-    runs-on: ubuntu-24.04  # pinned: seconds-long aggregator; stays on GitHub-hosted
+    runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}  # must follow the variable: it is the REQUIRED check — pinned, it can't start during a billing lockout and blocks the merge
     needs: [lint-and-test, secret-scan{{#if governance}}, governance{{/if governance}}]
     if: always()
     steps:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -4,9 +4,9 @@ name: CI
 # `self-hosted` to run CI on your own runner — the escape hatch when a private
 # repo exhausts its GitHub Actions minutes. Toggle with `just ci-local-on` /
 # `ci-local-off`; setup guide: .agents/docs/guides/self-hosted-ci-runner.md.
-# Secret/PAT-bearing workflows{{#if lifecycle}} (board-automation, validate-pr,
-# issue-validation, …){{/if lifecycle}} deliberately stay on GitHub-hosted
-# ephemeral runners.
+# Secret/PAT-bearing workflows deliberately stay on GitHub-hosted ephemeral runners.
+{{#if lifecycle}}# Pinned here: board-automation, validate-pr, issue-validation, project-init-upgrade.
+{{/if lifecycle}}
 
 on:
   push:

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -81,6 +81,15 @@ fuzz:
 # what CI runs
 ci: setup lint typecheck test-cov audit
 
+# route CI to a self-hosted runner when Actions minutes run out (PI-666);
+# requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
+ci-local-on:
+    gh variable set CI_RUNS_ON --body self-hosted
+
+# back to GitHub-hosted runners
+ci-local-off:
+    gh variable delete CI_RUNS_ON
+
 # serve the docs site locally
 docs:
     uv run --with mkdocs-material --with "mkdocstrings[python]" mkdocs serve
@@ -158,6 +167,15 @@ scan:
 
 # what CI runs
 ci: setup lint typecheck test audit
+
+# route CI to a self-hosted runner when Actions minutes run out (PI-666);
+# requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
+ci-local-on:
+    gh variable set CI_RUNS_ON --body self-hosted
+
+# back to GitHub-hosted runners
+ci-local-off:
+    gh variable delete CI_RUNS_ON
 {{/if node}}{{#if go}}# justfile — the canonical command interface (scaffolded by project-init).
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
@@ -231,6 +249,15 @@ scan:
 
 # what CI runs
 ci: lint test-cov audit
+
+# route CI to a self-hosted runner when Actions minutes run out (PI-666);
+# requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
+ci-local-on:
+    gh variable set CI_RUNS_ON --body self-hosted
+
+# back to GitHub-hosted runners
+ci-local-off:
+    gh variable delete CI_RUNS_ON
 {{/if go}}{{#if rust}}# justfile — the canonical command interface (scaffolded by project-init).
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
@@ -310,6 +337,15 @@ scan:
 
 # what CI runs
 ci: lint test-cov audit
+
+# route CI to a self-hosted runner when Actions minutes run out (PI-666);
+# requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
+ci-local-on:
+    gh variable set CI_RUNS_ON --body self-hosted
+
+# back to GitHub-hosted runners
+ci-local-off:
+    gh variable delete CI_RUNS_ON
 {{/if rust}}{{#if delivery_service}}
 # --- container parity (delivery=service): same image local and in cloud ---
 

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -1,0 +1,94 @@
+"""PI-666: the CI_RUNS_ON self-hosted-runner escape hatch.
+
+Compute jobs in the scaffolded ci.yml read `vars.CI_RUNS_ON` (one repo
+variable routes CI to a self-hosted runner when a private repo runs out of
+Actions minutes). Security invariant, asserted in BOTH directions: the
+secret/PAT-bearing workflows and the pinned ci.yml jobs (scorecard, ci-gate)
+never use the variable, so tokens never materialize on a user's machine.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_EXPR = "${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}"
+
+# Workflows that carry secrets/PATs or deploy credentials — must stay pinned.
+_PINNED_WORKFLOWS = (
+    "board-automation.yml",
+    "validate-pr.yml",
+    "issue-validation.yml",
+    "project-init-upgrade.yml",
+)
+
+
+def _jobs_with_runs_on(text: str) -> dict[str, str]:
+    """Map job id -> its runs-on line (first one under the job)."""
+    jobs: dict[str, str] = {}
+    current = None
+    for line in text.splitlines():
+        m = re.match(r"^  ([a-z][a-z0-9-]*):\s*$", line)
+        if m:
+            current = m.group(1)
+        elif current and "runs-on:" in line and current not in jobs:
+            jobs[current] = line.strip()
+    return jobs
+
+
+class TestCiRunsOnEscapeHatch:
+    def test_compute_jobs_use_the_variable(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        jobs = _jobs_with_runs_on(
+            (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
+        )
+        assert jobs, "no jobs parsed from ci.yml"
+        for job, runs_on in jobs.items():
+            if job in ("scorecard", "ci-gate"):
+                continue
+            assert _EXPR in runs_on, f"{job} should read CI_RUNS_ON: {runs_on}"
+
+    def test_scorecard_and_gate_stay_pinned(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        jobs = _jobs_with_runs_on(
+            (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
+        )
+        for job in ("scorecard", "ci-gate"):
+            if job in jobs:  # presence depends on scaffold options
+                assert _EXPR not in jobs[job], f"{job} must stay GitHub-hosted"
+                assert "ubuntu-24.04" in jobs[job]
+
+    def test_secret_bearing_workflows_never_use_the_variable(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        wf_dir = tmp_target / ".github" / "workflows"
+        checked = 0
+        for name in _PINNED_WORKFLOWS:
+            f = wf_dir / name
+            if not f.exists():
+                continue
+            checked += 1
+            assert "CI_RUNS_ON" not in f.read_text(), (
+                f"{name} carries a PAT/secret — must never route to self-hosted"
+            )
+        assert checked, "no pinned workflows found to check"
+
+    def test_justfile_toggles_present(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        justfile = (tmp_target / "justfile").read_text()
+        assert "gh variable set CI_RUNS_ON --body self-hosted" in justfile
+        assert "gh variable delete CI_RUNS_ON" in justfile
+
+    def test_guide_ships_with_trust_model(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        guide = (
+            tmp_target / ".agents" / "docs" / "guides" / "self-hosted-ci-runner.md"
+        ).read_text()
+        assert "--ephemeral" in guide
+        assert "registration-token" in guide
+        assert "trusted collaborators" in guide
+        assert "public-fork" in guide
+        # The don't-flip-without-a-runner warning.
+        assert "queue forever" in guide

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -79,6 +79,35 @@ class TestCiRunsOnEscapeHatch:
             )
         assert checked, "no pinned workflows found to check"
 
+    def test_header_renders_as_valid_comments_without_lifecycle(self, tmp_path: Path):
+        """PR #670 review: the lifecycle-gated name-drop must never splice a
+        non-comment line into the YAML header when lifecycle is off."""
+        from project_init.scaffold import load_preset, overlay_layers
+        from tests.helpers import make_variables
+
+        preset = load_preset("obsidian-only")
+        extra = overlay_layers(
+            [], no_plugin=True, memory_stack="obsidian-only", lifecycle=False
+        )
+        preset = {**preset, "layers": [*preset["layers"], *extra]}
+        target = tmp_path / "p"
+        scaffold(
+            target,
+            preset,
+            make_variables(
+                memory_stack="obsidian-only",
+                no_plugin="true",
+                plugin_mode="",
+                lifecycle="",
+                lifecycle_off="true",
+            ),
+        )
+        text = (target / ".github" / "workflows" / "ci.yml").read_text()
+        header = text.split("\non:", 1)[0]
+        for line in header.splitlines()[1:]:  # skip "name: CI"
+            assert not line or line.startswith("#"), f"non-comment header line: {line!r}"
+        assert "board-automation" not in text
+
     def test_justfile_toggles_present(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         justfile = (tmp_target / "justfile").read_text()

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -47,19 +47,23 @@ class TestCiRunsOnEscapeHatch:
         )
         assert jobs, "no jobs parsed from ci.yml"
         for job, runs_on in jobs.items():
-            if job in ("scorecard", "ci-gate"):
+            if job == "scorecard":
                 continue
             assert _EXPR in runs_on, f"{job} should read CI_RUNS_ON: {runs_on}"
 
-    def test_scorecard_and_gate_stay_pinned(self, tmp_target: Path):
+    def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         jobs = _jobs_with_runs_on(
             (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
         )
-        for job in ("scorecard", "ci-gate"):
-            if job in jobs:  # presence depends on scaffold options
-                assert _EXPR not in jobs[job], f"{job} must stay GitHub-hosted"
-                assert "ubuntu-24.04" in jobs[job]
+        # scorecard: OSSF-hosted requirement; schedule-gated so it never
+        # blocks a PR — safe to pin.
+        if "scorecard" in jobs:
+            assert _EXPR not in jobs["scorecard"]
+        # ci-gate is the REQUIRED check: pinned, it couldn't start during a
+        # billing lockout and would block the merge — the exact scenario this
+        # feature exists for (Codex P1 on PR #670).
+        assert _EXPR in jobs["ci-gate"]
 
     def test_secret_bearing_workflows_never_use_the_variable(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -144,6 +144,9 @@ _ADDED_SINCE_BASELINE = {
     ".agents/skills/token_efficiency/SKILL.md",
     # PI-657: guard/per-surface mechanics moved out of always-loaded AGENTS.md
     ".agents/docs/guides/enforcement.md",
+    # PI-666: self-hosted-runner escape-hatch guide (ci.yml + justfile edits
+    # already excluded above)
+    ".agents/docs/guides/self-hosted-ci-runner.md",
     # PI-661: zero-token statusline context meter (wired in settings.json,
     # which is already excluded above)
     ".agents/hooks/statusline.sh",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -128,6 +128,9 @@ _ADDED_SINCE_BASELINE = {
     ".agents/skills/token_efficiency/SKILL.md",
     # PI-657: guard/per-surface mechanics moved out of always-loaded AGENTS.md
     ".agents/docs/guides/enforcement.md",
+    # PI-666: self-hosted-runner escape-hatch guide (ci.yml + justfile edits
+    # already excluded above)
+    ".agents/docs/guides/self-hosted-ci-runner.md",
     # PI-661: zero-token statusline context meter (wired in settings.json,
     # which is already excluded above)
     ".agents/hooks/statusline.sh",


### PR DESCRIPTION
Closes #666 (PR 1 of 2 per the implementation plan in the issue; PR 2 = the `local_ci` detection/suggestion skill follows separately)

When a **private** repo exhausts its GitHub Actions minutes, every job fails at start with the billing message and there's no way onto a self-hosted runner short of hand-editing every workflow. Self-hosted runners bill **zero** minutes and keep checks reporting, so branch protection stays intact.

- **`ci.yml.tmpl`**: 11 compute jobs now read `runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}` — one repo variable flips CI to a self-hosted runner, unset restores GitHub-hosted. **Pinned with in-file reasons:** `scorecard` (OSSF action requires GitHub-hosted) and `ci-gate` (seconds-long aggregator).
- **Security invariant, tested in both directions** (`test_ci_runs_on.py`): every unpinned ci.yml job uses the variable, AND the secret/PAT-bearing lifecycle workflows (`board-automation`, `validate-pr`, `issue-validation`, `project-init-upgrade`) provably never contain `CI_RUNS_ON` — tokens never materialize on a user's machine (per the security review noted in the issue).
- **`just ci-local-on` / `ci-local-off`** toggles (thin `gh variable` wrappers) in every language block.
- **New scaffolded guide** `.agents/docs/guides/self-hosted-ci-runner.md(.tmpl)`: diagnosis commands (`gh run list` startup_failure, billing API), runner registration with **`--ephemeral` recommended**, the trust model (private + trusted collaborators only; never public forks), the don't-set-the-variable-without-a-live-runner warning, and honest alternatives.
- **`--lifecycle none` correctness**: workflow name-drops in prose are gated behind `{{#if lifecycle}}` (caught by the existing `test_lifecycle_none` dangling-reference contract during development).

Byte-identity: ci.yml/justfile already excluded; guide added to both exclusion sets.

`just lint` green; full serial suite 2057 passed / 5 skipped.