### PR TITLE
chore(PI-638): CI Python version matrix doesn't match declared support (3.11-3.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ jobs:
   lint-and-test:
     name: Lint and test
     runs-on: ubuntu-24.04
+    # Test across the full declared support window (#638). pyproject sets
+    # requires-python >=3.11 with 3.11-3.13 classifiers, but this job used to pin
+    # only 3.12 — a break on 3.11 or 3.13 would ship uncaught. The matrix must
+    # stay in sync with the classifiers; tests/contracts/test_repo_ci_python_matrix.py
+    # fails CI if they drift. Matrixing renames the check to "Lint and test
+    # (3.xx)", which is why "CI gate" (below) is the single required context, not
+    # this job — see its comment.
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
@@ -22,7 +33,7 @@ jobs:
           version: "0.11.7"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       # shellcheck ships preinstalled on ubuntu-24.04; shfmt does not. The
       # scaffolded-output lint guard (test_shell_lint_gate.py) skips when its
@@ -325,3 +336,36 @@ jobs:
           cd "$WIN_TARGET"
           out=$(bash .agents/hooks/_py.sh -c "print('resolver-ok')")
           test "$out" = "resolver-ok"
+
+  # All-green gate (#638/#589): the SINGLE required status check for branch
+  # protection. Branch protection requires only "CI gate", so the required
+  # context is robust to the matrix — adding/removing a Python version never
+  # renames it, and there is no un-expanded matrix name (e.g. "Lint and test
+  # (3.11)") for GitHub to fail to match against, which would leave main
+  # permanently blocked on a missing context. `if: always()` so the gate runs
+  # even when an upstream job fails, then fails itself unless every dependency
+  # succeeded. Mirrors the ci-gate the scaffolded ci.yml.tmpl ships (the repo's
+  # own CI was behind its own product).
+  #
+  # needs = only jobs that ALWAYS run: a skipped need counts as not-success and
+  # would red the gate. wheel-smoke skips only when lint-and-test fails (gate
+  # should be red then anyway); the conditional portability jobs are deliberately
+  # out (they skip on non-shell PRs and were never required contexts).
+  ci-gate:
+    name: CI gate
+    runs-on: ubuntu-24.04
+    needs: [lint-and-test, wheel-smoke, secret-scan, shellcheck]
+    if: always()
+    steps:
+      - name: Require all upstream jobs to succeed
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Upstream job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required job did not succeed (got: $result)."
+              exit 1
+            fi
+          done
+          echo "All required jobs passed."

--- a/tests/contracts/test_repo_ci_python_matrix.py
+++ b/tests/contracts/test_repo_ci_python_matrix.py
@@ -1,0 +1,55 @@
+"""#638: this repo's own CI must test every Python it declares support for.
+
+pyproject sets requires-python >=3.11 with 3.11-3.13 classifiers, but ci.yml's
+lint-and-test job pinned only 3.12 — a break on 3.11 or 3.13 would ship uncaught.
+This guard fails if the CI matrix and the declared classifiers drift.
+
+Distinct from tests/contracts/test_python_version_set.py, which guards the
+*scaffolded template's* matrix against the CLI's SUPPORTED_PYTHON_VERSIONS. This
+one guards the *scaffolder repo's own* CI against its own pyproject.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from tests.workflow import job, load_workflow, needs
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _classifier_pythons() -> list[str]:
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    prefix = "Programming Language :: Python :: "
+    return sorted(
+        rest
+        for c in data["project"]["classifiers"]
+        if c.startswith(prefix) and re.fullmatch(r"\d+\.\d+", (rest := c[len(prefix) :].strip()))
+    )
+
+
+def _matrix_pythons() -> list[str]:
+    matrix = job(load_workflow(_ROOT), "lint-and-test").get("strategy", {}).get("matrix", {})
+    versions = matrix.get("python-version")
+    assert isinstance(versions, list), "lint-and-test has no python-version matrix (#638)"
+    return sorted(str(v) for v in versions)
+
+
+def test_ci_matrix_matches_declared_classifiers():
+    assert _matrix_pythons() == _classifier_pythons(), (
+        "ci.yml lint-and-test matrix and pyproject Python classifiers drifted — "
+        "keep them equal (#638)"
+    )
+
+
+def test_ci_gate_depends_on_the_matrixed_job():
+    """The matrix renames "Lint and test" to "Lint and test (3.xx)", so branch
+    protection requires "CI gate" instead. That gate is only meaningful if it
+    actually depends on the matrixed job — else a green gate could mask a red run.
+    """
+    assert "lint-and-test" in needs(load_workflow(_ROOT), "ci-gate"), (
+        "ci-gate must `needs: lint-and-test` — it is the required check standing "
+        "in for the matrixed job (#638)"
+    )


### PR DESCRIPTION
## What

Makes the repo's own CI test the full Python support window it declares, and introduces the single required gate that keeps that safe.

- **#638** — `lint-and-test` now runs a `["3.11","3.12","3.13"]` matrix (was pinned to 3.12 only), matching `requires-python >=3.11` + the 3.11–3.13 classifiers.
- **#589 (core)** — matrixing renames the check to `Lint and test (3.xx)`, which would strand branch protection on the now-missing `Lint and test` context. Added a `ci-gate` aggregator (`needs` the always-run blocking jobs, `if: always()`, fails unless all succeeded) as the **single required status check** — robust to matrix renames. Mirrors the `ci-gate` the scaffolded `ci.yml.tmpl` already ships.
- **Drift guard** — `tests/contracts/test_repo_ci_python_matrix.py` fails CI if the matrix and classifiers drift, or if `ci-gate` stops depending on `lint-and-test`.

## Branch-protection migration (applied with the merge)

Required contexts change from `Lint and test` + `Wheel smoke test` → **`CI gate`** (wheel-smoke is covered by ci-gate's `needs`). The two `validate-pr` contexts stay required.

## Verification

- Suite passes on **3.11** and **3.13** (isolated envs), not just 3.12 — 2262 passed, 10 skipped.
- `actionlint` validates the matrix + ci-gate.
- Broke the guard to prove it fires: dropping 3.13 from the matrix fails `test_ci_matrix_matches_declared_classifiers`.

## Scope note

#589's optional UI-grouping (splitting jobs into ~3 named workflow files) and replicating the gate pattern to the template are **not** in this PR; #589 stays open for those. This delivers its load-bearing criterion (one required gate).

Closes #638
Addresses #589