### PR TITLE
docs(PI-743): ship the 'assert behaviour, not text' refinement to scaffolds

### DIFF
--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -40,7 +40,7 @@ follow the inline quick-references in the rules below.
 
 - **TDD** — write failing tests before any implementation.
 - **Verify the premise before you plan against it** — an issue description, a stale comment, or a tool's documented behavior is a *claim*, not a fact. Check it against the code, or run the tool, before building on it. Say what you verified and how.
-- **A test that cannot fail is worse than no test** — after writing a guard, break the thing it guards, watch it fail, then restore. A test asserting a config file's *text* passes while the tool it configures crashes and checks nothing.
+- **A test that cannot fail is worse than no test** — break what a guard guards, watch it fail, restore (also the helper you write to fix it). Matching *text* passes on a comment, docstring, or data; assert parsed structure or behaviour, not a substring.
 {{#if lifecycle}}- **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue.
 - **GitHub workflow** — for any push, PR, review, or merge action, load the `github_workflow` skill{{#if no_plugin}} (`.agents/skills/github_workflow/SKILL.md`){{/if no_plugin}}. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `type(KEY-N): desc` (no scope = no issue) | body includes `Closes #N`.
 {{/if lifecycle}}{{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.

--- a/templates/base/AGENTS.md.tmpl
+++ b/templates/base/AGENTS.md.tmpl
@@ -40,7 +40,7 @@ follow the inline quick-references in the rules below.
 
 - **TDD** — write failing tests before any implementation.
 - **Verify the premise before you plan against it** — an issue description, a stale comment, or a tool's documented behavior is a *claim*, not a fact. Check it against the code, or run the tool, before building on it. Say what you verified and how.
-- **A test that cannot fail is worse than no test** — break what a guard guards, watch it fail, restore (also the helper you write to fix it). Matching *text* passes on a comment, docstring, or data; assert parsed structure or behaviour, not a substring.
+- **A test that cannot fail is worse than no test** — break what a guard guards, watch it fail, restore (also the helper you write to fix it). Matching *text* passes on a comment, docstring, or data; assert parsed structure or behavior, not a substring.
 {{#if lifecycle}}- **GitHub Projects** — work is tracked on the GitHub Projects board backed by GitHub Issues. Before starting non-trivial work, create or reference an issue.
 - **GitHub workflow** — for any push, PR, review, or merge action, load the `github_workflow` skill{{#if no_plugin}} (`.agents/skills/github_workflow/SKILL.md`){{/if no_plugin}}. Quick ref: branch = `<type>/<KEY>-<n>-<slug>` | PR title = `type(KEY-N): desc` (no scope = no issue) | body includes `Closes #N`.
 {{/if lifecycle}}{{#if lint_command}}- **Commands** — the `justfile` is the canonical command surface: `just --list` shows every recipe (`setup`, `lint`, `format`, `test`, `docs`, `ci`). Prefer `just <recipe>` over raw tool invocations so every agent and CI run the same commands.


### PR DESCRIPTION
## Why

The scaffolded `AGENTS.md` already ships *"A test that cannot fail is worse than no test"* and *"Verify the premise"*. This session (#733/#727/#737/#738/#739) hit that exact failure **five times, each inside the fix for it** — but the base wording named neither the specific trap nor the technique.

The recurring shape: a guard that greps the rendered artefact for a string is satisfied by that string appearing in a **comment, a docstring, or as data** — not by the behaviour. E.g. `assert "just fuzz" in ci` passed with the `run:` step deleted (matched a comment); a helper written to stop comment-matching then matched a shell comment in a `run:` value.

## Change

Sharpened the line-43 rule **in place** in `templates/base/AGENTS.md.tmpl`:
- the common failure is matching *text* a comment / docstring / data also satisfies;
- assert parsed structure or observed behaviour, not a rendered substring;
- the defect recurs in the helper you write to fix it — break-test that too.

## Constrained by the gate it describes

`AGENTS.md` is the always-loaded tier with a hard **<1000-word budget** (`test_enforcement_guide`), and it sat at **994** — 5 words of headroom. My first drafts (1039 / 1021 / 1013 words) **failed that budget test** — the gate did its job — so I rewrote the rule in place rather than appending. Final render: **997 words**.

## Out of scope (flagged, not changed)

Line 41 — *"TDD — write failing tests before any implementation"* — is in tension with the break-it discipline this session validated (test-first writes each assertion when you're most sure it's right, which is when these five bugs were introduced). Changing it is a maintainer decision, not a docs drive-by. Left as-is; noted here for a separate call.

## Verification

- `test_agents_md_stays_under_word_budget` passes (997 < 1000).
- Renders clean on a multi-agent scaffold, no template markers.
- Repo's own `AGENTS.md` is a redirect to `CLAUDE.md` (which already states the rule) — no repo-side sync.
- Full suite: **2260 passed, 10 skipped**; ruff clean.

Closes #743
