### PR TITLE
fix(PI-738): stop license-scan swallowing a stale lockfile, and unbreak fresh scaffolds

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -689,11 +689,44 @@ jobs:
         with:
           bun-version: latest
 
+      # Two defects, both fixed here (#738).
+      #
+      # 1. `--frozen-lockfile 2>/dev/null || bun install` silently accepted a
+      #    STALE lockfile: the frozen install fails, `||` swallows it, and a
+      #    non-frozen install rewrites bun.lock and pulls the undeclared dep —
+      #    so the license scan inspected a dependency set the repo never
+      #    committed. Verified against bun 1.3.14. `lint-and-test` above already
+      #    runs frozen with no fallback, so failing fast here is consistency,
+      #    not an escalation.
+      # 2. A fresh scaffold has no package.json, and `bun install` exits 1 there
+      #    ("could not find a package.json file to install from") — this job was
+      #    born red on a project's first CI run.
+      #
+      # The scan step is skipped rather than left to no-op: `bunx
+      # license-checker` exits 0 when there is no package.json, which would turn
+      # "nothing was scanned" into a green gate (#688).
+      - name: Check for package.json
+        id: pkg
+        run: |
+          if [ -f package.json ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No package.json yet — nothing to license-scan."
+          fi
+
       # license-checker reads node_modules, so install deps first.
       - name: Install dependencies
-        run: bun install --frozen-lockfile 2>/dev/null || bun install
+        if: steps.pkg.outputs.exists == 'true'
+        run: |
+          if [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile
+          else
+            bun install
+          fi
 
       - name: License scan (license-checker)
+        if: steps.pkg.outputs.exists == 'true'
         run: just license
 {{/if node}}{{#if go}}
       - name: Set up Go

--- a/tests/contracts/test_license_scan.py
+++ b/tests/contracts/test_license_scan.py
@@ -8,12 +8,29 @@ non-blocking (not in ci-gate's needs), the same rollout semgrep/scorecard used.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
+
+
+def _job_code(ci: str, job: str) -> str:
+    """`job`'s block with comment lines removed.
+
+    Asserting the ABSENCE of a command over the raw block is a trap: this job's
+    own comment quotes the very command it must not run
+    (`--frozen-lockfile 2>/dev/null || bun install`, #738), so a naive
+    `not in job` check fails on the prose. Strip comments and assert over code.
+    """
+    match = re.search(rf"^  {re.escape(job)}:$", ci, flags=re.MULTILINE)
+    assert match is not None, f"no `{job}:` job in the rendered workflow"
+    rest = ci[match.start() :]
+    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
+    block = rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
+    return "\n".join(line for line in block.splitlines() if not line.strip().startswith("#"))
 
 
 def _scaffold(target: Path, language: str = "python", **overrides: str) -> Path:
@@ -103,3 +120,39 @@ class TestLicenseDocumented:
     def test_rules_mention_license(self, tmp_path: Path, language: str, rules_file: str):
         rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
         assert "license" in rules.lower()
+
+
+class TestNodeLicenseScanInstall:
+    """#738: the node install step must not swallow a stale lockfile, and the job
+    must not be born red on a fresh scaffold.
+    """
+
+    def _job(self, tmp_path: Path) -> str:
+        return _job_code(_ci(_scaffold(tmp_path / "n", "node")), "license-scan")
+
+    def test_no_silent_fallback_off_frozen_lockfile(self, tmp_path: Path):
+        """`--frozen-lockfile 2>/dev/null || bun install` rewrites bun.lock and
+        installs the undeclared dep, so the scan inspects a dependency set the
+        repo never committed. Verified against bun 1.3.14.
+        """
+        job = self._job(tmp_path)
+        assert "|| bun install" not in job, job
+        assert "2>/dev/null" not in job, job
+
+    def test_frozen_only_when_a_lockfile_exists(self, tmp_path: Path):
+        job = self._job(tmp_path)
+        assert "bun install --frozen-lockfile" in job
+        assert "[ -f bun.lock ]" in job
+
+    def test_install_and_scan_are_skipped_without_a_package_json(self, tmp_path: Path):
+        """A fresh scaffold has no package.json: `bun install` exits 1 there, and
+        `bunx license-checker` exits 0 — born red, then vacuously green. Both
+        steps gate on the manifest check instead.
+        """
+        job = self._job(tmp_path)
+        assert "steps.pkg.outputs.exists == 'true'" in job
+        gated = [
+            line for line in job.splitlines()
+            if line.strip().startswith("if: steps.pkg.outputs.exists")
+        ]
+        assert len(gated) == 2, f"expected install + scan gated, got {len(gated)}:\n{job}"


### PR DESCRIPTION
## Problem

`ci.yml.tmpl`'s node `license-scan` ran:

```yaml
- name: Install dependencies
  run: bun install --frozen-lockfile 2>/dev/null || bun install
```

Two defects, both **verified against bun 1.3.14** rather than inferred.

**1. A stale lockfile is silently accepted.** The frozen install fails, `||` swallows it, and a non-frozen install rewrites `bun.lock` and pulls the undeclared dep. The license scan then inspects a dependency set the repo never committed. `2>/dev/null` hides why.

```
old: EXIT=0 — bun.lock rewritten, undeclared dep installed
new: error: lockfile had changes, but lockfile is frozen   EXIT=1
```

**2. The job was born red.** A fresh scaffold has no `package.json`, and `bun install` exits 1 there (`Bun could not find a package.json file to install from`) — so *both* branches of the one-liner failed on a project's first CI run.

## The question in the issue, answered by checking

#738 asked whether failing fast would newly red an upgraded scaffold with a stale lockfile, and whether `license-scan` needs `lint-and-test`'s `just setup` escape hatch.

It does not. `lint-and-test` **already** runs `--frozen-lockfile` with no fallback, so an inconsistent `package.json`/lockfile already reds CI — and blockingly, since `lint-and-test` is in `ci-gate`'s `needs`. Making `license-scan` match is consistency, not escalation.

## Changes

- `Check for package.json` step gates both install and scan.
- Install uses `--frozen-lockfile` only when a lockfile exists — the idiom `lint-and-test` already uses.
- The **scan step is skipped**, not merely left to no-op: `bunx license-checker` exits **0** with no `package.json`, so "nothing was scanned" would read as a green gate (#688).
- `TestNodeLicenseScanInstall` in `test_license_scan.py`.

## A trap worth naming

The job's own comment now quotes the command it must not run. Asserting `"|| bun install" not in job` over the raw block **false-positives on the prose**:

```
raw block contains "|| bun install"?   True    <- the comment quotes it
comment-stripped contains it?          False
```

So `_job_code()` strips comment lines before asserting. This is the fourth time this session that a check matched a comment instead of code (#736 ×3). It is the same reason #739 exists.

## Verification

- Restoring the old one-liner fails all 3 new tests.
- Rendered all four languages: `actionlint` and YAML clean.
- Full suite: **2254 passed, 10 skipped**.

Closes #738
