### PR TITLE
feat(PI-671): local_ci skill + monitor_pr billing-lockout hint

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -189,6 +189,13 @@ for c in json.load(sys.stdin):
     if c.get('name') != 'review/decision' and c.get('bucket') == 'pending':
         print('  -', c.get('name'))" 2>/dev/null || true
     echo "Re-run once the check registers, or investigate why it never started."
+    # PI-671: a billing/minutes lockout means checks NEVER register — point
+    # at the escape hatch instead of leaving the user to rediscover it.
+    if gh run list --limit 5 --json conclusion --jq '.[].conclusion' 2>/dev/null | grep -q startup_failure; then
+      echo "Note: recent runs show startup_failure — GitHub Actions may be out of"
+      echo "minutes or billing-locked. Load the local_ci skill (self-hosted runner"
+      echo "escape hatch: just ci-local-on)."
+    fi
     exit 1
   fi
   sleep 10

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -189,6 +189,13 @@ for c in json.load(sys.stdin):
     if c.get('name') != 'review/decision' and c.get('bucket') == 'pending':
         print('  -', c.get('name'))" 2>/dev/null || true
     echo "Re-run once the check registers, or investigate why it never started."
+    # PI-671: a billing/minutes lockout means checks NEVER register — point
+    # at the escape hatch instead of leaving the user to rediscover it.
+    if gh run list --limit 5 --json conclusion --jq '.[].conclusion' 2>/dev/null | grep -q startup_failure; then
+      echo "Note: recent runs show startup_failure — GitHub Actions may be out of"
+      echo "minutes or billing-locked. Load the local_ci skill (self-hosted runner"
+      echo "escape hatch: just ci-local-on)."
+    fi
     exit 1
   fi
   sleep 10

--- a/plugins/project-init-workflow/.agents-plugin/plugin.json
+++ b/plugins/project-init-workflow/.agents-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/skills/local_ci/SKILL.md
+++ b/plugins/project-init-workflow/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/plugins/project-init-workflow/skills/local_ci/SKILL.md
+++ b/plugins/project-init-workflow/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.0.1"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.agents-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.3.0"
+__plugin_version__ = "0.4.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/amp/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/amp/dot_agents/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/templates/amp/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/amp/dot_agents/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/templates/base/dot_agents/project-init.md.tmpl
+++ b/templates/base/dot_agents/project-init.md.tmpl
@@ -36,6 +36,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Skill | `token_efficiency` | token-frugal working habits for long coding/debugging sessions |
 | Skill | `checkpoint` | checkpoint-and-clear session handoff (gitignored) |
 | Skill | `diagram` | draw/iterate diagrams (Mermaid-first, committed source) |
+| Skill | `local_ci` | Actions minutes lockout → self-hosted runner escape hatch |
 | Skill | `add_hook` | add a new deterministic hook |
 | Skill | `add_command` | add a new slash command |
 {{#if lifecycle}}| Skill | `audit` | full project health scan, creates issue with findings |

--- a/templates/base/dot_agents/skills/README.md.tmpl
+++ b/templates/base/dot_agents/skills/README.md.tmpl
@@ -13,6 +13,7 @@ Each skill is a directory `.agents/skills/<name>/SKILL.md`. See [`INDEX.md`](IND
 | `token_efficiency` | Long coding/debugging session — token-frugal habits for tool output, reads, and responses |
 | `checkpoint` | Long session — write a gitignored handoff, /clear, resume cheap |
 | `diagram` | Draw architecture/code/idea diagrams as version-controlled Mermaid source |
+| `local_ci` | Actions billing lockout — diagnose and move CI to a self-hosted runner |
 | `add_hook` | When you need a new deterministic hook (safety, lint, logging) |
 | `add_command` | When you need a new slash command for a recurring workflow |
 {{/if no_plugin}}{{#if plugin_mode}}

--- a/templates/codex/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/codex/dot_agents/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/templates/codex/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/codex/dot_agents/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/templates/fallback/dot_agents/skills/INDEX.md.tmpl
+++ b/templates/fallback/dot_agents/skills/INDEX.md.tmpl
@@ -16,6 +16,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 {{/if memory}}| Work token-efficiently in a long session | `.agents/skills/token_efficiency/SKILL.md` |
 | Checkpoint a long session (save state, /clear, resume) | `.agents/skills/checkpoint/SKILL.md` |
 | Draw/iterate on architecture, code, or idea diagrams | `.agents/skills/diagram/SKILL.md` |
+| CI won't start / out of Actions minutes | `.agents/skills/local_ci/SKILL.md` |
 | Record an architectural decision (ADR) | `.agents/skills/add_adr/SKILL.md` |
 | Report / file a bug or issue | `.agents/skills/report_upstream_issue/SKILL.md` |
 | Add a hook | `.agents/skills/add_hook/SKILL.md` |

--- a/templates/fallback/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/fallback/dot_agents/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/templates/fallback/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/fallback/dot_agents/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/templates/junie/dot_junie/skills/local_ci/SKILL.md
+++ b/templates/junie/dot_junie/skills/local_ci/SKILL.md
@@ -23,8 +23,11 @@ not started because recent account payments have failed or your spending
 limit needs to be increased."* Check remaining minutes:
 
 ```bash
-gh api /users/{username}/settings/billing/actions   # personal repos
-gh api /orgs/{org}/settings/billing/actions         # org repos
+# Enhanced billing platform (current; filter for Actions usage):
+gh api "/users/{username}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+gh api "/organizations/{org}/settings/billing/usage" --jq '[.usageItems[] | select(.product == "actions")]'
+# Accounts not yet on the enhanced platform: the legacy endpoint still answers:
+gh api /users/{username}/settings/billing/actions
 ```
 
 If runs are failing for any *other* reason, this skill does not apply — fix

--- a/templates/junie/dot_junie/skills/local_ci/SKILL.md
+++ b/templates/junie/dot_junie/skills/local_ci/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: local_ci
+description: Diagnose a GitHub Actions billing/minutes lockout and move CI to a self-hosted runner — the escape hatch when a private repo runs out of free minutes
+when_to_use: Use when CI jobs fail to start, the PR merge gate stalls with checks that never register, or the user mentions "out of Actions minutes", "billing", "spending limit", or "CI won't run".
+user-invocable: true
+---
+
+# Local CI — when GitHub Actions minutes run out
+
+On a **private** repo that exhausts its Actions minutes (or hits a
+spending-limit/payment problem), every job fails at start and the required
+checks never report — the merge gate stalls. Verification itself never
+stops (see step 2); only the remote checks do.
+
+## 1. Diagnose — confirm it's the billing lockout
+
+```bash
+gh run list --limit 5 --json conclusion,displayTitle
+```
+
+The lockout signature is `startup_failure` with the annotation *"The job was
+not started because recent account payments have failed or your spending
+limit needs to be increased."* Check remaining minutes:
+
+```bash
+gh api /users/{username}/settings/billing/actions   # personal repos
+gh api /orgs/{org}/settings/billing/actions         # org repos
+```
+
+If runs are failing for any *other* reason, this skill does not apply — fix
+the actual failure.
+
+## 2. Immediate unblock — the gate already runs locally
+
+`just ci` runs the **same recipes CI runs** (the justfile is the single
+command surface), and the pre-push git hook already enforces it on every
+push. Nothing about correctness is blocked — keep working; only the merge
+gate needs the fix below.
+
+## 3. Durable fix — self-hosted runner (zero billed minutes)
+
+Follow `.agents/docs/guides/self-hosted-ci-runner.md`: register a runner
+(**`--ephemeral` recommended**), verify it shows online under Settings →
+Actions → Runners, then:
+
+```bash
+just ci-local-on    # sets the CI_RUNS_ON repo variable → compute jobs run on your runner
+```
+
+Checks keep reporting to GitHub; branch protection and the merge gate stay
+intact. Revert any time with `just ci-local-off`.
+
+**Do not set the variable before the runner is online** — jobs queue forever,
+which is quieter and worse than the billing error.
+
+## 4. Honest alternatives
+
+- Make the repo **public** — Actions becomes free.
+- Raise the spending limit (Settings → Billing).
+- Wait for the monthly reset (usage resets on your billing date).
+
+## Safety rails (non-negotiable)
+
+- The secret/PAT-bearing workflows are deliberately pinned to GitHub-hosted
+  runners — never point them at `CI_RUNS_ON`.
+- Never bypass required checks by posting statuses from local runs —
+  self-attestation defeats the gate; the runner path keeps real checks.
+- Self-hosted runners are for private repos with trusted collaborators only;
+  never for public-fork PRs.

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -233,6 +233,13 @@ for c in json.load(sys.stdin):
     if c.get('name') != 'review/decision' and c.get('bucket') == 'pending':
         print('  -', c.get('name'))" 2>/dev/null || true
     echo "Re-run once the check registers, or investigate why it never started."
+    # PI-671: a billing/minutes lockout means checks NEVER register — point
+    # at the escape hatch instead of leaving the user to rediscover it.
+    if gh run list --limit 5 --json conclusion --jq '.[].conclusion' 2>/dev/null | grep -q startup_failure; then
+      echo "Note: recent runs show startup_failure — GitHub Actions may be out of"
+      echo "minutes or billing-locked. Load the local_ci skill (self-hosted runner"
+      echo "escape hatch: just ci-local-on)."
+    fi
     exit 1
   fi
   sleep 10

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -157,6 +157,8 @@ _ADDED_SINCE_BASELINE = {
     # PI-665: diagram skill (collaborative Mermaid-first diagramming);
     # INDEX/README/project-init.md rows already excluded above
     ".agents/skills/diagram/SKILL.md",
+    # PI-671: local_ci skill (Actions billing-lockout escape hatch)
+    ".agents/skills/local_ci/SKILL.md",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -141,6 +141,8 @@ _ADDED_SINCE_BASELINE = {
     # PI-665: diagram skill (collaborative Mermaid-first diagramming);
     # INDEX/README/project-init.md rows already excluded above
     ".agents/skills/diagram/SKILL.md",
+    # PI-671: local_ci skill (Actions billing-lockout escape hatch)
+    ".agents/skills/local_ci/SKILL.md",
     # #605: Guards log the governance signal (decision + command)
     ".agents/hooks/_usage_log.sh",
     ".agents/hooks/prod_guard.py",

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -52,7 +52,7 @@ class TestLocalCiSkill:
         assert "just ci-local-on" in content
         assert "self-hosted-ci-runner.md" in content
         # Safety rails.
-        assert "never point them at `CI_RUNS_ON`" in content.lower() or "never point them at" in content
+        assert "never point them at `CI_RUNS_ON`" in content
         assert "self-attestation" in content
         assert "queue forever" in content
 

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -45,7 +45,8 @@ class TestLocalCiSkill:
         assert "user-invocable: true" in content
         # Diagnosis before action.
         assert "startup_failure" in content
-        assert "settings/billing/actions" in content
+        assert "settings/billing/usage" in content  # enhanced billing platform
+        assert "settings/billing/actions" in content  # legacy fallback, still documented
         # The just-ci-parity unblock and the durable fix.
         assert "just ci" in content
         assert "just ci-local-on" in content

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -1,0 +1,108 @@
+"""PI-671: the local_ci skill + monitor_pr.sh billing-lockout hint.
+
+When a private repo exhausts its Actions minutes, jobs fail at start
+(`startup_failure`) and required checks never register. The skill diagnoses
+the lockout and routes to the CI_RUNS_ON escape hatch (#670); monitor_pr.sh's
+CI-timeout path points at the skill so the user isn't left rediscovering it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_GH_STUB = """#!/bin/bash
+STATE_DIR="${GH_STUB_DIR:?}"
+case "$*" in
+*"run list"*)
+  cat "$STATE_DIR/run_list"
+  ;;
+*"pr checks"*)
+  # One check, permanently pending → drives monitor_pr into the CI timeout.
+  echo '[{"name":"ci","state":"QUEUED","bucket":"pending"}]'
+  ;;
+*"--json url"*)
+  echo "https://example.invalid/pr/1"
+  ;;
+*)
+  exit 0
+  ;;
+esac
+"""
+
+
+class TestLocalCiSkill:
+    def test_present_with_the_method(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (
+            tmp_target / ".agents" / "skills" / "local_ci" / "SKILL.md"
+        ).read_text()
+        assert "name: local_ci" in content
+        assert "user-invocable: true" in content
+        # Diagnosis before action.
+        assert "startup_failure" in content
+        assert "settings/billing/actions" in content
+        # The just-ci-parity unblock and the durable fix.
+        assert "just ci" in content
+        assert "just ci-local-on" in content
+        assert "self-hosted-ci-runner.md" in content
+        # Safety rails.
+        assert "never point them at `CI_RUNS_ON`" in content.lower() or "never point them at" in content
+        assert "self-attestation" in content
+        assert "queue forever" in content
+
+    def test_listed_in_skill_tables(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        for rel in (
+            ".agents/skills/INDEX.md",
+            ".agents/skills/README.md",
+            ".agents/project-init.md",
+        ):
+            assert "local_ci" in (tmp_target / rel).read_text(), rel
+
+
+class TestMonitorLockoutHint:
+    def _run_monitor(self, tmp_target: Path, tmp_path: Path, run_list_json: str) -> str:
+        script = tmp_target / ".agents" / "scripts" / "monitor_pr.sh"
+        stub_bin = tmp_path / "stub-bin"
+        stub_bin.mkdir(exist_ok=True)
+        gh = stub_bin / "gh"
+        gh.write_text(_GH_STUB)
+        gh.chmod(0o755)
+        slp = stub_bin / "sleep"
+        slp.write_text("#!/bin/sh\nexit 0\n")
+        slp.chmod(0o755)
+        state = tmp_path / "state"
+        state.mkdir(exist_ok=True)
+        (state / "run_list").write_text(run_list_json)
+        env = os.environ.copy()
+        env["PATH"] = f"{stub_bin}:{env['PATH']}"
+        env["GH_STUB_DIR"] = str(state)
+        result = subprocess.run(
+            ["bash", str(script), "1"],
+            capture_output=True,
+            text=True,
+            cwd=tmp_target,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 1  # CI-timeout path fails closed, as before
+        return result.stdout
+
+    def test_hint_on_startup_failure(self, tmp_target: Path, tmp_path: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        out = self._run_monitor(tmp_target, tmp_path, '"startup_failure"\n"success"\n')
+        assert "local_ci" in out
+        assert "ci-local-on" in out
+
+    def test_no_hint_on_healthy_runs(self, tmp_target: Path, tmp_path: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        out = self._run_monitor(tmp_target, tmp_path, '"success"\n"success"\n')
+        assert "local_ci" not in out
+        # The pre-existing timeout guidance is intact.
+        assert "did not settle" in out


### PR DESCRIPTION
Closes #671 — PR 2 of the plan in #666 (PR 1 = #670, merged).

The escape hatch (#670) only helps if the user finds it. This PR makes project-init notice the lockout and suggest it:

- **`local_ci` skill** (ADR-010 split + all surfaces): (1) diagnose — `gh run list` `startup_failure` signature + billing API usage check, with an explicit "if runs fail for any other reason this skill does not apply"; (2) immediate unblock — `just ci` locally IS the CI gate (recipes identical by design) and the pre-push hook already enforces it; (3) durable fix — runner guide + `just ci-local-on`, with the don't-set-before-the-runner-is-online warning; (4) honest alternatives; (5) safety rails (PAT workflows stay hosted, no self-attested checks, trusted-collaborators-only).
- **`monitor_pr.sh`** (template + repo copy): the fail-closed CI-timeout branch now checks recent runs for `startup_failure` and prints a 3-line pointer at the skill. Healthy runs: zero behavior change (asserted).
- Workflow plugin **0.4.0** (payload change, ADR-010).
- Tests: skill content + discoverability tables; monitor hint via stubbed `gh` — both the firing path (startup_failure → hint) and the non-firing path (healthy → no hint, pre-existing timeout guidance intact).

`just lint` green; full serial suite 2062 passed / 5 skipped.