### PR TITLE
fix(PI-726): add a real format gate, and stop rules docs promising one

### DIFF
--- a/.agents/hooks/dag_workflow.py
+++ b/.agents/hooks/dag_workflow.py
@@ -31,6 +31,7 @@ Issue-ref prefix detection:
 
 stdlib only.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -168,7 +169,13 @@ def check_ci_green() -> tuple[bool, str]:
         # miscounted as "still running" forever — and a red one as pending —
         # while the CheckRun `conclusion`/`status` fields stay authoritative.
         state = (entry.get("state") or "").upper()
-        if conclusion in {"FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED"} or state in {
+        if conclusion in {
+            "FAILURE",
+            "TIMED_OUT",
+            "CANCELLED",
+            "ERROR",
+            "ACTION_REQUIRED",
+        } or state in {
             "FAILURE",
             "ERROR",
         }:
@@ -527,7 +534,9 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         # running push_branch.sh while on main bypasses the direct-push guard,
         # since the internal `git push` subprocess is invisible to the
         # PreToolUse hook (PI-202).
-        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
+        sys.stderr.write(
+            "push: refusing to push main/master directly — open a feature branch + PR\n"
+        )
         return 1
 
     code, sha_out = _git(["rev-parse", branch])
@@ -572,30 +581,22 @@ def cmd_promote(pr_number: int | None) -> int:
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
-        sys.stderr.write(
-            "promote: no PR found for current branch. Pass a PR number.\n"
-        )
+        sys.stderr.write("promote: no PR found for current branch. Pass a PR number.\n")
         return 1
-    code, out = _gh(
-        ["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"]
-    )
+    code, out = _gh(["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"])
     if code != 0:
         sys.stderr.write(f"promote: cannot read PR #{pr_number}\n")
         return 1
     if out.strip() == "false":
         _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-        sys.stdout.write(
-            f"PR #{pr_number} is already ready for review: {url.strip()}\n"
-        )
+        sys.stdout.write(f"PR #{pr_number} is already ready for review: {url.strip()}\n")
         return 0
     code, _ = _gh(["pr", "ready", str(pr_number)])
     if code != 0:
         sys.stderr.write(f"promote: gh pr ready failed for #{pr_number}\n")
         return code
     _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-    sys.stdout.write(
-        f"PR #{pr_number} is now ready for review: {url.strip()}\n"
-    )
+    sys.stdout.write(f"PR #{pr_number} is now ready for review: {url.strip()}\n")
     return 0
 
 
@@ -609,9 +610,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
-    code, head = _gh(
-        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
-    )
+    code, head = _gh(["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"])
     head = head.strip()
     if code != 0 or not head:
         sys.stderr.write(
@@ -658,9 +657,7 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def cmd_create_pr_nojira(
-    type_: str, title: str, branch: str | None, base: str | None
-) -> int:
+def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str | None) -> int:
     """Create a no-issue feature branch (if needed) and open a draft PR."""
     if type_ not in _VALID_TYPES:
         sys.stderr.write(
@@ -678,9 +675,7 @@ def cmd_create_pr_nojira(
         else:
             slug = _slugify(title)
             if not slug:
-                sys.stderr.write(
-                    "ERROR: title must contain at least one letter or number\n"
-                )
+                sys.stderr.write("ERROR: title must contain at least one letter or number\n")
                 return 1
             prefix = "nojira-"
             max_slug = max(12, 80 - len(type_) - 1 - len(prefix))
@@ -688,9 +683,7 @@ def cmd_create_pr_nojira(
             branch = f"{type_}/{prefix}{slug}"
 
     if not _BRANCH_RE.match(branch):
-        sys.stderr.write(
-            f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n"
-        )
+        sys.stderr.write(f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n")
         return 1
 
     if current == branch:

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -31,6 +31,7 @@ Issue-ref prefix detection:
 
 stdlib only.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -168,7 +169,13 @@ def check_ci_green() -> tuple[bool, str]:
         # miscounted as "still running" forever — and a red one as pending —
         # while the CheckRun `conclusion`/`status` fields stay authoritative.
         state = (entry.get("state") or "").upper()
-        if conclusion in {"FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED"} or state in {
+        if conclusion in {
+            "FAILURE",
+            "TIMED_OUT",
+            "CANCELLED",
+            "ERROR",
+            "ACTION_REQUIRED",
+        } or state in {
             "FAILURE",
             "ERROR",
         }:
@@ -527,7 +534,9 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         # running push_branch.sh while on main bypasses the direct-push guard,
         # since the internal `git push` subprocess is invisible to the
         # PreToolUse hook (PI-202).
-        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
+        sys.stderr.write(
+            "push: refusing to push main/master directly — open a feature branch + PR\n"
+        )
         return 1
 
     code, sha_out = _git(["rev-parse", branch])
@@ -572,30 +581,22 @@ def cmd_promote(pr_number: int | None) -> int:
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
-        sys.stderr.write(
-            "promote: no PR found for current branch. Pass a PR number.\n"
-        )
+        sys.stderr.write("promote: no PR found for current branch. Pass a PR number.\n")
         return 1
-    code, out = _gh(
-        ["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"]
-    )
+    code, out = _gh(["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"])
     if code != 0:
         sys.stderr.write(f"promote: cannot read PR #{pr_number}\n")
         return 1
     if out.strip() == "false":
         _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-        sys.stdout.write(
-            f"PR #{pr_number} is already ready for review: {url.strip()}\n"
-        )
+        sys.stdout.write(f"PR #{pr_number} is already ready for review: {url.strip()}\n")
         return 0
     code, _ = _gh(["pr", "ready", str(pr_number)])
     if code != 0:
         sys.stderr.write(f"promote: gh pr ready failed for #{pr_number}\n")
         return code
     _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-    sys.stdout.write(
-        f"PR #{pr_number} is now ready for review: {url.strip()}\n"
-    )
+    sys.stdout.write(f"PR #{pr_number} is now ready for review: {url.strip()}\n")
     return 0
 
 
@@ -609,9 +610,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
-    code, head = _gh(
-        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
-    )
+    code, head = _gh(["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"])
     head = head.strip()
     if code != 0 or not head:
         sys.stderr.write(
@@ -658,9 +657,7 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def cmd_create_pr_nojira(
-    type_: str, title: str, branch: str | None, base: str | None
-) -> int:
+def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str | None) -> int:
     """Create a no-issue feature branch (if needed) and open a draft PR."""
     if type_ not in _VALID_TYPES:
         sys.stderr.write(
@@ -678,9 +675,7 @@ def cmd_create_pr_nojira(
         else:
             slug = _slugify(title)
             if not slug:
-                sys.stderr.write(
-                    "ERROR: title must contain at least one letter or number\n"
-                )
+                sys.stderr.write("ERROR: title must contain at least one letter or number\n")
                 return 1
             prefix = "nojira-"
             max_slug = max(12, 80 - len(type_) - 1 - len(prefix))
@@ -688,9 +683,7 @@ def cmd_create_pr_nojira(
             branch = f"{type_}/{prefix}{slug}"
 
     if not _BRANCH_RE.match(branch):
-        sys.stderr.write(
-            f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n"
-        )
+        sys.stderr.write(f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n")
         return 1
 
     if current == branch:

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -31,6 +31,7 @@ Issue-ref prefix detection:
 
 stdlib only.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -168,7 +169,13 @@ def check_ci_green() -> tuple[bool, str]:
         # miscounted as "still running" forever — and a red one as pending —
         # while the CheckRun `conclusion`/`status` fields stay authoritative.
         state = (entry.get("state") or "").upper()
-        if conclusion in {"FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED"} or state in {
+        if conclusion in {
+            "FAILURE",
+            "TIMED_OUT",
+            "CANCELLED",
+            "ERROR",
+            "ACTION_REQUIRED",
+        } or state in {
             "FAILURE",
             "ERROR",
         }:
@@ -527,7 +534,9 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         # running push_branch.sh while on main bypasses the direct-push guard,
         # since the internal `git push` subprocess is invisible to the
         # PreToolUse hook (PI-202).
-        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
+        sys.stderr.write(
+            "push: refusing to push main/master directly — open a feature branch + PR\n"
+        )
         return 1
 
     code, sha_out = _git(["rev-parse", branch])
@@ -572,30 +581,22 @@ def cmd_promote(pr_number: int | None) -> int:
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
-        sys.stderr.write(
-            "promote: no PR found for current branch. Pass a PR number.\n"
-        )
+        sys.stderr.write("promote: no PR found for current branch. Pass a PR number.\n")
         return 1
-    code, out = _gh(
-        ["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"]
-    )
+    code, out = _gh(["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"])
     if code != 0:
         sys.stderr.write(f"promote: cannot read PR #{pr_number}\n")
         return 1
     if out.strip() == "false":
         _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-        sys.stdout.write(
-            f"PR #{pr_number} is already ready for review: {url.strip()}\n"
-        )
+        sys.stdout.write(f"PR #{pr_number} is already ready for review: {url.strip()}\n")
         return 0
     code, _ = _gh(["pr", "ready", str(pr_number)])
     if code != 0:
         sys.stderr.write(f"promote: gh pr ready failed for #{pr_number}\n")
         return code
     _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-    sys.stdout.write(
-        f"PR #{pr_number} is now ready for review: {url.strip()}\n"
-    )
+    sys.stdout.write(f"PR #{pr_number} is now ready for review: {url.strip()}\n")
     return 0
 
 
@@ -609,9 +610,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
-    code, head = _gh(
-        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
-    )
+    code, head = _gh(["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"])
     head = head.strip()
     if code != 0 or not head:
         sys.stderr.write(
@@ -658,9 +657,7 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def cmd_create_pr_nojira(
-    type_: str, title: str, branch: str | None, base: str | None
-) -> int:
+def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str | None) -> int:
     """Create a no-issue feature branch (if needed) and open a draft PR."""
     if type_ not in _VALID_TYPES:
         sys.stderr.write(
@@ -678,9 +675,7 @@ def cmd_create_pr_nojira(
         else:
             slug = _slugify(title)
             if not slug:
-                sys.stderr.write(
-                    "ERROR: title must contain at least one letter or number\n"
-                )
+                sys.stderr.write("ERROR: title must contain at least one letter or number\n")
                 return 1
             prefix = "nojira-"
             max_slug = max(12, 80 - len(type_) - 1 - len(prefix))
@@ -688,9 +683,7 @@ def cmd_create_pr_nojira(
             branch = f"{type_}/{prefix}{slug}"
 
     if not _BRANCH_RE.match(branch):
-        sys.stderr.write(
-            f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n"
-        )
+        sys.stderr.write(f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n")
         return 1
 
     if current == branch:

--- a/templates/base/dot_agents/rules/go.md
+++ b/templates/base/dot_agents/rules/go.md
@@ -15,7 +15,8 @@ just sbom           # CycloneDX SBOM via cyclonedx-gomod (#574) — release.yml 
 just license        # dependency license scan (#579) — deny copyleft; tune --disallowed_types
 just fuzz           # replay fuzz-test seed corpora (#580) — native go test -fuzz, CI-safe
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
-golangci-lint fmt   # gofumpt (stricter than gofmt) — no separate binary needed
+                    # ALSO the format gate: `formatters: gofumpt` in .golangci.yml makes `run` fail on unformatted code (#726)
+golangci-lint fmt   # WRITES gofumpt formatting (stricter than gofmt) — no separate binary needed
 ```
 
 ## Fuzzing (native `go test -fuzz`, #580)

--- a/templates/base/dot_agents/rules/python.md
+++ b/templates/base/dot_agents/rules/python.md
@@ -12,7 +12,8 @@ Uses [`uv`](https://docs.astral.sh/uv/).
 uv sync                           # install deps
 uv run <command>                  # run in the project venv
 uv run ruff check .               # lint
-uv run ruff format .              # format
+uv run ruff format .              # WRITES formatting; `ruff format --check .` is the gate,
+                                  # part of `just lint` — CI runs it (#726)
 uv run --with "mypy>=1.10" mypy src/  # type check (strict mode, per mypy.ini)
 uv run pytest -n auto -q          # tests (parallel mode, requires pytest-xdist)
 uv run pytest -q --tb=short       # tests (single-threaded fallback)

--- a/templates/base/dot_agents/rules/rust.md
+++ b/templates/base/dot_agents/rules/rust.md
@@ -15,7 +15,7 @@ cargo cyclonedx --format json                     # CycloneDX SBOM (`just sbom`,
 cargo deny check licenses                         # license compliance (`just license`, #579) — allow-list in deny.toml (denies GPL/AGPL)
 cargo test                                        # property-based tests with proptest (`just fuzz`, #580)
 cargo clippy -- -D warnings -D clippy::pedantic -D clippy::cognitive_complexity -D missing_docs   # lint + complexity + public-API docs
-cargo fmt --check                                 # verifies only; `cargo fmt` (no flag) writes changes
+cargo fmt --check                                 # format gate — part of `just lint`, CI runs it (#726); `cargo fmt` writes
 ```
 
 ## Enforced complexity and docs (parity with Python's ruff gate)

--- a/templates/base/dot_agents/rules/typescript.md
+++ b/templates/base/dot_agents/rules/typescript.md
@@ -23,6 +23,8 @@ disabled on purpose — that carve-out is for config, not for product code.
 ```bash
 bunx tsc --noEmit   # type check (strict mode, per tsconfig.base.json)
 bunx eslint .        # lint (type-aware: no-floating-promises, no-unsafe-*, per eslint.config.mjs)
+bunx @biomejs/biome format .   # format gate — exits 1 on unformatted; part of `just lint` (#726).
+                               # `biome format --write .` (i.e. `just format`) writes the fixes.
 bun test             # tests + coverage gate (>= 70%, per bunfig.toml) — always on, no extra flag needed
 bun audit            # dependency CVE/advisory scan — CI always runs this
 ```

--- a/templates/base/dot_agents/rules/typescript.md
+++ b/templates/base/dot_agents/rules/typescript.md
@@ -23,8 +23,10 @@ disabled on purpose — that carve-out is for config, not for product code.
 ```bash
 bunx tsc --noEmit   # type check (strict mode, per tsconfig.base.json)
 bunx eslint .        # lint (type-aware: no-floating-promises, no-unsafe-*, per eslint.config.mjs)
-bunx @biomejs/biome format .   # format gate — exits 1 on unformatted; part of `just lint` (#726).
-                               # `biome format --write .` (i.e. `just format`) writes the fixes.
+bunx @biomejs/biome format .   # format gate — exits 1 on unformatted, leaves files untouched.
+                               # Part of `just lint` (#726). There is NO `--check` flag: biome
+                               # rejects it ("`--check` is not expected in this context") — the
+                               # no-flag form IS the check. `--write` (i.e. `just format`) fixes.
 bun test             # tests + coverage gate (>= 70%, per bunfig.toml) — always on, no extra flag needed
 bun audit            # dependency CVE/advisory scan — CI always runs this
 ```

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -114,9 +114,11 @@ setup:
     bun add -d eslint typescript typescript-eslint eslint-plugin-jsdoc eslint-plugin-tsdoc @biomejs/biome
 
 # lint project code (jsdoc/tsdoc + complexity gates per eslint.config.mjs).
-# `biome format` without --write is a check: it exits 1 on an unformatted file
-# (#726). Deliberately not `biome ci`, which also runs biome's linter and would
-# duplicate eslint, the owner of the lint gates here.
+# `biome format` without --write IS the check: verified against biome 2.x, it
+# leaves files byte-identical and exits 1 on a diff (#726). Do not "fix" this by
+# adding --check — biome rejects the flag ("`--check` is not expected in this
+# context"). Deliberately not `biome ci` either, which also runs biome's linter
+# and would duplicate eslint, the owner of the lint gates here.
 lint:
     bunx eslint .
     bunx @biomejs/biome format .

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -9,9 +9,12 @@
 setup:
     sh -c 'if [ ! -f pyproject.toml ]; then echo "No pyproject.toml yet — nothing to sync."; elif grep -q "^\[dependency-groups\]" pyproject.toml; then uv sync --group dev; else uv sync; fi'
 
-# lint project code (docstring + complexity gates per ruff.toml)
+# lint project code (docstring + complexity gates per ruff.toml).
+# `ruff format --check` verifies formatting without writing — `just format`
+# writes. Without this, an unformatted file merged green (#726).
 lint:
     uv run ruff check .
+    uv run ruff format --check .
     sh -c 'if command -v shellcheck >/dev/null 2>&1; then find .agents -name "*.sh" -exec shellcheck -S error -x {} +; else echo "shellcheck not installed — skipping shell lint (CI still runs it). Install: https://github.com/koalaman/shellcheck#installing or run \`mise install\`."; fi'
     sh -c 'if command -v shfmt >/dev/null 2>&1; then find .agents -name "*.sh" -exec shfmt -d -i 2 {} +; else echo "shfmt not installed — skipping shfmt check (CI still runs it). Install: https://github.com/mvdan/sh#shfmt or run \`mise install\`."; fi'
     bash .agents/scripts/lint_context_budget.sh
@@ -110,9 +113,13 @@ code-map:
 setup:
     bun add -d eslint typescript typescript-eslint eslint-plugin-jsdoc eslint-plugin-tsdoc @biomejs/biome
 
-# lint project code (jsdoc/tsdoc + complexity gates per eslint.config.mjs)
+# lint project code (jsdoc/tsdoc + complexity gates per eslint.config.mjs).
+# `biome format` without --write is a check: it exits 1 on an unformatted file
+# (#726). Deliberately not `biome ci`, which also runs biome's linter and would
+# duplicate eslint, the owner of the lint gates here.
 lint:
     bunx eslint .
+    bunx @biomejs/biome format .
     sh -c 'if command -v shellcheck >/dev/null 2>&1; then find .agents -name "*.sh" -exec shellcheck -S error -x {} +; else echo "shellcheck not installed — skipping shell lint (CI still runs it). Install: https://github.com/koalaman/shellcheck#installing or run \`mise install\`."; fi'
     sh -c 'if command -v shfmt >/dev/null 2>&1; then find .agents -name "*.sh" -exec shfmt -d -i 2 {} +; else echo "shfmt not installed — skipping shfmt check (CI still runs it). Install: https://github.com/mvdan/sh#shfmt or run \`mise install\`."; fi'
     bash .agents/scripts/lint_context_budget.sh
@@ -281,6 +288,7 @@ build:
 # with no pub items it only asks for a crate-level `//!` doc.
 lint:
     cargo clippy -- -D warnings -D clippy::pedantic -D clippy::cognitive_complexity -D missing_docs
+    cargo fmt --check
     sh -c 'if command -v shellcheck >/dev/null 2>&1; then find .agents -name "*.sh" -exec shellcheck -S error -x {} +; else echo "shellcheck not installed — skipping shell lint (CI still runs it). Install: https://github.com/koalaman/shellcheck#installing or run \`mise install\`."; fi'
     sh -c 'if command -v shfmt >/dev/null 2>&1; then find .agents -name "*.sh" -exec shfmt -d -i 2 {} +; else echo "shfmt not installed — skipping shfmt check (CI still runs it). Install: https://github.com/mvdan/sh#shfmt or run \`mise install\`."; fi'
     bash .agents/scripts/lint_context_budget.sh

--- a/templates/governance/dot_agents/scripts/governance_gate.py
+++ b/templates/governance/dot_agents/scripts/governance_gate.py
@@ -73,9 +73,7 @@ def find_cards(gov_dir: Path) -> list[Path]:
     still a real card.
     """
     return [
-        p
-        for p in gov_dir.rglob("SYSTEM_CARD.md")
-        if p.relative_to(gov_dir).parts[0] != "examples"
+        p for p in gov_dir.rglob("SYSTEM_CARD.md") if p.relative_to(gov_dir).parts[0] != "examples"
     ]
 
 
@@ -133,8 +131,14 @@ def validate_card(card: Path, root: Path, gov_dir: Path, max_age: int) -> list[s
     if role and not is_placeholder(role) and role not in ROLES:
         errs.append(f"role must be one of {sorted(ROLES)}; got {role!r}")
     classification = fm.get("classification", "")
-    if classification and not is_placeholder(classification) and classification not in CLASSIFICATIONS:
-        errs.append(f"classification must be one of {sorted(CLASSIFICATIONS)}; got {classification!r}")
+    if (
+        classification
+        and not is_placeholder(classification)
+        and classification not in CLASSIFICATIONS
+    ):
+        errs.append(
+            f"classification must be one of {sorted(CLASSIFICATIONS)}; got {classification!r}"
+        )
     allowed = fm.get("allowed", "").lower()
     if allowed and not is_placeholder(allowed) and allowed not in ALLOWED_VALUES:
         errs.append(f"allowed must be true|false; got {fm.get('allowed')!r}")

--- a/templates/lifecycle/dot_agents/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_agents/hooks/dag_workflow.py
@@ -31,6 +31,7 @@ Issue-ref prefix detection:
 
 stdlib only.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -168,7 +169,13 @@ def check_ci_green() -> tuple[bool, str]:
         # miscounted as "still running" forever — and a red one as pending —
         # while the CheckRun `conclusion`/`status` fields stay authoritative.
         state = (entry.get("state") or "").upper()
-        if conclusion in {"FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED"} or state in {
+        if conclusion in {
+            "FAILURE",
+            "TIMED_OUT",
+            "CANCELLED",
+            "ERROR",
+            "ACTION_REQUIRED",
+        } or state in {
             "FAILURE",
             "ERROR",
         }:
@@ -527,7 +534,9 @@ def cmd_push(branch: str | None, max_retries: int, *, force: bool = False) -> in
         # running push_branch.sh while on main bypasses the direct-push guard,
         # since the internal `git push` subprocess is invisible to the
         # PreToolUse hook (PI-202).
-        sys.stderr.write("push: refusing to push main/master directly — open a feature branch + PR\n")
+        sys.stderr.write(
+            "push: refusing to push main/master directly — open a feature branch + PR\n"
+        )
         return 1
 
     code, sha_out = _git(["rev-parse", branch])
@@ -572,30 +581,22 @@ def cmd_promote(pr_number: int | None) -> int:
     if pr_number is None:
         pr_number = _detect_pr_number()
     if pr_number is None:
-        sys.stderr.write(
-            "promote: no PR found for current branch. Pass a PR number.\n"
-        )
+        sys.stderr.write("promote: no PR found for current branch. Pass a PR number.\n")
         return 1
-    code, out = _gh(
-        ["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"]
-    )
+    code, out = _gh(["pr", "view", str(pr_number), "--json", "isDraft", "-q", ".isDraft"])
     if code != 0:
         sys.stderr.write(f"promote: cannot read PR #{pr_number}\n")
         return 1
     if out.strip() == "false":
         _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-        sys.stdout.write(
-            f"PR #{pr_number} is already ready for review: {url.strip()}\n"
-        )
+        sys.stdout.write(f"PR #{pr_number} is already ready for review: {url.strip()}\n")
         return 0
     code, _ = _gh(["pr", "ready", str(pr_number)])
     if code != 0:
         sys.stderr.write(f"promote: gh pr ready failed for #{pr_number}\n")
         return code
     _, url = _gh(["pr", "view", str(pr_number), "--json", "url", "-q", ".url"])
-    sys.stdout.write(
-        f"PR #{pr_number} is now ready for review: {url.strip()}\n"
-    )
+    sys.stdout.write(f"PR #{pr_number} is now ready for review: {url.strip()}\n")
     return 0
 
 
@@ -609,9 +610,7 @@ def cmd_finish(pr_number: int | None, review_cycle: int | None) -> int:
     if pr_number is None:
         sys.stderr.write("finish: no PR found for current branch.\n")
         return 1
-    code, head = _gh(
-        ["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"]
-    )
+    code, head = _gh(["pr", "view", str(pr_number), "--json", "headRefName", "-q", ".headRefName"])
     head = head.strip()
     if code != 0 or not head:
         sys.stderr.write(
@@ -658,9 +657,7 @@ def _slugify(text: str) -> str:
     return s.strip("-")
 
 
-def cmd_create_pr_nojira(
-    type_: str, title: str, branch: str | None, base: str | None
-) -> int:
+def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str | None) -> int:
     """Create a no-issue feature branch (if needed) and open a draft PR."""
     if type_ not in _VALID_TYPES:
         sys.stderr.write(
@@ -678,9 +675,7 @@ def cmd_create_pr_nojira(
         else:
             slug = _slugify(title)
             if not slug:
-                sys.stderr.write(
-                    "ERROR: title must contain at least one letter or number\n"
-                )
+                sys.stderr.write("ERROR: title must contain at least one letter or number\n")
                 return 1
             prefix = "nojira-"
             max_slug = max(12, 80 - len(type_) - 1 - len(prefix))
@@ -688,9 +683,7 @@ def cmd_create_pr_nojira(
             branch = f"{type_}/{prefix}{slug}"
 
     if not _BRANCH_RE.match(branch):
-        sys.stderr.write(
-            f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n"
-        )
+        sys.stderr.write(f"ERROR: branch '{branch}' must start with feat|fix|chore|docs|test/\n")
         return 1
 
     if current == branch:

--- a/templates/observability/dot_agents/observability/usage_report.py
+++ b/templates/observability/dot_agents/observability/usage_report.py
@@ -451,8 +451,7 @@ def render_text(report: dict, transcript: Path) -> str:
     lines += ["", "== Top context contributors (tool_result volume) =="]
     if contributors:
         lines.extend(
-            f"    {name}: {chars:,} chars (≈{chars // 4:,} tokens)"
-            for name, chars in contributors
+            f"    {name}: {chars:,} chars (≈{chars // 4:,} tokens)" for name, chars in contributors
         )
     else:
         lines.append("    (none)")

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -143,6 +143,13 @@ delegation boundary. Deliberate content change, not move-drift — only the
 `.agents/agents/explore.md` hash was re-pinned across all four combos, after
 verifying every other file still matched.
 
+Exception (PI-726): `dag_workflow.py` was reformatted by `ruff format`. `just
+lint` now carries `ruff format --check .`, and the shipped hook was not
+format-clean — so every fresh python scaffold would have failed its own lint gate
+on day one (the #698 class of bug). Deliberate formatting change, not move-drift
+— only the `.agents/hooks/dag_workflow.py` hash was re-pinned across all four
+combos, after verifying every other file still matched.
+
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -132,6 +132,13 @@ delegation boundary. Deliberate content change, not move-drift — only the
 `.agents/agents/explore.md` hash was re-pinned across all four combos, after
 verifying every other file still matched.
 
+Exception (PI-726): `dag_workflow.py` was reformatted by `ruff format`. `just
+lint` now carries `ruff format --check .`, and the shipped hook was not
+format-clean — so every fresh python scaffold would have failed its own lint gate
+on day one (the #698 class of bug). Deliberate formatting change, not move-drift
+— only the `.agents/hooks/dag_workflow.py` hash was re-pinned across all four
+combos, after verifying every other file still matched.
+
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -661,6 +661,11 @@ class TestFormatGate:
     def test_node_lint_checks_formatting(self, tmp_target: Path):
         recipe = self._lint_recipe(self._justfile(tmp_target, "node"))
         assert "@biomejs/biome format ." in recipe
+        # Must not WRITE from the lint gate. Verified against biome 2.x:
+        # `format .` leaves files byte-identical and exits 1 on a diff, while
+        # `--write` mutates. There is no `format --check` flag — biome rejects it
+        # with "`--check` is not expected in this context" (PR #728 review).
+        assert "--write" not in recipe
         # `biome ci` would also run biome's linter and duplicate eslint.
         assert "biome ci" not in recipe
 
@@ -702,6 +707,10 @@ class TestFormatGate:
             text=True,
             check=False,
         )
-        if result.returncode == 2:  # ruff not importable as a module here
-            pytest.skip("ruff not available as a module")
-        assert result.returncode == 0, result.stdout + result.stderr
+        # No skip: ruff is a declared dev dependency, so a non-zero exit here is
+        # either real drift or a broken invocation. Skipping on rc==2 would let
+        # the gate vanish silently — the failure mode this whole PR is about
+        # (PR #728 review).
+        assert result.returncode == 0, (
+            f"ruff format --check exited {result.returncode}\n{result.stdout}{result.stderr}"
+        )

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -633,3 +633,75 @@ class TestQualityPlugins:
         content = (target / "AGENTS.md").read_text()
         assert "pr-review-toolkit" in content
         assert "code-review@claude-plugins-official" in content
+
+
+class TestFormatGate:
+    """PI-726: `just lint` must reject an unformatted file, in every language.
+
+    Every `format` recipe *writes*; none checked. So an unformatted file merged
+    green for python, node and rust. Go was the exception all along —
+    `.golangci.yml` enables `gofumpt` under `formatters:`, and `golangci-lint
+    run` exits 1 on unformatted code (verified against golangci-lint 2.1.6).
+    Adding a fourth gate there would be redundant, so Go gets docs, not a check.
+
+    `rust.md` documented `cargo fmt --check` while nothing ran it — a rules file
+    promising a gate that did not exist (the map-not-territory failure, #688).
+    """
+
+    def _justfile(self, target: Path, language: str) -> str:
+        return (_scaffold_language(target, language) / "justfile").read_text(encoding="utf-8")
+
+    def _lint_recipe(self, justfile: str) -> str:
+        body = justfile.split("\nlint:", 1)[1]
+        return body.split("\n\n", 1)[0]
+
+    def test_python_lint_checks_formatting(self, tmp_target: Path):
+        assert "ruff format --check ." in self._lint_recipe(self._justfile(tmp_target, "python"))
+
+    def test_node_lint_checks_formatting(self, tmp_target: Path):
+        recipe = self._lint_recipe(self._justfile(tmp_target, "node"))
+        assert "@biomejs/biome format ." in recipe
+        # `biome ci` would also run biome's linter and duplicate eslint.
+        assert "biome ci" not in recipe
+
+    def test_rust_lint_checks_formatting(self, tmp_target: Path):
+        assert "cargo fmt --check" in self._lint_recipe(self._justfile(tmp_target, "rust"))
+
+    def test_go_relies_on_gofumpt_in_golangci_run(self, tmp_target: Path):
+        """Not a missing gate: `run` reports gofumpt findings and exits non-zero."""
+        target = _scaffold_language(tmp_target, "go")
+        golangci = (target / ".golangci.yml").read_text(encoding="utf-8")
+        assert "formatters:" in golangci
+        assert "gofumpt" in golangci
+        # No redundant `cargo fmt`-style step bolted onto the go lint recipe.
+        assert "gofumpt" not in self._lint_recipe((target / "justfile").read_text(encoding="utf-8"))
+
+    def test_format_recipes_still_write(self, tmp_target: Path):
+        """The check belongs to `lint`; `format` remains the fixer."""
+        for language, writer in (
+            ("python", "ruff format ."),
+            ("rust", "cargo fmt"),
+        ):
+            justfile = self._justfile(tmp_target / language, language)
+            format_recipe = justfile.split("\nformat:", 1)[1].split("\n\n", 1)[0]
+            assert writer in format_recipe
+
+    def test_shipped_python_templates_are_format_clean(self):
+        """A fresh scaffold must pass the gate it ships (#698 shipped this bug once).
+
+        `.agents/hooks/dag_workflow.py` was not ruff-format clean, so every new
+        python project would have failed `just lint` on day one.
+        """
+        import subprocess
+        import sys
+
+        root = Path(__file__).resolve().parents[2]
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "format", "--check", str(root / "templates")],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 2:  # ruff not importable as a module here
+            pytest.skip("ruff not available as a module")
+        assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -18,7 +18,7 @@
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
   ".agents/hooks/_usage_log.sh": "252e0bb9bca5565c19727ed758823e5aea643c0fbf351b18f7a5fd056d5f4729",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/github_command_guard.sh": "f95046b6bbbae9ad85ab2ff7aa69d5bc546e58da8f17a854f1fb850c847eb0c3",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -17,7 +17,7 @@
   ".agents/docs/guides/using-memory.md": "96a7cd24433cff71e5c61c9ccff4f23aa1cb8019ca993aa1bb9b9989f08252f8",
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -17,7 +17,7 @@
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
   ".agents/hooks/_usage_log.sh": "252e0bb9bca5565c19727ed758823e5aea643c0fbf351b18f7a5fd056d5f4729",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/github_command_guard.sh": "f95046b6bbbae9ad85ab2ff7aa69d5bc546e58da8f17a854f1fb850c847eb0c3",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -16,7 +16,7 @@
   ".agents/docs/guides/using-memory.md": "96a7cd24433cff71e5c61c9ccff4f23aa1cb8019ca993aa1bb9b9989f08252f8",
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -19,7 +19,7 @@
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
   ".agents/hooks/_usage_log.sh": "252e0bb9bca5565c19727ed758823e5aea643c0fbf351b18f7a5fd056d5f4729",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/github_command_guard.sh": "f95046b6bbbae9ad85ab2ff7aa69d5bc546e58da8f17a854f1fb850c847eb0c3",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -18,7 +18,7 @@
   ".agents/docs/guides/using-memory.md": "96a7cd24433cff71e5c61c9ccff4f23aa1cb8019ca993aa1bb9b9989f08252f8",
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -18,7 +18,7 @@
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
   ".agents/hooks/_usage_log.sh": "252e0bb9bca5565c19727ed758823e5aea643c0fbf351b18f7a5fd056d5f4729",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/github_command_guard.sh": "f95046b6bbbae9ad85ab2ff7aa69d5bc546e58da8f17a854f1fb850c847eb0c3",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/post_edit_lint.sh": "60a5302e007db1b88d21f88c0a0f418e09d68700e5d83581f76ed549e61eb7fc",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -17,7 +17,7 @@
   ".agents/docs/guides/using-memory.md": "96a7cd24433cff71e5c61c9ccff4f23aa1cb8019ca993aa1bb9b9989f08252f8",
   ".agents/hooks/README.md": "16a281118a540125c68fc7f4c215d866a948e6a6ef82692b873d1b48033dcef2",
   ".agents/hooks/_py.sh": "8e93087539398af2516ea4c697893a98987d4d91a969a10899503b136829db0e",
-  ".agents/hooks/dag_workflow.py": "b374fc7c73cc72adcc0c6f6b34664b9b6b22c56d415f61f286185658cc2add96",
+  ".agents/hooks/dag_workflow.py": "8d06ccce9dc90a9f8c5d0c7fabd9cb7870c781f9e59fc7022068b99ab1acb5bf",
   ".agents/hooks/package_guard.py": "44265b35420f46909e8bb63ae598c5fe626e39c5f0b00817c53c64917f28e09b",
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",


### PR DESCRIPTION
## Problem

Every `format` recipe **writes**; none **checked**. An unformatted file merged green for python, node and rust.

And `templates/base/dot_agents/rules/rust.md:18` documented a gate that did not exist:

```
cargo fmt --check    # verifies only; `cargo fmt` (no flag) writes changes
```

Nothing ran it — not the justfile, not CI. `go.md:18` presented `golangci-lint fmt` (which *writes*) as the format command, without mentioning the thing that actually checks. **This is #688's map-not-territory failure caught in the wild**: a hand-written doc restating a gate no code enforced.

## Go was never broken — verified, not assumed

`.golangci.yml:39-42` enables `gofumpt` under `formatters:`. The docs do **not** state whether `golangci-lint run` reports formatter findings or whether they only apply via `golangci-lint fmt` — I read both the config reference and the formatters page, and neither says. So I downloaded golangci-lint 2.1.6 and a Go toolchain and ran it:

```
A) unformatted-but-valid Go   -> 1 issues: * gofumpt: 1    EXIT=1
B) after `golangci-lint fmt`  -> 0 issues.                 EXIT=0
```

Go's format gate is real. It gets **corrected docs, not a redundant fourth check**.

## What `just lint` now runs

| Language | Check | Verified |
|---|---|---|
| python | `ruff format --check .` | exit 1 unformatted / 0 clean |
| node | `bunx @biomejs/biome format .` | exit 1 unformatted / 0 clean |
| rust | `cargo fmt --check` | **not run locally** — no rust toolchain; it is the exact command `rust.md` already documented |
| go | (none added) | gofumpt in `golangci-lint run`, proven above |

Node uses `biome format` without `--write`, **not** `biome ci`: the latter also runs Biome's linter, duplicating eslint, which owns the lint gates here.

## The prerequisite the gate exposed

Adding the check immediately showed that **three shipped `.py` files were not ruff-format clean**: `dag_workflow.py`, `governance_gate.py`, `usage_report.py`. So a fresh python scaffold would have **failed its own lint gate on day one** — precisely the #698 bug, shipped again.

Formatted them. A contract test now fails if any shipped template drifts out of format, so this cannot recur silently. Verified non-vacuous: appending `x   =    1` to a shipped template makes it fail.

Confirmed a fresh scaffold passes: `6 files already formatted, EXIT=0`.

## Docs corrected

`rust.md`, `go.md`, `python.md`, `typescript.md` now describe the gate that exists — which recipe writes, which one checks, and that CI runs it.

## Verification

- 6 new contract assertions in `TestFormatGate`, incl. that `format` recipes still *write* and that Go gains no redundant step.
- Byte-identity fixtures: only `.agents/hooks/dag_workflow.py` re-pinned across all four combos, after verifying no other file drifted. Both test docstrings carry the exception note.
- Full suite green (2191 passed), `ruff check` clean, shellcheck gate passes.

## Follow-up, not fixed here

**This repo itself is not `ruff format` clean** — running it rewrites ~80 unrelated files, so its own `just lint` still has no format check while the scaffold it ships does. Same irony as #637. Worth its own issue.

Closes #726

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1