### PR TITLE
fix(PI-719): review-status.yml never loaded — invalid Actions trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,17 +157,6 @@ jobs:
           printf '%s\n' "${files[@]}"
           uvx --from 'shellcheck-py==0.11.0.1' shellcheck --severity=warning "${files[@]}"
 
-      # PI-719: an invalid trigger name made GitHub reject review-status.yml at
-      # load time — every run a startup failure with no jobs, for a full day,
-      # because YAML parsed fine and nothing linted the workflow schema. Lint
-      # this repo's workflows AND the rendered scaffold's, so a broken trigger
-      # can neither land here nor ship to a new project. Pinned for determinism.
-      - name: actionlint workflow files (this repo + rendered scaffold)
-        run: |
-          set -euo pipefail
-          uvx --from 'actionlint-py==1.7.12.24' actionlint \
-            .github/workflows/*.yml /tmp/sc-target/.github/workflows/*.yml
-
   # PI-363 Layer 3 gate: only spend the 10x-billed macOS minutes when shell or
   # template files actually change. Ordinary PRs skip the macOS job entirely.
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,17 @@ jobs:
           printf '%s\n' "${files[@]}"
           uvx --from 'shellcheck-py==0.11.0.1' shellcheck --severity=warning "${files[@]}"
 
+      # PI-719: an invalid trigger name made GitHub reject review-status.yml at
+      # load time — every run a startup failure with no jobs, for a full day,
+      # because YAML parsed fine and nothing linted the workflow schema. Lint
+      # this repo's workflows AND the rendered scaffold's, so a broken trigger
+      # can neither land here nor ship to a new project. Pinned for determinism.
+      - name: actionlint workflow files (this repo + rendered scaffold)
+        run: |
+          set -euo pipefail
+          uvx --from 'actionlint-py==1.7.12.24' actionlint \
+            .github/workflows/*.yml /tmp/sc-target/.github/workflows/*.yml
+
   # PI-363 Layer 3 gate: only spend the 10x-billed macOS minutes when shell or
   # template files actually change. Ordinary PRs skip the macOS job entirely.
   changes:

--- a/.github/workflows/review-status.yml
+++ b/.github/workflows/review-status.yml
@@ -23,9 +23,17 @@ name: Review status
 on:
   pull_request_review:
     types: [submitted, edited, dismissed]
-  # Resolving the last thread must flip the check green without a new review.
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  # Inline review comments are the thread activity we CAN see. Resolving a thread
+  # emits no workflow event at all — `pull_request_review_thread` is a webhook
+  # event, not an Actions trigger, and naming it made GitHub reject this entire
+  # file at load time (#719). So a resolution only refreshes the status once some
+  # other event follows: a comment, a review, or a push.
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  # PR comments (the review-response convention) are a reliable post-resolution
+  # nudge. `issue_comment` also fires for plain issues; the job guards on that.
+  issue_comment:
+    types: [created]
   # A new commit needs its own status, or the required check is missing on the
   # head SHA and the PR is blocked with nothing to click.
   pull_request:
@@ -38,13 +46,16 @@ permissions:
 jobs:
   set-review-status:
     name: Set review/decision status
+    # issue_comment fires for plain issues too; only PRs have a head SHA to
+    # attach a commit status to (#719).
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     runs-on: ubuntu-24.04
     steps:
       - name: Post commit status
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
+          # pull_request* events carry .pull_request; issue_comment carries .issue.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
@@ -55,6 +66,12 @@ jobs:
           REVIEW_URL: ${{ github.event.review.html_url }}
         run: |
           set -euo pipefail
+
+          # Resolve the head SHA from the API rather than the payload: only the
+          # pull_request* events carry .pull_request.head.sha, and posting the
+          # status to the wrong (or empty) SHA leaves the check missing (#719).
+          SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json headRefOid -q '.headRefOid')
 
           DECISION=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json reviewDecision -q '.reviewDecision // ""')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     # `patch = ["subprocess"]` in [tool.coverage.run] landed in coverage 7.10.
     "coverage>=7.10",
     "pytest-xdist>=3.0",
+    # Workflow-schema gate (#719): an invalid trigger made GitHub reject a whole
+    # workflow file at load time. Declared here so tests/integration/
+    # test_workflow_lint_gate.py never silently skips.
+    "actionlint-py>=1.7.12",
     "jsonschema>=4.26.0",
     "pyyaml>=6.0.3",
 ]

--- a/templates/lifecycle/dot_github/workflows/review-status.yml
+++ b/templates/lifecycle/dot_github/workflows/review-status.yml
@@ -23,9 +23,17 @@ name: Review status
 on:
   pull_request_review:
     types: [submitted, edited, dismissed]
-  # Resolving the last thread must flip the check green without a new review.
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  # Inline review comments are the thread activity we CAN see. Resolving a thread
+  # emits no workflow event at all — `pull_request_review_thread` is a webhook
+  # event, not an Actions trigger, and naming it made GitHub reject this entire
+  # file at load time (#719). So a resolution only refreshes the status once some
+  # other event follows: a comment, a review, or a push.
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  # PR comments (the review-response convention) are a reliable post-resolution
+  # nudge. `issue_comment` also fires for plain issues; the job guards on that.
+  issue_comment:
+    types: [created]
   # A new commit needs its own status, or the required check is missing on the
   # head SHA and the PR is blocked with nothing to click.
   pull_request:
@@ -38,13 +46,16 @@ permissions:
 jobs:
   set-review-status:
     name: Set review/decision status
+    # issue_comment fires for plain issues too; only PRs have a head SHA to
+    # attach a commit status to (#719).
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     runs-on: ubuntu-24.04
     steps:
       - name: Post commit status
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
+          # pull_request* events carry .pull_request; issue_comment carries .issue.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
@@ -55,6 +66,12 @@ jobs:
           REVIEW_URL: ${{ github.event.review.html_url }}
         run: |
           set -euo pipefail
+
+          # Resolve the head SHA from the API rather than the payload: only the
+          # pull_request* events carry .pull_request.head.sha, and posting the
+          # status to the wrong (or empty) SHA leaves the check missing (#719).
+          SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json headRefOid -q '.headRefOid')
 
           DECISION=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json reviewDecision -q '.reviewDecision // ""')

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -106,7 +106,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -85,7 +85,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -103,7 +103,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -82,7 +82,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -107,7 +107,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -86,7 +86,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -104,7 +104,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -83,7 +83,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "844c5f632a999dc335b26ccd0441c379de342135f6386cc4fafc20448a511772",
+  ".github/workflows/review-status.yml": "8a1df21457cef1bb47d1bdb998bfa95f5dcdb731f5c0f729cf4d88841e08a05f",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/integration/test_workflow_lint_gate.py
+++ b/tests/integration/test_workflow_lint_gate.py
@@ -27,16 +27,29 @@ from tests.helpers import make_variables
 _ROOT = Path(__file__).resolve().parents[2]
 _ACTIONLINT = shutil.which("actionlint")
 
+# actionlint-py is a declared dev dependency, so `uv run pytest` always has the
+# binary and this gate never silently skips — in CI or locally. The guard only
+# fires for someone running pytest outside the project environment (PR #720
+# review: the previous message claimed CI installed it, and CI did not).
 pytestmark = pytest.mark.skipif(
     _ACTIONLINT is None,
-    reason="actionlint not installed (CI installs it; run via `uvx --from actionlint-py actionlint`)",
+    reason="actionlint not on PATH — run under `uv run` so the dev group is active",
 )
 
 
 def _lint(paths: list[Path]) -> subprocess.CompletedProcess:
+    """Schema validity only — triggers, expressions, contexts.
+
+    `-shellcheck=` / `-pyflakes=` disable actionlint's embedded linters, which
+    fire only when those tools happen to be on PATH. CI runners preinstall
+    shellcheck and developer machines usually don't, so leaving them enabled
+    makes this gate pass locally and fail in CI on `run:` style findings
+    (SC2016/SC2086 "info") unrelated to whether the workflow loads. The
+    scaffolded shell scripts get a real shellcheck run in `test_shell_lint_gate`.
+    """
     assert paths, "no workflow files found — the glob is wrong, not the repo"
     return subprocess.run(
-        [_ACTIONLINT, *[str(p) for p in paths]],
+        [_ACTIONLINT, "-shellcheck=", "-pyflakes=", *[str(p) for p in paths]],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/integration/test_workflow_lint_gate.py
+++ b/tests/integration/test_workflow_lint_gate.py
@@ -1,0 +1,61 @@
+"""GitHub Actions workflow files must actually load.
+
+PI-719: `review-status.yml` named `pull_request_review_thread` as a trigger. That
+is a webhook event, not an Actions trigger, so GitHub rejected the whole file at
+load time — every run became a startup failure with no jobs, posting no
+`review/decision` status. It went unnoticed for a day because nothing yet
+depended on that status.
+
+Nothing in the suite ran a workflow linter, so no test could have caught it: YAML
+parsed fine, and the contract tests only asserted on the file's *text*. This gate
+runs `actionlint` over both the repo's own workflows and the ones a scaffold
+emits — the rendered output, not the templates, so `{{...}}` gating bugs surface
+too.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import load_preset, overlay_layers, scaffold
+from tests.helpers import make_variables
+
+_ROOT = Path(__file__).resolve().parents[2]
+_ACTIONLINT = shutil.which("actionlint")
+
+pytestmark = pytest.mark.skipif(
+    _ACTIONLINT is None,
+    reason="actionlint not installed (CI installs it; run via `uvx --from actionlint-py actionlint`)",
+)
+
+
+def _lint(paths: list[Path]) -> subprocess.CompletedProcess:
+    assert paths, "no workflow files found — the glob is wrong, not the repo"
+    return subprocess.run(
+        [_ACTIONLINT, *[str(p) for p in paths]],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_this_repos_workflows_load():
+    result = _lint(sorted((_ROOT / ".github" / "workflows").glob("*.yml")))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_scaffolded_workflows_load(tmp_path: Path):
+    """Renders the templates, so an invalid trigger cannot ship to a new project."""
+    preset = load_preset("obsidian-only")
+    extra = overlay_layers([], no_plugin=True, memory_stack="obsidian-only", lifecycle=True)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    target = tmp_path / "proj"
+    scaffold(target, preset, make_variables(no_plugin="true", plugin_mode=""))
+
+    workflows = sorted((target / ".github" / "workflows").glob("*.yml"))
+    result = _lint(workflows)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,12 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071, upload-time = "2026-03-31T06:21:35.015Z" }
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -562,6 +568,7 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "actionlint-py" },
     { name = "coverage" },
     { name = "jsonschema" },
     { name = "pytest" },
@@ -580,6 +587,7 @@ provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "actionlint-py", specifier = ">=1.7.12" },
     { name = "coverage", specifier = ">=7.10" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "pytest", specifier = ">=8.0" },


### PR DESCRIPTION
## Problem

PR #716 (PI-715) added `pull_request_review_thread` as a trigger to `review-status.yml`. **It is not a valid GitHub Actions trigger** — it exists as a webhook event but is absent from the events-that-trigger-workflows list. GitHub rejects the entire workflow file at load time.

Every run since #716 merged has been a **startup failure**: zero jobs, zero check-runs, no `review/decision` status, and the workflow's display name degraded to its file path.

```
b88fe125 push failure 2026-07-10T06:54:30Z
4596e82c push failure 2026-07-09T23:05:52Z   <- first failure, right after #716
--------------- before #716 ---------------
a55b047b pull_request_review success 2026-07-09T17:33:32Z
```

Confirmed three ways: `gh run view` says "This run likely failed because of a workflow file issue"; the runs have no jobs and no check-runs; `actionlint` reports `unknown Webhook event "pull_request_review_thread"`. GitHub's current docs list `pull_request`, `pull_request_review`, `pull_request_review_comment`, and `pull_request_target` — no `_thread`.

It went unnoticed for a day because `review/decision` is not a required check on `main`, and `monitor_pr.sh` queries `reviewDecision` and review threads through the API rather than reading the commit status. **I introduced this in #716 and did not catch it**, because the tests only asserted on the file's text and `yaml.safe_load()` parses it fine.

## Fix

- **Drop the invalid trigger.** Resolving a review thread emits *no* workflow event, so #716's "clearing the last thread flips the check green" is unachievable as designed. `pull_request_review_comment` and `issue_comment` (guarded with `github.event.issue.pull_request`) refresh the status on the comment activity that accompanies a resolution round.
- **Resolve the head SHA from the API**, not the payload. Only `pull_request*` events carry `.pull_request.head.sha`; on `issue_comment` the status would have been posted to an empty SHA.
- **Add an actionlint gate** — in CI and as `tests/integration/test_workflow_lint_gate.py` — over this repo's workflows *and* the workflows a scaffold renders, so a broken trigger can neither land here nor ship to a new project.

## Verification

- `actionlint` clean over all root workflows and all rendered scaffold workflows.
- The gate is **non-vacuous**: reintroducing `pull_request_review_thread` makes both tests fail; removing it makes them pass.
- Byte-identity fixtures: only `.github/workflows/review-status.yml` re-pinned, after verifying no other file drifted.
- Full suite green (2177 passed), `ruff check` clean.

## Consequence for #715's goal

`review/decision` cannot be made a required status check until this lands. Even after it lands, a thread resolved with no accompanying comment, review, or push will not refresh the status — worth knowing before anyone makes it required.

Closes #719

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1