### PR TITLE
fix(PI-706): gate the CI verdict on the API head matching the pushed tip

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -301,16 +301,34 @@ _has_review_activity() {
 # predecessor reads as "CI failed" (observed on #705), and a green one would
 # merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
 # rather than the API, so it sees the pushed tip immediately: wait until the two
-# agree before any check result is trusted. Fails open (returns 0) whenever the
-# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
-# — leaving behavior exactly as it was before this gate existed.
+# agree before any check result is trusted.
+#
+# Two distinct outcomes when the SHAs don't line up:
+#   * skipped entirely (return 0, unchanged behavior) when no expected SHA can
+#     be established — a cross-repo PR, a deleted branch, no `origin`, or the
+#     gate switched off with PI_HEAD_SYNC_TIMEOUT=0;
+#   * fail closed (exit 1) when an expected SHA IS known and the API never
+#     catches up to it within the timeout, since every check result on hand
+#     may belong to some other commit.
 _wait_for_head_sync() {
-  local head_ref remote_sha api_sha elapsed
+  local head_info head_ref cross_repo remote_sha api_sha elapsed
   if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
     return 0
   fi
-  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
-    -q '.headRefName' 2>/dev/null || true)
+  # Cross-repo (fork) PRs: headRefName carries only the branch name, so
+  # `ls-remote origin refs/heads/$head_ref` would resolve a base-repo branch
+  # that merely shares the name (`main`, `feature`) and then wait out the
+  # timeout against a SHA from the wrong repository (PR #712 review). The
+  # fork's remote isn't configured here — skip rather than guess.
+  head_info=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" \
+    --json headRefName,isCrossRepository \
+    -q '.headRefName + " " + (.isCrossRepository | tostring)' 2>/dev/null || true)
+  [ -n "$head_info" ] || return 0
+  head_ref=${head_info% *}
+  cross_repo=${head_info##* }
+  if [ "$cross_repo" = "true" ]; then
+    return 0
+  fi
   [ -n "$head_ref" ] || return 0
   remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
   [ -n "$remote_sha" ] || return 0
@@ -356,8 +374,8 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
 fi
 
 # PI-706: how long to wait for the API's PR head to catch up with the pushed
-# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
-# origin` cannot see the head branch and the wait would be pure latency).
+# tip. 0 disables the gate — an escape hatch for mirrors and other setups where
+# `git ls-remote origin` reports a SHA the API will never converge on.
 HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
 case "$HEAD_SYNC_TIMEOUT" in
 '' | *[!0-9]*)

--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -294,6 +294,45 @@ _has_review_activity() {
   [ "$count" -gt 0 ]
 }
 
+# PI-706: `gh pr checks` reports the rollup for whatever commit the API believes
+# is the PR head. Right after a push the API can still serve the PREVIOUS
+# headRefOid (replication lag); that commit's checks are already settled, so the
+# CI wait below breaks on the first poll and judges the wrong commit — a red
+# predecessor reads as "CI failed" (observed on #705), and a green one would
+# merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
+# rather than the API, so it sees the pushed tip immediately: wait until the two
+# agree before any check result is trusted. Fails open (returns 0) whenever the
+# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
+# — leaving behavior exactly as it was before this gate existed.
+_wait_for_head_sync() {
+  local head_ref remote_sha api_sha elapsed
+  if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
+    return 0
+  fi
+  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
+    -q '.headRefName' 2>/dev/null || true)
+  [ -n "$head_ref" ] || return 0
+  remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
+  [ -n "$remote_sha" ] || return 0
+  elapsed=0
+  while true; do
+    api_sha=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefOid \
+      -q '.headRefOid' 2>/dev/null || true)
+    if [ "$api_sha" = "$remote_sha" ]; then
+      return 0
+    fi
+    if [ "$elapsed" -ge "$HEAD_SYNC_TIMEOUT" ]; then
+      echo "PR #$PR_NUMBER: GitHub still reports head ${api_sha:-<unknown>}, but the" >&2
+      echo "  remote branch $head_ref is at $remote_sha (${HEAD_SYNC_TIMEOUT}s elapsed)." >&2
+      echo "  Refusing to judge check results that may belong to another commit." >&2
+      echo "  Re-run shortly, or set PI_HEAD_SYNC_TIMEOUT=0 to skip this gate." >&2
+      exit 1
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+}
+
 # --- Wait for all CI checks (excludes review/decision commit status) ---
 # Guard: if checks haven't registered yet (empty list), keep polling.
 # An empty list is indistinguishable from "all done" without this guard,
@@ -315,6 +354,19 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
   echo "PI_CI_TIMEOUT must be a positive integer (seconds); got '${PI_CI_TIMEOUT:-}'" >&2
   exit 2
 fi
+
+# PI-706: how long to wait for the API's PR head to catch up with the pushed
+# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
+# origin` cannot see the head branch and the wait would be pure latency).
+HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
+case "$HEAD_SYNC_TIMEOUT" in
+'' | *[!0-9]*)
+  echo "PI_HEAD_SYNC_TIMEOUT must be a non-negative integer (seconds); got '${PI_HEAD_SYNC_TIMEOUT:-}'" >&2
+  exit 2
+  ;;
+esac
+_wait_for_head_sync
+
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -301,16 +301,34 @@ _has_review_activity() {
 # predecessor reads as "CI failed" (observed on #705), and a green one would
 # merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
 # rather than the API, so it sees the pushed tip immediately: wait until the two
-# agree before any check result is trusted. Fails open (returns 0) whenever the
-# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
-# — leaving behavior exactly as it was before this gate existed.
+# agree before any check result is trusted.
+#
+# Two distinct outcomes when the SHAs don't line up:
+#   * skipped entirely (return 0, unchanged behavior) when no expected SHA can
+#     be established — a cross-repo PR, a deleted branch, no `origin`, or the
+#     gate switched off with PI_HEAD_SYNC_TIMEOUT=0;
+#   * fail closed (exit 1) when an expected SHA IS known and the API never
+#     catches up to it within the timeout, since every check result on hand
+#     may belong to some other commit.
 _wait_for_head_sync() {
-  local head_ref remote_sha api_sha elapsed
+  local head_info head_ref cross_repo remote_sha api_sha elapsed
   if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
     return 0
   fi
-  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
-    -q '.headRefName' 2>/dev/null || true)
+  # Cross-repo (fork) PRs: headRefName carries only the branch name, so
+  # `ls-remote origin refs/heads/$head_ref` would resolve a base-repo branch
+  # that merely shares the name (`main`, `feature`) and then wait out the
+  # timeout against a SHA from the wrong repository (PR #712 review). The
+  # fork's remote isn't configured here — skip rather than guess.
+  head_info=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" \
+    --json headRefName,isCrossRepository \
+    -q '.headRefName + " " + (.isCrossRepository | tostring)' 2>/dev/null || true)
+  [ -n "$head_info" ] || return 0
+  head_ref=${head_info% *}
+  cross_repo=${head_info##* }
+  if [ "$cross_repo" = "true" ]; then
+    return 0
+  fi
   [ -n "$head_ref" ] || return 0
   remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
   [ -n "$remote_sha" ] || return 0
@@ -356,8 +374,8 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
 fi
 
 # PI-706: how long to wait for the API's PR head to catch up with the pushed
-# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
-# origin` cannot see the head branch and the wait would be pure latency).
+# tip. 0 disables the gate — an escape hatch for mirrors and other setups where
+# `git ls-remote origin` reports a SHA the API will never converge on.
 HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
 case "$HEAD_SYNC_TIMEOUT" in
 '' | *[!0-9]*)

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -294,6 +294,45 @@ _has_review_activity() {
   [ "$count" -gt 0 ]
 }
 
+# PI-706: `gh pr checks` reports the rollup for whatever commit the API believes
+# is the PR head. Right after a push the API can still serve the PREVIOUS
+# headRefOid (replication lag); that commit's checks are already settled, so the
+# CI wait below breaks on the first poll and judges the wrong commit — a red
+# predecessor reads as "CI failed" (observed on #705), and a green one would
+# merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
+# rather than the API, so it sees the pushed tip immediately: wait until the two
+# agree before any check result is trusted. Fails open (returns 0) whenever the
+# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
+# — leaving behavior exactly as it was before this gate existed.
+_wait_for_head_sync() {
+  local head_ref remote_sha api_sha elapsed
+  if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
+    return 0
+  fi
+  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
+    -q '.headRefName' 2>/dev/null || true)
+  [ -n "$head_ref" ] || return 0
+  remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
+  [ -n "$remote_sha" ] || return 0
+  elapsed=0
+  while true; do
+    api_sha=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefOid \
+      -q '.headRefOid' 2>/dev/null || true)
+    if [ "$api_sha" = "$remote_sha" ]; then
+      return 0
+    fi
+    if [ "$elapsed" -ge "$HEAD_SYNC_TIMEOUT" ]; then
+      echo "PR #$PR_NUMBER: GitHub still reports head ${api_sha:-<unknown>}, but the" >&2
+      echo "  remote branch $head_ref is at $remote_sha (${HEAD_SYNC_TIMEOUT}s elapsed)." >&2
+      echo "  Refusing to judge check results that may belong to another commit." >&2
+      echo "  Re-run shortly, or set PI_HEAD_SYNC_TIMEOUT=0 to skip this gate." >&2
+      exit 1
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+}
+
 # --- Wait for all CI checks (excludes review/decision commit status) ---
 # Guard: if checks haven't registered yet (empty list), keep polling.
 # An empty list is indistinguishable from "all done" without this guard,
@@ -315,6 +354,19 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
   echo "PI_CI_TIMEOUT must be a positive integer (seconds); got '${PI_CI_TIMEOUT:-}'" >&2
   exit 2
 fi
+
+# PI-706: how long to wait for the API's PR head to catch up with the pushed
+# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
+# origin` cannot see the head branch and the wait would be pure latency).
+HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
+case "$HEAD_SYNC_TIMEOUT" in
+'' | *[!0-9]*)
+  echo "PI_HEAD_SYNC_TIMEOUT must be a non-negative integer (seconds); got '${PI_HEAD_SYNC_TIMEOUT:-}'" >&2
+  exit 2
+  ;;
+esac
+_wait_for_head_sync
+
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -301,16 +301,34 @@ _has_review_activity() {
 # predecessor reads as "CI failed" (observed on #705), and a green one would
 # merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
 # rather than the API, so it sees the pushed tip immediately: wait until the two
-# agree before any check result is trusted. Fails open (returns 0) whenever the
-# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
-# — leaving behavior exactly as it was before this gate existed.
+# agree before any check result is trusted.
+#
+# Two distinct outcomes when the SHAs don't line up:
+#   * skipped entirely (return 0, unchanged behavior) when no expected SHA can
+#     be established — a cross-repo PR, a deleted branch, no `origin`, or the
+#     gate switched off with PI_HEAD_SYNC_TIMEOUT=0;
+#   * fail closed (exit 1) when an expected SHA IS known and the API never
+#     catches up to it within the timeout, since every check result on hand
+#     may belong to some other commit.
 _wait_for_head_sync() {
-  local head_ref remote_sha api_sha elapsed
+  local head_info head_ref cross_repo remote_sha api_sha elapsed
   if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
     return 0
   fi
-  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
-    -q '.headRefName' 2>/dev/null || true)
+  # Cross-repo (fork) PRs: headRefName carries only the branch name, so
+  # `ls-remote origin refs/heads/$head_ref` would resolve a base-repo branch
+  # that merely shares the name (`main`, `feature`) and then wait out the
+  # timeout against a SHA from the wrong repository (PR #712 review). The
+  # fork's remote isn't configured here — skip rather than guess.
+  head_info=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" \
+    --json headRefName,isCrossRepository \
+    -q '.headRefName + " " + (.isCrossRepository | tostring)' 2>/dev/null || true)
+  [ -n "$head_info" ] || return 0
+  head_ref=${head_info% *}
+  cross_repo=${head_info##* }
+  if [ "$cross_repo" = "true" ]; then
+    return 0
+  fi
   [ -n "$head_ref" ] || return 0
   remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
   [ -n "$remote_sha" ] || return 0
@@ -356,8 +374,8 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
 fi
 
 # PI-706: how long to wait for the API's PR head to catch up with the pushed
-# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
-# origin` cannot see the head branch and the wait would be pure latency).
+# tip. 0 disables the gate — an escape hatch for mirrors and other setups where
+# `git ls-remote origin` reports a SHA the API will never converge on.
 HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
 case "$HEAD_SYNC_TIMEOUT" in
 '' | *[!0-9]*)

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -294,6 +294,45 @@ _has_review_activity() {
   [ "$count" -gt 0 ]
 }
 
+# PI-706: `gh pr checks` reports the rollup for whatever commit the API believes
+# is the PR head. Right after a push the API can still serve the PREVIOUS
+# headRefOid (replication lag); that commit's checks are already settled, so the
+# CI wait below breaks on the first poll and judges the wrong commit — a red
+# predecessor reads as "CI failed" (observed on #705), and a green one would
+# merge a commit whose CI never ran. `git ls-remote` answers from git's endpoint
+# rather than the API, so it sees the pushed tip immediately: wait until the two
+# agree before any check result is trusted. Fails open (returns 0) whenever the
+# expected SHA cannot be established — a fork PR, a deleted branch, no `origin`
+# — leaving behavior exactly as it was before this gate existed.
+_wait_for_head_sync() {
+  local head_ref remote_sha api_sha elapsed
+  if [ "$HEAD_SYNC_TIMEOUT" -eq 0 ]; then
+    return 0
+  fi
+  head_ref=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefName \
+    -q '.headRefName' 2>/dev/null || true)
+  [ -n "$head_ref" ] || return 0
+  remote_sha=$(git ls-remote origin "refs/heads/$head_ref" 2>/dev/null | cut -f1 || true)
+  [ -n "$remote_sha" ] || return 0
+  elapsed=0
+  while true; do
+    api_sha=$(GH_PROMPT_DISABLED=1 gh pr view "$PR_NUMBER" --json headRefOid \
+      -q '.headRefOid' 2>/dev/null || true)
+    if [ "$api_sha" = "$remote_sha" ]; then
+      return 0
+    fi
+    if [ "$elapsed" -ge "$HEAD_SYNC_TIMEOUT" ]; then
+      echo "PR #$PR_NUMBER: GitHub still reports head ${api_sha:-<unknown>}, but the" >&2
+      echo "  remote branch $head_ref is at $remote_sha (${HEAD_SYNC_TIMEOUT}s elapsed)." >&2
+      echo "  Refusing to judge check results that may belong to another commit." >&2
+      echo "  Re-run shortly, or set PI_HEAD_SYNC_TIMEOUT=0 to skip this gate." >&2
+      exit 1
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+}
+
 # --- Wait for all CI checks (excludes review/decision commit status) ---
 # Guard: if checks haven't registered yet (empty list), keep polling.
 # An empty list is indistinguishable from "all done" without this guard,
@@ -315,6 +354,19 @@ if [ "$CI_TIMEOUT" -eq 0 ]; then
   echo "PI_CI_TIMEOUT must be a positive integer (seconds); got '${PI_CI_TIMEOUT:-}'" >&2
   exit 2
 fi
+
+# PI-706: how long to wait for the API's PR head to catch up with the pushed
+# tip. 0 disables the gate (escape hatch for forks/mirrors where `git ls-remote
+# origin` cannot see the head branch and the wait would be pure latency).
+HEAD_SYNC_TIMEOUT="${PI_HEAD_SYNC_TIMEOUT:-120}"
+case "$HEAD_SYNC_TIMEOUT" in
+'' | *[!0-9]*)
+  echo "PI_HEAD_SYNC_TIMEOUT must be a non-negative integer (seconds); got '${PI_HEAD_SYNC_TIMEOUT:-}'" >&2
+  exit 2
+  ;;
+esac
+_wait_for_head_sync
+
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"

--- a/tests/integration/test_monitor_head_sync.py
+++ b/tests/integration/test_monitor_head_sync.py
@@ -1,0 +1,117 @@
+"""PI-706: monitor_pr.sh must not judge checks belonging to another commit.
+
+Right after a push, GitHub's API can still report the PREVIOUS commit as the
+PR head. Its checks are already settled, so the CI wait loop broke on the first
+poll and evaluated the wrong commit: a red predecessor read as "CI failed"
+(observed on #705), and a green one would have merged a commit whose CI never
+ran. The script now waits until the API's headRefOid matches the branch tip
+that `git ls-remote` reports before trusting any check result.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_NEW_SHA = "1111111111111111111111111111111111111111"
+_OLD_SHA = "2222222222222222222222222222222222222222"
+
+# The previous commit's checks: settled (no pending) and failing. Reading these
+# for the just-pushed commit is exactly the bug.
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"--json headRefName"*) echo "feature" ;;
+*"--json headRefOid"*) echo "$PI_TEST_API_SHA" ;;
+*"pr checks"*) echo '[{"name":"ci","state":"FAILURE","bucket":"fail"}]' ;;
+*"run list"*) echo '"success"' ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*) exit 0 ;;
+esac
+"""
+
+# `git ls-remote` answers from git's endpoint, which sees the pushed tip
+# immediately; every other git call is delegated to the real binary.
+_GIT_STUB = """#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\\trefs/heads/feature\\n' "$PI_TEST_REMOTE_SHA"
+  exit 0
+fi
+exec {real_git} "$@"
+"""
+
+
+def _stub_bin(tmp_path: Path) -> Path:
+    stub_bin = tmp_path / "stub-bin"
+    stub_bin.mkdir()
+    gh = stub_bin / "gh"
+    gh.write_text(_GH_STUB)
+    gh.chmod(0o755)
+    git = stub_bin / "git"
+    git.write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    git.chmod(0o755)
+    # No-op sleep so the bounded waits resolve instantly.
+    slp = stub_bin / "sleep"
+    slp.write_text("#!/bin/sh\nexit 0\n")
+    slp.chmod(0o755)
+    return stub_bin
+
+
+def _run(tmp_target: Path, tmp_path: Path, api_sha: str, **overrides: str):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    script = tmp_target / ".agents" / "scripts" / "monitor_pr.sh"
+    env = os.environ.copy()
+    env["PATH"] = f"{_stub_bin(tmp_path)}:{env['PATH']}"
+    env["PI_TEST_API_SHA"] = api_sha
+    env["PI_TEST_REMOTE_SHA"] = _NEW_SHA
+    env.update(overrides)
+    return subprocess.run(
+        ["bash", str(script), "1"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_stale_api_head_never_reaches_the_check_verdict(
+    tmp_target: Path, tmp_path: Path
+):
+    result = _run(
+        tmp_target, tmp_path, api_sha=_OLD_SHA, PI_HEAD_SYNC_TIMEOUT="10"
+    )
+    assert result.returncode == 1
+    assert "Refusing to judge check results" in result.stderr
+    assert _OLD_SHA in result.stderr and _NEW_SHA in result.stderr
+    # The previous commit's red checks must not be reported as this PR's verdict.
+    assert "CI failed" not in result.stdout
+
+
+def test_synced_api_head_passes_through_to_the_check_verdict(
+    tmp_target: Path, tmp_path: Path
+):
+    result = _run(tmp_target, tmp_path, api_sha=_NEW_SHA)
+    assert result.returncode == 1
+    assert "CI failed on PR #1" in result.stdout
+    assert "Refusing to judge check results" not in result.stderr
+
+
+def test_head_sync_timeout_zero_disables_the_gate(tmp_target: Path, tmp_path: Path):
+    result = _run(tmp_target, tmp_path, api_sha=_OLD_SHA, PI_HEAD_SYNC_TIMEOUT="0")
+    assert result.returncode == 1
+    assert "CI failed on PR #1" in result.stdout
+    assert "Refusing to judge check results" not in result.stderr
+
+
+def test_invalid_head_sync_timeout_fails_closed(tmp_target: Path, tmp_path: Path):
+    result = _run(
+        tmp_target, tmp_path, api_sha=_NEW_SHA, PI_HEAD_SYNC_TIMEOUT="soon"
+    )
+    assert result.returncode == 2
+    assert "non-negative integer" in result.stderr

--- a/tests/integration/test_monitor_head_sync.py
+++ b/tests/integration/test_monitor_head_sync.py
@@ -25,7 +25,7 @@ _OLD_SHA = "2222222222222222222222222222222222222222"
 # for the just-pushed commit is exactly the bug.
 _GH_STUB = """#!/bin/bash
 case "$*" in
-*"--json headRefName"*) echo "feature" ;;
+*"--json headRefName"*) echo "feature ${PI_TEST_CROSS_REPO:-false}" ;;
 *"--json headRefOid"*) echo "$PI_TEST_API_SHA" ;;
 *"pr checks"*) echo '[{"name":"ci","state":"FAILURE","bucket":"fail"}]' ;;
 *"run list"*) echo '"success"' ;;
@@ -46,13 +46,17 @@ exec {real_git} "$@"
 
 
 def _stub_bin(tmp_path: Path) -> Path:
+    real_git = shutil.which("git")
+    # Without this, the stub renders as `exec None "$@"` and the suite fails
+    # with a shell error that says nothing about the missing binary.
+    assert real_git, "git must be on PATH to stub `git ls-remote`"
     stub_bin = tmp_path / "stub-bin"
     stub_bin.mkdir()
     gh = stub_bin / "gh"
     gh.write_text(_GH_STUB)
     gh.chmod(0o755)
     git = stub_bin / "git"
-    git.write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    git.write_text(_GIT_STUB.format(real_git=real_git))
     git.chmod(0o755)
     # No-op sleep so the bounded waits resolve instantly.
     slp = stub_bin / "sleep"
@@ -104,6 +108,21 @@ def test_synced_api_head_passes_through_to_the_check_verdict(
 
 def test_head_sync_timeout_zero_disables_the_gate(tmp_target: Path, tmp_path: Path):
     result = _run(tmp_target, tmp_path, api_sha=_OLD_SHA, PI_HEAD_SYNC_TIMEOUT="0")
+    assert result.returncode == 1
+    assert "CI failed on PR #1" in result.stdout
+    assert "Refusing to judge check results" not in result.stderr
+
+
+def test_cross_repo_pr_skips_the_gate(tmp_target: Path, tmp_path: Path):
+    """A fork's `headRefName` may name a base-repo branch that isn't its head.
+
+    `ls-remote origin refs/heads/feature` would then answer with the base repo's
+    `feature`, and the gate would wait out its timeout against a SHA from the
+    wrong repository. Skip instead of guessing (PR #712 review).
+    """
+    result = _run(
+        tmp_target, tmp_path, api_sha=_OLD_SHA, PI_TEST_CROSS_REPO="true"
+    )
     assert result.returncode == 1
     assert "CI failed on PR #1" in result.stdout
     assert "Refusing to judge check results" not in result.stderr


### PR DESCRIPTION
## Problem

`gh pr checks` reports the rollup for whatever commit the API believes is the PR head. Right after a push, the API can still serve the **previous** `headRefOid` (replication lag). That commit's checks are already settled, so the CI wait loop in `monitor_pr.sh` broke on its first poll and judged the wrong commit:

- a **red** predecessor read as "CI failed" — observed on #705, where the new run went green a minute later;
- a **green** predecessor would have merged a commit whose CI never ran.

The existing empty-list guard only covers "no checks yet"; it cannot distinguish stale-but-settled from done.

## Fix

Before any check result is trusted, wait until the API's `headRefOid` agrees with the branch tip that `git ls-remote` reports. `ls-remote` answers from git's endpoint rather than the REST/GraphQL API, so it sees the pushed tip immediately.

The gate **fails open** whenever the expected SHA cannot be established — a fork PR, a deleted branch, no `origin` — leaving behavior exactly as before. `PI_HEAD_SYNC_TIMEOUT` (default 120s, `0` disables) bounds the wait and fails closed on expiry.

Shared lifecycle script: edited in `templates/`, synced to `.agents/` and `.claude/` via `just sync-agents` + `just sync-claude` (PI-685).

## Testing

New `tests/integration/test_monitor_head_sync.py` stubs `gh` and `git ls-remote` to cover four cases: stale API head never reaches the check verdict; synced head passes through to it; `PI_HEAD_SYNC_TIMEOUT=0` disables the gate; an invalid timeout fails closed.

Full suite green (2122 passed), `ruff check` clean, shellcheck gate passes.

Closes #706

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1