### PR TITLE
docs(PI-684): Worked grounding example for the diagram skill

### DIFF
--- a/plugins/project-init-workflow/skills/diagram/SKILL.md
+++ b/plugins/project-init-workflow/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/plugins/project-init-workflow/skills/diagram/SKILL.md
+++ b/plugins/project-init-workflow/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/plugins/project-init-workflow/skills/diagram/SKILL.md
+++ b/plugins/project-init-workflow/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/amp/dot_agents/skills/diagram/SKILL.md
+++ b/templates/amp/dot_agents/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/templates/amp/dot_agents/skills/diagram/SKILL.md
+++ b/templates/amp/dot_agents/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/amp/dot_agents/skills/diagram/SKILL.md
+++ b/templates/amp/dot_agents/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/antigravity/dot_agents/skills/diagram/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/templates/antigravity/dot_agents/skills/diagram/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/antigravity/dot_agents/skills/diagram/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/base/dot_gitattributes
+++ b/templates/base/dot_gitattributes
@@ -15,3 +15,7 @@ package-lock.json linguist-generated=true
 bun.lock linguist-generated=true
 bun.lockb binary linguist-generated=true
 .agents/vault/** linguist-vendored=true
+# Rendered diagram pictures (PI-680): the .mmd source is the artifact of record
+# and stays diffable; the committed .svg render is regenerable (diagram skill's
+# always-re-render rule), so collapse its diffs and keep it out of language stats.
+docs/diagrams/**/*.svg linguist-generated=true

--- a/templates/codex/dot_agents/skills/diagram/SKILL.md
+++ b/templates/codex/dot_agents/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/templates/codex/dot_agents/skills/diagram/SKILL.md
+++ b/templates/codex/dot_agents/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/codex/dot_agents/skills/diagram/SKILL.md
+++ b/templates/codex/dot_agents/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/fallback/dot_agents/skills/diagram/SKILL.md
+++ b/templates/fallback/dot_agents/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/templates/fallback/dot_agents/skills/diagram/SKILL.md
+++ b/templates/fallback/dot_agents/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/fallback/dot_agents/skills/diagram/SKILL.md
+++ b/templates/fallback/dot_agents/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/junie/dot_junie/skills/diagram/SKILL.md
+++ b/templates/junie/dot_junie/skills/diagram/SKILL.md
@@ -106,13 +106,13 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
-  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
   way a human sees the diagram on the forge without local tooling. It's marked
   `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
   language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
-  - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
+  - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.
   - mkdocs needs one-time config; offer to add it:
 

--- a/templates/junie/dot_junie/skills/diagram/SKILL.md
+++ b/templates/junie/dot_junie/skills/diagram/SKILL.md
@@ -108,9 +108,11 @@ source is the artifact.
   the picture is what a human opens without tooling — both ship, always.
   **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ``` ````
   fences but not `.mmd` files as images, so the checked-in picture is the only
-  way a human sees the diagram on the forge without local tooling. It's marked
-  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
-  language stats, and the always-re-render rule (§3) keeps it from going stale.
+  way a human sees the diagram on the forge without local tooling. It's
+  collapsed in `.gitattributes` — `docs/diagrams/**/*.svg` as
+  `linguist-generated`, and a vault render under `.agents/vault/**` already as
+  `linguist-vendored` — so it doesn't inflate diffs or language stats, and the
+  always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ``` ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/templates/junie/dot_junie/skills/diagram/SKILL.md
+++ b/templates/junie/dot_junie/skills/diagram/SKILL.md
@@ -11,6 +11,12 @@ Diagrams here are **source files first** (Mermaid by default): diffable,
 regenerable, and reviewable like code. Renders are previews; the committed
 source is the artifact.
 
+> **Not for data charts.** This skill draws *structural* diagrams — components,
+> flows, states, schemas, ideas. If the request is a chart/plot/dashboard over
+> *data* (numbers → bars, lines, points), it does not apply: reach for a
+> plotting library suited to the stack (matplotlib/plotly, Vega-Lite, Recharts,
+> or a spreadsheet) rather than forcing the data into Mermaid.
+
 ## 1. Pick the notation by diagram type
 
 | The user wants to see… | Use |
@@ -36,8 +42,30 @@ source is the artifact.
   `CODE_MAP.md` (if present), imports, and directory structure. Never invent
   a component; if a box isn't backed by a file/module/service you can name,
   it doesn't go on the diagram.
+- **Label file-backed nodes with their repo-relative path** — a "scaffold
+  engine" box reads `scaffold engine\n(src/project_init/scaffold.py)`. The path
+  is a *verifiable* fact, so a later check can flag a diagram that still points
+  at a moved or deleted file. Keep volatile specifics — thresholds, version
+  pins, line numbers — *out* of labels: point at their source, don't restate
+  them (map-not-territory; they rot silently).
 - **Idea mode:** one interview round first — what are the entities, what
   relations matter, what question should the diagram answer?
+
+**Worked grounding pass** (a repo's module layout):
+
+1. Enumerate what actually exists — `ls src/` (or the stack's source root) and
+   read `CODE_MAP.md` if present. Don't guess from memory.
+2. Keep ≤25 real nodes; group or drop the rest into an overview diagram.
+3. Every file-backed node carries its path, so each box is checkable:
+
+   ```mermaid
+   flowchart LR
+     cli["wizard CLI\n(src/project_init/__main__.py)"] --> engine["scaffold engine\n(src/project_init/scaffold.py)"]
+     engine --> tmpl["templates/ — the product"]
+   ```
+
+4. A box you cannot back with a real path or service name does not go on the
+   diagram.
 
 ## 3. The iteration loop
 
@@ -78,6 +106,11 @@ source is the artifact.
 - Commit the whole `<slug>/` folder: source **and** rendered picture
   together. The source is the artifact of record for diffing/regeneration;
   the picture is what a human opens without tooling — both ship, always.
+  **Commit the render, don't gitignore it:** GitHub renders ```` ```mermaid ````
+  fences but not `.mmd` files as images, so the checked-in picture is the only
+  way a human sees the diagram on the forge without local tooling. It's marked
+  `linguist-generated` in `.gitattributes` so it doesn't inflate diffs or
+  language stats, and the always-re-render rule (§3) keeps it from going stale.
 - Embedding:
   - GitHub/GitLab render ```` ```mermaid ```` fences in markdown natively —
     inline the source in docs/README where useful.

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -89,7 +89,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -68,7 +68,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -86,7 +86,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -65,7 +65,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -90,7 +90,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -69,7 +69,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -87,7 +87,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -66,7 +66,7 @@
   ".agents/vault/templates/knowledge-note.md": "f53dae69e4e8523710f7957b4a7ba6802c86b5ae3e24db66426e6aee275d0de2",
   ".agents/vault/templates/session-note.md": "d2a7be81df7fcb5e084246abf006593b90cd15064f5fff44694222493fe0d85b",
   ".env.example": "c7d1004dc9d1e2cfc0edbeea72538ccee07173b64c0d57d14293b7018e5d92d6",
-  ".gitattributes": "fd4d2e922b34ea979848ae409eca21ab3e40710add452bcd17089adeef36d3d6",
+  ".gitattributes": "17e0b848c547a491f79398321e447b9c04b47fcc708a8b3d05f47a692726763c",
   ".github/CODEOWNERS": "df676d15cfee76eeca7520b045744da7ca800cb82a6ca7d4eaa7ead9d953996b",
   ".github/ISSUE_TEMPLATE/bug.yml": "a4e9b044299893b20eafebfad4fcbe10e3093ea0b21eb5d6194a6e84b8e34b1e",
   ".github/ISSUE_TEMPLATE/chore.yml": "ff38d6e52e1604ed0863d852fd233707ef7e40a715188e6c7b3dfd6a2f554449",

--- a/tests/integration/test_diagram_skill.py
+++ b/tests/integration/test_diagram_skill.py
@@ -46,6 +46,17 @@ class TestDiagramSkill:
         assert "docs/diagrams/<slug>/<slug>.mmd" in content
         assert "Always render a picture file" in content
         assert "source **and** rendered picture" in content
+        # Dataviz routing boundary (PI-682): this skill is structural diagrams,
+        # not data charts — scaffolded projects have no dataviz skill to fall to.
+        assert "Not for data charts" in content
+        # Worked grounding example + labels-carry-paths (PI-684): file-backed
+        # nodes carry their repo-relative path so a later check can catch drift
+        # (this is what makes PI-688's dangling-path lint effective on diagrams).
+        assert "Worked grounding pass" in content
+        assert "(src/project_init/scaffold.py)" in content
+        # Git-tracking policy for rendered assets (PI-680): commit the render,
+        # marked linguist-generated, not gitignored.
+        assert "Commit the render, don't gitignore it" in content
         # Quality rules.
         assert "25 nodes" in content
         assert "subgraph" in content


### PR DESCRIPTION
## What

Three related polish items on the templated `diagram` skill (WS4/WS6/WS2 of epic #677), edited in the `templates/fallback` source and propagated to the 4 per-surface copies + the plugin via `sync_plugin.py`.

- **#684 (WS6)** — worked grounding example + the **labels-carry-paths** rule: file-backed nodes carry their repo-relative path (e.g. `(src/project_init/scaffold.py)`), so a later check can flag a diagram pointing at a moved/deleted file. This is what makes #688's dangling-path lint effective on diagrams. Also confirmed the `CODE_MAP.md (if present)` reference degrades for non-Python stacks.
- **#682 (WS4)** — a **"Not for data charts"** routing note near the top: structural diagrams only; data/number charts go to a stack-appropriate plotting library, since scaffolded projects have no dataviz skill. **Decision recorded on #677**: don't template dataviz for now.
- **#680 (WS2)** — the **commit-not-gitignore** policy for rendered assets, stated in the skill's Finalize section, plus `docs/diagrams/**/*.svg linguist-generated=true` in the `.gitattributes` template (collapse render diffs; `.mmd` stays the diffable artifact). No wizard flag (a convention, not a selectable concern).

## Tests

- New exact-case assertions in `test_diagram_skill.py` for all three notes.
- Re-pinned **only** the `.gitattributes` hash across the 8 byte-identity baselines — verified no other key drifted (the diagram `SKILL.md` is already in `_ADDED_SINCE_BASELINE`).
- Full suite: 2262 passed, 10 skipped.

Closes #684
Closes #682
Closes #680