### PR TITLE
fix(PI-689): kill the third CCR pin literal and document the checker's scope

### DIFF
--- a/templates/multi_model/dot_agents/scripts/setup_models.sh
+++ b/templates/multi_model/dot_agents/scripts/setup_models.sh
@@ -11,7 +11,15 @@
 # is user-run, in your project, exactly like the graphify setup script.
 set -euo pipefail
 
-# --- pinned, vetted versions (ADR-016 §5; bumped via upgrade-as-PR) -----------
+# --- external packages --------------------------------------------------------
+# CCR sits on the scaffolded project's request path, so its version is *pinned
+# and vetted* (ADR-016 §5; bumped via upgrade-as-PR by
+# tools/check_third_party_updates.py, which reads tools/pinned_third_party.toml).
+#
+# Claude Code is deliberately NOT pinned (#689): it is the operator's own CLI,
+# not something this scaffold puts in the request path, and freezing it would
+# hold every scaffolded project behind a bump PR on a fast-moving tool. It is
+# installed at upstream latest and is absent from the manifest by design.
 CCR_PKG="@musistudio/claude-code-router"
 CCR_VERSION="2.0.0"
 CLAUDE_PKG="@anthropic-ai/claude-code"

--- a/tests/contracts/test_multi_model_overlay.py
+++ b/tests/contracts/test_multi_model_overlay.py
@@ -19,7 +19,23 @@ import pytest
 from project_init.scaffold import load_preset, overlay_layers, scaffold
 from tests.helpers import make_variables
 
-PINNED_CCR_VERSION = "2.0.0"
+
+def _pinned_ccr_version() -> str:
+    """Read the CCR pin from the manifest — never restate it (#689).
+
+    This module used to carry its own `PINNED_CCR_VERSION = "2.0.0"` literal, a
+    third copy alongside `tools/pinned_third_party.toml` and `setup_models.sh`.
+    `check_third_party_updates.py apply` bumps the first two in lockstep and knew
+    nothing about the third, so a routine version bump left this test asserting a
+    version the scaffold no longer ships.
+    """
+    import tomllib
+
+    manifest = Path(__file__).resolve().parents[2] / "tools" / "pinned_third_party.toml"
+    return tomllib.loads(manifest.read_text(encoding="utf-8"))["tools"]["ccr"]["pinned"]
+
+
+PINNED_CCR_VERSION = _pinned_ccr_version()
 
 
 def _scaffold(target: Path, *, multi_model: bool) -> Path:

--- a/tests/contracts/test_third_party_pin_contract.py
+++ b/tests/contracts/test_third_party_pin_contract.py
@@ -6,6 +6,7 @@ template/manifest relationship, not pure logic (per docs/development/testing.md)
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 from pathlib import Path
 
@@ -32,3 +33,74 @@ def test_manifest_pin_matches_installer_version():
         f"manifest pins ccr at {pinned} but setup_models.sh disagrees — run "
         "tools/check_third_party_updates.py apply ccr <version>"
     )
+
+
+def test_no_contract_test_restates_a_managed_pin():
+    """`apply` bumps the manifest and every `used_in` file. A version literal in a
+    test is invisible to it, so a routine bump leaves the test asserting a version
+    the scaffold no longer ships (#689).
+
+    Contract tests must read the pin from the manifest, as
+    `test_multi_model_overlay._pinned_ccr_version()` does.
+
+    An AST walk, not a text grep: matching `ast.Constant` values exactly means a
+    docstring that *mentions* `"2.0.0"` is not an offender (its constant is the
+    whole docstring), while `X = "2.0.0"` is. A line-based filter here was
+    vacuous — `PINNED_CCR_VERSION` contains the substring "pinned".
+
+    Scoped to tests/contracts/: `tests/unit/test_third_party_updates.py` uses the
+    version as fixture data for the bumper itself, which is legitimate.
+    """
+    mod = _load_module()
+    managed = {tool["pinned"] for tool in mod.load_manifest().values()}
+
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "tests" / "contracts").glob("*.py")):
+        if path.name == "test_third_party_pin_contract.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and node.value in managed:
+                offenders.append(f"{path.name}:{node.lineno}: literal {node.value!r}")
+
+    assert not offenders, (
+        "a contract test restates a manifest-managed pin as a literal; read it from "
+        "tools/pinned_third_party.toml instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_claude_code_is_installed_unpinned_by_design():
+    """#689: not an oversight — the operator's own CLI, off the request path.
+
+    Pinning it would hold every scaffolded project behind a bump PR on a
+    fast-moving tool. The installer must say so, and the manifest must not claim
+    ownership of a version it never bumps.
+    """
+    mod = _load_module()
+    # Exact package match: CCR's own name (@musistudio/claude-code-router)
+    # contains the substring "claude-code".
+    packages = {tool["package"] for tool in mod.load_manifest().values()}
+    assert "@anthropic-ai/claude-code" not in packages, (
+        "claude-code is in the manifest but nothing pins or bumps it"
+    )
+
+    installer = (
+        REPO_ROOT / "templates" / "multi_model" / "dot_agents" / "scripts" / "setup_models.sh"
+    ).read_text(encoding="utf-8")
+    assert 'CLAUDE_PKG="@anthropic-ai/claude-code"' in installer
+    assert "CLAUDE_VERSION" not in installer, "a version pin appeared without a manifest entry"
+    assert "deliberately NOT pinned" in installer, "the decision must stay recorded at the pin site"
+
+
+def test_every_manifest_tool_declares_where_its_pin_lives():
+    """`apply` rewrites `used_in`; an entry with none silently bumps nothing."""
+    mod = _load_module()
+    for tool_id, tool in mod.load_manifest().items():
+        assert tool.get("used_in"), f"{tool_id}: no `used_in` — `apply` would rewrite nothing"
+        assert tool.get("version_var"), f"{tool_id}: no `version_var` — `apply` cannot substitute"
+        for rel in tool["used_in"]:
+            path = REPO_ROOT / rel
+            assert path.is_file(), f"{tool_id}: used_in path does not exist: {rel}"
+            assert f'{tool["version_var"]}="{tool["pinned"]}"' in path.read_text(
+                encoding="utf-8"
+            ), f"{tool_id}: {rel} does not carry {tool['version_var']}=\"{tool['pinned']}\""

--- a/tools/check_third_party_updates.py
+++ b/tools/check_third_party_updates.py
@@ -13,6 +13,20 @@ the deterministic, no-LLM core of the scheduled "third-party-updates" workflow:
 The workflow runs `check --json`, security-scans each candidate (npm audit), then
 `apply`s and opens a PR — never auto-merged. Stdlib only (tomllib + urllib); no
 new dependencies, no LLM (CLAUDE.md / ADR-001).
+
+Scope — what this does NOT own (#689):
+
+* **npm only.** `fetch_latest` raises on any other ecosystem rather than
+  guessing a registry API. Adding one means adding a fetcher, not just a
+  manifest entry.
+* **GitHub Actions pins** (`uses: owner/action@sha`) are owned by
+  `renovate.json`, which already opens bump PRs for them.
+* **Version numbers quoted in prose** — docs, ADRs, review notes — are dated
+  context ("as of 2026-07, codex was 0.138.0"), not managed pins. They are not
+  tracked here and must not be silently rewritten.
+
+Anything a scaffolded project *installs at a pinned version* belongs in the
+manifest. A tool it installs unpinned (tracking upstream latest) does not.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## The issue's premise was partly wrong

#689 says `@anthropic-ai/claude-code` is "pinned but absent from the manifest — checked by nothing." Verified: **it is not pinned at all.**

```sh
# templates/multi_model/dot_agents/scripts/setup_models.sh
CCR_VERSION="2.0.0"
CLAUDE_PKG="@anthropic-ai/claude-code"      # no version

bun add -g "$CLAUDE_PKG"                    # latest
bun add -g "${CCR_PKG}@${CCR_VERSION}"      # pinned
```

There is no claude-code version literal anywhere in `tools/`, `tests/`, or `templates/`. So "add it to the manifest" would mean **introducing** a pin, not closing a gap — a policy call, not a bug fix.

**Decision: leave it unpinned.** It is the operator's own CLI, not something the scaffold puts on a project's request path, and pinning it would hold every scaffolded project behind a bump PR on a fast-moving tool. What *was* wrong is that `# --- pinned, vetted versions ---` sat directly above it. The comment now says what is true, and the rationale lives at the pin site.

## The real defect

`tests/contracts/test_multi_model_overlay.py:22` carried `PINNED_CCR_VERSION = "2.0.0"` — a **third** copy of the pin, alongside `pinned_third_party.toml` and `setup_models.sh`. `check_third_party_updates.py apply` bumps the first two in lockstep and knows nothing about the third, so a routine CCR bump would leave this test asserting a version the scaffold no longer ships. It now reads the manifest.

## Guards added

| Guard | Catches |
|---|---|
| `test_no_contract_test_restates_a_managed_pin` | any contract test hardcoding a manifest-managed version |
| `test_every_manifest_tool_declares_where_its_pin_lives` | a manifest entry with no `used_in`/`version_var` — `apply` would rewrite nothing |
| `test_claude_code_is_installed_unpinned_by_design` | claude-code silently gaining a pin, or entering the manifest |

The first uses an **AST walk, not a text grep**. My first attempt was a line filter that skipped any line containing `"pinned"` — which silently skipped `PINNED_CCR_VERSION` itself. It passed with the literal reintroduced. Matching `ast.Constant` values exactly also means a docstring that *mentions* `"2.0.0"` is not an offender, while `X = "2.0.0"` is.

Every guard was verified non-vacuous: reintroducing the literal fails the first; adding a `CLAUDE_VERSION` fails the third.

## Scope, documented

The checker's docstring now records what it does **not** own: npm only (`fetch_latest` raises on any other ecosystem), GitHub Actions pins belong to `renovate.json`, and version numbers quoted in prose are dated context, not managed pins.

Full suite green (2180 passed), `ruff check` clean, shellcheck gate passes.

Closes #689

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1