### PR TITLE
chore(PI-737): install just in CI so the commit-hook gates run, and fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
         with:
           bun-version: latest
 
+      # Same reasoning again (#737). The two git pre-commit hook tests in
+      # test_commit_hook_gates.py drive the real hook, which shells out to
+      # `just lint` — the hook's two most interesting behaviours (block a bad
+      # STAGED commit; do NOT block a good staged commit when the worktree is
+      # dirty) were never exercised in CI because `just` was absent and the
+      # tests skipped. Pinned to the same SHA the scaffolded ci.yml.tmpl uses.
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+
       - name: Sync dev dependencies
         run: uv sync --group dev --locked
 

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -17,6 +17,7 @@ are bypassable with `--no-verify`, mirroring the existing gitleaks posture.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -25,6 +26,22 @@ import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import fallback_preset, fallback_variables, make_variables
+
+
+def _require_tool(name: str) -> None:
+    """Fail in CI, skip locally, when `name` is not on PATH.
+
+    `skipif` here meant these tests skipped in CI for as long as `just` was
+    absent from the runner (#737) — the hook's two most interesting behaviours
+    were never exercised by a gate. A skipped test is not a gate; the same shape
+    as #733 (bun) and #719 (actionlint). `ci.yml` installs both tools, so a
+    missing one is a broken workflow, not a reason to pass quietly.
+    """
+    if shutil.which(name):
+        return
+    if os.environ.get("CI"):
+        pytest.fail(f"{name} is not on PATH — CI must install it (ci.yml) or this gate tests nothing (#737).")
+    pytest.skip(f"{name} not available — install it to run this gate locally")
 
 
 def _git_hooks(target: Path) -> tuple[str, str]:
@@ -71,9 +88,9 @@ def test_pre_commit_gate_has_per_file_shell_block(tmp_target: Path):
     assert "Shell format errors (shfmt)" in gate
 
 
-@pytest.mark.skipif(shutil.which("shfmt") is None, reason="shfmt not available")
 def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
     """End-to-end: a badly-formatted staged .sh is shfmt-fixed and re-staged."""
+    _require_tool("shfmt")
     target = tmp_path / "proj"
     scaffold(target, fallback_preset(), fallback_variables(language="python", python="true"))
     hook = target / ".agents" / "hooks" / "pre_commit_gate.sh"
@@ -103,9 +120,9 @@ def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
     assert staged == bad.read_text()
 
 
-@pytest.mark.skipif(shutil.which("shfmt") is None, reason="shfmt not available")
 def test_pre_commit_gate_blocks_a_broken_staged_shell(tmp_path: Path):
     """A staged .sh shfmt can't parse must block the commit (deny), not slip through."""
+    _require_tool("shfmt")
     target = tmp_path / "proj"
     scaffold(target, fallback_preset(), fallback_variables(language="python", python="true"))
     hook = target / ".agents" / "hooks" / "pre_commit_gate.sh"
@@ -125,7 +142,6 @@ def test_pre_commit_gate_blocks_a_broken_staged_shell(tmp_path: Path):
     assert '"permissionDecision": "deny"' in result.stdout, result.stdout
 
 
-@pytest.mark.skipif(shutil.which("just") is None, reason="just not available")
 def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
     """A staged lint error must not be masked by an unstaged fix (Codex #596).
 
@@ -133,6 +149,7 @@ def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
     check is independent of the real ruff toolchain — the point under test is the
     stash-the-index mechanism, not what `just lint` runs.
     """
+    _require_tool("just")
     target = tmp_path / "proj"
     scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
     hook = target / ".github" / "hooks" / "pre-commit"
@@ -161,9 +178,9 @@ def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
     assert (target / "x.txt").read_text() == "GOOD\n", "unstaged changes were not restored"
 
 
-@pytest.mark.skipif(shutil.which("just") is None, reason="just not available")
 def test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index(tmp_path: Path):
     """The inverse of the above: unrelated dirty WIP must not fail a clean commit."""
+    _require_tool("just")
     target = tmp_path / "proj"
     scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
     hook = target / ".github" / "hooks" / "pre-commit"


### PR DESCRIPTION
## Problem

`tests/integration/test_commit_hook_gates.py` drives the **real** scaffolded git `pre-commit` hook, which shells out to `just lint`. This repo's CI never installed `just`, so the two tests exercising the hook's most interesting behaviours skipped there:

- a staged lint error must **not** be masked by an unstaged fix
- a clean staged commit must **not** be blocked by unrelated dirty WIP

A skipped test is not a gate. Third instance of the same shape — #733 (bun), #719 (actionlint).

## Changes

- **`ci.yml`**: install `just` via `extractions/setup-just`, SHA-pinned to the same commit the scaffolded `ci.yml.tmpl` already uses.
- **All four `skipif`s → `_require_tool()`**: `pytest.fail` under `CI`, `pytest.skip` locally. This also covers `shfmt`: CI installs it, so if that step ever broke, those two tests would likewise skip green rather than go red.

## Verification (non-vacuous)

Each break keeps the hook **parseable** (`bash -n`), so the tests fail for the reason intended:

| Break | Result |
|---|---|
| `just lint \|\| true` (lint can never fail) | `test_git_pre_commit_lints_the_index_not_the_worktree` fails: *"pre-commit passed on a staged lint error hidden by an unstaged fix"* |
| `git apply` instead of `git apply -R` (no index isolation) | both hook tests fail |
| `CI=1`, `just`/`shfmt` off `PATH` | 4 failures — *"CI must install it"* |
| no `CI` env, tools off `PATH` | 4 skips |

**My first attempt at those breaks was worthless**, and it is worth recording why. Replacing `just lint` with `true # just lint` commented out the trailing `); then`, so the hook died of a **syntax error**. `test_git_pre_commit_lints_the_index_not_the_worktree` (expects a non-zero exit) then *passed* on the crash, while `test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index` (expects zero) *failed*. Both moved for reasons unrelated to the behaviour under test. Redone with parseable edits — that is precisely the defect class this issue is about.

Also confirmed all 7 tests pass in a clean environment (`env -u XDG_RUNTIME_DIR`). Locally a stale `XDG_RUNTIME_DIR` makes `just` fail with `I/O error in runtime dir /run/user/1000/just`, and the hook's error message blames the scaffold — a trap for the next person.

Full suite: **2251 passed, 10 skipped**. `actionlint` clean on the modified `ci.yml`.

## Acceptance

- [x] `just` is installed in CI, SHA-pinned
- [x] Both tests **run** in CI (verify in the pytest summary after this merges — expect skips to drop)
- [x] A missing `just` **fails** in CI and only skips locally
- [x] Verified non-vacuously: break the pre-commit hook, watch the test fail, restore

Closes #737
