### PR TITLE
fix(PI-727): run just fuzz in CI for every language, nightly and non-blocking

### DIFF
--- a/templates/base/dot_agents/rules/go.md
+++ b/templates/base/dot_agents/rules/go.md
@@ -13,7 +13,7 @@ just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always
 just audit          # dependency CVE/advisory scan (govulncheck) — CI always runs this
 just sbom           # CycloneDX SBOM via cyclonedx-gomod (#574) — release.yml attaches it to Releases
 just license        # dependency license scan (#579) — deny copyleft; tune --disallowed_types
-just fuzz           # replay fuzz-test seed corpora (#580) — native go test -fuzz; CI runs it nightly, not per-PR
+just fuzz           # replay fuzz-test seed corpora: `go test -run=Fuzz` (#580) — NOT active `-fuzz`; CI runs it nightly, not per-PR
 just typecheck      # `go vet ./...` — type-only pass; redundant with golangci-lint by design (#725)
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
                     # ALSO the format gate: `formatters: gofumpt` in .golangci.yml makes `run` fail on unformatted code (#726)

--- a/templates/base/dot_agents/rules/go.md
+++ b/templates/base/dot_agents/rules/go.md
@@ -32,9 +32,10 @@ go test -run='^$' -fuzz=FuzzMyTarget -fuzztime=30s ./...
 
 Pattern/tooling, **not** a blocking gate. **When it runs:** the CI `fuzz` job is
 schedule-only (nightly) and non-blocking — never on a PR (#727). Seed replay is
-deterministic, so nightly repetition costs nothing; it is placed there to match
-the other three languages. Run `just fuzz` locally whenever you touch a fuzz
-target.
+deterministic, so repeating it nightly surfaces no *new* inputs the way
+Hypothesis/proptest/fast-check do — it still consumes CI minutes. It runs nightly
+to keep the four languages uniform. Run `just fuzz` locally whenever you touch a
+fuzz target.
 
 `govulncheck` (`go install golang.org/x/vuln/cmd/govulncheck@latest`) only
 reports vulnerabilities actually reachable from your code, not every

--- a/templates/base/dot_agents/rules/go.md
+++ b/templates/base/dot_agents/rules/go.md
@@ -13,7 +13,7 @@ just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always
 just audit          # dependency CVE/advisory scan (govulncheck) — CI always runs this
 just sbom           # CycloneDX SBOM via cyclonedx-gomod (#574) — release.yml attaches it to Releases
 just license        # dependency license scan (#579) — deny copyleft; tune --disallowed_types
-just fuzz           # replay fuzz-test seed corpora (#580) — native go test -fuzz, CI-safe
+just fuzz           # replay fuzz-test seed corpora (#580) — native go test -fuzz; CI runs it nightly, not per-PR
 just typecheck      # `go vet ./...` — type-only pass; redundant with golangci-lint by design (#725)
 golangci-lint run   # revive, godoclint, gocognit, cyclop, dupl, errcheck, govet, staticcheck, gosec — see .golangci.yml
                     # ALSO the format gate: `formatters: gofumpt` in .golangci.yml makes `run` fail on unformatted code (#726)
@@ -30,8 +30,11 @@ corpora deterministically (CI-safe); active fuzzing targets one function:
 go test -run='^$' -fuzz=FuzzMyTarget -fuzztime=30s ./...
 ```
 
-Pattern/tooling, **not** a blocking gate — the CI `fuzz` job runs seed-corpus
-replay only and is non-blocking.
+Pattern/tooling, **not** a blocking gate. **When it runs:** the CI `fuzz` job is
+schedule-only (nightly) and non-blocking — never on a PR (#727). Seed replay is
+deterministic, so nightly repetition costs nothing; it is placed there to match
+the other three languages. Run `just fuzz` locally whenever you touch a fuzz
+target.
 
 `govulncheck` (`go install golang.org/x/vuln/cmd/govulncheck@latest`) only
 reports vulnerabilities actually reachable from your code, not every

--- a/templates/base/dot_agents/rules/node.md
+++ b/templates/base/dot_agents/rules/node.md
@@ -16,7 +16,7 @@ bun run lint      # lint
 bun test          # tests
 just sbom         # CycloneDX SBOM via cdxgen (#574) — release.yml attaches it to Releases
 just license      # dependency license scan (#579) — deny GPL/AGPL; tune the recipe's --failOn list
-just fuzz         # property-based tests with fast-check (#580) — runs under `bun test`
+just fuzz         # property-based tests with fast-check (#580) — runs under `bun test`; CI runs it nightly, not per-PR
 ```
 
 ## Property-based testing (fast-check, #580)
@@ -38,3 +38,7 @@ test("clamp stays within bounds", () => {
 ```
 
 Pattern/tooling, **not** a blocking gate — property tests live alongside unit tests.
+
+**When it runs:** the CI `fuzz` job is schedule-only (nightly) and non-blocking —
+never on a PR (#727). fast-check draws fresh seeds each run, so nightly explores
+inputs a per-PR run would only repeat. Run `just fuzz` locally at will.

--- a/templates/base/dot_agents/rules/python.md
+++ b/templates/base/dot_agents/rules/python.md
@@ -56,3 +56,8 @@ def test_clamp_stays_within_bounds(lo, hi, x):
 Pattern/tooling, **not** a blocking gate — property tests live alongside unit
 tests and complement mutation testing (which checks existing tests) and the
 coverage floor (which checks how much is exercised).
+
+**When it runs:** the CI `fuzz` job is schedule-only (nightly) and non-blocking —
+never on a PR (#727), the same placement mutation testing already uses.
+Hypothesis draws fresh seeds each run, so nightly explores inputs a per-PR run
+would only repeat. Run `just fuzz` locally at will.

--- a/templates/base/dot_agents/rules/rust.md
+++ b/templates/base/dot_agents/rules/rust.md
@@ -54,6 +54,10 @@ Pattern/tooling, **not** a blocking gate — property tests live alongside unit 
 For coverage-guided binary fuzzing, `cargo-fuzz` (libFuzzer, nightly) is the
 heavier option; proptest is the stable-toolchain default.
 
+**When it runs:** the CI `fuzz` job is schedule-only (nightly) and non-blocking —
+never on a PR (#727). proptest draws fresh seeds each run, so nightly explores
+inputs a per-PR run would only repeat. Run `just fuzz` locally at will.
+
 `cargo llvm-cov` needs `cargo install cargo-llvm-cov` + `rustup component add
 llvm-tools-preview` once locally; `cargo audit` only needs `cargo install
 cargo-audit` (no llvm-tools-preview — that component is specific to

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -713,31 +713,82 @@ jobs:
       - name: License scan (cargo-deny)
         run: just license
 {{/if rust}}
-{{#if go}}
-  # Go native fuzzing (#580): go test -fuzz is built into the toolchain (1.18+),
-  # no third-party dependency. This job replays the fuzz-test SEED CORPORA
-  # deterministically — a short, CI-safe mode (no unbounded input generation).
-  # Non-blocking (NOT in ci-gate's needs): fuzzing is a pattern to surface edge
-  # cases, not a uniform gate like ruff/coverage that applies to every project.
-  # Promote it — or add a scheduled active `-fuzztime` run — once you have fuzz
-  # targets worth gating on.
+  # Property-based testing / fuzzing (#580, #727). `just fuzz` exists in every
+  # language, so it runs in CI in every language — previously only Go had a job,
+  # and the other three shipped a recipe nothing ever invoked: dead surface that
+  # reads as covered.
+  #
+  # WHY NIGHTLY, NOT PER-PR (#727). Fuzzing is a pattern for surfacing edge
+  # cases, not a uniform gate like ruff or coverage. Per-PR it would tax every
+  # push for near-zero value on a fresh scaffold. Nightly is also where it earns
+  # its keep: Hypothesis, proptest and fast-check draw FRESH random seeds each
+  # run, so a nightly job explores inputs a per-PR run would only repeat. (Go's
+  # `go test -run=Fuzz` is a deterministic seed-corpus replay, so it gains
+  # nothing from repetition — but uniformity across the four languages is worth
+  # more than one job placed differently.) This is the same rollout mutation
+  # testing already uses: schedule-gated, non-blocking, promote when you have a
+  # baseline worth gating on.
+  #
+  # Non-blocking: NOT in ci-gate's `needs`. To gate on it, add a `-fuzztime`
+  # active-fuzzing step and promote it there deliberately.
+  #
+  # Only one language renders per scaffold, so this costs exactly one nightly
+  # job — the same as the Go-only job it replaces.
   fuzz:
-    name: Go fuzz (seed corpus replay)
+    name: Fuzz / property tests
     runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
+    if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version-file: go.mod
 
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
-      - name: Replay fuzz seed corpora
+      # A fresh scaffold ships no manifest. Skip rather than fail: a nightly run
+      # that is red from day one is a notification people learn to ignore. Only
+      # one language renders per scaffold, so testing all four names needs no
+      # per-language variable.
+      - name: Check for a project manifest
+        id: manifest
+        run: |
+          if [ -f pyproject.toml ] || [ -f package.json ] || [ -f go.mod ] || [ -f Cargo.toml ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No project manifest yet — nothing to fuzz."
+          fi
+{{#if python}}
+      - name: Install uv
+        if: steps.manifest.outputs.exists == 'true'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.7"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+{{/if python}}{{#if node}}
+      - name: Install Bun
+        if: steps.manifest.outputs.exists == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        if: steps.manifest.outputs.exists == 'true'
+        run: bun install --frozen-lockfile 2>/dev/null || bun install
+{{/if node}}{{#if go}}
+      - name: Set up Go
+        if: steps.manifest.outputs.exists == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+{{/if go}}{{#if rust}}
+      - name: Install Rust toolchain
+        if: steps.manifest.outputs.exists == 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+{{/if rust}}
+      - name: Run property/fuzz tests
+        if: steps.manifest.outputs.exists == 'true'
         run: just fuzz
-{{/if go}}
 
   # OpenSSF Scorecard (#576): standardized security-posture scoring (branch
   # protection, dependency pinning, SAST presence, token permissions, ...).

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -794,9 +794,18 @@ jobs:
         with:
           bun-version: latest
 
+      # `--frozen-lockfile 2>/dev/null || bun install` would silently fall back to
+      # a NON-frozen install when the lockfile is merely out of date, letting
+      # dependency drift through CI (PR #736 review) — and `2>/dev/null` hides why.
+      # Use frozen only when a lockfile exists; otherwise a plain install.
       - name: Install dependencies
         if: steps.manifest.outputs.exists == 'true'
-        run: bun install --frozen-lockfile 2>/dev/null || bun install
+        run: |
+          if [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile
+          else
+            bun install
+          fi
 {{/if node}}{{#if go}}
       - name: Set up Go
         if: steps.manifest.outputs.exists == 'true'

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -17,10 +17,13 @@ on:
     # Weekly OpenSSF Scorecard security-posture run (#576). The scorecard job
     # below is schedule-gated, so it never runs — or blocks — on a PR.
     - cron: "0 4 * * 1"
-{{#if python}}
-    # Nightly mutation-testing run (PI-138/#563).
+    # Nightly run: the `fuzz` job in every language, plus `mutation-tests` for
+    # python (PI-138/#563). Each schedule-gated job below matches on its OWN
+    # cron via `github.event.schedule` — `github.event_name == 'schedule'` alone
+    # fires on EVERY cron here, which silently made `fuzz` weekly for node/go/
+    # rust (where this nightly entry used to be absent) and made scorecard run
+    # nightly for python (PR #736 review, Copilot + Codex).
     - cron: "0 3 * * *"
-{{/if python}}
   # Optimization: Only run CI when relevant files change
   # Uncomment and adjust paths as needed for your project
 
@@ -476,7 +479,8 @@ jobs:
   mutation-tests:
     name: Mutation tests (mutmut)
     runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
-    if: github.event_name == 'schedule'
+    # Nightly cron only — not the weekly Scorecard one (see `on.schedule`).
+    if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -734,10 +738,15 @@ jobs:
   #
   # Only one language renders per scaffold, so this costs exactly one nightly
   # job — the same as the Go-only job it replaces.
+  #
+  # The `if:` matches the NIGHTLY cron specifically. `github.event_name ==
+  # 'schedule'` alone fires on every cron in `on.schedule`, which would make
+  # this job weekly-and-nightly and (worse) couple unrelated jobs' cadences.
   fuzz:
     name: Fuzz / property tests
     runs-on: ${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}
-    if: github.event_name == 'schedule'
+    # Nightly cron only — not the weekly Scorecard one (see `on.schedule`).
+    if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -804,7 +813,8 @@ jobs:
   scorecard:
     name: OpenSSF Scorecard
     runs-on: ubuntu-24.04  # pinned: OSSF scorecard-action requires GitHub-hosted runners
-    if: github.event_name == 'schedule'
+    # Weekly cron only — not the nightly one (see `on.schedule`).
+    if: github.event_name == 'schedule' && github.event.schedule == '0 4 * * 1'
     permissions:
       security-events: write   # upload the SARIF result to code scanning
       id-token: write          # only needed if publish_results is turned on

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -23,6 +23,10 @@ on:
     # fires on EVERY cron here, which silently made `fuzz` weekly for node/go/
     # rust (where this nightly entry used to be absent) and made scorecard run
     # nightly for python (PR #736 review, Copilot + Codex).
+    #
+    # NOTE: a cron triggers the whole workflow. Ungated jobs (lint-and-test,
+    # secret-scan, semgrep, license-scan, ci-gate) run on it too — see the
+    # `fuzz` job's comment for how to restrict cron runs to gated jobs only.
     - cron: "0 3 * * *"
   # Optimization: Only run CI when relevant files change
   # Uncomment and adjust paths as needed for your project
@@ -736,8 +740,17 @@ jobs:
   # Non-blocking: NOT in ci-gate's `needs`. To gate on it, add a `-fuzztime`
   # active-fuzzing step and promote it there deliberately.
   #
-  # Only one language renders per scaffold, so this costs exactly one nightly
-  # job — the same as the Go-only job it replaces.
+  # Only one language renders per scaffold, so exactly one `fuzz` job exists.
+  #
+  # COST, STATED HONESTLY (PR #736 review). A cron entry triggers the WHOLE
+  # workflow, not just the jobs gated on it. The nightly cron therefore also runs
+  # every ungated job — `lint-and-test`, `secret-scan`, `semgrep`, `license-scan`
+  # — plus `ci-gate`. Python scaffolds have behaved this way since the nightly
+  # mutmut cron landed (#563); #727 extends the same nightly run to node/go/rust.
+  # To make cron runs execute ONLY the schedule-gated jobs, add
+  # `if: github.event_name != 'schedule'` to each ungated job AND to `ci-gate`
+  # — `ci-gate` is `if: always()` and treats a skipped `needs` job as a failure,
+  # so gating the others without gating it turns every nightly run red.
   #
   # The `if:` matches the NIGHTLY cron specifically. `github.event_name ==
   # 'schedule'` alone fires on every cron in `on.schedule`, which would make

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -266,7 +266,9 @@ license:
 #   go test -run='^$' -fuzz=FuzzMyTarget -fuzztime=30s ./...
 # Built into the toolchain (go 1.18+). Pattern/tooling, NOT a blocking gate: CI
 # runs this in the nightly `fuzz` job, never on a PR (#727). Seed replay is
-# deterministic, so nightly costs nothing and keeps all four languages uniform.
+# deterministic, so repeating it nightly surfaces no NEW inputs (unlike the other
+# three languages) — it still uses CI minutes; it runs nightly to keep the four
+# languages uniform.
 fuzz:
     sh -c 'if find . -name "*.go" | grep -q .; then go test -run="Fuzz" ./...; else echo "No Go sources yet — nothing to fuzz."; fi'
 

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -78,7 +78,9 @@ license:
 
 # property-based tests with Hypothesis (#580). Property tests are opt-in per file
 # (import hypothesis); this recipe makes Hypothesis available without adding it as
-# a permanent dependency. Pattern/tooling, NOT a blocking gate.
+# a permanent dependency. Pattern/tooling, NOT a blocking gate: CI runs this in
+# the nightly `fuzz` job, never on a PR (#727). Hypothesis draws fresh seeds each
+# run, so the nightly job explores inputs a per-PR run would only repeat.
 fuzz:
     uv run --with hypothesis --with pytest-xdist pytest -n auto --tb=short -q
 
@@ -171,7 +173,9 @@ license:
 
 # property-based tests with fast-check (#580). Add the dep once: bun add -d
 # fast-check. Property tests are opt-in per file and run under `bun test`.
-# Pattern/tooling, NOT a blocking gate.
+# Pattern/tooling, NOT a blocking gate: CI runs this in the nightly `fuzz` job,
+# never on a PR (#727). fast-check draws fresh seeds each run, so the nightly job
+# explores inputs a per-PR run would only repeat.
 fuzz:
     bun test
 
@@ -260,7 +264,9 @@ license:
 # (short, CI-safe; no unbounded input generation). For active fuzzing that
 # generates new inputs, target one function:
 #   go test -run='^$' -fuzz=FuzzMyTarget -fuzztime=30s ./...
-# Built into the toolchain (go 1.18+). Pattern/tooling, NOT a blocking gate.
+# Built into the toolchain (go 1.18+). Pattern/tooling, NOT a blocking gate: CI
+# runs this in the nightly `fuzz` job, never on a PR (#727). Seed replay is
+# deterministic, so nightly costs nothing and keeps all four languages uniform.
 fuzz:
     sh -c 'if find . -name "*.go" | grep -q .; then go test -run="Fuzz" ./...; else echo "No Go sources yet — nothing to fuzz."; fi'
 
@@ -365,7 +371,9 @@ license:
 
 # property-based tests with proptest (#580). Add the dep once: cargo add --dev
 # proptest. Property tests are opt-in per file (proptest! macro) and run under
-# `cargo test`. Pattern/tooling, NOT a blocking gate.
+# `cargo test`. Pattern/tooling, NOT a blocking gate: CI runs this in the nightly
+# `fuzz` job, never on a PR (#727). proptest draws fresh seeds each run, so the
+# nightly job explores inputs a per-PR run would only repeat.
 fuzz:
     cargo test
 

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -12,6 +12,7 @@ per run, so nightly is where repetition buys new inputs.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,21 @@ def _scaffold(target: Path, language: str = "python") -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
     scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags), strict=True)
     return target
+
+
+def _job_block(ci: str, job: str) -> str:
+    """Return the YAML block for `job`, sliced at the NEXT top-level job key.
+
+    Not at a comment marker: a reworded comment would then break the test with no
+    functional change (PR #736 review). Not via a YAML parse either — this repo
+    keeps pyyaml out of the test deps. Comment lines between jobs belong to the
+    job that follows, so the block may carry a trailing comment; that is fine,
+    every assertion here looks for a presence, not an absence.
+    """
+    start = ci.index(f"\n  {job}:")
+    rest = ci[start + 1 :]
+    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
+    return rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
 
 
 class TestFuzzRecipe:
@@ -71,8 +87,7 @@ class TestFuzzJob:
         """
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
         assert '- cron: "0 3 * * *"' in ci, f"{language} has no nightly cron"
-        job = ci[ci.index("\n  fuzz:") :]
-        job = job[: job.index("\n    steps:")]
+        job = _job_block(ci, "fuzz")
         assert (
             "if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'" in job
         ), job
@@ -118,8 +133,7 @@ class TestFuzzJob:
         """A fuzz job that cannot run its own recipe is the skipped-test defect
         in another costume (#733). Assert the toolchain is actually installed."""
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        job = ci[ci.index("\n  fuzz:") :]
-        job = job[: job.index("\n  # OpenSSF Scorecard")]
+        job = _job_block(ci, "fuzz")
         assert setup_step in job, job
 
     @pytest.mark.parametrize("language", _LANGUAGES)

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -36,10 +36,28 @@ def _job_block(ci: str, job: str) -> str:
     job that follows, so the block may carry a trailing comment; that is fine,
     every assertion here looks for a presence, not an absence.
     """
-    start = ci.index(f"\n  {job}:")
-    rest = ci[start + 1 :]
+    match = re.search(rf"^  {re.escape(job)}:$", ci, flags=re.MULTILINE)
+    assert match is not None, f"no `{job}:` job in the rendered workflow"
+    rest = ci[match.start() :]
     nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
     return rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
+
+
+def _needs(ci: str, job: str) -> str:
+    """Return `job`'s whole `needs:` section — inline list OR multiline items.
+
+    Reading only the `needs:` line would let a later reformat to a multiline list
+    hide `fuzz` in a `- fuzz` item while the test still passed (PR #736 review).
+    """
+    block = _job_block(ci, job).splitlines()
+    start = next(i for i, line in enumerate(block) if line.strip().startswith("needs:"))
+    section = [block[start]]
+    for line in block[start + 1 :]:
+        if line.strip().startswith("-") or not line.strip():
+            section.append(line)
+        else:
+            break
+    return "\n".join(section)
 
 
 class TestFuzzRecipe:
@@ -117,11 +135,8 @@ class TestFuzzJob:
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_fuzz_non_blocking(self, tmp_path: Path, language: str):
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        gate_start = ci.index("ci-gate:")
-        needs_line = next(
-            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
-        )
-        assert "fuzz" not in needs_line, "the fuzz job must stay non-blocking"
+        needs = _needs(ci, "ci-gate")
+        assert "fuzz" not in needs, f"the fuzz job must stay non-blocking:\n{needs}"
 
     @pytest.mark.parametrize(
         "language,setup_step",

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -48,16 +48,28 @@ def _needs(ci: str, job: str) -> str:
 
     Reading only the `needs:` line would let a later reformat to a multiline list
     hide `fuzz` in a `- fuzz` item while the test still passed (PR #736 review).
+    Continuation is decided by INDENT, not by a leading `-`: YAML allows comment
+    lines among the items, and stopping at the first one truncated the section
+    and reintroduced the same false negative (PR #736 review, cycle 7).
+
+    Comment lines are stripped from the result, so a comment mentioning a job
+    name cannot produce a false positive either.
     """
     block = _job_block(ci, job).splitlines()
-    start = next(i for i, line in enumerate(block) if line.strip().startswith("needs:"))
+    start = next(
+        (i for i, line in enumerate(block) if line.strip().startswith("needs:")), None
+    )
+    assert start is not None, f"`{job}:` has no `needs:` section"
+    indent = len(block[start]) - len(block[start].lstrip())
     section = [block[start]]
     for line in block[start + 1 :]:
-        if line.strip().startswith("-") or not line.strip():
-            section.append(line)
-        else:
+        stripped = line.strip()
+        blank_or_comment = not stripped or stripped.startswith("#")
+        deeper = len(line) - len(line.lstrip()) > indent
+        if not (blank_or_comment or deeper):
             break
-    return "\n".join(section)
+        section.append(line)
+    return "\n".join(line for line in section if not line.strip().startswith("#"))
 
 
 class TestFuzzRecipe:

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -59,12 +59,40 @@ class TestFuzzJob:
         assert "just fuzz" in ci
 
     @pytest.mark.parametrize("language", _LANGUAGES)
-    def test_job_is_schedule_only(self, tmp_path: Path, language: str):
-        """Nightly, never per-PR — the placement mutation testing already uses."""
+    def test_job_runs_nightly_not_merely_on_some_schedule(self, tmp_path: Path, language: str):
+        """Nightly, never per-PR — the placement mutation testing already uses.
+
+        Asserting only `event_name == 'schedule'` does NOT pin the cadence: the
+        job then fires on every cron in `on.schedule`. The nightly cron used to
+        live inside `{{#if python}}`, so node/go/rust rendered a fuzz job that ran
+        WEEKLY while the docs said nightly — the very map-not-territory defect
+        this issue is about, caught in review of PR #736 rather than by this test.
+        Pin both halves: the cron must exist, and the job must match on it.
+        """
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        assert '- cron: "0 3 * * *"' in ci, f"{language} has no nightly cron"
         job = ci[ci.index("\n  fuzz:") :]
         job = job[: job.index("\n    steps:")]
-        assert "if: github.event_name == 'schedule'" in job, job
+        assert (
+            "if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'" in job
+        ), job
+
+    @pytest.mark.parametrize("language", _LANGUAGES)
+    def test_no_schedule_gated_job_matches_every_cron(self, tmp_path: Path, language: str):
+        """A bare `event_name == 'schedule'` gate fires on EVERY cron.
+
+        With two crons defined, that silently couples job cadences: adding the
+        nightly entry for fuzz would otherwise have promoted the weekly Scorecard
+        run to nightly too (PR #736 review). Every schedule-gated job must name
+        the cron it wants.
+        """
+        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        offenders = [
+            line.strip()
+            for line in ci.splitlines()
+            if "github.event_name == 'schedule'" in line and "github.event.schedule" not in line
+        ]
+        assert not offenders, f"schedule-gated jobs must match their own cron: {offenders}"
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_fuzz_non_blocking(self, tmp_path: Path, language: str):

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -1,9 +1,13 @@
-"""#580: property-based testing / fuzzing wired per language.
+"""#580/#727: property-based testing / fuzzing wired per language.
 
-Each language gets a `just fuzz` recipe and a documented pattern in its rules
-file. Go — whose fuzzing is native to the toolchain — additionally gets a real,
-CI-safe (seed-corpus replay) CI job. Everything is scoped as opt-in pattern/
-tooling, NOT a blocking gate: the Go fuzz job is not in ci-gate's needs.
+Each language gets a `just fuzz` recipe, a documented pattern in its rules file,
+and a CI job that actually invokes the recipe. #727: only Go used to have a job,
+so three of four languages shipped a recipe nothing ever ran.
+
+The job is schedule-only (nightly) and non-blocking — NOT in ci-gate's needs —
+the same rollout mutation testing uses. Fuzzing is a pattern for surfacing edge
+cases, not a uniform gate; and Hypothesis/proptest/fast-check draw fresh seeds
+per run, so nightly is where repetition buys new inputs.
 """
 
 from __future__ import annotations
@@ -38,29 +42,61 @@ class TestFuzzRecipe:
         assert needle in justfile
 
 
-class TestGoFuzzJob:
-    def test_job_present_for_go(self, tmp_path: Path):
-        ci = (_scaffold(tmp_path / "go", "go") / ".github" / "workflows" / "ci.yml").read_text()
-        assert "fuzz:" in ci
-        assert "Go fuzz" in ci
-        # CI-safe: seed-corpus replay via the recipe, not unbounded generation.
+_LANGUAGES = ["python", "node", "go", "rust"]
+
+
+class TestFuzzJob:
+    """#727: `just fuzz` exists in every language, so a CI job must exist in every
+    language. Previously only Go had one, and python/node/rust shipped a recipe
+    nothing ever invoked — dead surface that reads as covered.
+    """
+
+    @pytest.mark.parametrize("language", _LANGUAGES)
+    def test_job_present_for_every_language(self, tmp_path: Path, language: str):
+        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        assert "\n  fuzz:" in ci
+        assert "Fuzz / property tests" in ci
         assert "just fuzz" in ci
 
-    def test_go_fuzz_non_blocking(self, tmp_path: Path):
-        ci = (_scaffold(tmp_path / "go", "go") / ".github" / "workflows" / "ci.yml").read_text()
+    @pytest.mark.parametrize("language", _LANGUAGES)
+    def test_job_is_schedule_only(self, tmp_path: Path, language: str):
+        """Nightly, never per-PR — the placement mutation testing already uses."""
+        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        job = ci[ci.index("\n  fuzz:") :]
+        job = job[: job.index("\n    steps:")]
+        assert "if: github.event_name == 'schedule'" in job, job
+
+    @pytest.mark.parametrize("language", _LANGUAGES)
+    def test_fuzz_non_blocking(self, tmp_path: Path, language: str):
+        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
         gate_start = ci.index("ci-gate:")
         needs_line = next(
             line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
         )
-        assert "fuzz" not in needs_line, "the Go fuzz job must stay non-blocking"
+        assert "fuzz" not in needs_line, "the fuzz job must stay non-blocking"
 
-    @pytest.mark.parametrize("language", ["python", "node", "rust"])
-    def test_go_fuzz_job_absent_for_non_go(self, tmp_path: Path, language: str):
+    @pytest.mark.parametrize(
+        "language,setup_step",
+        [
+            ("python", "astral-sh/setup-uv"),
+            ("node", "oven-sh/setup-bun"),
+            ("go", "actions/setup-go"),
+            ("rust", "actions-rust-lang/setup-rust-toolchain"),
+        ],
+    )
+    def test_job_installs_the_language_toolchain(
+        self, tmp_path: Path, language: str, setup_step: str
+    ):
+        """A fuzz job that cannot run its own recipe is the skipped-test defect
+        in another costume (#733). Assert the toolchain is actually installed."""
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        assert "Go fuzz" not in ci
+        job = ci[ci.index("\n  fuzz:") :]
+        job = job[: job.index("\n  # OpenSSF Scorecard")]
+        assert setup_step in job, job
 
-    def test_renders_cleanly(self, tmp_path: Path):
-        ci = (_scaffold(tmp_path / "go", "go") / ".github" / "workflows" / "ci.yml").read_text()
+    @pytest.mark.parametrize("language", _LANGUAGES)
+    def test_renders_cleanly(self, tmp_path: Path, language: str):
+        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
         assert "{{#if" not in ci and "{{/if" not in ci
 
 
@@ -79,3 +115,19 @@ class TestFuzzDocumented:
         assert tool in rules
         # Explicitly scoped as pattern/tooling, not a blocking gate.
         assert "not** a blocking gate" in rules or "not a blocking gate" in rules
+
+    @pytest.mark.parametrize(
+        "language,rules_file",
+        [("python", "python.md"), ("node", "node.md"), ("go", "go.md"), ("rust", "rust.md")],
+    )
+    def test_rules_say_when_fuzzing_runs(self, tmp_path: Path, language: str, rules_file: str):
+        """#727: no language may ship a recipe without saying when CI invokes it.
+
+        The go doc previously implied a per-PR job and the other three said
+        nothing at all — a doc restating a gate that does not exist as written is
+        the map-not-territory failure (#688).
+        """
+        rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
+        assert "**When it runs:**" in rules, f"{rules_file} does not say when fuzzing runs"
+        assert "schedule-only (nightly)" in rules
+        assert "never on a PR" in rules

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -100,7 +100,9 @@ class TestFuzzJob:
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_job_present_for_every_language(self, tmp_path: Path, language: str):
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        assert "\n  fuzz:" in ci
+        # _job_block asserts the job key exists, with a clearer message than a
+        # `"\n  fuzz:" in ci` check — which would also break if fuzz ever became
+        # the first job (PR #736 review).
         job = _job_block(ci, "fuzz")
         assert "name: Fuzz / property tests" in job
         # `run:` — not a bare `"just fuzz" in ci`, which the job's own prose
@@ -135,12 +137,20 @@ class TestFuzzJob:
         nightly entry for fuzz would otherwise have promoted the weekly Scorecard
         run to nightly too (PR #736 review). Every schedule-gated job must name
         the cron it wants.
+
+        Scans `if:` lines ONLY. The workflow's own prose comments quote
+        `github.event_name == 'schedule'` while explaining this very rule, so a
+        whole-file scan would flag them — today it passes only because those
+        quotes happen to fall on lines that also mention `github.event.schedule`
+        or wrap mid-expression (PR #736 review).
         """
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
         offenders = [
             line.strip()
             for line in ci.splitlines()
-            if "github.event_name == 'schedule'" in line and "github.event.schedule" not in line
+            if line.strip().startswith("if:")
+            and "github.event_name == 'schedule'" in line
+            and "github.event.schedule" not in line
         ]
         assert not offenders, f"schedule-gated jobs must match their own cron: {offenders}"
 

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -71,8 +71,13 @@ class TestFuzzJob:
     def test_job_present_for_every_language(self, tmp_path: Path, language: str):
         ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
         assert "\n  fuzz:" in ci
-        assert "Fuzz / property tests" in ci
-        assert "just fuzz" in ci
+        job = _job_block(ci, "fuzz")
+        assert "name: Fuzz / property tests" in job
+        # `run:` — not a bare `"just fuzz" in ci`, which the job's own prose
+        # comment satisfies. That assertion passed with the run step gutted to
+        # `run: echo nothing` (PR #736 review): the whole point of #727 is a job
+        # that INVOKES the recipe, so assert the invocation (#688).
+        assert "run: just fuzz" in job, job
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_job_runs_nightly_not_merely_on_some_schedule(self, tmp_path: Path, language: str):

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -495,8 +495,10 @@ class TestCiQualityGates:
         # names its own cron via `github.event.schedule`, so a shared cron does
         # not imply a shared job.
         assert "mutation-tests:" not in ci
-        # `mutmut` as a bare word also appears in the scorecard job's prose
-        # comment in every language — assert the command, not the mention.
+        # The bare word `mutmut` renders for EVERY language in two prose comments
+        # — the `fuzz` job's (explaining the nightly cron's history) and the
+        # scorecard job's ("mirroring how semgrep/mutmut were introduced").
+        # Assert the command, not the mention.
         assert "mutmut run" not in ci
 
 

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -486,14 +486,18 @@ class TestCiQualityGates:
         assert "cron:" in self.ci
 
     @pytest.mark.parametrize("language", ["node", "go", "rust"])
-    def test_mutmut_schedule_absent_for_other_languages(self, tmp_target: Path, language):
+    def test_mutmut_job_absent_for_other_languages(self, tmp_target: Path, language):
         target = _scaffold_language(tmp_target, language)
         ci = (target / ".github" / "workflows" / "ci.yml").read_text()
-        # The nightly mutation cron is Python-only; the weekly Scorecard cron
-        # (#576) is language-agnostic, so assert on the mutation-specific pieces
-        # rather than the presence of any cron at all.
-        assert "0 3 * * *" not in ci, f"nightly mutation cron must not render for {language}"
+        # mutmut is python-only, so the JOB must not render. The nightly cron is
+        # NOT a proxy for that any more: #727 made it language-agnostic because
+        # the `fuzz` job needs it in every language. Each schedule-gated job now
+        # names its own cron via `github.event.schedule`, so a shared cron does
+        # not imply a shared job.
         assert "mutation-tests:" not in ci
+        # `mutmut` as a bare word also appears in the scorecard job's prose
+        # comment in every language — assert the command, not the mention.
+        assert "mutmut run" not in ci
 
 
 class TestVulnerabilityScanGate:


### PR DESCRIPTION
## Problem

`just fuzz` shipped for **all four** languages, but only **go** had a CI job. Three of four languages shipped a recipe nothing ever invoked — dead surface that reads as covered — and the asymmetry was undocumented.

## Decision (recorded in `ci.yml.tmpl`)

The issue recommended option (2): document fuzzing as local/nightly for all four, and move the go job to the nightly schedule. Taken, and extended — moving go's job to nightly while leaving python/node/rust with *no* job would still fail the acceptance criterion *"either all CI-invoked or none"*.

So: **one language-agnostic `fuzz` job** that every language renders. Only one language renders per scaffold, so exactly one `fuzz` job exists.

**Cost, corrected (review cycle 4).** An earlier draft of this PR claimed it "costs exactly one nightly job". That was wrong: a cron entry triggers the **whole workflow**, so the nightly run also executes every ungated job — `lint-and-test`, `secret-scan`, `semgrep`, `license-scan` — plus `ci-gate`. Python scaffolds have behaved this way since the nightly mutmut cron (#563); this PR extends the same nightly run to node/go/rust. The comment in `ci.yml.tmpl` now says so, and documents how to restrict cron runs to the gated jobs — including the trap that `ci-gate` is `if: always()` and treats a skipped `needs` job as a failure, so gating the others without gating it turns every nightly run red on the required check.

**Nightly, not per-PR**, and non-blocking (not in `ci-gate`'s `needs`) — the placement mutation testing already uses. It is also where fuzzing earns its keep: Hypothesis, proptest and fast-check draw **fresh random seeds each run**, so a nightly job explores inputs a per-PR run would only repeat. Go's `go test -run=Fuzz` is a deterministic seed-corpus replay and gains nothing from repetition, but uniformity across the four languages is worth more than one job placed differently.

## The bug review caught — the same one this PR was fixing

Copilot and Codex independently spotted that `- cron: "0 3 * * *"` lived inside `{{#if python}}`. For node/go/rust the only cron rendered was the **weekly** Scorecard one, so `if: github.event_name == 'schedule'` would have made `fuzz` run **weekly** while the recipe comments, the rules docs and my new tests all said *nightly*. That is exactly the map-not-territory defect (#688) this issue is about — shipped inside the fix for it. My own test could not catch it: it asserted the schedule *gate*, not the *cadence*.

Fixed by hoisting the nightly cron out of `{{#if python}}` and gating every schedule-only job on its **own** cron via `github.event.schedule`. A bare `event_name` gate fires on every cron, so adding the nightly entry would otherwise have promoted Scorecard to a nightly run for all four languages.

Confirmed per language after rendering:

| Language | nightly `0 3 * * *` | weekly `0 4 * * 1` |
|---|---|---|
| python | `mutation-tests`, `fuzz` | `scorecard` |
| node / go / rust | `fuzz` | `scorecard` |

## Changes

- **`ci.yml.tmpl`**: language-agnostic `fuzz` job, matched to the nightly cron, per-language toolchain setup, guarded on a project manifest so a fresh scaffold is not born red. Checks all four manifest names rather than introducing a `{{fuzz_manifest}}` variable — only one language renders, so no 3-path variable contract is needed. Nightly cron hoisted out of `{{#if python}}`; `mutation-tests` and `scorecard` now name their own crons.
- **`justfile.tmpl` + `rules/{python,node,go,rust}.md`**: say *when* fuzzing runs. `go.md` previously implied a per-PR job; the other three said nothing. `go.md`'s recipe one-liner also claimed `go test -fuzz` when the recipe replays seed corpora with `go test -run=Fuzz` — corrected.
- **`test_fuzzing.py`**: `TestGoFuzzJob` → `TestFuzzJob`, parametrized over all four languages. Asserts the job exists, **runs nightly** (cron present *and* matched), is non-blocking, installs the toolchain its own recipe needs, and that **no** schedule-gated job uses a bare `event_name` gate.
- **`test_quality_toolchain.py`**: `test_mutmut_schedule_absent_for_other_languages` asserted `"0 3 * * *" not in ci` as a proxy for "no mutmut job". The cron is no longer a proxy for the job, so it asserts the intent directly and is renamed `test_mutmut_job_absent_for_other_languages`.

## Verification (non-vacuous — each guard broken, observed failing, restored)

| Break | Result |
|---|---|
| re-gate the job to go only | 9 tests fail |
| drop the schedule gate (per-PR) | 4 tests fail |
| nightly cron back inside `{{#if python}}` | 3 tests fail (node/go/rust only — python legitimately had it) |
| fuzz reverted to a bare `event_name` gate | 4 tests fail |
| mutmut job ungated to all languages | 3 tests fail |
| remove `setup-uv` from the fuzz job | 1 test fails |
| `rust.md` stops saying when it runs | 1 test fails |

Rendered all four languages: no unrendered `{{#if}}` tags, valid YAML, zero bare schedule gates, `actionlint` clean on each. Full suite: **2251 passed, 10 skipped**.

## Acceptance

- [x] `just fuzz` behaves consistently across languages — all four CI-invoked, nightly
- [x] The choice is recorded (comment block in `ci.yml.tmpl`), and the rules docs say when fuzzing runs
- [x] No language ships a recipe that nothing ever calls without saying so

Closes #727
