### PR TITLE
chore(PI-637): Add dependency vulnerability scanning (pip-audit or Dependabot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,14 @@ jobs:
         # a dip is visible in the log and never blocks an unrelated PR.
         run: uv run pytest --tb=short -q --cov --cov-report=term-missing
 
+      # Dependency vulnerability scan (#637). gitleaks (secret-scan job) catches
+      # committed secrets; nothing else here catches a correctly-spelled dep
+      # already in uv.lock with a known CVE. pip-audit is pulled in ephemerally
+      # via `uv run --with`, the same pattern the scaffolded ci.yml.tmpl uses —
+      # no dev-dependency to forget. Mirrors the template's `just audit` step.
+      - name: Dependency vulnerability scan (pip-audit)
+        run: just audit
+
   wheel-smoke:
     name: Wheel smoke test
     runs-on: ubuntu-24.04

--- a/justfile
+++ b/justfile
@@ -36,8 +36,15 @@ test-quick:
 docs:
     uv run --extra docs mkdocs serve
 
+# scan dependencies for known CVEs (#637). pip-audit is pulled in ephemerally
+# via `uv run --with`, mirroring the pattern the scaffolded ci.yml.tmpl ships —
+# no dev-dependency to forget. Complements gitleaks (which scans for secrets,
+# not vulnerable-but-correctly-spelled deps already in the lockfile).
+audit:
+    uv run --with pip-audit pip-audit
+
 # what CI runs
-ci: lint test
+ci: lint test audit
 
 # sync the plugin payload from templates (PI-129)
 sync-plugin:

--- a/justfile
+++ b/justfile
@@ -40,8 +40,15 @@ docs:
 # via `uv run --with`, mirroring the pattern the scaffolded ci.yml.tmpl ships —
 # no dev-dependency to forget. Complements gitleaks (which scans for secrets,
 # not vulnerable-but-correctly-spelled deps already in the lockfile).
+#
+# --all-extras is load-bearing: pip-audit scans the *installed* environment, and
+# the advisories this recipe first caught (idna/urllib3) live in the `docs`
+# extra (mkdocs-material -> requests), which is a real CI path (docs.yml) but is
+# NOT synced by `lint-and-test`'s `uv sync --group dev`. Without --all-extras the
+# gate would run in an env where those packages aren't even installed and report
+# clean while a docs-extra CVE ships — a gate that can't fire (#637 review).
 audit:
-    uv run --with pip-audit pip-audit
+    uv run --all-extras --with pip-audit pip-audit
 
 # what CI runs
 ci: lint test audit

--- a/uv.lock
+++ b/uv.lock
@@ -608,15 +608,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -271,11 +271,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1005,11 +1005,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds dependency-vulnerability scanning to the repo's own CI, dogfooding what the scaffolded `ci.yml.tmpl` already ships.

- New `audit` justfile recipe: `uv run --with pip-audit pip-audit` (ephemeral, no dev-dependency to forget), wired into `just ci` and a discrete `Dependency vulnerability scan (pip-audit)` step in `lint-and-test`.
- The gate immediately caught real advisories in transitive deps pulled via `mkdocs-material` → `requests`: bumped `idna` 3.13→3.18 (PYSEC-2026-215) and `urllib3` 2.6.3→2.7.0 (PYSEC-2026-141/142) in `uv.lock`. Audit now reports **no known vulnerabilities**.

## Why

Gitleaks scans for committed secrets, but nothing checked for known CVEs in a correctly-spelled dependency already in the lockfile. The template ships this; the repo's own CI was behind its own product.

## Verification

- `just audit` → no known vulnerabilities.
- Full suite green: 2260 passed, 10 skipped.
- Broke it to prove the gate works: pre-bump, `pip-audit` reported 5 advisories and the step would have failed CI red; post-bump it passes.

Closes #637