### PR TITLE
fix(PI-673): semgrep via uvx — pip install fails on self-hosted runners

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -562,6 +562,8 @@ jobs:
       # self-hosted alike (CI_RUNS_ON switch, PI-666/PI-673).
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.7"
 
       - name: Run Semgrep
         env:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -556,18 +556,25 @@ jobs:
           # commit reachable, not just the latest diff.
           fetch-depth: 0
 
+      # uvx (not bare `pip`): a self-hosted runner has no writable system
+      # site-packages, so `pip install semgrep` fails there (externally-managed
+      # env). uvx runs it from an ephemeral, pinned env on hosted and
+      # self-hosted alike (CI_RUNS_ON switch, PI-666/PI-673).
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
       - name: Run Semgrep
         env:
           SEMGREP_ENABLE_VERSION_CHECK: "0"
         run: |
-          pip install --quiet semgrep==1.168.0
+          SEMGREP="uvx semgrep@1.168.0"
           RULESETS="--config p/secrets --config p/owasp-top-ten{{#if python}} --config p/python{{/if python}}{{#if node}} --config p/typescript{{/if node}}{{#if go}} --config p/golang{{/if go}}{{#if rust}} --config p/rust{{/if rust}}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Scan only the diff against the PR's base commit.
-            semgrep scan --error --metrics=off $RULESETS \
+            $SEMGREP scan --error --metrics=off $RULESETS \
               --baseline-commit "${{ github.event.pull_request.base.sha }}"
           else
-            semgrep scan --error --metrics=off $RULESETS
+            $SEMGREP scan --error --metrics=off $RULESETS
           fi
 
   # Dependency license compliance (#579): flag copyleft (GPL/AGPL) dependencies

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -115,7 +115,14 @@ class TestCiRunsOnEscapeHatch:
         kinds, and the scaffold bans pip anyway."""
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         ci = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
-        assert "pip install" not in ci
+        # Executable lines only — the explanatory comment legitimately names
+        # the failure mode ("pip install semgrep fails there").
+        runnable = [
+            ln for ln in ci.splitlines() if not ln.lstrip().startswith("#")
+        ]
+        assert not [ln for ln in runnable if "pip install" in ln], (
+            "pip must not be executed in scaffolded CI"
+        )
         assert "uvx semgrep@" in ci
 
     def test_justfile_toggles_present(self, tmp_target: Path):

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -108,6 +108,16 @@ class TestCiRunsOnEscapeHatch:
             assert not line or line.startswith("#"), f"non-comment header line: {line!r}"
         assert "board-automation" not in text
 
+    def test_semgrep_uses_uvx_not_pip(self, tmp_target: Path):
+        """PI-673 (downstream zarija #115): pip install fails on self-hosted
+        runners (externally-managed env) — exactly where CI_RUNS_ON routes the
+        job. uvx runs semgrep from an ephemeral pinned env on both runner
+        kinds, and the scaffold bans pip anyway."""
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        ci = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "pip install" not in ci
+        assert "uvx semgrep@" in ci
+
     def test_justfile_toggles_present(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         justfile = (tmp_target / "justfile").read_text()


### PR DESCRIPTION
Closes #673

Downstream discovery (zarija #115 / PR #116) after the CI_RUNS_ON escape hatch shipped: the scaffolded semgrep job ran `pip install semgrep`, which fails on self-hosted runners (externally-managed environment) — exactly where the toggle now routes it. Also violated the scaffold's own "uv/bun only, no pip" principle.

- `setup-uv` step (same pinned action the other jobs use) + `SEMGREP="uvx semgrep@1.168.0"` — ephemeral pinned env, identical behavior on hosted and self-hosted.
- Test: rendered ci.yml has no `pip install` on executable lines (the explanatory comment legitimately names the failure mode) and uses `uvx semgrep@`.

`just lint` green; full serial suite green (2063 passed equivalent — one new test).