### PR TITLE
feat(PI-714): make review cycles configurable and explained in the wizard

### DIFF
--- a/.agents/scripts/gh_host.sh
+++ b/.agents/scripts/gh_host.sh
@@ -69,6 +69,17 @@ gh_profile() {
   printf '%s\n' "${prof:-individual}"
 }
 
+# Review-fix cycles monitor_pr.sh runs before it stops asking for another pass
+# (#714). 0 means no review control: merge as soon as CI is green. Anchored on
+# this file's location for the same reason gh_profile is. Falls back to 2 — the
+# default the wizard explains — when unset or absent.
+review_cycles() {
+  local cfg n=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && n=$(sed -nE 's/^[[:space:]]*review_cycles:[[:space:]]*([0-9]+).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "${n:-2}"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -48,7 +48,16 @@ PY="$SCRIPT_DIR/../hooks/_py.sh"
 PR_NUMBER="${1:-}"
 MODE=""
 REVIEW_CYCLE=0
-MAX_REVIEW_CYCLES=2
+# #714: review-fix cycles before the script stops asking for another pass.
+# Precedence: PI_REVIEW_CYCLES env > config.yaml `review_cycles` > 2.
+# 0 disables review control entirely — merge as soon as CI is green.
+MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"
+case "$MAX_REVIEW_CYCLES" in
+'' | *[!0-9]*)
+  echo "review cycles must be a non-negative integer; got '$MAX_REVIEW_CYCLES'" >&2
+  exit 2
+  ;;
+esac
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -456,6 +465,19 @@ fi
 REVIEW_TIMEOUT=360
 REVIEW_ELAPSED=0
 REVIEW_DECISION=$(_get_review_decision)
+
+# #714: review_cycles=0 means the operator declined review control. Skip the whole
+# review gate — the wait, the changes-requested cycle, the unresolved-thread check
+# — and merge on green CI. Deliberately NOT an admin override: if an approval
+# policy is in force the merge still blocks, because "no review control" is a
+# choice about this script's cycles, not a licence to bypass branch protection.
+# Set before the max-cycles check below, which would otherwise read 0 >= 0 as
+# "cycles exhausted" and force an admin merge.
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
+  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  REVIEW_DECISION="SKIPPED"
+fi
+
 if [ "$MODE" = "--merge" ] && [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ] && [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ]; then
   echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — skipping reviewer wait and force-merging with admin override."
   _admin_merge

--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -58,6 +58,9 @@ case "$MAX_REVIEW_CYCLES" in
   exit 2
   ;;
 esac
+# Base-10, so a config.yaml or PI_REVIEW_CYCLES carrying "08" can never reach an
+# arithmetic context as octal (PR #717 review).
+MAX_REVIEW_CYCLES=$((10#$MAX_REVIEW_CYCLES))
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -110,6 +113,11 @@ case "$REVIEW_CYCLE" in
   exit 2
   ;;
 esac
+# The digits-only check above accepts "08", which arithmetic expansion then reads
+# as octal: `NEXT=$((REVIEW_CYCLE + 1))` dies with "value too great for base"
+# (PR #717 review). `[ ]` comparisons parse base-10 and are unaffected, but the
+# $(( )) sites are not — normalize once, here, rather than at each use.
+REVIEW_CYCLE=$((10#$REVIEW_CYCLE))
 
 # --admin, --no-review and --review-cycle only take effect while merging. Warn
 # loudly if they were passed without --merge (e.g. `monitor_pr.sh 12 --admin`)

--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -473,8 +473,14 @@ REVIEW_DECISION=$(_get_review_decision)
 # choice about this script's cycles, not a licence to bypass branch protection.
 # Set before the max-cycles check below, which would otherwise read 0 >= 0 as
 # "cycles exhausted" and force an admin merge.
-if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
-  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+# Not gated on --merge: a monitor-only run would otherwise sit in the reviewer
+# wait loop for a gate the operator switched off (PR #717 review).
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ]; then
+  if [ "$MODE" = "--merge" ]; then
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  else
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; skipping the review gate."
+  fi
   REVIEW_DECISION="SKIPPED"
 fi
 

--- a/.claude/scripts/gh_host.sh
+++ b/.claude/scripts/gh_host.sh
@@ -69,6 +69,17 @@ gh_profile() {
   printf '%s\n' "${prof:-individual}"
 }
 
+# Review-fix cycles monitor_pr.sh runs before it stops asking for another pass
+# (#714). 0 means no review control: merge as soon as CI is green. Anchored on
+# this file's location for the same reason gh_profile is. Falls back to 2 — the
+# default the wizard explains — when unset or absent.
+review_cycles() {
+  local cfg n=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && n=$(sed -nE 's/^[[:space:]]*review_cycles:[[:space:]]*([0-9]+).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "${n:-2}"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -48,7 +48,16 @@ PY="$SCRIPT_DIR/../hooks/_py.sh"
 PR_NUMBER="${1:-}"
 MODE=""
 REVIEW_CYCLE=0
-MAX_REVIEW_CYCLES=2
+# #714: review-fix cycles before the script stops asking for another pass.
+# Precedence: PI_REVIEW_CYCLES env > config.yaml `review_cycles` > 2.
+# 0 disables review control entirely — merge as soon as CI is green.
+MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"
+case "$MAX_REVIEW_CYCLES" in
+'' | *[!0-9]*)
+  echo "review cycles must be a non-negative integer; got '$MAX_REVIEW_CYCLES'" >&2
+  exit 2
+  ;;
+esac
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -456,6 +465,19 @@ fi
 REVIEW_TIMEOUT=360
 REVIEW_ELAPSED=0
 REVIEW_DECISION=$(_get_review_decision)
+
+# #714: review_cycles=0 means the operator declined review control. Skip the whole
+# review gate — the wait, the changes-requested cycle, the unresolved-thread check
+# — and merge on green CI. Deliberately NOT an admin override: if an approval
+# policy is in force the merge still blocks, because "no review control" is a
+# choice about this script's cycles, not a licence to bypass branch protection.
+# Set before the max-cycles check below, which would otherwise read 0 >= 0 as
+# "cycles exhausted" and force an admin merge.
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
+  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  REVIEW_DECISION="SKIPPED"
+fi
+
 if [ "$MODE" = "--merge" ] && [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ] && [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ]; then
   echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — skipping reviewer wait and force-merging with admin override."
   _admin_merge

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -58,6 +58,9 @@ case "$MAX_REVIEW_CYCLES" in
   exit 2
   ;;
 esac
+# Base-10, so a config.yaml or PI_REVIEW_CYCLES carrying "08" can never reach an
+# arithmetic context as octal (PR #717 review).
+MAX_REVIEW_CYCLES=$((10#$MAX_REVIEW_CYCLES))
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -110,6 +113,11 @@ case "$REVIEW_CYCLE" in
   exit 2
   ;;
 esac
+# The digits-only check above accepts "08", which arithmetic expansion then reads
+# as octal: `NEXT=$((REVIEW_CYCLE + 1))` dies with "value too great for base"
+# (PR #717 review). `[ ]` comparisons parse base-10 and are unaffected, but the
+# $(( )) sites are not — normalize once, here, rather than at each use.
+REVIEW_CYCLE=$((10#$REVIEW_CYCLE))
 
 # --admin, --no-review and --review-cycle only take effect while merging. Warn
 # loudly if they were passed without --merge (e.g. `monitor_pr.sh 12 --admin`)

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -473,8 +473,14 @@ REVIEW_DECISION=$(_get_review_decision)
 # choice about this script's cycles, not a licence to bypass branch protection.
 # Set before the max-cycles check below, which would otherwise read 0 >= 0 as
 # "cycles exhausted" and force an admin merge.
-if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
-  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+# Not gated on --merge: a monitor-only run would otherwise sit in the reviewer
+# wait loop for a gate the operator switched off (PR #717 review).
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ]; then
+  if [ "$MODE" = "--merge" ]; then
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  else
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; skipping the review gate."
+  fi
   REVIEW_DECISION="SKIPPED"
 fi
 

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -48,9 +48,18 @@ The most-used flags:
 | `--python-version` | `3.11`, `3.12`, `3.13`, `3.14` | `pyproject.toml`'s `requires-python` floor, else `3.11` |
 | `--memory` | `none`, `auto`, `obsidian-only`, `obsidian-graphify`, `obsidian-graphify-rag` | the preset's tier |
 | `--lifecycle` | `github`, `none` | `github` |
+| `--review-cycles` | `0` (no review control), `1`, `2`, … | `2` (requires `--lifecycle github`) |
 | `--mcps` | `context7`, `context7-http` (comma-separated) | none |
 | `--browser` | flag (Playwright MCP) | off |
 | `--strict` | flag (fail on unrendered placeholders) | off |
+
+A **review cycle** is one pass of the merge gate: push → the review agents comment
+→ you resolve → they re-review. `--review-cycles` sizes how many `monitor_pr.sh`
+runs before it stops asking for another. `0` disables review control and merges on
+green CI — it is *not* an admin override, so an approval policy still blocks the
+merge. Whatever the count, the merge rule is the same: once the agents' comments
+are resolved (or none arise), the PR is free to merge. Change it later in
+`.agents/config.yaml`, or per-run with `PI_REVIEW_CYCLES`.
 
 `--python-version` is the single source for "what Python is this project on": it
 pins `mise.toml`'s toolchain, `mypy.ini`'s typeshed baseline, and the floor of the

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -107,6 +107,12 @@ class ScaffoldInputs:
     # at run time), so a --python-version that disagrees is rejected outright
     # rather than half-applied; see _reject_conflicting_python_version.
     python_version: str = ""
+    # Review-fix cycles the scaffolded monitor_pr.sh runs before it stops asking
+    # for another pass (#714). Rendered into .agents/config.yaml and read back by
+    # gh_host.sh's review_cycles(). 0 = no review control (merge on green CI).
+    # Only meaningful with the GitHub lifecycle; a --lifecycle none project ships
+    # no monitor_pr.sh, so the wizard doesn't ask and the key isn't rendered.
+    review_cycles: int = 2
 
 
 # Every CPython a Python scaffold is willing to target (#628). Kept byte-equal
@@ -141,6 +147,30 @@ def _python_floor_from_pyproject(target: Path | None) -> str | None:
     except Exception:
         return None
     return None
+
+
+def _resolve_review_cycles(args, parser: argparse.ArgumentParser) -> int:
+    """Resolve --review-cycles for a non-interactive run (#714).
+
+    A `--lifecycle none` scaffold ships no monitor_pr.sh, so the count has
+    nowhere to land: reject an explicit flag rather than record a value the
+    project can never read, and otherwise fall back to 0.
+    """
+    if args.lifecycle == "none":
+        if args.review_cycles is not None:
+            parser.error(
+                f"--review-cycles {args.review_cycles} requires the GitHub lifecycle "
+                "(got --lifecycle none); no merge gate is scaffolded to run them."
+            )
+        return 0
+    if args.review_cycles is None:
+        return 2
+    if args.review_cycles < 0:
+        parser.error(
+            f"--review-cycles must be a non-negative integer (got {args.review_cycles}); "
+            "0 disables review control."
+        )
+    return args.review_cycles
 
 
 def _reject_python_version_without_python(
@@ -331,6 +361,18 @@ def _build_parser() -> argparse.ArgumentParser:
             "minimalist scaffold). Forge-portable quality hooks (commit-msg, "
             "gitleaks, lint/format gate, prod-safety) stay either way. Overrides "
             "the preset's default."
+        ),
+    )
+    p.add_argument(
+        "--review-cycles",
+        metavar="N",
+        type=int,
+        default=None,
+        help=(
+            "Review-fix passes the merge gate runs before it stops asking for "
+            "another (#714): 0 disables review control and merges on green CI, "
+            "1 comments once then merges, 2 (default) re-reviews the resolved "
+            "comments. Requires the GitHub lifecycle."
         ),
     )
     p.add_argument(
@@ -1171,6 +1213,37 @@ def _choose_lifecycle_interactive(default: str = "github") -> str:
     return _LIFECYCLE_TIERS[choice - 1]
 
 
+def _choose_review_cycles_interactive(default: int = 2) -> int:
+    """Explain review cycles, then ask how many the merge gate should run (#714).
+
+    Only reached when the GitHub lifecycle is selected — a `--lifecycle none`
+    project ships no monitor_pr.sh, so there is no cycle count to configure.
+    """
+    from rich.panel import Panel
+
+    body = (
+        "A [bold]review cycle[/bold] is one pass of the merge gate: "
+        "[bold]push → the review agents comment → you resolve → they re-review[/bold]. "
+        "monitor_pr.sh runs up to this many before it stops asking for another.\n\n"
+        "[bold]0[/bold]  [dim]no review control — merge as soon as CI is green[/dim]\n"
+        "[bold]1[/bold]  [dim]comment once, resolve, merge[/dim]\n"
+        "[bold]2[/bold]  [dim]the resolved comments are reviewed too, then merge[/dim]\n"
+        "[bold]3+[/bold] [dim]additional re-review rounds[/dim]\n\n"
+        "Whatever the count, the merge rule is the same: once the review agents' "
+        "comments are resolved — or none arise — the PR is free to merge.\n\n"
+        "[cyan]Helps:[/cyan] the second pass is where a fix's own bugs surface; "
+        "review agents routinely find a flaw in the patch that answered them.\n"
+        "[dim]Cost: each cycle is another round-trip before a merge. Default: 2. "
+        "Change later in .agents/config.yaml, or per-run with PI_REVIEW_CYCLES.[/dim]"
+    )
+    console.print(Panel(body, title="Review cycles (before merge)", border_style="cyan"))
+    while True:
+        raw = _prompt("Review cycles", default=str(default)).strip()
+        if raw.isdigit():
+            return int(raw)
+        console.print("[red]Enter a non-negative integer (0 disables review control).[/red]")
+
+
 # Wizard-explanation standard (#472, ADR-023): every selectable concern explains
 # its value before asking — what it ships · a "Helps:" line · the honest cost ·
 # the safe default. Heavyweight concerns (memory, lifecycle, overlays) render a
@@ -1261,6 +1334,7 @@ WIZARD_CONCERN_FLAGS: dict[str, str] = {
     "profile": "profile",
     "memory": "memory",
     "lifecycle": "lifecycle",
+    "review_cycles": "review_cycles",
     "delivery": "delivery",
     "deploy": "deploy",
     "iac": "iac",
@@ -1503,6 +1577,7 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     cli_vscode: bool = False,
     cli_agents: str | None = None,
     cli_python_version: str | None = None,
+    cli_review_cycles: int | None = None,
     target: Path | None = None,
 ) -> ScaffoldInputs:
     """Prompt for the profile, project basics, MCPs, governance, and overlays.
@@ -1618,6 +1693,15 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     # GitHub lifecycle tier (#476). The --lifecycle flag wins; otherwise the
     # wizard explains it and asks, defaulting to the chosen preset's tier.
     resolved_lifecycle = lifecycle_flag or _choose_lifecycle_interactive(default=preset_lifecycle)
+    # #714: cycles configure the scaffolded monitor_pr.sh, which only ships with
+    # the lifecycle. Asking a `--lifecycle none` user to size a review gate they
+    # will never run is noise, so the prompt is gated on the resolved tier.
+    if resolved_lifecycle == "none":
+        review_cycles = 0
+    elif cli_review_cycles is not None:
+        review_cycles = cli_review_cycles
+    else:
+        review_cycles = _choose_review_cycles_interactive()
     # An explicit --agents (including `--agents claude` for a claude-only
     # project) is honored; an absent flag (None) opens the surface chooser —
     # mirroring how every other concern flag wins over its interactive prompt.
@@ -1646,6 +1730,7 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         profile=resolved_profile,
         no_egress=no_egress,
         python_version=python_version,
+        review_cycles=review_cycles,
         delivery=resolved_delivery,
         deploy=resolved_deploy,
         iac=resolved_iac,
@@ -2215,6 +2300,9 @@ def _build_variables(
 
     return {
         "python_floor": python_floor,
+        # #714: read back by gh_host.sh's review_cycles(); only rendered under
+        # the {{#if lifecycle}} gate in config.yaml.tmpl.
+        "review_cycles": str(inputs.review_cycles),
         "project_name": project_name,
         # Kebab-cased name for identifier-ish slots (deploy app-name stubs);
         # a name with no ASCII alphanumerics falls back to a generic slug.
@@ -2412,6 +2500,7 @@ def _resolve_inputs(
         profile=profile,
         no_egress=args.no_egress,
         python_version=args.python_version or "",
+        review_cycles=_resolve_review_cycles(args, parser),
         delivery=delivery,
         deploy=deploy,
         iac=iac,
@@ -2706,6 +2795,7 @@ def _cli(argv: list[str]) -> int:
             profile=args.profile,
             no_egress=args.no_egress,
             cli_python_version=args.python_version,
+            cli_review_cycles=args.review_cycles,
             target=target,
             cli_overlays=(
                 args.delivery,

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -149,14 +149,20 @@ def _python_floor_from_pyproject(target: Path | None) -> str | None:
     return None
 
 
-def _validate_review_cycles(args, parser: argparse.ArgumentParser) -> None:
+def _validate_review_cycles(
+    args, parser: argparse.ArgumentParser, effective_lifecycle: str | None
+) -> None:
     """Reject an unusable --review-cycles before the target dir or any prompt.
 
     Runs on BOTH paths (PR #717 review). The interactive wizard used to copy the
     raw value, so `--review-cycles -1` recorded a count that later crashed
-    monitor_pr.sh, and `--lifecycle none --review-cycles 2` was silently dropped.
-    A tier chosen at the prompt still can't be known here; the wizard warns and
-    drops in that case.
+    monitor_pr.sh, and a lifecycle-none pairing was dropped in silence.
+
+    ``effective_lifecycle`` is the tier this run will actually scaffold, or None
+    when it isn't knowable yet. A *preset* may set ``lifecycle = "none"`` with no
+    --lifecycle flag in sight (PR #717 review, cycle 2), so checking args alone
+    let that combination through. In an interactive run the preset only seeds the
+    prompt's default, so the tier stays unknown here and the wizard warns instead.
     """
     if args.review_cycles is None:
         return
@@ -165,16 +171,17 @@ def _validate_review_cycles(args, parser: argparse.ArgumentParser) -> None:
             f"--review-cycles must be a non-negative integer (got {args.review_cycles}); "
             "0 disables review control."
         )
-    if args.lifecycle == "none":
+    if effective_lifecycle == "none":
         parser.error(
             f"--review-cycles {args.review_cycles} requires the GitHub lifecycle "
-            "(got --lifecycle none); no merge gate is scaffolded to run them."
+            "(the run resolves to lifecycle 'none'); no merge gate is scaffolded "
+            "to run them."
         )
 
 
-def _resolve_review_cycles(args) -> int:
+def _resolve_review_cycles(args, effective_lifecycle: str) -> int:
     """The non-interactive count (#714). _validate_review_cycles has already run."""
-    if args.lifecycle == "none":
+    if effective_lifecycle == "none":
         return 0
     return 2 if args.review_cycles is None else args.review_cycles
 
@@ -2504,6 +2511,9 @@ def _resolve_inputs(
         iac = resolve_iac(args.iac)
     except ValueError as e:
         parser.error(str(e))
+    # #714: the tier this run actually scaffolds — a preset may set it, with no
+    # --lifecycle flag present (PR #717 review, cycle 2).
+    effective_lifecycle = _normalize_lifecycle(args.lifecycle) or preset_lifecycle
     return ScaffoldInputs(
         project_name=args.name,
         project_description=args.description,
@@ -2519,7 +2529,7 @@ def _resolve_inputs(
         profile=profile,
         no_egress=args.no_egress,
         python_version=args.python_version or "",
-        review_cycles=_resolve_review_cycles(args),
+        review_cycles=_resolve_review_cycles(args, effective_lifecycle),
         delivery=delivery,
         deploy=deploy,
         iac=iac,
@@ -2527,7 +2537,7 @@ def _resolve_inputs(
         governance=args.governance,
         observability=args.observability,
         memory=_normalize_memory(args.memory) or preset_memory,
-        lifecycle=_normalize_lifecycle(args.lifecycle) or preset_lifecycle,
+        lifecycle=effective_lifecycle,
         want_docs=not args.no_docs,
         renovate=not args.no_renovate,
     )
@@ -2791,7 +2801,6 @@ def _cli(argv: list[str]) -> int:
     # interactive run the language is still unknown here — the wizard warns.
     effective_language = args.language or ("none" if args.non_interactive else None)
     _reject_python_version_without_python(args.python_version, effective_language, parser)
-    _validate_review_cycles(args, parser)
     _reject_conflicting_python_version(args.python_version, target, parser)
 
     # Select preset BEFORE creating the target directory — a typo'd --preset
@@ -2803,6 +2812,16 @@ def _cli(argv: list[str]) -> int:
     # Lifecycle-tier fallback when --lifecycle is absent (#476): the preset's
     # tier (a preset may set lifecycle = "none" to be minimal), default "github".
     preset_lifecycle = _resolve_preset_lifecycle(preset, parser)
+
+    # Interactive runs may still change the tier at the prompt, so only a
+    # non-interactive run can be judged here; the wizard warns in that case.
+    _validate_review_cycles(
+        args,
+        parser,
+        (_normalize_lifecycle(args.lifecycle) or preset_lifecycle)
+        if args.non_interactive
+        else _normalize_lifecycle(args.lifecycle),
+    )
 
     # Validate non-interactive args / gather interactive input BEFORE creating
     # the target directory (PI-20, PI-199: a bad flag OR a Ctrl-C at an

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -149,28 +149,34 @@ def _python_floor_from_pyproject(target: Path | None) -> str | None:
     return None
 
 
-def _resolve_review_cycles(args, parser: argparse.ArgumentParser) -> int:
-    """Resolve --review-cycles for a non-interactive run (#714).
+def _validate_review_cycles(args, parser: argparse.ArgumentParser) -> None:
+    """Reject an unusable --review-cycles before the target dir or any prompt.
 
-    A `--lifecycle none` scaffold ships no monitor_pr.sh, so the count has
-    nowhere to land: reject an explicit flag rather than record a value the
-    project can never read, and otherwise fall back to 0.
+    Runs on BOTH paths (PR #717 review). The interactive wizard used to copy the
+    raw value, so `--review-cycles -1` recorded a count that later crashed
+    monitor_pr.sh, and `--lifecycle none --review-cycles 2` was silently dropped.
+    A tier chosen at the prompt still can't be known here; the wizard warns and
+    drops in that case.
     """
-    if args.lifecycle == "none":
-        if args.review_cycles is not None:
-            parser.error(
-                f"--review-cycles {args.review_cycles} requires the GitHub lifecycle "
-                "(got --lifecycle none); no merge gate is scaffolded to run them."
-            )
-        return 0
     if args.review_cycles is None:
-        return 2
+        return
     if args.review_cycles < 0:
         parser.error(
             f"--review-cycles must be a non-negative integer (got {args.review_cycles}); "
             "0 disables review control."
         )
-    return args.review_cycles
+    if args.lifecycle == "none":
+        parser.error(
+            f"--review-cycles {args.review_cycles} requires the GitHub lifecycle "
+            "(got --lifecycle none); no merge gate is scaffolded to run them."
+        )
+
+
+def _resolve_review_cycles(args) -> int:
+    """The non-interactive count (#714). _validate_review_cycles has already run."""
+    if args.lifecycle == "none":
+        return 0
+    return 2 if args.review_cycles is None else args.review_cycles
 
 
 def _reject_python_version_without_python(
@@ -1696,7 +1702,20 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
     # #714: cycles configure the scaffolded monitor_pr.sh, which only ships with
     # the lifecycle. Asking a `--lifecycle none` user to size a review gate they
     # will never run is noise, so the prompt is gated on the resolved tier.
+    #
+    # PR #717 review: a CLI value reaching the wizard used to be copied raw —
+    # `--review-cycles -1` wrote an invalid config that later crashed
+    # monitor_pr.sh, and a flag paired with an interactively-chosen
+    # `lifecycle none` was dropped in silence. main() rejects a negative value
+    # and an explicit `--lifecycle none` up front; what it cannot know is a tier
+    # the user picks at the prompt, so that case warns and drops here rather
+    # than aborting a wizard the user has already half-answered.
     if resolved_lifecycle == "none":
+        if cli_review_cycles is not None:
+            console.print(
+                f"[yellow]--review-cycles {cli_review_cycles} ignored: no merge gate is "
+                "scaffolded with lifecycle 'none'.[/yellow]"
+            )
         review_cycles = 0
     elif cli_review_cycles is not None:
         review_cycles = cli_review_cycles
@@ -2500,7 +2519,7 @@ def _resolve_inputs(
         profile=profile,
         no_egress=args.no_egress,
         python_version=args.python_version or "",
-        review_cycles=_resolve_review_cycles(args, parser),
+        review_cycles=_resolve_review_cycles(args),
         delivery=delivery,
         deploy=deploy,
         iac=iac,
@@ -2772,6 +2791,7 @@ def _cli(argv: list[str]) -> int:
     # interactive run the language is still unknown here — the wizard warns.
     effective_language = args.language or ("none" if args.non_interactive else None)
     _reject_python_version_without_python(args.python_version, effective_language, parser)
+    _validate_review_cycles(args, parser)
     _reject_conflicting_python_version(args.python_version, target, parser)
 
     # Select preset BEFORE creating the target directory — a typo'd --preset

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -149,6 +149,9 @@ def _overlay_off_defaults() -> dict[str, str]:
         "license_apache": "",
         "license_proprietary": "",
         "python_floor": "3.11",
+        # #714: pre-714 records carry no review_cycles; re-render with the
+        # default the wizard explains rather than dropping the key.
+        "review_cycles": "2",
     }
 
 

--- a/templates/base/dot_agents/config.yaml.tmpl
+++ b/templates/base/dot_agents/config.yaml.tmpl
@@ -13,6 +13,8 @@ project:
   project_init_host: {{project_init_host}}  # upstream GitHub host (github.com | *.ghe.com | GHES) — #255/#259
   project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use feat(PI-42):
   github_project_number: 1 # numeric GitHub Project V2 board number{{#if lifecycle}} — single source of truth read by board-automation.yml, create_issue.sh, and setup_github.sh (#556){{/if lifecycle}}
+{{#if lifecycle}}  review_cycles: {{review_cycles}}       # review-fix passes monitor_pr.sh runs before it stops asking (#714); 0 = no review control, merge on green CI. Override per-run with PI_REVIEW_CYCLES.
+{{/if lifecycle}}
 
 language: {{language}}            # python | node | go | none
 

--- a/templates/base/dot_agents/scripts/gh_host.sh
+++ b/templates/base/dot_agents/scripts/gh_host.sh
@@ -69,6 +69,17 @@ gh_profile() {
   printf '%s\n' "${prof:-individual}"
 }
 
+# Review-fix cycles monitor_pr.sh runs before it stops asking for another pass
+# (#714). 0 means no review control: merge as soon as CI is green. Anchored on
+# this file's location for the same reason gh_profile is. Falls back to 2 — the
+# default the wizard explains — when unset or absent.
+review_cycles() {
+  local cfg n=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && n=$(sed -nE 's/^[[:space:]]*review_cycles:[[:space:]]*([0-9]+).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "${n:-2}"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -48,7 +48,16 @@ PY="$SCRIPT_DIR/../hooks/_py.sh"
 PR_NUMBER="${1:-}"
 MODE=""
 REVIEW_CYCLE=0
-MAX_REVIEW_CYCLES=2
+# #714: review-fix cycles before the script stops asking for another pass.
+# Precedence: PI_REVIEW_CYCLES env > config.yaml `review_cycles` > 2.
+# 0 disables review control entirely — merge as soon as CI is green.
+MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"
+case "$MAX_REVIEW_CYCLES" in
+'' | *[!0-9]*)
+  echo "review cycles must be a non-negative integer; got '$MAX_REVIEW_CYCLES'" >&2
+  exit 2
+  ;;
+esac
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -456,6 +465,19 @@ fi
 REVIEW_TIMEOUT=360
 REVIEW_ELAPSED=0
 REVIEW_DECISION=$(_get_review_decision)
+
+# #714: review_cycles=0 means the operator declined review control. Skip the whole
+# review gate — the wait, the changes-requested cycle, the unresolved-thread check
+# — and merge on green CI. Deliberately NOT an admin override: if an approval
+# policy is in force the merge still blocks, because "no review control" is a
+# choice about this script's cycles, not a licence to bypass branch protection.
+# Set before the max-cycles check below, which would otherwise read 0 >= 0 as
+# "cycles exhausted" and force an admin merge.
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
+  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  REVIEW_DECISION="SKIPPED"
+fi
+
 if [ "$MODE" = "--merge" ] && [ "$REVIEW_CYCLE" -ge "$MAX_REVIEW_CYCLES" ] && [ "$REVIEW_DECISION" = "REVIEW_REQUIRED" ]; then
   echo "Max review cycles ($MAX_REVIEW_CYCLES) reached — skipping reviewer wait and force-merging with admin override."
   _admin_merge

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -58,6 +58,9 @@ case "$MAX_REVIEW_CYCLES" in
   exit 2
   ;;
 esac
+# Base-10, so a config.yaml or PI_REVIEW_CYCLES carrying "08" can never reach an
+# arithmetic context as octal (PR #717 review).
+MAX_REVIEW_CYCLES=$((10#$MAX_REVIEW_CYCLES))
 NO_REVIEW=0
 ALLOW_ADMIN=0
 
@@ -110,6 +113,11 @@ case "$REVIEW_CYCLE" in
   exit 2
   ;;
 esac
+# The digits-only check above accepts "08", which arithmetic expansion then reads
+# as octal: `NEXT=$((REVIEW_CYCLE + 1))` dies with "value too great for base"
+# (PR #717 review). `[ ]` comparisons parse base-10 and are unaffected, but the
+# $(( )) sites are not — normalize once, here, rather than at each use.
+REVIEW_CYCLE=$((10#$REVIEW_CYCLE))
 
 # --admin, --no-review and --review-cycle only take effect while merging. Warn
 # loudly if they were passed without --merge (e.g. `monitor_pr.sh 12 --admin`)

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -473,8 +473,14 @@ REVIEW_DECISION=$(_get_review_decision)
 # choice about this script's cycles, not a licence to bypass branch protection.
 # Set before the max-cycles check below, which would otherwise read 0 >= 0 as
 # "cycles exhausted" and force an admin merge.
-if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]; then
-  echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+# Not gated on --merge: a monitor-only run would otherwise sit in the reviewer
+# wait loop for a gate the operator switched off (PR #717 review).
+if [ "$MAX_REVIEW_CYCLES" -eq 0 ]; then
+  if [ "$MODE" = "--merge" ]; then
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; merging on green CI."
+  else
+    echo "PR #$PR_NUMBER: CI passed. review_cycles=0 — no review control; skipping the review gate."
+  fi
   REVIEW_DECISION="SKIPPED"
 fi
 

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -115,6 +115,8 @@ class TestAgentSelection:
         monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
         monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
         monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "github")
+        # PI-714: a lifecycle-on wizard now asks for review cycles.
+        monkeypatch.setattr(cli, "_choose_review_cycles_interactive", lambda *a, **k: 2)
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 
         result = cli._gather_inputs_interactive(

--- a/tests/contracts/test_docs_renovate.py
+++ b/tests/contracts/test_docs_renovate.py
@@ -198,6 +198,8 @@ class TestInteractiveFlags:
         monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
         monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "none")
         monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "github")
+        # PI-714: a lifecycle-on wizard now asks for review cycles.
+        monkeypatch.setattr(cli, "_choose_review_cycles_interactive", lambda *a, **k: 2)
         monkeypatch.setattr(cli, "_choose_agents_interactive", lambda *a, **k: ["claude", "vscode"])
         # Confirm.ask → True: docs/renovate would land ON if the flags were ignored.
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: True)

--- a/tests/contracts/test_governance_overlay.py
+++ b/tests/contracts/test_governance_overlay.py
@@ -203,6 +203,8 @@ class TestInteractiveResolution:
         monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
         monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
         monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "github")
+        # PI-714: a lifecycle-on wizard now asks for review cycles.
+        monkeypatch.setattr(cli, "_choose_review_cycles_interactive", lambda *a, **k: 2)
         monkeypatch.setattr(cli, "_choose_agents_interactive", lambda *a, **k: ["claude", "vscode"])
         # Every Confirm.ask (devcontainer/mise/vscode/multi-model/governance) → decline.
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -326,7 +326,8 @@ class TestScaffoldGitHubFiles:
         assert "--delete-branch" in content
         assert "reviewDecision" in content
         assert "Waiting for reviewer" in content
-        assert "MAX_REVIEW_CYCLES=2" in content
+        # PI-714: config-driven, no longer a hardcoded literal.
+        assert 'MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"' in content
         assert "REVIEW_TIMEOUT=360" in content
         assert "--no-review" in content
 

--- a/tests/contracts/test_wizard_explanations.py
+++ b/tests/contracts/test_wizard_explanations.py
@@ -51,6 +51,7 @@ def _explainer_calls() -> dict:
         "profile": cli._choose_profile_interactive,
         "memory": cli._choose_memory_interactive,
         "lifecycle": cli._choose_lifecycle_interactive,
+        "review_cycles": cli._choose_review_cycles_interactive,
         "delivery": lambda: cli._choose_delivery_interactive("python"),
         "deploy": cli._choose_deploy_interactive,
         "iac": cli._choose_iac_interactive,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,6 +41,7 @@ def make_variables(**overrides: str) -> dict[str, str]:
         "project_init_plugin_version": "0.1.0",
         "project_init_version_prev": "",
         "python_floor": "3.11",
+        "review_cycles": "2",
         "language": "python",
         "delivery": "prototype",
         "delivery_library": "",

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -389,7 +389,8 @@ class TestGitHubWorkflowHooks:
         assert "_get_review_decision" in content
         assert "Waiting for reviewer" in content
         assert "could not fetch reviewDecision" in content
-        assert "MAX_REVIEW_CYCLES=2" in content
+        # PI-714: the count is config-driven now, not a literal.
+        assert 'MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"' in content
         assert "REVIEW_TIMEOUT=360" in content
         assert "--no-review" in content
 

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -160,6 +160,7 @@ def _wizard(
     monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
     monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
     monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "github")
+    monkeypatch.setattr(cli, "_choose_review_cycles_interactive", lambda *a, **k: 2)
     monkeypatch.setattr(cli, "_choose_agents_interactive", lambda: ["claude"])
     monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
 

--- a/tests/integration/test_review_cycles.py
+++ b/tests/integration/test_review_cycles.py
@@ -217,6 +217,59 @@ def test_interactive_runs_validate_the_flag_before_prompting(tmp_path: Path, ext
     assert not (tmp_path / ".agents").exists()
 
 
+class _Args:
+    """Minimal argparse.Namespace stand-in for the resolver under test."""
+
+    def __init__(self, *, lifecycle=None, review_cycles=None, non_interactive=True):
+        self.lifecycle = lifecycle
+        self.review_cycles = review_cycles
+        self.non_interactive = non_interactive
+
+
+def _effective(args, preset_lifecycle):
+    import project_init.__main__ as cli
+
+    return cli._normalize_lifecycle(args.lifecycle) or preset_lifecycle
+
+
+def test_preset_lifecycle_none_zeroes_cycles():
+    """PR #717 review, cycle 2: validation read args.lifecycle only.
+
+    A preset can resolve the tier to "none" with no --lifecycle flag present, so
+    cycles defaulted to 2 for a project that scaffolds no merge gate at all.
+    """
+    import project_init.__main__ as cli
+
+    args = _Args()
+    assert cli._resolve_review_cycles(args, _effective(args, "none")) == 0
+    # And the flagged tier still wins when the preset says none.
+    args = _Args(lifecycle="github")
+    assert cli._resolve_review_cycles(args, _effective(args, "none")) == 2
+
+
+def test_preset_lifecycle_none_rejects_an_explicit_flag():
+    import argparse
+
+    import project_init.__main__ as cli
+
+    parser = argparse.ArgumentParser()
+    args = _Args(review_cycles=2)
+    with pytest.raises(SystemExit):
+        cli._validate_review_cycles(args, parser, _effective(args, "none"))
+
+
+def test_interactive_defers_when_only_the_preset_says_none():
+    """The tier is still the prompt's to choose, so main() must not reject here."""
+    import argparse
+
+    import project_init.__main__ as cli
+
+    parser = argparse.ArgumentParser()
+    args = _Args(review_cycles=2, non_interactive=False)
+    # main() passes None (unknown) for an interactive run; no error.
+    cli._validate_review_cycles(args, parser, None)
+
+
 def test_review_cycles_explainer_states_its_value(capsys, monkeypatch):
     import project_init.__main__ as cli
 

--- a/tests/integration/test_review_cycles.py
+++ b/tests/integration/test_review_cycles.py
@@ -116,9 +116,12 @@ def test_monitor_pr_env_override_beats_config(tmp_target: Path):
     body = (tmp_target / ".agents" / "scripts" / "monitor_pr.sh").read_text()
     assert 'MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"' in body
     # 0 skips the review gate, and must not reach _admin_merge.
-    zero_block = body.split('if [ "$MAX_REVIEW_CYCLES" -eq 0 ]', 1)[1][:400]
+    zero_block = body.split('if [ "$MAX_REVIEW_CYCLES" -eq 0 ]', 1)[1][:500]
     assert 'REVIEW_DECISION="SKIPPED"' in zero_block
     assert "_admin_merge" not in zero_block
+    # PR #717 review: the branch must not be gated on --merge, or a monitor-only
+    # run waits for a reviewer the operator switched off.
+    assert 'if [ "$MAX_REVIEW_CYCLES" -eq 0 ] && [ "$MODE" = "--merge" ]' not in body
 
 
 def test_wizard_skips_the_prompt_when_lifecycle_is_declined(monkeypatch):
@@ -281,39 +284,51 @@ def test_review_cycles_explainer_states_its_value(capsys, monkeypatch):
     assert "Default: 2" in out
 
 
-def test_environment_override_is_honored(tmp_target: Path, tmp_path: Path):
-    """PI_REVIEW_CYCLES=0 must disable the gate without editing config.yaml."""
+def test_zero_cycles_skips_the_review_gate_without_merge(tmp_target: Path, tmp_path: Path):
+    """PR #717 review: monitor-only runs entered the reviewer wait loop anyway."""
+    result = _run_monitor_zero(tmp_target, tmp_path, merge=False)
+    assert "Waiting for reviewer" not in result.stdout, result.stdout
+    assert "skipping the review gate" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+_ZERO_GH_STUB = """#!/bin/bash
+case "$*" in
+*"pr checks"*) echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]' ;;
+*"--json headRefName"*) echo "feature true" ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "0" ;;
+*"--json mergeStateStatus"*) echo "CLEAN" ;;
+*"--json state"*) echo "MERGED" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*) exit 0 ;;
+esac
+"""
+
+
+def _run_monitor_zero(tmp_target: Path, tmp_path: Path, *, merge: bool):
+    """Drive the real script with PI_REVIEW_CYCLES=0 and a stubbed gh."""
     scaffold(tmp_target, fallback_preset(), fallback_variables())
     stub = tmp_path / "bin"
-    stub.mkdir()
-    (stub / "gh").write_text(
-        "#!/bin/bash\n"
-        'case "$*" in\n'
-        '*"pr checks"*) echo \'[{"name":"ci","state":"SUCCESS","bucket":"pass"}]\' ;;\n'
-        '*"--json headRefName"*) echo "feature true" ;;\n'
-        '*"--json reviewDecision"*) echo "" ;;\n'
-        '*"--json reviews"*) echo "0" ;;\n'
-        '*"--json mergeStateStatus"*) echo "CLEAN" ;;\n'
-        '*"--json state"*) echo "MERGED" ;;\n'
-        '*"--json url"*) echo "https://example.invalid/pr/1" ;;\n'
-        "*) exit 0 ;;\n"
-        "esac\n"
-    )
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(_ZERO_GH_STUB)
     (stub / "gh").chmod(0o755)
     (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
     (stub / "sleep").chmod(0o755)
     env = os.environ.copy()
     env["PATH"] = f"{stub}:{env['PATH']}"
     env["PI_REVIEW_CYCLES"] = "0"
-    result = subprocess.run(
-        ["bash", str(tmp_target / ".agents" / "scripts" / "monitor_pr.sh"), "1", "--merge"],
-        capture_output=True,
-        text=True,
-        cwd=tmp_target,
-        env=env,
-        timeout=60,
-        check=False,
+    argv = ["bash", str(tmp_target / ".agents" / "scripts" / "monitor_pr.sh"), "1"]
+    if merge:
+        argv.append("--merge")
+    return subprocess.run(
+        argv, capture_output=True, text=True, cwd=tmp_target, env=env, timeout=60, check=False
     )
+
+
+def test_environment_override_is_honored(tmp_target: Path, tmp_path: Path):
+    """PI_REVIEW_CYCLES=0 must disable the gate without editing config.yaml."""
+    result = _run_monitor_zero(tmp_target, tmp_path, merge=True)
     # Zero reviews exist; with cycles=0 the gate is skipped entirely.
     assert "review_cycles=0" in result.stdout, result.stdout + result.stderr
     assert "Waiting for a review" not in result.stdout

--- a/tests/integration/test_review_cycles.py
+++ b/tests/integration/test_review_cycles.py
@@ -149,6 +149,74 @@ def test_wizard_skips_the_prompt_when_lifecycle_is_declined(monkeypatch):
     assert not any("Review cycles" in label for label in seen)
 
 
+def _wizard_with_flag(monkeypatch, *, lifecycle: str, cli_cycles: int | None):
+    import project_init.__main__ as cli
+
+    answers = iter(["proj", "desc", "go", "", "none"])
+    monkeypatch.setattr(cli, "_prompt", lambda *a, **k: next(answers))
+    monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
+    monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
+    monkeypatch.setattr(cli, "_choose_delivery_interactive", lambda language: "prototype")
+    monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
+    monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
+    monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: lifecycle)
+    monkeypatch.setattr(cli, "_choose_review_cycles_interactive", lambda *a, **k: 2)
+    monkeypatch.setattr(cli, "_choose_agents_interactive", lambda: ["claude"])
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+    return cli._gather_inputs_interactive(
+        default_name="proj",
+        no_plugin=False,
+        profile="individual",
+        cli_review_cycles=cli_cycles,
+    )
+
+
+def test_wizard_warns_when_a_chosen_lifecycle_none_drops_the_flag(monkeypatch, capsys):
+    """PR #717 review: the value used to be dropped in silence.
+
+    main() cannot reject this — the tier is picked at the prompt, after parsing.
+    """
+    inputs = _wizard_with_flag(monkeypatch, lifecycle="none", cli_cycles=3)
+    assert inputs.review_cycles == 0
+    assert "--review-cycles 3 ignored" in capsys.readouterr().out
+
+
+def test_wizard_honors_the_flag_over_the_prompt(monkeypatch):
+    inputs = _wizard_with_flag(monkeypatch, lifecycle="github", cli_cycles=4)
+    assert inputs.review_cycles == 4
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected"),
+    [
+        (["--review-cycles", "-1"], "non-negative integer"),
+        (["--lifecycle", "none", "--review-cycles", "2"], "requires the GitHub lifecycle"),
+    ],
+)
+def test_interactive_runs_validate_the_flag_before_prompting(tmp_path: Path, extra, expected):
+    """PR #717 review: validation lived only on the non-interactive path."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "project_init",
+            str(tmp_path),
+            "--preset",
+            "core",
+            "--agents",
+            "claude",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        input="",
+        check=False,
+    )
+    assert result.returncode != 0
+    assert expected in result.stderr
+    assert not (tmp_path / ".agents").exists()
+
+
 def test_review_cycles_explainer_states_its_value(capsys, monkeypatch):
     import project_init.__main__ as cli
 

--- a/tests/integration/test_review_cycles.py
+++ b/tests/integration/test_review_cycles.py
@@ -1,0 +1,198 @@
+"""PI-714: review cycles are configurable, explained, and lifecycle-gated.
+
+`monitor_pr.sh` hardcoded MAX_REVIEW_CYCLES=2 and nothing told the user it
+existed. The count now comes from `.agents/config.yaml` (written by the wizard or
+`--review-cycles`), read back by gh_host.sh's `review_cycles()`, overridable
+per-run via PI_REVIEW_CYCLES.
+
+0 means no review control: merge as soon as CI is green. It is NOT an admin
+override — an approval policy, if one is in force, still blocks the merge.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_BASE = (
+    "--non-interactive",
+    "--preset",
+    "core",
+    "--agents",
+    "claude",
+    "--name",
+    "t",
+    "--description",
+    "t",
+    "--language",
+    "python",
+)
+
+
+def _scaffold(target: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "project_init", str(target), *_BASE, *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _config_cycles(target: Path) -> str | None:
+    """The `review_cycles:` key — never the value inside the `variables:` JSON."""
+    text = (target / ".agents" / "config.yaml").read_text()
+    m = re.search(r"^[ \t]*review_cycles:[ \t]*(\d+)", text, re.M)
+    return m.group(1) if m else None
+
+
+@pytest.mark.parametrize("cycles", ["0", "1", "2", "5"])
+def test_review_cycles_flag_lands_in_config(tmp_path: Path, cycles: str):
+    assert _scaffold(tmp_path, "--review-cycles", cycles).returncode == 0
+    assert _config_cycles(tmp_path) == cycles
+
+
+def test_default_is_two(tmp_path: Path):
+    assert _scaffold(tmp_path).returncode == 0
+    assert _config_cycles(tmp_path) == "2"
+
+
+def test_lifecycle_none_renders_no_cycle_key(tmp_path: Path):
+    """No monitor_pr.sh ships, so there is no gate to size."""
+    assert _scaffold(tmp_path, "--lifecycle", "none").returncode == 0
+    assert _config_cycles(tmp_path) is None
+    assert not (tmp_path / ".agents" / "scripts" / "monitor_pr.sh").exists()
+
+
+def test_review_cycles_without_lifecycle_is_rejected(tmp_path: Path):
+    result = _scaffold(tmp_path, "--lifecycle", "none", "--review-cycles", "2")
+    assert result.returncode != 0
+    assert "requires the GitHub lifecycle" in result.stderr
+    assert not (tmp_path / ".agents").exists()
+
+
+def test_negative_review_cycles_is_rejected(tmp_path: Path):
+    result = _scaffold(tmp_path, "--review-cycles", "-1")
+    assert result.returncode != 0
+    assert "non-negative integer" in result.stderr
+
+
+def test_gh_host_reads_the_configured_count(tmp_path: Path):
+    assert _scaffold(tmp_path, "--review-cycles", "3").returncode == 0
+    result = subprocess.run(
+        ["bash", "-c", ". .agents/scripts/gh_host.sh; review_cycles"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout.strip() == "3"
+
+
+def test_gh_host_falls_back_to_two_without_a_key(tmp_target: Path):
+    """A pre-714 project has no review_cycles key; don't read it as zero."""
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    cfg = tmp_target / ".agents" / "config.yaml"
+    cfg.write_text(re.sub(r"^[ \t]*review_cycles:.*\n", "", cfg.read_text(), flags=re.M))
+    result = subprocess.run(
+        ["bash", "-c", ". .agents/scripts/gh_host.sh; review_cycles"],
+        cwd=tmp_target,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout.strip() == "2"
+
+
+def test_monitor_pr_env_override_beats_config(tmp_target: Path):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    body = (tmp_target / ".agents" / "scripts" / "monitor_pr.sh").read_text()
+    assert 'MAX_REVIEW_CYCLES="${PI_REVIEW_CYCLES:-$(review_cycles)}"' in body
+    # 0 skips the review gate, and must not reach _admin_merge.
+    zero_block = body.split('if [ "$MAX_REVIEW_CYCLES" -eq 0 ]', 1)[1][:400]
+    assert 'REVIEW_DECISION="SKIPPED"' in zero_block
+    assert "_admin_merge" not in zero_block
+
+
+def test_wizard_skips_the_prompt_when_lifecycle_is_declined(monkeypatch):
+    """A --lifecycle none user must not be asked to size a gate they never run."""
+    import project_init.__main__ as cli
+
+    seen: list[str] = []
+    answers = iter(["proj", "desc", "go", "", "none"])
+
+    def fake_prompt(label, *a, **k):
+        seen.append(str(label))
+        return next(answers)
+
+    monkeypatch.setattr(cli, "_prompt", fake_prompt)
+    monkeypatch.setattr(cli, "_choose_mcps_interactive", lambda catalog: [])
+    monkeypatch.setattr(cli, "_choose_browser_interactive", lambda: False)
+    monkeypatch.setattr(cli, "_choose_delivery_interactive", lambda language: "prototype")
+    monkeypatch.setattr(cli, "_choose_iac_interactive", lambda: "none")
+    monkeypatch.setattr(cli, "_choose_memory_interactive", lambda *a, **k: "obsidian-only")
+    monkeypatch.setattr(cli, "_choose_lifecycle_interactive", lambda *a, **k: "none")
+    monkeypatch.setattr(cli, "_choose_agents_interactive", lambda: ["claude"])
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+
+    inputs = cli._gather_inputs_interactive(
+        default_name="proj", no_plugin=False, profile="individual"
+    )
+    assert inputs.review_cycles == 0
+    assert not any("Review cycles" in label for label in seen)
+
+
+def test_review_cycles_explainer_states_its_value(capsys, monkeypatch):
+    import project_init.__main__ as cli
+
+    monkeypatch.setattr(cli, "_prompt", lambda *a, **k: "2")
+    assert cli._choose_review_cycles_interactive() == 2
+    out = capsys.readouterr().out
+    assert "no review control" in out
+    assert "Helps:" in out
+    assert "Default: 2" in out
+
+
+def test_environment_override_is_honored(tmp_target: Path, tmp_path: Path):
+    """PI_REVIEW_CYCLES=0 must disable the gate without editing config.yaml."""
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    (stub / "gh").write_text(
+        "#!/bin/bash\n"
+        'case "$*" in\n'
+        '*"pr checks"*) echo \'[{"name":"ci","state":"SUCCESS","bucket":"pass"}]\' ;;\n'
+        '*"--json headRefName"*) echo "feature true" ;;\n'
+        '*"--json reviewDecision"*) echo "" ;;\n'
+        '*"--json reviews"*) echo "0" ;;\n'
+        '*"--json mergeStateStatus"*) echo "CLEAN" ;;\n'
+        '*"--json state"*) echo "MERGED" ;;\n'
+        '*"--json url"*) echo "https://example.invalid/pr/1" ;;\n'
+        "*) exit 0 ;;\n"
+        "esac\n"
+    )
+    (stub / "gh").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env["PI_REVIEW_CYCLES"] = "0"
+    result = subprocess.run(
+        ["bash", str(tmp_target / ".agents" / "scripts" / "monitor_pr.sh"), "1", "--merge"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    # Zero reviews exist; with cycles=0 the gate is skipped entirely.
+    assert "review_cycles=0" in result.stdout, result.stdout + result.stderr
+    assert "Waiting for a review" not in result.stdout

--- a/tests/integration/test_review_cycles.py
+++ b/tests/integration/test_review_cycles.py
@@ -326,6 +326,64 @@ def _run_monitor_zero(tmp_target: Path, tmp_path: Path, *, merge: bool):
     )
 
 
+# reviews=1 + unresolved=2 drives the script into the unresolved-comments branch,
+# which is where `NEXT=$((REVIEW_CYCLE + 1))` lives — the octal crash site.
+_OCTAL_GH_STUB = """#!/bin/bash
+case "$*" in
+*"pr checks"*) echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]' ;;
+*"--json headRefName"*) echo "feature true" ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "1" ;;
+*"--json nameWithOwner"*) echo "o/r" ;;
+*"api graphql"*) echo "2" ;;
+*"--json mergeStateStatus"*) echo "CLEAN" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*) exit 0 ;;
+esac
+"""
+
+
+@pytest.mark.parametrize("value", ["08", "09"])
+def test_leading_zero_cycle_counts_are_not_read_as_octal(
+    tmp_target: Path, tmp_path: Path, value: str
+):
+    """PR #717 review: the digits-only guard accepts "08".
+
+    `[ ]` comparisons parse base-10 and are fine, but `$((REVIEW_CYCLE + 1))`
+    dies with "value too great for base". Normalize at parse time.
+    """
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    stub = tmp_path / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(_OCTAL_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    result = subprocess.run(
+        [
+            "bash",
+            str(tmp_target / ".agents" / "scripts" / "monitor_pr.sh"),
+            "1",
+            "--merge",
+            "--review-cycle",
+            value,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert "value too great for base" not in combined, combined
+    # It reached the review-cycle branch, so the arithmetic really did execute.
+    assert "unresolved review comment(s)" in result.stdout, combined
+    assert f"--review-cycle {int(value, 10) + 1}" in result.stdout, combined
+
+
 def test_environment_override_is_honored(tmp_target: Path, tmp_path: Path):
     """PI_REVIEW_CYCLES=0 must disable the gate without editing config.yaml."""
     result = _run_monitor_zero(tmp_target, tmp_path, merge=True)


### PR DESCRIPTION
## Problem

`monitor_pr.sh` hardcoded `MAX_REVIEW_CYCLES=2` and nothing surfaced it. A scaffolded project inherited a two-cycle review protocol it never agreed to and could not tune.

## Design

The count flows through the existing seams — no `.sh.tmpl` conversion needed, because `config.yaml` already renders variables and `gh_host.sh` already reads `profile` out of it:

```
wizard / --review-cycles → .agents/config.yaml → gh_host.sh review_cycles() → monitor_pr.sh
                                                  PI_REVIEW_CYCLES overrides per-run
```

| Cycles | Meaning |
|---|---|
| `0` | no review control — merge as soon as CI is green |
| `1` | comment once, resolve, merge |
| `2` (default) | the resolved comments get reviewed too, then merge |
| `3+` | additional re-review rounds |

Whatever the count, the merge rule is the same: **once the review agents' comments are resolved — or none arise — the PR is free to merge.**

**`0` is not an admin override.** It skips *this script's* review gate; if an approval policy is in force the merge still blocks. "No review control" is a choice about cycles, not a licence to bypass branch protection. The zero branch is set *before* the max-cycles check, which would otherwise read `0 >= 0` as "cycles exhausted" and force an `--admin` merge — the exact bug this would have shipped.

**Registered as a selectable concern (ADR-023), not a mechanical flag.** `0` trades review control for speed; that cost has to be stated before asking, so it gets an explainer panel, a `WIZARD_CONCERN_FLAGS` entry, and a render check in `test_wizard_explanations.py`.

**Gated on the lifecycle.** A `--lifecycle none` project ships no `monitor_pr.sh`, so there is no gate to size: the wizard never asks, the `review_cycles` key is not rendered into `config.yaml`, and an explicit `--review-cycles` is rejected rather than recorded where nothing can read it.

## Verification

14 tests in `tests/integration/test_review_cycles.py`, plus a live check of the scaffolded output:

- `--review-cycles 0|1|2|5` land in `config.yaml`; default is `2`
- `--lifecycle none` renders **no** `review_cycles:` key and no `monitor_pr.sh`
- `--lifecycle none --review-cycles 2` → rejected, nothing written
- `--review-cycles -1` → rejected
- `gh_host.sh review_cycles()` reads the configured value back, and falls back to `2` for a pre-714 project with no key (not `0`)
- the reader's `sed` cannot match the `review_cycles` value embedded in `config.yaml`'s `variables:` JSON blob
- `PI_REVIEW_CYCLES=0` disables the gate against the real script with a stubbed `gh`
- the explainer states "no review control", `Helps:`, and `Default: 2`
- the wizard does **not** ask when lifecycle is declined

Adding a prompt shifted four scripted-wizard tests; each now stubs `_choose_review_cycles_interactive` with a comment. `tests/helpers.make_variables` gained `review_cycles` — without it the placeholder rendered literally and 342 tests failed.

Full suite green (2158 passed), `ruff check` clean, shellcheck gate passes.

Closes #714

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1