### PR TITLE
feat(PI-687): give the explore subagent an orientation contract

### DIFF
--- a/.agents/agents/explore.md
+++ b/.agents/agents/explore.md
@@ -10,5 +10,24 @@ You are a read-only codebase researcher. Investigate the question and return a
 concise, `file:path`-cited answer — what exists, where it lives, and how the
 pieces connect. Never modify files.
 
-- Prefer reading targeted excerpts over whole files; cast a wide net with Grep/Glob first.
+## Orient before you sweep
+
+These are maps, not the territory. Each may be absent — check, don't assume.
+
+1. **Read first, to pick targets.** `.agents/docs/CODE_MAP.md` (module index),
+   `.agents/memory/MEMORY.md` (project facts), `.agents/CAPABILITIES.md` (tools
+   and MCP servers available to you). They narrow where to look. They are not
+   the answer.
+2. **Verify in the source before asserting any specific value.** Names,
+   thresholds, signatures and line numbers in a map go stale. Never report a
+   specific from the map alone — open the file.
+3. **A cited path that is missing means the map is stale.** Fall back to a
+   Grep/Glob sweep rather than repeating what the map claimed.
+4. **Report the staleness you found.** If a map cited a path that no longer
+   exists, or a value the source contradicts, say so in your answer — otherwise
+   the caller keeps trusting it.
+
+## Reporting
+
+- Prefer reading targeted excerpts over whole files.
 - Report the conclusion and the key paths, not a file dump.

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -10,5 +10,24 @@ You are a read-only codebase researcher. Investigate the question and return a
 concise, `file:path`-cited answer — what exists, where it lives, and how the
 pieces connect. Never modify files.
 
-- Prefer reading targeted excerpts over whole files; cast a wide net with Grep/Glob first.
+## Orient before you sweep
+
+These are maps, not the territory. Each may be absent — check, don't assume.
+
+1. **Read first, to pick targets.** `.agents/docs/CODE_MAP.md` (module index),
+   `.agents/memory/MEMORY.md` (project facts), `.agents/CAPABILITIES.md` (tools
+   and MCP servers available to you). They narrow where to look. They are not
+   the answer.
+2. **Verify in the source before asserting any specific value.** Names,
+   thresholds, signatures and line numbers in a map go stale. Never report a
+   specific from the map alone — open the file.
+3. **A cited path that is missing means the map is stale.** Fall back to a
+   Grep/Glob sweep rather than repeating what the map claimed.
+4. **Report the staleness you found.** If a map cited a path that no longer
+   exists, or a value the source contradicts, say so in your answer — otherwise
+   the caller keeps trusting it.
+
+## Reporting
+
+- Prefer reading targeted excerpts over whole files.
 - Report the conclusion and the key paths, not a file dump.

--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -20,7 +20,8 @@ below); everything else is reusable by any agent.
 {{#if memory}}- [`.agents/memory/MEMORY.md`](.agents/memory/MEMORY.md) — memory index (read first for context)
 {{/if memory}}- [`.agents/docs/`](.agents/docs/) — system of record: ADRs and development guides
 {{#if python}}- `.agents/docs/CODE_MAP.md` — generated map of what each module does; **read before grepping** (generate/refresh with `just code-map`)
-{{/if python}}{{#if obsidian}}- [`.agents/vault/`](.agents/vault/) — human workspace (Obsidian vault)
+{{/if python}}- [`.agents/CAPABILITIES.md`](.agents/CAPABILITIES.md) — generated inventory of the hooks, skills and MCP servers this project ships
+{{#if obsidian}}- [`.agents/vault/`](.agents/vault/) — human workspace (Obsidian vault)
 {{/if obsidian}}
 ## Skills (load on demand)
 

--- a/templates/base/dot_agents/agents/explore.md
+++ b/templates/base/dot_agents/agents/explore.md
@@ -10,5 +10,24 @@ You are a read-only codebase researcher. Investigate the question and return a
 concise, `file:path`-cited answer — what exists, where it lives, and how the
 pieces connect. Never modify files.
 
-- Prefer reading targeted excerpts over whole files; cast a wide net with Grep/Glob first.
+## Orient before you sweep
+
+These are maps, not the territory. Each may be absent — check, don't assume.
+
+1. **Read first, to pick targets.** `.agents/docs/CODE_MAP.md` (module index),
+   `.agents/memory/MEMORY.md` (project facts), `.agents/CAPABILITIES.md` (tools
+   and MCP servers available to you). They narrow where to look. They are not
+   the answer.
+2. **Verify in the source before asserting any specific value.** Names,
+   thresholds, signatures and line numbers in a map go stale. Never report a
+   specific from the map alone — open the file.
+3. **A cited path that is missing means the map is stale.** Fall back to a
+   Grep/Glob sweep rather than repeating what the map claimed.
+4. **Report the staleness you found.** If a map cited a path that no longer
+   exists, or a value the source contradicts, say so in your answer — otherwise
+   the caller keeps trusting it.
+
+## Reporting
+
+- Prefer reading targeted excerpts over whole files.
 - Report the conclusion and the key paths, not a file dump.

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -134,6 +134,15 @@ review. Deliberate content change, not move-drift — only the
 after verifying every other file still matched.
 The same PI-715 change reworded the `github_workflow` SKILL.md (`--no-review` is no longer the routine merge path); its hash was re-pinned in the no_plugin combos only, where the skill ships as a file rather than through the plugin.
 
+Exception (PI-687): `agents/explore.md` gained a four-step orientation contract —
+read CODE_MAP/MEMORY/CAPABILITIES first to pick targets, verify every specific
+against the source, treat a missing cited path as staleness, and report it. The
+discovery subagent previously named no orientation artifact, so AGENTS.md's
+"read CODE_MAP first, delegate sweeps to explore" threw the map away at the
+delegation boundary. Deliberate content change, not move-drift — only the
+`.agents/agents/explore.md` hash was re-pinned across all four combos, after
+verifying every other file still matched.
+
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -123,6 +123,15 @@ review. Deliberate content change, not move-drift — only the
 after verifying every other file still matched.
 The same PI-715 change reworded the `github_workflow` SKILL.md (`--no-review` is no longer the routine merge path); its hash was re-pinned in the no_plugin combos only, where the skill ships as a file rather than through the plugin.
 
+Exception (PI-687): `agents/explore.md` gained a four-step orientation contract —
+read CODE_MAP/MEMORY/CAPABILITIES first to pick targets, verify every specific
+against the source, treat a missing cited path as staleness, and report it. The
+discovery subagent previously named no orientation artifact, so AGENTS.md's
+"read CODE_MAP first, delegate sweeps to explore" threw the map away at the
+delegation boundary. Deliberate content change, not move-drift — only the
+`.agents/agents/explore.md` hash was re-pinned across all four combos, after
+verifying every other file still matched.
+
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_subagent_specs.py
+++ b/tests/contracts/test_subagent_specs.py
@@ -34,3 +34,34 @@ def test_ships_reusable_subagent_specs(tmp_path: Path):
         # model-agnostic by default so the spec works on any session model
         assert fm.get("model") == "inherit"
         assert body, f"{name}.md needs a system-prompt body"
+
+
+def test_explore_carries_the_orientation_contract(tmp_path: Path):
+    """#687: the one agent whose job is discovery used to grep blind.
+
+    AGENTS.md tells the *main* agent to read CODE_MAP first and delegate sweeps
+    to `explore` — but explore's own spec named no orientation artifact, so the
+    delegation threw away the map. The four steps below are the contract; they
+    also guard against the opposite failure, an agent reporting a stale map's
+    claims as fact.
+    """
+    target = tmp_path / "p"
+    scaffold(target, load_preset("obsidian-only"), make_variables(), strict=True)
+    body = (target / ".agents" / "agents" / "explore.md").read_text(encoding="utf-8")
+
+    # (1) point at the maps — exact paths, so a rename breaks this test
+    for artifact in (
+        ".agents/docs/CODE_MAP.md",
+        ".agents/memory/MEMORY.md",
+        ".agents/CAPABILITIES.md",
+    ):
+        assert artifact in body, f"explore.md must route to {artifact}"
+
+    # CODE_MAP ships only for python, MEMORY only above memory tier "none" —
+    # the spec must not assume either exists.
+    assert "may be absent" in body, "the contract must not assume the maps exist"
+
+    # (2)-(4) verify against source, treat a missing path as staleness, report it
+    assert "Verify in the source before asserting any specific value" in body
+    assert "means the map is stale" in body
+    assert "Report the staleness you found" in body

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -1,7 +1,7 @@
 {
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "24ee849b86aae94eb7a88a68a7c0ccb4836a84583bdde214925c23cc0f7f30e6",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "e082c3082b6574d155359740800ea82d3db804ccf0e7dca32247435867602adf",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -1,7 +1,7 @@
 {
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "24ee849b86aae94eb7a88a68a7c0ccb4836a84583bdde214925c23cc0f7f30e6",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "e082c3082b6574d155359740800ea82d3db804ccf0e7dca32247435867602adf",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -1,7 +1,7 @@
 {
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "ed6f477732b915423d43d735339adcf35d8c34c174079ae2076308871378ecdf",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "a39591217565f4cef615a42edaa99449093614edf374091551f2d261ba62fb63",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -1,7 +1,7 @@
 {
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "ed6f477732b915423d43d735339adcf35d8c34c174079ae2076308871378ecdf",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "a39591217565f4cef615a42edaa99449093614edf374091551f2d261ba62fb63",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -2,7 +2,7 @@
   ".agents/CAPABILITIES.md": "6aff96b4e6163256d4aa5d9ca3366a66d1995c1355d12e3257bede1351fdd60f",
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "24ee849b86aae94eb7a88a68a7c0ccb4836a84583bdde214925c23cc0f7f30e6",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "e082c3082b6574d155359740800ea82d3db804ccf0e7dca32247435867602adf",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -2,7 +2,7 @@
   ".agents/CAPABILITIES.md": "a8a14b381d30ee5e7f2f0fe07ace49bd5c2ba7c30c28b5de3a1a8045b68702de",
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "24ee849b86aae94eb7a88a68a7c0ccb4836a84583bdde214925c23cc0f7f30e6",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "e082c3082b6574d155359740800ea82d3db804ccf0e7dca32247435867602adf",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -2,7 +2,7 @@
   ".agents/CAPABILITIES.md": "893def9db6ee2046e56346c1c5a2b8193eff5c3ce31da1f3fac89f7ca009a7db",
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "ed6f477732b915423d43d735339adcf35d8c34c174079ae2076308871378ecdf",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "a39591217565f4cef615a42edaa99449093614edf374091551f2d261ba62fb63",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -2,7 +2,7 @@
   ".agents/CAPABILITIES.md": "9080ce7534f77e2333747a0a98c8e4fb7ac2d121371306d250c235a4d920c9d9",
   ".agents/agents/README.md": "3506bb3640ef057d3ee4b6359c315b1b59aa5f5de147b4f0ce3abd318a20d1e2",
   ".agents/agents/code-reviewer.md": "d384a5748dc54f49d0e4a763568abc2af7f6af7738d303b67007237e679b05c8",
-  ".agents/agents/explore.md": "aa1a4fcd1d0b3af36b1241f50a697bcb5443468b3561a2cd3f0ecd4156b4fed8",
+  ".agents/agents/explore.md": "7365179c18bc548b4fc488c49c08f586bff4304a529b2a78dff961df1ed2809a",
   ".agents/config.yaml": "ed6f477732b915423d43d735339adcf35d8c34c174079ae2076308871378ecdf",
   ".agents/docs/README.md": "62e435564824960f89fa4d8ba91b370f71f4a13c50ba12e0cc2e96a9facd8a7d",
   ".agents/docs/adr/adr-001-memory-stack.md": "a39591217565f4cef615a42edaa99449093614edf374091551f2d261ba62fb63",


### PR DESCRIPTION
## Problem

`AGENTS.md` tells the **main** agent to read `.agents/docs/CODE_MAP.md` before grepping, and to delegate broad sweeps to the `explore` subagent. But `explore.md` referenced **no** orientation artifact:

```
- Prefer reading targeted excerpts over whole files; cast a wide net with Grep/Glob first.
```

So the map was discarded at the delegation boundary. The one agent whose entire job is discovery grepped blind. Verified: `explore.md` mentioned none of CODE_MAP, MEMORY, or CAPABILITIES, and `test_subagent_specs.py` asserted only frontmatter (`name`, `description`, `model`) — never body text, so nothing could have caught it.

## The contract

Four steps, kept short because this is a token-budgeted subagent system prompt:

1. **Read first, to pick targets** — CODE_MAP (module index), MEMORY (project facts), CAPABILITIES (tools and MCP servers). They narrow where to look; they are not the answer.
2. **Verify in the source before asserting any specific value.** Names, thresholds, signatures, line numbers go stale.
3. **A cited path that is missing means the map is stale** — fall back to a sweep rather than repeating the claim.
4. **Report the staleness you found**, or the caller keeps trusting the map.

Steps 2–4 matter as much as step 1: routing an agent to a map without them just teaches it to report stale facts confidently. The spec states the maps **"may be absent"** — `CODE_MAP.md` ships only for python, `MEMORY.md` only above memory tier `none`, while `CAPABILITIES.md` is always emitted.

## Decisions this issue asked for

**Route `CAPABILITIES.md`.** It is generated by every scaffold, and its only "read this" referencers were three files in the optional `governance` overlay — built, but nothing routed to it. `AGENTS.md.tmpl` now links it. Checked on a minimal `--language go --memory none --lifecycle none` scaffold that the link is not dangling: the file is there.

**Memory for subagents: instruct, don't inject.** Step 1 of the contract covers it. A `SessionStart` hook was rejected — hooks do not fire per-subagent, so injection would hit every session for every agent, paying tokens for agents that never need memory. (Confirmed `session_setup.sh` does dependency bootstrap only and never touches `MEMORY.md`.)

## Propagation

`agents/explore.md` is declared **SYNCED** in `sync_agents_from_templates.py`, so the template edit propagates to this repo's `.agents/` and the `.claude/` mirror via `just sync-agents` + `just sync-claude`. `sync_plugin.py` ships skills and hooks only — no subagent specs — so there is no plugin copy to update.

## Verification

- New `test_explore_carries_the_orientation_contract` scaffolds and asserts the three exact artifact paths plus the exact-case contract phrases (a rename breaks the test).
- Byte-identity fixtures: only `.agents/agents/explore.md` re-pinned across all four combos, after verifying no other file drifted. Both test docstrings carry the exception note.
- Full suite green (2178 passed), `ruff check` clean.

Closes #687

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1