### PR TITLE
chore(PI-739): parse workflow YAML in contract tests instead of slicing strings

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -689,11 +689,44 @@ jobs:
         with:
           bun-version: latest
 
+      # Two defects, both fixed here (#738).
+      #
+      # 1. `--frozen-lockfile 2>/dev/null || bun install` silently accepted a
+      #    STALE lockfile: the frozen install fails, `||` swallows it, and a
+      #    non-frozen install rewrites bun.lock and pulls the undeclared dep —
+      #    so the license scan inspected a dependency set the repo never
+      #    committed. Verified against bun 1.3.14. `lint-and-test` above already
+      #    runs frozen with no fallback, so failing fast here is consistency,
+      #    not an escalation.
+      # 2. A fresh scaffold has no package.json, and `bun install` exits 1 there
+      #    ("could not find a package.json file to install from") — this job was
+      #    born red on a project's first CI run.
+      #
+      # The scan step is skipped rather than left to no-op: `bunx
+      # license-checker` exits 0 when there is no package.json, which would turn
+      # "nothing was scanned" into a green gate (#688).
+      - name: Check for package.json
+        id: pkg
+        run: |
+          if [ -f package.json ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No package.json yet — nothing to license-scan."
+          fi
+
       # license-checker reads node_modules, so install deps first.
       - name: Install dependencies
-        run: bun install --frozen-lockfile 2>/dev/null || bun install
+        if: steps.pkg.outputs.exists == 'true'
+        run: |
+          if [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile
+          else
+            bun install
+          fi
 
       - name: License scan (license-checker)
+        if: steps.pkg.outputs.exists == 'true'
         run: just license
 {{/if node}}{{#if go}}
       - name: Set up Go

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -12,64 +12,26 @@ per run, so nightly is where repetition buys new inputs.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
+from tests.workflow import (
+    job,
+    job_runs_command,
+    load_workflow,
+    needs,
+    schedule_crons,
+    uses,
+)
 
 
 def _scaffold(target: Path, language: str = "python") -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
     scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags), strict=True)
     return target
-
-
-def _job_block(ci: str, job: str) -> str:
-    """Return the YAML block for `job`, sliced at the NEXT top-level job key.
-
-    Not at a comment marker: a reworded comment would then break the test with no
-    functional change (PR #736 review). Not via a YAML parse either — this repo
-    keeps pyyaml out of the test deps. Comment lines between jobs belong to the
-    job that follows, so the block may carry a trailing comment; that is fine,
-    every assertion here looks for a presence, not an absence.
-    """
-    match = re.search(rf"^  {re.escape(job)}:$", ci, flags=re.MULTILINE)
-    assert match is not None, f"no `{job}:` job in the rendered workflow"
-    rest = ci[match.start() :]
-    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
-    return rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
-
-
-def _needs(ci: str, job: str) -> str:
-    """Return `job`'s whole `needs:` section — inline list OR multiline items.
-
-    Reading only the `needs:` line would let a later reformat to a multiline list
-    hide `fuzz` in a `- fuzz` item while the test still passed (PR #736 review).
-    Continuation is decided by INDENT, not by a leading `-`: YAML allows comment
-    lines among the items, and stopping at the first one truncated the section
-    and reintroduced the same false negative (PR #736 review, cycle 7).
-
-    Comment lines are stripped from the result, so a comment mentioning a job
-    name cannot produce a false positive either.
-    """
-    block = _job_block(ci, job).splitlines()
-    start = next(
-        (i for i, line in enumerate(block) if line.strip().startswith("needs:")), None
-    )
-    assert start is not None, f"`{job}:` has no `needs:` section"
-    indent = len(block[start]) - len(block[start].lstrip())
-    section = [block[start]]
-    for line in block[start + 1 :]:
-        stripped = line.strip()
-        blank_or_comment = not stripped or stripped.startswith("#")
-        deeper = len(line) - len(line.lstrip()) > indent
-        if not (blank_or_comment or deeper):
-            break
-        section.append(line)
-    return "\n".join(line for line in section if not line.strip().startswith("#"))
 
 
 class TestFuzzRecipe:
@@ -99,17 +61,14 @@ class TestFuzzJob:
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_job_present_for_every_language(self, tmp_path: Path, language: str):
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        # _job_block asserts the job key exists, with a clearer message than a
-        # `"\n  fuzz:" in ci` check — which would also break if fuzz ever became
-        # the first job (PR #736 review).
-        job = _job_block(ci, "fuzz")
-        assert "name: Fuzz / property tests" in job
-        # `run:` — not a bare `"just fuzz" in ci`, which the job's own prose
-        # comment satisfies. That assertion passed with the run step gutted to
-        # `run: echo nothing` (PR #736 review): the whole point of #727 is a job
-        # that INVOKES the recipe, so assert the invocation (#688).
-        assert "run: just fuzz" in job, job
+        wf = load_workflow(_scaffold(tmp_path / language, language))
+        fuzz = job(wf, "fuzz")  # asserts the job exists
+        assert fuzz["name"] == "Fuzz / property tests"
+        # A `run:` step invoking the recipe — not `"just fuzz" in ci`, which the
+        # job's own prose comment satisfies. That text check passed with the run
+        # step gutted to `run: echo nothing` (PR #736 review); parsing the steps
+        # asserts the invocation, not the mention (#688/#739).
+        assert job_runs_command(fuzz, "just fuzz"), fuzz
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_job_runs_nightly_not_merely_on_some_schedule(self, tmp_path: Path, language: str):
@@ -119,15 +78,14 @@ class TestFuzzJob:
         job then fires on every cron in `on.schedule`. The nightly cron used to
         live inside `{{#if python}}`, so node/go/rust rendered a fuzz job that ran
         WEEKLY while the docs said nightly — the very map-not-territory defect
-        this issue is about, caught in review of PR #736 rather than by this test.
-        Pin both halves: the cron must exist, and the job must match on it.
+        this issue is about (PR #736 review). Pin both halves: the cron must
+        exist, and the job must match on it.
         """
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        assert '- cron: "0 3 * * *"' in ci, f"{language} has no nightly cron"
-        job = _job_block(ci, "fuzz")
-        assert (
-            "if: github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'" in job
-        ), job
+        wf = load_workflow(_scaffold(tmp_path / language, language))
+        assert "0 3 * * *" in schedule_crons(wf), f"{language} has no nightly cron"
+        assert job(wf, "fuzz")["if"] == (
+            "github.event_name == 'schedule' && github.event.schedule == '0 3 * * *'"
+        )
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_no_schedule_gated_job_matches_every_cron(self, tmp_path: Path, language: str):
@@ -138,27 +96,23 @@ class TestFuzzJob:
         run to nightly too (PR #736 review). Every schedule-gated job must name
         the cron it wants.
 
-        Scans `if:` lines ONLY. The workflow's own prose comments quote
-        `github.event_name == 'schedule'` while explaining this very rule, so a
-        whole-file scan would flag them — today it passes only because those
-        quotes happen to fall on lines that also mention `github.event.schedule`
-        or wrap mid-expression (PR #736 review).
+        Reads each job's parsed `if:` expression, so a prose comment quoting the
+        bare gate cannot be mistaken for one — the string scan this replaced
+        passed only by luck of line wrapping (#739).
         """
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        wf = load_workflow(_scaffold(tmp_path / language, language))
         offenders = [
-            line.strip()
-            for line in ci.splitlines()
-            if line.strip().startswith("if:")
-            and "github.event_name == 'schedule'" in line
-            and "github.event.schedule" not in line
+            name
+            for name, spec in (wf.get("jobs") or {}).items()
+            if "github.event_name == 'schedule'" in str(spec.get("if", ""))
+            and "github.event.schedule" not in str(spec.get("if", ""))
         ]
         assert not offenders, f"schedule-gated jobs must match their own cron: {offenders}"
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_fuzz_non_blocking(self, tmp_path: Path, language: str):
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        needs = _needs(ci, "ci-gate")
-        assert "fuzz" not in needs, f"the fuzz job must stay non-blocking:\n{needs}"
+        wf = load_workflow(_scaffold(tmp_path / language, language))
+        assert "fuzz" not in needs(wf, "ci-gate"), "the fuzz job must stay non-blocking"
 
     @pytest.mark.parametrize(
         "language,setup_step",
@@ -174,9 +128,8 @@ class TestFuzzJob:
     ):
         """A fuzz job that cannot run its own recipe is the skipped-test defect
         in another costume (#733). Assert the toolchain is actually installed."""
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
-        job = _job_block(ci, "fuzz")
-        assert setup_step in job, job
+        wf = load_workflow(_scaffold(tmp_path / language, language))
+        assert any(setup_step in ref for ref in uses(job(wf, "fuzz"))), uses(job(wf, "fuzz"))
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_renders_cleanly(self, tmp_path: Path, language: str):

--- a/tests/contracts/test_governance_overlay.py
+++ b/tests/contracts/test_governance_overlay.py
@@ -21,6 +21,7 @@ from project_init.__main__ import main
 from project_init.scaffold import load_preset, overlay_layers, scaffold
 from project_init.upgrade import read_scaffold_record
 from tests.helpers import make_variables
+from tests.workflow import load_workflow, needs
 
 _GOV_README = Path(".agents") / "governance" / "README.md"
 
@@ -80,12 +81,8 @@ class TestGovernanceOn:
         assert "NIST AI RMF" in text
 
     @staticmethod
-    def _gate_needs(target: Path) -> str:
-        ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-        gate_start = ci.index("ci-gate:")
-        return next(
-            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
-        )
+    def _gate_needs(target: Path) -> list[str]:
+        return needs(load_workflow(target), "ci-gate")
 
     def test_governance_job_blocks_via_ci_gate(self, tmp_path: Path):
         # The job's comment calls it "the enforcement boundary" — only true if

--- a/tests/contracts/test_license_scan.py
+++ b/tests/contracts/test_license_scan.py
@@ -8,29 +8,13 @@ non-blocking (not in ci-gate's needs), the same rollout semgrep/scorecard used.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
-
-
-def _job_code(ci: str, job: str) -> str:
-    """`job`'s block with comment lines removed.
-
-    Asserting the ABSENCE of a command over the raw block is a trap: this job's
-    own comment quotes the very command it must not run
-    (`--frozen-lockfile 2>/dev/null || bun install`, #738), so a naive
-    `not in job` check fails on the prose. Strip comments and assert over code.
-    """
-    match = re.search(rf"^  {re.escape(job)}:$", ci, flags=re.MULTILINE)
-    assert match is not None, f"no `{job}:` job in the rendered workflow"
-    rest = ci[match.start() :]
-    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
-    block = rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
-    return "\n".join(line for line in block.splitlines() if not line.strip().startswith("#"))
+from tests.workflow import job, load_workflow, needs, run_commands, steps
 
 
 def _scaffold(target: Path, language: str = "python", **overrides: str) -> Path:
@@ -56,12 +40,8 @@ class TestLicenseScanJob:
         assert "license-scan:" in ci
 
     def test_non_blocking_not_in_ci_gate_needs(self, tmp_path: Path):
-        ci = _ci(_scaffold(tmp_path / "p", "python"))
-        gate_start = ci.index("ci-gate:")
-        needs_line = next(
-            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
-        )
-        assert "license-scan" not in needs_line, "license-scan must stay non-blocking initially"
+        wf = load_workflow(_scaffold(tmp_path / "p", "python"))
+        assert "license-scan" not in needs(wf, "ci-gate"), "license-scan must stay non-blocking initially"
 
     @pytest.mark.parametrize(
         "language,tool",
@@ -127,32 +107,32 @@ class TestNodeLicenseScanInstall:
     must not be born red on a fresh scaffold.
     """
 
-    def _job(self, tmp_path: Path) -> str:
-        return _job_code(_ci(_scaffold(tmp_path / "n", "node")), "license-scan")
+    def _job(self, tmp_path: Path) -> dict:
+        return job(load_workflow(_scaffold(tmp_path / "n", "node")), "license-scan")
 
     def test_no_silent_fallback_off_frozen_lockfile(self, tmp_path: Path):
         """`--frozen-lockfile 2>/dev/null || bun install` rewrites bun.lock and
         installs the undeclared dep, so the scan inspects a dependency set the
-        repo never committed. Verified against bun 1.3.14.
+        repo never committed. Verified against bun 1.3.14. Asserting over parsed
+        `run:` scripts, not raw text — the job comment quotes this command, and a
+        text `not in` check false-positived on the prose (#738/#739).
         """
-        job = self._job(tmp_path)
-        assert "|| bun install" not in job, job
-        assert "2>/dev/null" not in job, job
+        scripts = "\n".join(run_commands(self._job(tmp_path)))
+        assert "|| bun install" not in scripts, scripts
+        assert "2>/dev/null" not in scripts, scripts
 
     def test_frozen_only_when_a_lockfile_exists(self, tmp_path: Path):
-        job = self._job(tmp_path)
-        assert "bun install --frozen-lockfile" in job
-        assert "[ -f bun.lock ]" in job
+        scripts = "\n".join(run_commands(self._job(tmp_path)))
+        assert "bun install --frozen-lockfile" in scripts
+        assert "[ -f bun.lock ]" in scripts
 
     def test_install_and_scan_are_skipped_without_a_package_json(self, tmp_path: Path):
         """A fresh scaffold has no package.json: `bun install` exits 1 there, and
-        `bunx license-checker` exits 0 — born red, then vacuously green. Both
-        steps gate on the manifest check instead.
+        `bunx license-checker` exits 0 — born red, then vacuously green. So the
+        install and scan steps both gate on the package.json presence check.
         """
-        job = self._job(tmp_path)
-        assert "steps.pkg.outputs.exists == 'true'" in job
-        gated = [
-            line for line in job.splitlines()
-            if line.strip().startswith("if: steps.pkg.outputs.exists")
-        ]
-        assert len(gated) == 2, f"expected install + scan gated, got {len(gated)}:\n{job}"
+        job_steps = steps(self._job(tmp_path))
+        gated = [s for s in job_steps if s.get("if") == "steps.pkg.outputs.exists == 'true'"]
+        names = {s.get("name") for s in gated}
+        assert "Install dependencies" in names, [s.get("name") for s in job_steps]
+        assert "License scan (license-checker)" in names, [s.get("name") for s in job_steps]

--- a/tests/contracts/test_license_scan.py
+++ b/tests/contracts/test_license_scan.py
@@ -8,12 +8,29 @@ non-blocking (not in ci-gate's needs), the same rollout semgrep/scorecard used.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
+
+
+def _job_code(ci: str, job: str) -> str:
+    """`job`'s block with comment lines removed.
+
+    Asserting the ABSENCE of a command over the raw block is a trap: this job's
+    own comment quotes the very command it must not run
+    (`--frozen-lockfile 2>/dev/null || bun install`, #738), so a naive
+    `not in job` check fails on the prose. Strip comments and assert over code.
+    """
+    match = re.search(rf"^  {re.escape(job)}:$", ci, flags=re.MULTILINE)
+    assert match is not None, f"no `{job}:` job in the rendered workflow"
+    rest = ci[match.start() :]
+    nxt = re.search(r"^  [a-z][a-z0-9-]*:$", rest[len(f"  {job}:") :], flags=re.MULTILINE)
+    block = rest if nxt is None else rest[: len(f"  {job}:") + nxt.start()]
+    return "\n".join(line for line in block.splitlines() if not line.strip().startswith("#"))
 
 
 def _scaffold(target: Path, language: str = "python", **overrides: str) -> Path:
@@ -103,3 +120,39 @@ class TestLicenseDocumented:
     def test_rules_mention_license(self, tmp_path: Path, language: str, rules_file: str):
         rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
         assert "license" in rules.lower()
+
+
+class TestNodeLicenseScanInstall:
+    """#738: the node install step must not swallow a stale lockfile, and the job
+    must not be born red on a fresh scaffold.
+    """
+
+    def _job(self, tmp_path: Path) -> str:
+        return _job_code(_ci(_scaffold(tmp_path / "n", "node")), "license-scan")
+
+    def test_no_silent_fallback_off_frozen_lockfile(self, tmp_path: Path):
+        """`--frozen-lockfile 2>/dev/null || bun install` rewrites bun.lock and
+        installs the undeclared dep, so the scan inspects a dependency set the
+        repo never committed. Verified against bun 1.3.14.
+        """
+        job = self._job(tmp_path)
+        assert "|| bun install" not in job, job
+        assert "2>/dev/null" not in job, job
+
+    def test_frozen_only_when_a_lockfile_exists(self, tmp_path: Path):
+        job = self._job(tmp_path)
+        assert "bun install --frozen-lockfile" in job
+        assert "[ -f bun.lock ]" in job
+
+    def test_install_and_scan_are_skipped_without_a_package_json(self, tmp_path: Path):
+        """A fresh scaffold has no package.json: `bun install` exits 1 there, and
+        `bunx license-checker` exits 0 — born red, then vacuously green. Both
+        steps gate on the manifest check instead.
+        """
+        job = self._job(tmp_path)
+        assert "steps.pkg.outputs.exists == 'true'" in job
+        gated = [
+            line for line in job.splitlines()
+            if line.strip().startswith("if: steps.pkg.outputs.exists")
+        ]
+        assert len(gated) == 2, f"expected install + scan gated, got {len(gated)}:\n{job}"

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -16,6 +16,7 @@ import pytest
 
 from project_init.scaffold import scaffold
 from tests.helpers import fallback_preset, fallback_variables
+from tests.workflow import job, load_workflow, needs, steps
 
 
 def _scaffold_language(target: Path, language: str) -> Path:
@@ -79,22 +80,33 @@ class TestPythonToolchain:
         assert "just typecheck" in ci
 
     def test_ci_uv_sync_guarded_for_fresh_scaffold(self):
-        """2026-07 QA: a fresh scaffold ships no pyproject.toml — every CI job
+        """2026-07 QA: a fresh scaffold ships no pyproject.toml — every CI step
         that runs `uv sync --group dev` (integration tests, nightly mutation)
-        must guard on it like the justfile's setup recipe, or the first PR
-        shows red on jobs that have nothing to test yet."""
-        ci = (self.target / ".github" / "workflows" / "ci.yml").read_text()
-        lines = ci.splitlines()
-        syncs = [i for i, line in enumerate(lines) if "uv sync --group dev" in line]
-        assert syncs, "expected uv sync steps in the python CI workflow"
-        for i in syncs:
-            window = "\n".join(lines[max(0, i - 12) : i])
-            assert "pyproject.toml" in window, (
-                f"line {i + 1}: `uv sync --group dev` without a nearby "
-                "pyproject.toml existence guard"
-            )
-        # Both the integration-tests job and the mutation job carry a guard.
-        assert ci.count("No pyproject.toml yet") >= 2
+        must guard on it, or the first PR shows red on jobs that have nothing to
+        test yet.
+
+        Guarded structurally, two ways (parse, not a text window — #739): the
+        `pyproject.toml` check is either INSIDE the step's own `run:` script
+        (integration-tests) or in the step's `if:` referencing a prior
+        `Check for pyproject.toml` step (mutation-tests). The old ±12-line text
+        window happened to span both; a reformat that pushed the guard further
+        away would have silently passed.
+        """
+        wf = load_workflow(self.target)
+        found = 0
+        for job_name, spec in (wf.get("jobs") or {}).items():
+            for step in steps(spec):
+                run = step.get("run") or ""
+                if "uv sync --group dev" not in run:
+                    continue
+                found += 1
+                guarded = "pyproject.toml" in run or "pyproject" in str(step.get("if", ""))
+                assert guarded, (
+                    f"{job_name}: `uv sync --group dev` step has no pyproject.toml "
+                    f"guard (run block or step if:)"
+                )
+        # Both the integration-tests job and the nightly mutation job run it.
+        assert found >= 2, f"expected >=2 guarded uv sync steps, found {found}"
 
     def test_mkdocs_config_rendered(self):
         content = (self.target / "mkdocs.yml").read_text()
@@ -474,13 +486,9 @@ class TestCiQualityGates:
         assert "mutation-tests:" in self.ci
         assert "mutmut run" in self.ci
         assert "export-cicd-stats" in self.ci
-        assert "if: github.event_name == 'schedule'" in self.ci
-
-        gate_start = self.ci.index("ci-gate:")
-        gate_needs_line = next(
-            line for line in self.ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
-        )
-        assert "mutation-tests" not in gate_needs_line, "mutation-tests must stay non-blocking"
+        wf = load_workflow(self.target)
+        assert "schedule" in str(job(wf, "mutation-tests").get("if", ""))
+        assert "mutation-tests" not in needs(wf, "ci-gate"), "mutation-tests must stay non-blocking"
 
     def test_mutmut_schedule_present_for_python(self):
         assert "cron:" in self.ci
@@ -593,11 +601,9 @@ class TestSemgrepGate:
         assert "p/owasp-top-ten" in ci
         assert "--baseline-commit" in ci
 
-        gate_start = ci.index("ci-gate:")
-        gate_needs_line = next(
-            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
+        assert "semgrep" not in needs(load_workflow(target), "ci-gate"), (
+            "semgrep must stay non-blocking initially"
         )
-        assert "semgrep" not in gate_needs_line, "semgrep must stay non-blocking initially"
 
     def test_python_ruleset_selected(self, tmp_target: Path):
         target = _scaffold_language(tmp_target, "python")
@@ -795,8 +801,9 @@ class TestTypecheckParity:
         `Install just`, it failed with `just: command not found` on a fresh runner.
         """
         target = _scaffold_language(tmp_target, "go")
-        ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-        assert ci.index("- name: Install just") < ci.index("- name: Typecheck")
+        names = [s.get("name") for s in steps(job(load_workflow(target), "lint-and-test"))]
+        assert "Install just" in names and "Typecheck" in names, names
+        assert names.index("Install just") < names.index("Typecheck"), names
 
     def test_go_typecheck_is_guarded_for_a_source_less_module(self, tmp_target: Path):
         """PR #734 review (P2): `go vet ./...` exits 1 on a module with no .go

--- a/tests/contracts/test_scorecard.py
+++ b/tests/contracts/test_scorecard.py
@@ -15,6 +15,7 @@ import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
+from tests.workflow import load_workflow, needs
 
 
 def _scaffold_language(target: Path, language: str) -> Path:
@@ -59,12 +60,8 @@ class TestScorecardJob:
         assert "results.sarif" in ci
 
     def test_non_blocking_not_in_ci_gate_needs(self, tmp_path: Path):
-        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
-        gate_start = ci.index("ci-gate:")
-        gate_needs_line = next(
-            line for line in ci[gate_start:].splitlines() if line.lstrip().startswith("needs:")
-        )
-        assert "scorecard" not in gate_needs_line, "scorecard must stay non-blocking"
+        wf = load_workflow(_scaffold_language(tmp_path / "p", "python"))
+        assert "scorecard" not in needs(wf, "ci-gate"), "scorecard must stay non-blocking"
 
     def test_renders_cleanly_no_template_markers(self, tmp_path: Path):
         ci = _ci(_scaffold_language(tmp_path / "p", "python"))

--- a/tests/contracts/test_scorecard.py
+++ b/tests/contracts/test_scorecard.py
@@ -15,7 +15,7 @@ import pytest
 
 from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
-from tests.workflow import load_workflow, needs
+from tests.workflow import job, load_workflow, needs, schedule_crons
 
 
 def _scaffold_language(target: Path, language: str) -> Path:
@@ -38,10 +38,13 @@ class TestScorecardJob:
         assert re.search(r"ossf/scorecard-action@[0-9a-f]{40} # v\d+\.\d+\.\d+", ci)
 
     def test_scheduled_not_per_pr(self, tmp_path: Path):
-        ci = _ci(_scaffold_language(tmp_path / "p", "python"))
-        # A weekly cron drives it, and the job itself is schedule-gated.
-        assert "0 4 * * 1" in ci
-        assert "if: github.event_name == 'schedule'" in ci
+        # A weekly cron drives it, and the SCORECARD job itself is schedule-gated
+        # — asserted against the parsed job, not `"if: ...schedule..." in ci`,
+        # which any schedule-gated job (e.g. fuzz) satisfies even if scorecard
+        # loses its own gate (PR #742 review; the #739 defect class).
+        wf = load_workflow(_scaffold_language(tmp_path / "p", "python"))
+        assert "0 4 * * 1" in schedule_crons(wf)
+        assert "github.event_name == 'schedule'" in str(job(wf, "scorecard").get("if", ""))
 
     def test_weekly_cron_renders_for_every_language(self, tmp_path: Path):
         # Unlike the Python-only nightly mutation cron, the weekly Scorecard cron

--- a/tests/contracts/test_workflow_helpers.py
+++ b/tests/contracts/test_workflow_helpers.py
@@ -33,6 +33,13 @@ def test_needs_normalises_string_and_list():
     assert needs({"jobs": {"g": {}}}, "g") == []
 
 
+def test_needs_rejects_a_mapping_shape():
+    """A mapping `needs:` must assert, not silently become a list of its keys
+    (PR #742 review)."""
+    with pytest.raises(AssertionError, match="neither str nor list"):
+        needs({"jobs": {"g": {"needs": {"a": 1}}}}, "g")
+
+
 def test_job_missing_asserts_clearly():
     with pytest.raises(AssertionError, match="no `nope` job"):
         job({"jobs": {"a": {}}}, "nope")

--- a/tests/contracts/test_workflow_helpers.py
+++ b/tests/contracts/test_workflow_helpers.py
@@ -1,0 +1,49 @@
+"""Unit tests for tests/workflow.py — the workflow-YAML accessors (#739/#742).
+
+Five contract-test modules now trust these helpers, so their edge cases are
+guarded here rather than only through their callers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.workflow import (
+    job,
+    job_runs_command,
+    needs,
+    run_commands,
+    steps,
+    uses,
+)
+
+
+def test_job_runs_command_ignores_shell_comments():
+    """The bug this whole helper exists to prevent (#739), in the helper itself
+    (PR #742 review): a command kept only as a shell comment must not count."""
+    assert not job_runs_command({"steps": [{"run": "echo x  # just fuzz"}]}, "just fuzz")
+    assert not job_runs_command({"steps": [{"run": "# just fuzz\necho x"}]}, "just fuzz")
+    assert job_runs_command({"steps": [{"run": "just fuzz"}]}, "just fuzz")
+    assert job_runs_command({"steps": [{"run": "just fuzz  # replay"}]}, "just fuzz")
+
+
+def test_needs_normalises_string_and_list():
+    assert needs({"jobs": {"g": {"needs": "a"}}}, "g") == ["a"]
+    assert needs({"jobs": {"g": {"needs": ["a", "b"]}}}, "g") == ["a", "b"]
+    assert needs({"jobs": {"g": {}}}, "g") == []
+
+
+def test_job_missing_asserts_clearly():
+    with pytest.raises(AssertionError, match="no `nope` job"):
+        job({"jobs": {"a": {}}}, "nope")
+
+
+def test_steps_rejects_a_non_list():
+    with pytest.raises(AssertionError, match="not a list of mappings"):
+        steps({"steps": "oops"})
+
+
+def test_run_commands_and_uses_split_by_step_kind():
+    j = {"steps": [{"run": "echo a"}, {"uses": "actions/checkout@v6"}, {"run": "echo b"}]}
+    assert run_commands(j) == ["echo a", "echo b"]
+    assert uses(j) == ["actions/checkout@v6"]

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -65,8 +65,14 @@ def job_names(workflow: dict) -> list[str]:
 
 
 def needs(workflow: dict, name: str) -> list[str]:
-    """Job `name`'s `needs` as a list — `needs:` may be a string or a list."""
+    """Job `name`'s `needs` as a list — `needs:` may be a string or a list.
+
+    Asserts the shape: a bare `list(raw)` on a mapping would silently return its
+    keys, so a structurally wrong `needs:` could pass a contract test (PR #742
+    review).
+    """
     raw = job(workflow, name).get("needs") or []
+    assert isinstance(raw, (str, list)), f"`needs:` on `{name}` is neither str nor list: {type(raw).__name__}"
     return [raw] if isinstance(raw, str) else list(raw)
 
 
@@ -95,11 +101,16 @@ def _strip_shell_comments(script: str) -> str:
     shell script that can carry its OWN `#` comments — so `job_runs_command`
     would match a command kept only as a comment (`echo x  # just fuzz`),
     reintroducing the exact defect #739 fixes inside the helper that fixes it
-    (PR #742 review, Codex). Conservative and line-based: drop full-line comments
-    and inline comments introduced by whitespace-then-`#`. A `#` inside a quoted
-    string or `${#var}` is not stripped, so a needle hiding there could still
-    match — but that errs toward a false NEGATIVE (a real command not found ->
-    the test fails loudly), never a silent false positive.
+    (PR #742 review, Codex).
+
+    A naive line-based heuristic, NOT a shell parser: drop full-line comments,
+    and truncate each line at the first whitespace-then-`#`. That deliberately
+    over-strips — a `#` after whitespace INSIDE a quoted string (`echo "a # b"`)
+    is also cut (PR #742 review). The error direction is safe: over-stripping can
+    only DROP text, so a real command that followed such a `#` goes unmatched and
+    the test fails loudly — never a silent false positive. The callers match
+    tool invocations (`just fuzz`, `bun install …`) that do not appear as quoted
+    `#`-bearing data in these workflows, so the imprecision does not bite.
     """
     out = []
     for line in script.splitlines():
@@ -112,9 +123,12 @@ def _strip_shell_comments(script: str) -> str:
 
 
 def job_runs_command(job_dict: dict, needle: str) -> bool:
-    """True if any step's `run:` script actually INVOKES `needle`.
+    """True if `needle` appears in any step's `run:` script, comments removed.
 
-    Shell comments are stripped first, so a command preserved only as a comment
-    does not count (PR #742 review).
+    A substring match on the comment-stripped script, NOT a parse of the command
+    line — `echo "just fuzz"` (the needle as data) would still match (PR #742
+    review). It exists to reject the common failure it was built for: a needle
+    kept only as a comment. Pass a distinctive needle (a recipe/binary name) so
+    the data-vs-invocation gap stays theoretical.
     """
     return any(needle in _strip_shell_comments(cmd) for cmd in run_commands(job_dict))

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -1,0 +1,84 @@
+"""Structural access to a rendered GitHub Actions workflow (#739).
+
+The workflow contract tests used to slice `ci.yml` as text and substring-match.
+That is the "assert the prose, not the behaviour" trap this repo keeps hitting:
+`assert "just fuzz" in ci` passed while the `run:` step was deleted (matched a
+comment); a `needs:` read as one line missed a multiline `- fuzz`; asserting a
+command's *absence* false-positived on a comment quoting it. Three of PR #736's
+review findings and one in #741 trace to string-slicing.
+
+Parse the YAML instead. Comments vanish at parse time, `needs` is a list whatever
+its source formatting, a missing job raises rather than passing quietly.
+
+`pyyaml` is already a dev dependency (added for #719's workflow-schema gate). The
+"don't reach for pyyaml" rule in CLAUDE.md is about the *scaffolder's runtime* —
+it must stay small — not its test suite; `actionlint-py` and `shellcheck-py` are
+already dev-only test tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def load_workflow(target: Path, name: str = "ci.yml") -> dict:
+    """Parse a scaffolded workflow file into a dict."""
+    return yaml.safe_load((target / ".github" / "workflows" / name).read_text())
+
+
+def on_triggers(workflow: dict) -> dict:
+    """Return the `on:` block.
+
+    YAML 1.1 (pyyaml) parses the bareword `on` as the boolean `True`, so the
+    trigger block lives under the key `True`, not `"on"`. Every caller would trip
+    on this; centralise it here.
+    """
+    return workflow.get(True) or workflow.get("on") or {}
+
+
+def schedule_crons(workflow: dict) -> list[str]:
+    """Every cron expression in the `on.schedule` block."""
+    schedule = on_triggers(workflow).get("schedule") or []
+    return [entry["cron"] for entry in schedule if "cron" in entry]
+
+
+def job(workflow: dict, name: str) -> dict:
+    """Return job `name`, asserting it exists (a clear message, not a KeyError)."""
+    jobs = workflow.get("jobs") or {}
+    assert name in jobs, f"no `{name}` job in the workflow (jobs: {sorted(jobs)})"
+    return jobs[name]
+
+
+def job_names(workflow: dict) -> list[str]:
+    return list((workflow.get("jobs") or {}).keys())
+
+
+def needs(workflow: dict, name: str) -> list[str]:
+    """Job `name`'s `needs` as a list — `needs:` may be a string or a list."""
+    raw = job(workflow, name).get("needs") or []
+    return [raw] if isinstance(raw, str) else list(raw)
+
+
+def steps(job_dict: dict) -> list[dict]:
+    return job_dict.get("steps") or []
+
+
+def run_commands(job_dict: dict) -> list[str]:
+    """The `run:` script of every step in a job (skips `uses:` steps)."""
+    return [step["run"] for step in steps(job_dict) if "run" in step]
+
+
+def uses(job_dict: dict) -> list[str]:
+    """The `uses:` reference of every action step in a job."""
+    return [step["uses"] for step in steps(job_dict) if "uses" in step]
+
+
+def job_runs_command(job_dict: dict, needle: str) -> bool:
+    """True if any step's `run:` script contains `needle`.
+
+    Unlike `needle in ci_text`, this cannot be satisfied by a comment: `run:`
+    scripts are values, and a `#` inside one is shell, not a stripped comment.
+    """
+    return any(needle in cmd for cmd in run_commands(job_dict))

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -50,18 +50,25 @@ def on_triggers(workflow: dict) -> dict:
 def schedule_crons(workflow: dict) -> list[str]:
     """Every cron expression in the `on.schedule` block."""
     schedule = on_triggers(workflow).get("schedule") or []
-    return [entry["cron"] for entry in schedule if "cron" in entry]
+    assert isinstance(schedule, list), f"`on.schedule` is not a list: {type(schedule).__name__}"
+    return [entry["cron"] for entry in schedule if isinstance(entry, dict) and "cron" in entry]
+
+
+def _jobs(workflow: dict) -> dict:
+    jobs = workflow.get("jobs") or {}
+    assert isinstance(jobs, dict), f"`jobs:` is not a mapping: {type(jobs).__name__}"
+    return jobs
 
 
 def job(workflow: dict, name: str) -> dict:
     """Return job `name`, asserting it exists (a clear message, not a KeyError)."""
-    jobs = workflow.get("jobs") or {}
+    jobs = _jobs(workflow)
     assert name in jobs, f"no `{name}` job in the workflow (jobs: {sorted(jobs)})"
     return jobs[name]
 
 
 def job_names(workflow: dict) -> list[str]:
-    return list((workflow.get("jobs") or {}).keys())
+    return list(_jobs(workflow).keys())
 
 
 def needs(workflow: dict, name: str) -> list[str]:

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -18,14 +18,23 @@ already dev-only test tools.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
 
 
 def load_workflow(target: Path, name: str = "ci.yml") -> dict:
-    """Parse a scaffolded workflow file into a dict."""
-    return yaml.safe_load((target / ".github" / "workflows" / name).read_text())
+    """Parse a scaffolded workflow file into a mapping.
+
+    Asserts the top level is a mapping: an empty or malformed file parses to
+    None/str, and every downstream helper would then raise an opaque
+    AttributeError instead of a clear failure (PR #742 review).
+    """
+    text = (target / ".github" / "workflows" / name).read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text)
+    assert isinstance(parsed, dict), f"{name} did not parse to a mapping: {type(parsed).__name__}"
+    return parsed
 
 
 def on_triggers(workflow: dict) -> dict:
@@ -62,7 +71,11 @@ def needs(workflow: dict, name: str) -> list[str]:
 
 
 def steps(job_dict: dict) -> list[dict]:
-    return job_dict.get("steps") or []
+    raw = job_dict.get("steps") or []
+    assert isinstance(raw, list) and all(isinstance(s, dict) for s in raw), (
+        f"`steps:` is not a list of mappings: {type(raw).__name__}"
+    )
+    return raw
 
 
 def run_commands(job_dict: dict) -> list[str]:
@@ -75,10 +88,33 @@ def uses(job_dict: dict) -> list[str]:
     return [step["uses"] for step in steps(job_dict) if "uses" in step]
 
 
-def job_runs_command(job_dict: dict, needle: str) -> bool:
-    """True if any step's `run:` script contains `needle`.
+def _strip_shell_comments(script: str) -> str:
+    """Drop shell comments from a `run:` script before matching against it.
 
-    Unlike `needle in ci_text`, this cannot be satisfied by a comment: `run:`
-    scripts are values, and a `#` inside one is shell, not a stripped comment.
+    Parsing `run:` from YAML removes the *workflow* comments, but the value is a
+    shell script that can carry its OWN `#` comments — so `job_runs_command`
+    would match a command kept only as a comment (`echo x  # just fuzz`),
+    reintroducing the exact defect #739 fixes inside the helper that fixes it
+    (PR #742 review, Codex). Conservative and line-based: drop full-line comments
+    and inline comments introduced by whitespace-then-`#`. A `#` inside a quoted
+    string or `${#var}` is not stripped, so a needle hiding there could still
+    match — but that errs toward a false NEGATIVE (a real command not found ->
+    the test fails loudly), never a silent false positive.
     """
-    return any(needle in cmd for cmd in run_commands(job_dict))
+    out = []
+    for line in script.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        marker = re.search(r"\s#", line)
+        out.append(line[: marker.start()] if marker else line)
+    return "\n".join(out)
+
+
+def job_runs_command(job_dict: dict, needle: str) -> bool:
+    """True if any step's `run:` script actually INVOKES `needle`.
+
+    Shell comments are stripped first, so a command preserved only as a comment
+    does not count (PR #742 review).
+    """
+    return any(needle in _strip_shell_comments(cmd) for cmd in run_commands(job_dict))

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -44,7 +44,9 @@ def on_triggers(workflow: dict) -> dict:
     trigger block lives under the key `True`, not `"on"`. Every caller would trip
     on this; centralise it here.
     """
-    return workflow.get(True) or workflow.get("on") or {}
+    triggers = workflow.get(True) or workflow.get("on") or {}
+    assert isinstance(triggers, dict), f"`on:` is not a mapping: {type(triggers).__name__}"
+    return triggers
 
 
 def schedule_crons(workflow: dict) -> list[str]:


### PR DESCRIPTION
## Problem

The workflow contract tests asserted over the rendered `ci.yml` by **slicing text and substring-matching**. That is the "assert the prose, not the behaviour" trap this repo keeps hitting. Concretely, from PR #736 and #741:

- `assert "just fuzz" in ci` matched the job's own **comment** while the `run:` step was gutted to `echo nothing`.
- `needs:` read as a single line missed a multiline `- fuzz` item.
- Asserting a command's **absence** false-positived on a comment that quoted it.

Each fix grew a hand-rolled string parser. By the end, `_needs()` was an indent-aware, comment-stripping YAML-subset parser that took **four review cycles** to get right — a YAML parser written to avoid depending on one.

## Premise check (the #739 body was wrong)

#739 proposed *adding* pyyaml to the test deps and flagged a "no pyyaml in tests" convention. Checking rather than trusting: **pyyaml is already a dev dependency** (added for #719's workflow-schema gate, `pyproject.toml`). So the framing was moot — this is a pure refactor, no new dependency. `CLAUDE.md`'s "don't reach for pyyaml" is about the **scaffolder's runtime** staying small, not its test suite; `actionlint-py` and `shellcheck-py` are already dev-only test tools.

## Changes

- **`tests/workflow.py`** — `load_workflow`, `job`, `needs`, `steps`, `run_commands`, `uses`, `job_runs_command`, `schedule_crons`. Centralises the YAML-1.1 gotcha where pyyaml parses the bareword `on:` as the boolean `True` key.
- Migrated every string-slicing call site in `test_fuzzing`, `test_license_scan`, `test_quality_toolchain`, `test_governance_overlay`, `test_scorecard`. Deleted `_job_block` / `_needs` / `_job_code`.

Behaviour is now structural: comments vanish at parse time (a comment can neither satisfy nor defeat an assertion), `needs` is a list whatever the source formatting, and a missing job asserts with a clear message instead of passing quietly.

## Verification

Re-ran every historical break, **including the two the string versions originally missed**:

| Break | Result |
|---|---|
| gut `run: just fuzz` to `echo nothing` (comment intact) | fails |
| fuzz in `ci-gate.needs` as a **multiline** item | fails |
| nightly cron back inside `{{#if python}}` | fails (node/go/rust) |
| fuzz reverted to a bare `event_name` gate | fails (all four) |
| `license-scan` old `\|\| bun install` one-liner | fails |
| `uv sync` step stripped of its pyproject guard | fails |
| mutation-tests / semgrep / scorecard / governance in/out of `ci-gate.needs` | fails |

Full suite: **2254 passed, 10 skipped**. ruff + shell-lint clean.

Closes #739
