### PR TITLE
feat(PI-686): enforce staleness for the scaffolded CODE_MAP and own skills INDEX

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -158,6 +158,35 @@ jobs:
       - name: Typecheck
         run: just typecheck
 
+      # PI-686: CODE_MAP.md's header tells agents to "read this before grepping",
+      # but nothing checked it was current — the generator shipped wired only to
+      # a manual `just code-map`, so the map rotted silently and agents were
+      # routed to a stale index. Regenerate into a temp dir (gen_code_map.py
+      # writes .agents/docs/CODE_MAP.md relative to cwd) and compare bytes;
+      # never rewrite the committed file in CI. Skips cleanly before the first
+      # `just code-map` run, so a fresh scaffold is not born red.
+      - name: CODE_MAP is current
+        run: |
+          set -euo pipefail
+          map=".agents/docs/CODE_MAP.md"
+          gen=".agents/scripts/gen_code_map.py"
+          if [ ! -f "$map" ] || [ ! -f "$gen" ]; then
+            echo "no $map yet — generate it with 'just code-map' and commit."
+            exit 0
+          fi
+          scan="src"
+          [ -d "$scan" ] || scan="."
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          ( cd "$tmp" && uv run --no-project python \
+              "$GITHUB_WORKSPACE/$gen" "$GITHUB_WORKSPACE/$scan" >/dev/null )
+          if ! cmp -s "$tmp/$map" "$map"; then
+            echo "::error file=$map::CODE_MAP.md is stale — run 'just code-map' and commit"
+            diff -u "$map" "$tmp/$map" | head -n 40 || true
+            exit 1
+          fi
+          echo "$map is current."
+
       # Coverage gate (PI-138/PI-569): always on, not conditional — pytest-cov
       # is pulled in ephemerally via `uv run --with`, the same pattern mypy
       # (PI-558) and mutmut (PI-563) use, so there's no dev-dependency to

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -170,7 +170,14 @@ jobs:
           set -euo pipefail
           map=".agents/docs/CODE_MAP.md"
           gen=".agents/scripts/gen_code_map.py"
-          if [ ! -f "$map" ] || [ ! -f "$gen" ]; then
+          # A python scaffold always ships the generator, so its absence is a
+          # broken scaffold, not a not-yet-generated map — fail rather than
+          # silently pass a check that can never run (PR #724 review).
+          if [ ! -f "$gen" ]; then
+            echo "::error file=$gen::missing — the CODE_MAP staleness check cannot run"
+            exit 1
+          fi
+          if [ ! -f "$map" ]; then
             echo "no $map yet — generate it with 'just code-map' and commit."
             exit 0
           fi

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -38,16 +38,23 @@ class TestSkillIndex:
         skill added under this repo's `.agents/skills/` and forgotten in its
         INDEX passed CI. Only `test_wiki_skill.py` touched the own-repo INDEX, and
         only to assert the literal string "wiki".
+
+        Matches the *link*, not the bare directory name (PR #724 review): "wiki"
+        appearing in prose — or as a substring of a longer word — would satisfy a
+        name-only check while the skill went unindexed.
         """
         own_skills = _REPO_ROOT / ".agents" / "skills"
         own_index = own_skills / "INDEX.md"
         assert own_index.exists(), ".agents/skills/INDEX.md missing"
         index_text = own_index.read_text(encoding="utf-8")
         missing = [
-            d.name for d in sorted(own_skills.iterdir()) if d.is_dir() and d.name not in index_text
+            d.name
+            for d in sorted(own_skills.iterdir())
+            if d.is_dir() and f".agents/skills/{d.name}/SKILL.md" not in index_text
         ]
         assert not missing, (
-            "skill directories missing from .agents/skills/INDEX.md: " + ", ".join(missing)
+            "skill directories not linked from .agents/skills/INDEX.md "
+            "(expected `.agents/skills/<dir>/SKILL.md`): " + ", ".join(missing)
         )
 
     def test_index_scaffolded_into_project(self, tmp_path: Path):

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -31,6 +31,25 @@ class TestSkillIndex:
             "Skill directories not referenced in INDEX.md: " + ", ".join(missing)
         )
 
+    def test_this_repos_own_index_covers_every_skill_dir(self):
+        """PI-686: the template INDEX was guarded; this repo's own INDEX was not.
+
+        `_INDEX_PATH` above points at `templates/fallback/...INDEX.md.tmpl`, so a
+        skill added under this repo's `.agents/skills/` and forgotten in its
+        INDEX passed CI. Only `test_wiki_skill.py` touched the own-repo INDEX, and
+        only to assert the literal string "wiki".
+        """
+        own_skills = _REPO_ROOT / ".agents" / "skills"
+        own_index = own_skills / "INDEX.md"
+        assert own_index.exists(), ".agents/skills/INDEX.md missing"
+        index_text = own_index.read_text(encoding="utf-8")
+        missing = [
+            d.name for d in sorted(own_skills.iterdir()) if d.is_dir() and d.name not in index_text
+        ]
+        assert not missing, (
+            "skill directories missing from .agents/skills/INDEX.md: " + ", ".join(missing)
+        )
+
     def test_index_scaffolded_into_project(self, tmp_path: Path):
         target = tmp_path / "proj"
         preset = fallback_preset()
@@ -133,3 +152,33 @@ class TestSkillFrontmatter:
         audit = _REPO_ROOT / "templates" / "lifecycle_fallback" / "dot_agents" / "skills" / "audit"
         fm = self._frontmatter(audit / "SKILL.md")
         assert fm.get("context") == "fork"
+
+
+class TestCodeMapStaleness:
+    """PI-686: the scaffolded CODE_MAP had a generator but no staleness check.
+
+    `gen_code_map.py` was wired only to a manual `just code-map` recipe — absent
+    from the scaffolded ci.yml, pre-push hook, install_hooks.sh, and pre-commit
+    config. The file whose header says "read this before grepping" rotted freely
+    in every scaffolded project.
+    """
+
+    def _ci(self, tmp_path: Path, language: str) -> str:
+        target = tmp_path / f"proj-{language}"
+        scaffold(target, fallback_preset(), fallback_variables(**{language: "true"}))
+        return (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    def test_python_ci_checks_the_code_map(self, tmp_path: Path):
+        ci = self._ci(tmp_path, "python")
+        assert "CODE_MAP is current" in ci
+        # Compares, never rewrites the committed file.
+        assert "cmp -s" in ci
+        assert "run 'just code-map' and commit" in ci
+
+    def test_non_python_ci_omits_the_check(self, tmp_path: Path):
+        """The generator is a Python AST walker; there is nothing to map."""
+        target = tmp_path / "proj-go"
+        variables = fallback_variables(python="", go="true", language="go")
+        scaffold(target, fallback_preset(), variables)
+        ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        assert "CODE_MAP is current" not in ci

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -175,6 +175,20 @@ class TestCodeMapStaleness:
         assert "cmp -s" in ci
         assert "run 'just code-map' and commit" in ci
 
+    def test_missing_generator_fails_rather_than_skipping(self, tmp_path: Path):
+        """PR #724 review: a broken scaffold must not pass a check that can't run.
+
+        A missing map means "not generated yet" (skip); a missing generator means
+        the scaffold is broken (fail). The first guard conflated them.
+        """
+        ci = self._ci(tmp_path, "python")
+        step = ci.split("name: CODE_MAP is current", 1)[1].split("- name:", 1)[0]
+        assert "the CODE_MAP staleness check cannot run" in step
+        assert 'if [ ! -f "$gen" ]; then' in step
+        assert 'if [ ! -f "$map" ]; then' in step
+        # The two conditions are no longer OR-ed into one skip.
+        assert '[ ! -f "$map" ] || [ ! -f "$gen" ]' not in step
+
     def test_non_python_ci_omits_the_check(self, tmp_path: Path):
         """The generator is a Python AST walker; there is nothing to map."""
         target = tmp_path / "proj-go"


### PR DESCRIPTION
## Re-verified before implementing — half the issue was stale

Posted in full as an [issue comment](https://github.com/VytCepas/project-init/issues/686#issuecomment-4933274562):

| Item | Status |
|---|---|
| 1. `.agents/CAPABILITIES.md` staleness | **Moot.** The file does not exist, and `.gitignore:36-46` ignores `.agents/*` except an allowlist it is not on. It could not be committed even if regenerated. |
| 4. "this repo has no committed, current CODE_MAP" | **False.** It exists, is tracked, and is *already* enforced by `test_agents_template_sync.py:51`. |
| 2. Own skills INDEX coverage | **Real.** Implemented here. |
| 3. Scaffolded CODE_MAP staleness | **Real, and the substantive one.** Implemented here. |

## 3. Scaffolded CODE_MAP staleness

`gen_code_map.py` was invoked only by the `code-map` recipe in `justfile.tmpl:103`. Verified absent from the scaffolded `ci.yml.tmpl`, `pre-push.tmpl`, `install_hooks.sh`, and `dot_pre-commit-config.yaml.tmpl` — **no** regen-and-diff step anywhere. So the file whose own header says *"read this before grepping"* rotted freely in every scaffolded project, routing agents to a stale index. That is worse than having no map: an agent trusts it.

CI now regenerates into a temp dir and compares bytes. The generator writes `.agents/docs/CODE_MAP.md` **relative to cwd**, so running it from a temp dir produces a clean copy without touching the committed file — the same trick `test_committed_code_map_is_fresh` uses. It **skips cleanly** when the map doesn't exist, so a fresh scaffold is not born red before its first `just code-map`. Python-gated, since the generator is a Python AST walker.

**Chose CI over the pre-commit hook**, which the issue suggested as the cheapest home. The hook would have to compare the *staged* snapshot: the existing lint gate does an unstaged-patch dance to isolate the index, and a code-map check running after that restore would compare the working tree, so unrelated unstaged WIP would report a false "stale map". CI checks out exactly the commit, so the comparison is unambiguous.

## 2. Own skills INDEX coverage

`test_skill_index.py`'s `_INDEX_PATH` points at `templates/fallback/dot_agents/skills/INDEX.md.tmpl` — the **template**. The only assertion on this repo's own `.agents/skills/INDEX.md` was `test_wiki_skill.py:143-152`, checking for the literal string `"wiki"`. A newly added own-repo skill missing from INDEX passed CI. (All 7 current dirs *are* listed — the gap was the absent guard, not present drift.)

## Verification — behavior, not just presence

Ran the CI step's exact shell against a real scaffolded project:

| Scenario | Result |
|---|---|
| map current | `is current.` exit 0 |
| public function added, map not regenerated | **exit 1**, stale detected |
| after `just code-map` | exit 0 again |
| fresh scaffold, map never generated | **skipped**, exit 0 — not born red |

The INDEX guard was verified non-vacuous by dropping an unlisted skill dir into `.agents/skills/` and watching it fail.

Contract tests assert the step ships for python and is **absent** for a go scaffold. Rendered scaffold workflows stay actionlint-clean (the #719 gate).

Full suite green (2184 passed), `ruff check` clean.

Closes #686

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1