### PR TITLE
fix(PI-628): pin one Python version across mise, mypy, and the CI matrix

### DIFF
--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -54,9 +54,11 @@ The most-used flags:
 
 `--python-version` is the single source for "what Python is this project on": it
 pins `mise.toml`'s toolchain, `mypy.ini`'s typeshed baseline, and the floor of the
-CI test matrix to one value. On a greenfield scaffold the wizard asks; once your
-`pyproject.toml` declares `requires-python`, that becomes the source of truth and
-CI derives the matrix from it instead.
+CI test matrix to one value. On a greenfield scaffold the wizard asks. Once your
+`pyproject.toml` declares `requires-python`, that file is authoritative — CI
+re-derives the matrix from it on every run — so the wizard stops asking, and a
+`--python-version` that contradicts it is rejected rather than half-applied.
+To move an existing project, edit `requires-python` and re-run `project-init upgrade`.
 
 The full surface (delivery/deploy/IaC overlays, governance, observability,
 multi-model, agents, license, profile, …) is documented by `project-init --help`

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -45,11 +45,18 @@ The most-used flags:
 |------|--------|---------|
 | `--preset` | `core`, `auto`, `obsidian-only`, `obsidian-graphify`, `governed` (see `--list-presets`) | (asked interactively) |
 | `--language` | `python`, `node`, `go`, `rust`, `none` | `none` |
+| `--python-version` | `3.11`, `3.12`, `3.13`, `3.14` | `pyproject.toml`'s `requires-python` floor, else `3.11` |
 | `--memory` | `none`, `auto`, `obsidian-only`, `obsidian-graphify`, `obsidian-graphify-rag` | the preset's tier |
 | `--lifecycle` | `github`, `none` | `github` |
 | `--mcps` | `context7`, `context7-http` (comma-separated) | none |
 | `--browser` | flag (Playwright MCP) | off |
 | `--strict` | flag (fail on unrendered placeholders) | off |
+
+`--python-version` is the single source for "what Python is this project on": it
+pins `mise.toml`'s toolchain, `mypy.ini`'s typeshed baseline, and the floor of the
+CI test matrix to one value. On a greenfield scaffold the wizard asks; once your
+`pyproject.toml` declares `requires-python`, that becomes the source of truth and
+CI derives the matrix from it instead.
 
 The full surface (delivery/deploy/IaC overlays, governance, observability,
 multi-model, agents, license, profile, …) is documented by `project-init --help`

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -2677,7 +2677,12 @@ def _cli(argv: list[str]) -> int:
     _reject_bare_subcommand_target(args.target, parser)
     target = Path(args.target).resolve()
     # Before the target directory is created (PI-20) and before any prompt.
-    _reject_python_version_without_python(args.python_version, args.language, parser)
+    # --language is optional; a non-interactive run resolves an absent one to
+    # "none" (see _resolve_inputs), so validate against that rather than letting
+    # None read as "unknown" and slip the flag through (PR #713 review). In an
+    # interactive run the language is still unknown here — the wizard warns.
+    effective_language = args.language or ("none" if args.non_interactive else None)
+    _reject_python_version_without_python(args.python_version, effective_language, parser)
     _reject_conflicting_python_version(args.python_version, target, parser)
 
     # Select preset BEFORE creating the target directory — a typo'd --preset

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -103,7 +103,9 @@ class ScaffoldInputs:
     # mise.toml (toolchain pin), mypy.ini (typeshed baseline), and the CI
     # matrix floor — before this, those three disagreed on day one. Empty means
     # "derive": an existing pyproject.toml's requires-python floor, else 3.11.
-    # Precedence: --python-version > pyproject requires-python > prompt > 3.11.
+    # A declared requires-python is authoritative (CI derives its matrix from it
+    # at run time), so a --python-version that disagrees is rejected outright
+    # rather than half-applied; see _reject_conflicting_python_version.
     python_version: str = ""
 
 
@@ -139,6 +141,30 @@ def _python_floor_from_pyproject(target: Path | None) -> str | None:
     except Exception:
         return None
     return None
+
+
+def _reject_conflicting_python_version(
+    flag: str | None, target: Path | None, parser: argparse.ArgumentParser
+) -> None:
+    """Refuse a --python-version that contradicts a declared requires-python.
+
+    project-init does not own pyproject.toml, and the scaffolded CI matrix
+    derives from requires-python whenever it exists. Honoring the flag anyway
+    would pin mise.toml/mypy.ini to one version while CI tested another — mypy
+    would green-light syntax the oldest tested CPython cannot run (PR #713
+    review). One value or none: make the user reconcile the declaration.
+    """
+    if not flag:
+        return
+    declared = _python_floor_from_pyproject(target)
+    if declared and declared != flag:
+        parser.error(
+            f"--python-version {flag} conflicts with the requires-python floor "
+            f"({declared}) declared in pyproject.toml. CI derives its matrix from "
+            f"requires-python, so mise.toml and mypy.ini would pin {flag} while CI "
+            f"tested {declared}. Set requires-python to >={flag}, or drop "
+            f"--python-version to adopt the declared {declared}."
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -181,7 +207,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "the CI matrix floor to one version "
             f"(choices: {', '.join(SUPPORTED_PYTHON_VERSIONS)}; "
             "default: pyproject.toml's requires-python floor, else "
-            f"{SUPPORTED_PYTHON_VERSIONS[0]})"
+            f"{SUPPORTED_PYTHON_VERSIONS[0]}). Rejected if it contradicts a "
+            "declared requires-python."
         ),
     )
     p.add_argument(
@@ -2150,13 +2177,14 @@ def _build_variables(
     )
 
     # #628: one value answers "what Python is this project on" for mise.toml,
-    # mypy.ini, and the CI matrix floor. An explicit --python-version (or the
-    # wizard's answer, which lands in the same field) wins over the declared
-    # requires-python; a greenfield scaffold with neither falls back to the
-    # oldest supported CPython.
+    # mypy.ini, and the CI matrix floor. A declared requires-python is the
+    # source of truth (CI re-derives from it on every run); --python-version —
+    # or the wizard's answer, which lands in the same field — supplies the
+    # value when nothing declares one, and a contradicting flag was already
+    # rejected by _reject_conflicting_python_version. Neither: oldest supported.
     python_floor = (
-        inputs.python_version
-        or _python_floor_from_pyproject(target)
+        _python_floor_from_pyproject(target)
+        or inputs.python_version
         or SUPPORTED_PYTHON_VERSIONS[0]
     )
 
@@ -2623,6 +2651,8 @@ def _cli(argv: list[str]) -> int:
 
     _reject_bare_subcommand_target(args.target, parser)
     target = Path(args.target).resolve()
+    # Before the target directory is created (PI-20) and before any prompt.
+    _reject_conflicting_python_version(args.python_version, target, parser)
 
     # Select preset BEFORE creating the target directory — a typo'd --preset
     # should fail without leaving an empty dir behind.

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -99,6 +99,46 @@ class ScaffoldInputs:
     # Renovate config (#477, ADR-022): gates renovate.json (dependency-update bot).
     # Opt-OUT — default ON to preserve today's always-shipped config.
     renovate: bool = True
+    # Target CPython for a Python scaffold (#628). One value renders into
+    # mise.toml (toolchain pin), mypy.ini (typeshed baseline), and the CI
+    # matrix floor — before this, those three disagreed on day one. Empty means
+    # "derive": an existing pyproject.toml's requires-python floor, else 3.11.
+    # Precedence: --python-version > pyproject requires-python > prompt > 3.11.
+    python_version: str = ""
+
+
+# Every CPython a Python scaffold is willing to target (#628). Kept byte-equal
+# to the `KNOWN` list in templates/base/dot_github/workflows/ci.yml.tmpl, which
+# derives the test matrix from it — test_python_version_pins.py fails on drift.
+# The first entry is the default floor when nothing else declares one.
+SUPPORTED_PYTHON_VERSIONS: tuple[str, ...] = ("3.11", "3.12", "3.13", "3.14")
+
+
+def _python_floor_from_pyproject(target: Path | None) -> str | None:
+    """The requires-python floor declared by an existing pyproject.toml, if any.
+
+    Returns None for a greenfield scaffold — the case #628 is about, where no
+    file declares a version and every consumer used to invent its own.
+    """
+    if not target or not (target / "pyproject.toml").exists():
+        return None
+    try:
+        import tomllib
+
+        with (target / "pyproject.toml").open("rb") as f:
+            data = tomllib.load(f)
+        req = data.get("project", {}).get("requires-python", "")
+        if not req:
+            req = data.get("tool", {}).get("poetry", {}).get("dependencies", {}).get("python", "")
+        if req:
+            import re
+
+            m = re.search(r"(?:>=?|==|~=?|\^|^\s*)\s*(\d+\.\d+)", req)
+            if m and m.group(1):
+                return m.group(1)
+    except Exception:
+        return None
+    return None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -131,6 +171,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--language",
         choices=["python", "node", "go", "rust", "none"],
         help="Primary language/runtime",
+    )
+    p.add_argument(
+        "--python-version",
+        metavar="X.Y",
+        choices=list(SUPPORTED_PYTHON_VERSIONS),
+        help=(
+            "Target CPython for a Python project — pins mise.toml, mypy.ini, and "
+            "the CI matrix floor to one version "
+            f"(choices: {', '.join(SUPPORTED_PYTHON_VERSIONS)}; "
+            "default: pyproject.toml's requires-python floor, else "
+            f"{SUPPORTED_PYTHON_VERSIONS[0]})"
+        ),
     )
     p.add_argument(
         "--delivery",
@@ -1191,6 +1243,7 @@ WIZARD_MECHANICAL_FLAGS: frozenset[str] = frozenset(
         "name",
         "description",
         "language",
+        "python_version",
         "owner",
         "license",
         "agents",
@@ -1405,6 +1458,8 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     cli_mise: bool = False,
     cli_vscode: bool = False,
     cli_agents: str | None = None,
+    cli_python_version: str | None = None,
+    target: Path | None = None,
 ) -> ScaffoldInputs:
     """Prompt for the profile, project basics, MCPs, governance, and overlays.
 
@@ -1440,6 +1495,17 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         ("python", "node", "go", "rust", "none"),
         default=cli_language or "none",
     )
+    # #628: only a Python scaffold has a version to pin, and only a greenfield
+    # one has an unanswered question — when pyproject.toml already declares
+    # requires-python, that file is the source of truth and asking would invite
+    # a contradiction. An explicit --python-version still wins over both.
+    python_version = cli_python_version or ""
+    if not python_version and language == "python" and not _python_floor_from_pyproject(target):
+        python_version = _prompt_choice(
+            "Target Python (pins mise.toml, mypy.ini, and the CI matrix floor)",
+            SUPPORTED_PYTHON_VERSIONS,
+            default=SUPPORTED_PYTHON_VERSIONS[0],
+        )
     (
         delivery_flag,
         deploy_flag,
@@ -1527,6 +1593,7 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         no_plugin=no_plugin,
         profile=resolved_profile,
         no_egress=no_egress,
+        python_version=python_version,
         delivery=resolved_delivery,
         deploy=resolved_deploy,
         iac=resolved_iac,
@@ -2082,29 +2149,16 @@ def _build_variables(
         language, ("", "", "", "")
     )
 
-    python_floor = "3.11"
-    if target and (target / "pyproject.toml").exists():
-        try:
-            import tomllib
-
-            with (target / "pyproject.toml").open("rb") as f:
-                data = tomllib.load(f)
-                req = data.get("project", {}).get("requires-python", "")
-                if not req:
-                    req = (
-                        data.get("tool", {})
-                        .get("poetry", {})
-                        .get("dependencies", {})
-                        .get("python", "")
-                    )
-                if req:
-                    import re
-
-                    m = re.search(r"(?:>=?|==|~=?|\^|^\s*)\s*(\d+\.\d+)", req)
-                    if m and m.group(1):
-                        python_floor = m.group(1)
-        except Exception:
-            pass
+    # #628: one value answers "what Python is this project on" for mise.toml,
+    # mypy.ini, and the CI matrix floor. An explicit --python-version (or the
+    # wizard's answer, which lands in the same field) wins over the declared
+    # requires-python; a greenfield scaffold with neither falls back to the
+    # oldest supported CPython.
+    python_floor = (
+        inputs.python_version
+        or _python_floor_from_pyproject(target)
+        or SUPPORTED_PYTHON_VERSIONS[0]
+    )
 
     return {
         "python_floor": python_floor,
@@ -2304,6 +2358,7 @@ def _resolve_inputs(
         no_plugin=no_plugin,
         profile=profile,
         no_egress=args.no_egress,
+        python_version=args.python_version or "",
         delivery=delivery,
         deploy=deploy,
         iac=iac,
@@ -2589,6 +2644,8 @@ def _cli(argv: list[str]) -> int:
             no_plugin=args.no_plugin,
             profile=args.profile,
             no_egress=args.no_egress,
+            cli_python_version=args.python_version,
+            target=target,
             cli_overlays=(
                 args.delivery,
                 args.deploy,

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -143,6 +143,23 @@ def _python_floor_from_pyproject(target: Path | None) -> str | None:
     return None
 
 
+def _reject_python_version_without_python(
+    flag: str | None, language: str | None, parser: argparse.ArgumentParser
+) -> None:
+    """Refuse --python-version on a non-Python scaffold.
+
+    Every python_floor consumer is gated on the `python` flag, so the value
+    would render nowhere and a typo or wrapper bug would pass unnoticed
+    (PR #713 review). Only checkable when --language is explicit; the wizard
+    drops the flag with a warning instead, since language is chosen later.
+    """
+    if flag and language and language != "python":
+        parser.error(
+            f"--python-version {flag} requires --language python "
+            f"(got --language {language}); nothing would consume the value."
+        )
+
+
 def _reject_conflicting_python_version(
     flag: str | None, target: Path | None, parser: argparse.ArgumentParser
 ) -> None:
@@ -1527,6 +1544,14 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     # requires-python, that file is the source of truth and asking would invite
     # a contradiction. An explicit --python-version still wins over both.
     python_version = cli_python_version or ""
+    if python_version and language != "python":
+        # --language wasn't passed, so main() couldn't reject this pairing; the
+        # value would render nowhere. Drop it loudly rather than silently.
+        console.print(
+            f"[yellow]--python-version {python_version} ignored: it applies only to "
+            f"a python project (this is {language}).[/yellow]"
+        )
+        python_version = ""
     if not python_version and language == "python" and not _python_floor_from_pyproject(target):
         python_version = _prompt_choice(
             "Target Python (pins mise.toml, mypy.ini, and the CI matrix floor)",
@@ -2652,6 +2677,7 @@ def _cli(argv: list[str]) -> int:
     _reject_bare_subcommand_target(args.target, parser)
     target = Path(args.target).resolve()
     # Before the target directory is created (PI-20) and before any prompt.
+    _reject_python_version_without_python(args.python_version, args.language, parser)
     _reject_conflicting_python_version(args.python_version, target, parser)
 
     # Select preset BEFORE creating the target directory — a typo'd --preset

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -62,8 +62,13 @@ jobs:
           from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
           # Maintained ceiling set — every CPython this template is willing to
-          # test. The floor comes from requires-python (below), never from here.
+          # test. The floor comes from requires-python, else from the version
+          # project-init pinned at scaffold time; never from here. Kept
+          # byte-equal to SUPPORTED_PYTHON_VERSIONS in the scaffolder.
           KNOWN = ["3.11", "3.12", "3.13", "3.14"]
+
+          def _key(v):
+              return tuple(int(part) for part in v.split("."))
 
           spec = ""
           pyproject = pathlib.Path("pyproject.toml")
@@ -83,8 +88,10 @@ jobs:
                   # than failing the job on a bad requires-python.
                   versions = list(KNOWN)
           else:
-              # No declared floor yet (e.g. a fresh scaffold) — test the full set.
-              versions = list(KNOWN)
+              # No requires-python yet (a fresh scaffold, #628) — honor the floor
+              # project-init pinned into mise.toml and mypy.ini instead of fanning
+              # out across CPythons the project never claimed to support.
+              versions = [v for v in KNOWN if _key(v) >= _key("{{python_floor}}")]
           if not versions:
               # requires-python excludes every KNOWN version — fall back to the
               # newest so CI still runs instead of erroring on an empty matrix.
@@ -92,7 +99,7 @@ jobs:
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write("versions=" + json.dumps(versions) + "\n")
-          print("requires-python:", spec or "(none) -> full KNOWN set")
+          print("requires-python:", spec or '(none) -> floor {{python_floor}} from project-init')
           print("matrix:", versions)
           PY
 {{/if python}}

--- a/templates/base/mise.toml.tmpl
+++ b/templates/base/mise.toml.tmpl
@@ -19,7 +19,10 @@ just = "1"
 # commit.
 shellcheck = "latest"
 shfmt = "latest"
-{{#if python}}python = "3.12"
+{{#if python}}# Kept equal to mypy.ini's python_version and the CI matrix floor (#628) —
+# one answer to "what Python is this project on". Change all three together,
+# or re-run `project-init upgrade` after editing requires-python.
+python = "{{python_floor}}"
 uv = "latest"
 {{/if python}}{{#if node}}bun = "1"
 {{/if node}}{{#if go}}go = "1.24"

--- a/templates/base/mypy.ini.tmpl
+++ b/templates/base/mypy.ini.tmpl
@@ -3,8 +3,9 @@
 # only — test code and agent infra (.agents/**) are out of scope by construction,
 # the same way ruff.toml exempts them via per-file-ignores.
 #
-# python_version pins the typeshed/syntax baseline mypy checks against; keep it
-# aligned with your pyproject.toml's requires-python floor.
+# python_version pins the typeshed/syntax baseline mypy checks against. It is
+# the same value as mise.toml's python pin and the CI matrix floor (#628); keep
+# all three aligned with your pyproject.toml's requires-python floor.
 #
 # Deliberately NOT enabled: disallow_any_explicit / disallow_any_decorated.
 # Verified against real code (PI-570) — both fire on legitimate, idiomatic

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -104,7 +104,8 @@ class TestAgentSelection:
         fall back to claude-only (PR #167 review)."""
         import project_init.__main__ as cli
 
-        prompt_answers = iter(["proj", "desc", "python", "@owner", "none"])
+        # "3.11" answers the target-Python prompt a python scaffold now asks (#628).
+        prompt_answers = iter(["proj", "desc", "python", "3.11", "@owner", "none"])
         ask_answers = iter(["4,10", "4"])
         monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(prompt_answers))
         monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: next(ask_answers))

--- a/tests/contracts/test_docs_renovate.py
+++ b/tests/contracts/test_docs_renovate.py
@@ -189,7 +189,8 @@ class TestInteractiveFlags:
     def _mock_leaves(monkeypatch):
         import project_init.__main__ as cli
 
-        answers = iter(["proj", "desc", "python", "@owner", "none", "claude"])
+        # "3.11" answers the target-Python prompt a python scaffold now asks (#628).
+        answers = iter(["proj", "desc", "python", "3.11", "@owner", "none", "claude"])
         monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(answers))
         monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)

--- a/tests/contracts/test_governance_overlay.py
+++ b/tests/contracts/test_governance_overlay.py
@@ -194,7 +194,8 @@ class TestInteractiveResolution:
     def _mock_leaves(monkeypatch):
         import project_init.__main__ as cli
 
-        answers = iter(["proj", "desc", "python", "@owner", "none", "claude"])
+        # "3.11" answers the target-Python prompt a python scaffold now asks (#628).
+        answers = iter(["proj", "desc", "python", "3.11", "@owner", "none", "claude"])
         monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(answers))
         monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
         monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)

--- a/tests/contracts/test_python_version_set.py
+++ b/tests/contracts/test_python_version_set.py
@@ -1,0 +1,33 @@
+"""PI-628: the scaffolder's supported CPython set is the CI template's KNOWN set.
+
+`--python-version` validates against `SUPPORTED_PYTHON_VERSIONS`, and the
+scaffolded ci.yml filters its matrix out of a `KNOWN` list. If the two drift,
+a user can pin a floor CI will never test (or CI fans out to a CPython the
+wizard refuses to name).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from project_init.__main__ import SUPPORTED_PYTHON_VERSIONS
+
+_CI_TMPL = Path("templates/base/dot_github/workflows/ci.yml.tmpl")
+
+
+def test_ci_known_set_matches_the_cli_supported_set():
+    m = re.search(r"^\s*KNOWN = (\[[^\]]*\])", _CI_TMPL.read_text(), re.M)
+    assert m, "KNOWN list not found in ci.yml.tmpl — did the matrix step move?"
+    known = ast.literal_eval(m.group(1))
+    assert known == list(SUPPORTED_PYTHON_VERSIONS), (
+        f"ci.yml.tmpl KNOWN={known} but SUPPORTED_PYTHON_VERSIONS="
+        f"{list(SUPPORTED_PYTHON_VERSIONS)} — keep them equal (#628)"
+    )
+
+
+def test_supported_versions_are_sorted_oldest_first():
+    """The first entry is the default floor; an unsorted set would default wrong."""
+    keys = [tuple(int(p) for p in v.split(".")) for v in SUPPORTED_PYTHON_VERSIONS]
+    assert keys == sorted(keys), SUPPORTED_PYTHON_VERSIONS

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _BASE = (
     "--non-interactive",
     "--preset",
@@ -97,10 +99,15 @@ def test_unsupported_python_version_is_rejected(tmp_path: Path):
     assert not (tmp_path / "mise.toml").exists()
 
 
-def test_python_version_without_python_language_is_rejected(tmp_path: Path):
+@pytest.mark.parametrize("language", ["go", None])
+def test_python_version_without_python_language_is_rejected(tmp_path: Path, language):
     """Every python_floor consumer is gated on `python`, so the flag would render
     nowhere — a typo or wrapper bug must not pass unnoticed (PR #713 review).
+
+    An absent --language is the sharper case: non-interactive resolves it to
+    "none", so the run used to succeed with the pin rendered nowhere.
     """
+    lang_args = ["--language", language] if language else []
     result = subprocess.run(
         [
             sys.executable,
@@ -116,8 +123,7 @@ def test_python_version_without_python_language_is_rejected(tmp_path: Path):
             "t",
             "--description",
             "t",
-            "--language",
-            "go",
+            *lang_args,
             "--python-version",
             "3.13",
         ],

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -1,0 +1,138 @@
+"""PI-628: one Python scaffold must emit one Python version, not three.
+
+Before this, a single greenfield run wrote `python_version = 3.11` to mypy.ini
+(the `python_floor` default), `python = "3.12"` to mise.toml (hardcoded), and a
+CI matrix fanning 3.11-3.14 (no `requires-python` to derive from) — three
+different answers to "what Python is this project on".
+
+Precedence, exercised below: --python-version > pyproject requires-python > 3.11.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_BASE = (
+    "--non-interactive",
+    "--preset",
+    "core",
+    "--agents",
+    "claude",
+    "--name",
+    "t",
+    "--description",
+    "t",
+    "--language",
+    "python",
+    # mise.toml is gated on --mise; without it there is no toolchain pin to compare.
+    "--mise",
+)
+
+
+def _scaffold(target: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "project_init", str(target), *_BASE, *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _pins(target: Path) -> dict[str, str]:
+    """The three pins that used to disagree, read back from the rendered files."""
+    mise = re.search(r'^python = "([\d.]+)"', (target / "mise.toml").read_text(), re.M)
+    mypy = re.search(r"^python_version = ([\d.]+)", (target / "mypy.ini").read_text(), re.M)
+    ci = re.search(r'_key\("([\d.]+)"\)', (target / ".github/workflows/ci.yml").read_text())
+    assert mise and mypy and ci, "a pin is missing from the rendered output"
+    return {"mise": mise.group(1), "mypy": mypy.group(1), "ci_floor": ci.group(1)}
+
+
+def test_greenfield_scaffold_pins_one_python_version(tmp_path: Path):
+    assert _scaffold(tmp_path).returncode == 0
+    pins = _pins(tmp_path)
+    assert set(pins.values()) == {"3.11"}, pins
+
+
+def test_python_version_flag_drives_all_three_pins(tmp_path: Path):
+    assert _scaffold(tmp_path, "--python-version", "3.13").returncode == 0
+    pins = _pins(tmp_path)
+    assert set(pins.values()) == {"3.13"}, pins
+
+
+def test_declared_requires_python_wins_over_the_default(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
+    assert _scaffold(tmp_path).returncode == 0
+    pins = _pins(tmp_path)
+    assert set(pins.values()) == {"3.12"}, pins
+
+
+def test_flag_wins_over_declared_requires_python(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
+    assert _scaffold(tmp_path, "--python-version", "3.14").returncode == 0
+    pins = _pins(tmp_path)
+    assert set(pins.values()) == {"3.14"}, pins
+
+
+def test_unsupported_python_version_is_rejected(tmp_path: Path):
+    result = _scaffold(tmp_path, "--python-version", "3.9")
+    assert result.returncode != 0
+    assert "invalid choice: '3.9'" in result.stderr
+    # Rejected before the target is touched (PI-20): no half-scaffold left behind.
+    assert not (tmp_path / "mise.toml").exists()
+
+
+def _wizard(monkeypatch, answers: list[str], *, target: Path | None = None):
+    """Drive _gather_inputs_interactive, returning (inputs, prompt labels seen)."""
+    import project_init.__main__ as cli
+
+    seen: list[str] = []
+    answer_iter = iter(answers)
+
+    def fake_prompt(label, *a, **k):
+        seen.append(str(label))
+        return next(answer_iter)
+
+    monkeypatch.setattr(cli, "_prompt", fake_prompt)
+    monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
+    monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
+    monkeypatch.setattr(cli, "_choose_delivery_interactive", lambda language: "prototype")
+    monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
+    monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
+    monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "github")
+    monkeypatch.setattr(cli, "_choose_agents_interactive", lambda: ["claude"])
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+
+    inputs = cli._gather_inputs_interactive(
+        default_name="proj", no_plugin=False, profile="individual", target=target
+    )
+    return inputs, seen
+
+
+def _asked_for_python(seen: list[str]) -> bool:
+    return any("Target Python" in label for label in seen)
+
+
+def test_wizard_asks_for_python_on_a_greenfield_python_scaffold(monkeypatch):
+    inputs, seen = _wizard(monkeypatch, ["proj", "desc", "python", "3.13", "", "none"])
+    assert _asked_for_python(seen)
+    assert inputs.python_version == "3.13"
+
+
+def test_wizard_does_not_ask_for_python_on_a_non_python_scaffold(monkeypatch):
+    """A stray prompt here would silently eat the next answer in the wizard."""
+    inputs, seen = _wizard(monkeypatch, ["proj", "desc", "go", "", "none"])
+    assert not _asked_for_python(seen)
+    assert inputs.python_version == ""
+
+
+def test_wizard_does_not_ask_when_pyproject_already_declares_a_floor(
+    monkeypatch, tmp_path: Path
+):
+    """requires-python is the source of truth; asking would invite a contradiction."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
+    inputs, seen = _wizard(monkeypatch, ["proj", "desc", "python", "", "none"], target=tmp_path)
+    assert not _asked_for_python(seen)
+    assert inputs.python_version == ""

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -5,7 +5,9 @@ Before this, a single greenfield run wrote `python_version = 3.11` to mypy.ini
 CI matrix fanning 3.11-3.14 (no `requires-python` to derive from) — three
 different answers to "what Python is this project on".
 
-Precedence, exercised below: --python-version > pyproject requires-python > 3.11.
+A declared requires-python is authoritative, since the scaffolded CI re-derives
+its matrix from that file on every run. --python-version supplies the value when
+nothing declares one, and is rejected outright when it contradicts one.
 """
 
 from __future__ import annotations
@@ -69,11 +71,22 @@ def test_declared_requires_python_wins_over_the_default(tmp_path: Path):
     assert set(pins.values()) == {"3.12"}, pins
 
 
-def test_flag_wins_over_declared_requires_python(tmp_path: Path):
+def test_flag_contradicting_requires_python_is_rejected(tmp_path: Path):
+    """CI re-derives its matrix from requires-python on every run, so honoring the
+    flag would pin mypy to 3.14 typeshed while CI ran the code on 3.12 — syntax
+    that type-checks clean and then breaks the oldest job (PR #713 review).
+    """
     (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
-    assert _scaffold(tmp_path, "--python-version", "3.14").returncode == 0
-    pins = _pins(tmp_path)
-    assert set(pins.values()) == {"3.14"}, pins
+    result = _scaffold(tmp_path, "--python-version", "3.14")
+    assert result.returncode != 0
+    assert "conflicts with the requires-python floor (3.12)" in result.stderr
+    assert not (tmp_path / "mise.toml").exists()
+
+
+def test_flag_agreeing_with_requires_python_is_accepted(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
+    assert _scaffold(tmp_path, "--python-version", "3.12").returncode == 0
+    assert set(_pins(tmp_path).values()) == {"3.12"}
 
 
 def test_unsupported_python_version_is_rejected(tmp_path: Path):

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -97,7 +97,46 @@ def test_unsupported_python_version_is_rejected(tmp_path: Path):
     assert not (tmp_path / "mise.toml").exists()
 
 
-def _wizard(monkeypatch, answers: list[str], *, target: Path | None = None):
+def test_python_version_without_python_language_is_rejected(tmp_path: Path):
+    """Every python_floor consumer is gated on `python`, so the flag would render
+    nowhere — a typo or wrapper bug must not pass unnoticed (PR #713 review).
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "project_init",
+            str(tmp_path),
+            "--non-interactive",
+            "--preset",
+            "core",
+            "--agents",
+            "claude",
+            "--name",
+            "t",
+            "--description",
+            "t",
+            "--language",
+            "go",
+            "--python-version",
+            "3.13",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "requires --language python" in result.stderr
+    assert not (tmp_path / ".agents").exists()
+
+
+def _wizard(
+    monkeypatch,
+    answers: list[str],
+    *,
+    target: Path | None = None,
+    python_version: str | None = None,
+):
     """Drive _gather_inputs_interactive, returning (inputs, prompt labels seen)."""
     import project_init.__main__ as cli
 
@@ -119,7 +158,11 @@ def _wizard(monkeypatch, answers: list[str], *, target: Path | None = None):
     monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 
     inputs = cli._gather_inputs_interactive(
-        default_name="proj", no_plugin=False, profile="individual", target=target
+        default_name="proj",
+        no_plugin=False,
+        profile="individual",
+        target=target,
+        cli_python_version=python_version,
     )
     return inputs, seen
 
@@ -139,6 +182,15 @@ def test_wizard_does_not_ask_for_python_on_a_non_python_scaffold(monkeypatch):
     inputs, seen = _wizard(monkeypatch, ["proj", "desc", "go", "", "none"])
     assert not _asked_for_python(seen)
     assert inputs.python_version == ""
+
+
+def test_wizard_drops_python_version_when_the_language_is_not_python(monkeypatch, capsys):
+    """--language wasn't passed, so main() couldn't reject the pairing; the wizard
+    must drop the value loudly rather than carry a flag nothing consumes.
+    """
+    inputs, _ = _wizard(monkeypatch, ["proj", "desc", "go", "", "none"], python_version="3.13")
+    assert inputs.python_version == ""
+    assert "--python-version 3.13 ignored" in capsys.readouterr().out
 
 
 def test_wizard_does_not_ask_when_pyproject_already_declares_a_floor(


### PR DESCRIPTION
## Problem

A single greenfield Python scaffold emitted **three different answers** to "what Python is this project on":

| File | Value | Where it came from |
|---|---|---|
| `mypy.ini` | `3.11` | `python_floor`, whose default is 3.11 when no `pyproject.toml` exists — the normal greenfield case |
| `mise.toml` | `3.12` | hardcoded in `mise.toml.tmpl` |
| CI matrix | `3.11`–`3.14` | the full `KNOWN` set, since `requires-python` is absent |

So on day one mise provisions 3.12, mypy checks against 3.11 typeshed, and CI tests four versions — and none of them is necessarily the one the user intends.

## Fix

One value feeds all three. `--python-version` (choices `3.11`–`3.14`) is a **mechanical** flag per ADR-023 — an input value like `--name`, not a selectable concern, so it needs no explainer panel; `test_wizard_explanations.py` classifies it via `WIZARD_MECHANICAL_FLAGS`.

**Resolution order:**

1. A declared `requires-python` in `pyproject.toml` is **authoritative** — the scaffolded CI re-derives its matrix from that file on every run, so nothing else can outrank it.
2. `--python-version` supplies the value when nothing declares one.
3. Otherwise `3.11`, the oldest supported CPython.

A `--python-version` that **contradicts** a declared `requires-python` is rejected before the target directory is created, rather than half-applied. (Caught in review — see below.) The wizard asks only on a greenfield Python scaffold; when `requires-python` exists it stays silent, and non-Python scaffolds never see the prompt.

The CI template's no-`requires-python` branch now starts the matrix at the scaffolded floor rather than fanning across the full `KNOWN` set, so a `--python-version 3.13` project tests `[3.13, 3.14]`.

A contract test pins `KNOWN` in `ci.yml.tmpl` byte-equal to `SUPPORTED_PYTHON_VERSIONS` in the scaffolder, so a user can never pin a floor CI won't test.

## Review finding (Codex, P2)

The first revision let `--python-version` win over a declared `requires-python` for `mise.toml` and `mypy.ini` — but the generated CI still entered its `if spec:` branch and derived the matrix from `requires-python`. Reproduced: `requires-python = ">=3.12"` + `--python-version 3.14` rendered both local pins at 3.14 while CI tested `['3.12', '3.13', '3.14']`. mypy would then type-check against 3.14 typeshed and green-light syntax the 3.12 job cannot run.

Making CI follow the rendered floor instead would have traded one incoherence for another — CI testing only 3.14 while the package metadata still advertised 3.12 support. `requires-python` is the project's public contract and project-init does not own `pyproject.toml`, so the conflict now **fails closed** with a message naming both values and the two ways out.

## Verification

Beyond the tests, I scaffolded real projects and executed the rendered CI matrix script in a clean cwd:

- greenfield, no flag → all three read `3.11`, matrix `[3.11, 3.12, 3.13, 3.14]`
- `--python-version 3.13` → all three read `3.13`, matrix `[3.13, 3.14]`
- existing `requires-python = ">=3.12"`, no flag → all three read `3.12`
- existing `requires-python = ">=3.12"` + `--python-version 3.14` → rejected, nothing written
- existing `requires-python = ">=3.12"` + `--python-version 3.12` → accepted
- `--python-version 3.9` → rejected before the target dir is created
- wizard: prompts for Python, silent for Go, silent when `requires-python` exists

Three scripted-wizard tests needed an extra answer because a new prompt was inserted; each is annotated.

Full suite green (2134 passed), `ruff check` clean.

Closes #628

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1