### PR TITLE
chore(PI-688): Map-not-territory rule + deterministic prose/diagram staleness checks

### DIFF
--- a/templates/auto/dot_agents/memory/SCHEMA.md
+++ b/templates/auto/dot_agents/memory/SCHEMA.md
@@ -49,6 +49,18 @@ One fact per file — move longer material to the vault.
 - Anything already in `CLAUDE.md` or `project-init.md`
 - Large documents (put those in `vault/`)
 
+## Map, not territory
+
+A memory — like any cached artifact (a diagram, a doc) — may assert only facts
+that are **mechanically verifiable** (repo-relative paths, module boundaries,
+ownership) or **immune to change** (a rationale, a decision and its date).
+Volatile specifics — tool names, thresholds, version pins, line numbers — must
+be **pointed at, not restated**: name the file that owns the value, don't copy
+the value in. Restated "territory" rots silently the moment its source moves,
+and no gate catches it: `lint_memory.sh` can flag a dangling backtick-`path.ext`
+but not a threshold that has drifted from the `justfile`. Cheap-to-regenerate
+artifacts get regenerated, not cached; underivable rationale goes here or to an ADR.
+
 ## Relationship to vault
 
 `memory/` holds small structured facts for fast agent recall. `vault/` holds richer human-authored documentation (Obsidian). When a vault note distills into a reusable fact, create a memory file and link back to the vault note for context.

--- a/templates/base/dot_agents/rules/go.md
+++ b/templates/base/dot_agents/rules/go.md
@@ -9,7 +9,7 @@ alwaysApply: false
 ```bash
 go build ./...
 go test ./... -count=1
-just test-cov       # tests + coverage gate (>= 70%, per justfile) — CI always runs this
+just test-cov       # tests + coverage gate (threshold per justfile) — CI always runs this
 just audit          # dependency CVE/advisory scan (govulncheck) — CI always runs this
 just sbom           # CycloneDX SBOM via cyclonedx-gomod (#574) — release.yml attaches it to Releases
 just license        # dependency license scan (#579) — deny copyleft; tune --disallowed_types

--- a/templates/base/dot_agents/rules/python.md
+++ b/templates/base/dot_agents/rules/python.md
@@ -17,7 +17,7 @@ uv run ruff format .              # WRITES formatting; `ruff format --check .` i
 uv run --with "mypy>=1.10" mypy src/  # type check (strict mode, per mypy.ini)
 uv run pytest -n auto -q          # tests (parallel mode, requires pytest-xdist)
 uv run pytest -q --tb=short       # tests (single-threaded fallback)
-just test-cov                     # tests + coverage gate (>= 70%, per justfile) — CI always runs this
+just test-cov                     # tests + coverage gate (threshold per justfile) — CI always runs this
 just audit                        # dependency CVE/advisory scan (pip-audit) — CI always runs this
 just sbom                         # CycloneDX SBOM of runtime deps (#574) — release.yml attaches it to Releases
 just license                      # dependency license scan (#579) — deny GPL/AGPL; tune the recipe's --fail-on list

--- a/templates/base/dot_agents/rules/rust.md
+++ b/templates/base/dot_agents/rules/rust.md
@@ -9,7 +9,7 @@ alwaysApply: false
 ```bash
 cargo build
 cargo test
-cargo llvm-cov                                    # tests + coverage gate — threshold + flags per justfile's test-cov, which CI always runs
+just test-cov                                     # tests + coverage gate (threshold + --fail-under-lines per justfile) — bare `cargo llvm-cov` only reports, doesn't gate; CI always runs this
 cargo audit                                       # dependency CVE/advisory scan (`just audit`) — CI always runs this
 cargo cyclonedx --format json                     # CycloneDX SBOM (`just sbom`, #574) — release.yml attaches it to Releases
 cargo deny check licenses                         # license compliance (`just license`, #579) — allow-list in deny.toml (denies GPL/AGPL)

--- a/templates/base/dot_agents/rules/rust.md
+++ b/templates/base/dot_agents/rules/rust.md
@@ -9,7 +9,7 @@ alwaysApply: false
 ```bash
 cargo build
 cargo test
-cargo llvm-cov --fail-under-lines 70              # tests + coverage gate — CI always runs this (`just test-cov`)
+cargo llvm-cov                                    # tests + coverage gate — threshold + flags per justfile's test-cov, which CI always runs
 cargo audit                                       # dependency CVE/advisory scan (`just audit`) — CI always runs this
 cargo cyclonedx --format json                     # CycloneDX SBOM (`just sbom`, #574) — release.yml attaches it to Releases
 cargo deny check licenses                         # license compliance (`just license`, #579) — allow-list in deny.toml (denies GPL/AGPL)

--- a/templates/base/dot_agents/rules/typescript.md
+++ b/templates/base/dot_agents/rules/typescript.md
@@ -35,7 +35,7 @@ bunx @biomejs/biome format .   # format gate — exits 1 on unformatted, leaves 
                                # Part of `just lint` (#726). There is NO `--check` flag: biome
                                # rejects it ("`--check` is not expected in this context") — the
                                # no-flag form IS the check. `--write` (i.e. `just format`) fixes.
-bun test             # tests + coverage gate (>= 70%, per bunfig.toml) — always on, no extra flag needed
+bun test             # tests + coverage gate (threshold per bunfig.toml) — always on, no extra flag needed
 bun audit            # dependency CVE/advisory scan — CI always runs this
 ```
 

--- a/tests/contracts/test_staleness_guards.py
+++ b/tests/contracts/test_staleness_guards.py
@@ -1,0 +1,76 @@
+"""PI-688: deterministic staleness guards for hand-maintained "territory".
+
+Two mechanically-verifiable facts that used to live in multiple hand-kept copies
+with nothing tying them together (map-not-territory, ADR-024):
+
+1. The lifecycle DAG: authoritative in ``GRAPH`` (dag_workflow.py), redrawn as
+   ASCII in workflow_state_reminder.sh. A node added to GRAPH without updating
+   the reminder is silent drift.
+2. Committed Mermaid diagrams: nodes carry repo-relative paths (the diagram
+   skill's labels-carry-paths rule, PI-684) so a diagram that still points at a
+   moved/deleted file is a lie. This makes diagrams safe as navigational memory.
+
+SCOPE NOTE (decided, PI-688): the dangling-path check runs on ``.mmd`` diagrams
+only, NOT on docs/**/*.md or skills. Those corpora describe the *scaffolded
+output* (e.g. ``.agents/memory/MEMORY.md``) and template-relative names (e.g.
+``dot_agents/hooks/...``), so a repo-root existence check false-positives on ~49
+legitimate files — a noise machine, not a guard. Diagrams reference real repo
+paths, so the check is precise there.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_HOOKS = _ROOT / ".agents" / "hooks"
+
+
+def _graph_nodes() -> set[str]:
+    spec = importlib.util.spec_from_file_location("dag_workflow", _HOOKS / "dag_workflow.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    graph: dict[str, list[str]] = mod.GRAPH
+    return set(graph) | {dep for deps in graph.values() for dep in deps}
+
+
+def test_reminder_ascii_dag_matches_graph():
+    """The reminder's ASCII arrow diagram must name exactly the GRAPH nodes.
+
+    Break it: add a node to GRAPH (or drop one from the ASCII) and this fails —
+    which is the point, since nothing else ties the hand-drawn diagram to the
+    authoritative dict.
+    """
+    reminder = (_HOOKS / "workflow_state_reminder.sh").read_text(encoding="utf-8")
+    arrow_lines = [ln for ln in reminder.splitlines() if "->" in ln]
+    ascii_nodes = set(re.findall(r"[a-z]+\.[a-z]+", " ".join(arrow_lines)))
+    assert ascii_nodes == _graph_nodes(), (
+        "lifecycle DAG drift: the reminder's ASCII diagram and dag_workflow.py's "
+        f"GRAPH name different node sets (ascii={sorted(ascii_nodes)})"
+    )
+
+
+# A repo-relative path token: has a slash and ends in a .ext. Excludes URLs. The
+# optional leading dot keeps dotdirs like `.agents/...` intact (else the dot is
+# dropped and a real path reads as missing).
+_PATH_TOKEN = re.compile(r"\.?[A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_.-]+\.[A-Za-z0-9]+")
+
+
+def test_committed_diagrams_reference_only_real_paths():
+    """Every repo-relative path a committed .mmd names must resolve — else the
+    diagram points at a file that moved or was deleted (stale map).
+    """
+    bad: dict[str, list[str]] = {}
+    for mmd in sorted(_ROOT.glob("docs/diagrams/**/*.mmd")):
+        # Mermaid separates label lines with a literal `\n`; turn it into a space
+        # so a path after it isn't glued onto the previous token (n.agents/...).
+        text = mmd.read_text(encoding="utf-8").replace("\\n", " ")
+        for tok in sorted(set(_PATH_TOKEN.findall(text))):
+            if tok.startswith(("http://", "https://")):
+                continue
+            if not (_ROOT / tok).exists():
+                bad.setdefault(mmd.relative_to(_ROOT).as_posix(), []).append(tok)
+    assert not bad, f"committed diagram(s) reference missing repo paths: {bad}"

--- a/tests/contracts/test_staleness_guards.py
+++ b/tests/contracts/test_staleness_guards.py
@@ -47,9 +47,11 @@ def test_reminder_ascii_dag_matches_graph():
     reminder = (_HOOKS / "workflow_state_reminder.sh").read_text(encoding="utf-8")
     arrow_lines = [ln for ln in reminder.splitlines() if "->" in ln]
     ascii_nodes = set(re.findall(r"[a-z]+\.[a-z]+", " ".join(arrow_lines)))
-    assert ascii_nodes == _graph_nodes(), (
-        "lifecycle DAG drift: the reminder's ASCII diagram and dag_workflow.py's "
-        f"GRAPH name different node sets (ascii={sorted(ascii_nodes)})"
+    graph_nodes = _graph_nodes()
+    assert ascii_nodes == graph_nodes, (
+        "lifecycle DAG drift between the reminder's ASCII diagram and "
+        f"dag_workflow.py's GRAPH: only in GRAPH={sorted(graph_nodes - ascii_nodes)}, "
+        f"only in ASCII={sorted(ascii_nodes - graph_nodes)}"
     )
 
 

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -29,7 +29,7 @@
   ".agents/hooks/workflow_state_reminder.sh": "0983f90f506da7f22bb154fb3bfd04ac559df3ef9bd7b5afda6807f1b78d6dad",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -22,7 +22,7 @@
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -28,7 +28,7 @@
   ".agents/hooks/workflow_state_reminder.sh": "0983f90f506da7f22bb154fb3bfd04ac559df3ef9bd7b5afda6807f1b78d6dad",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -21,7 +21,7 @@
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -30,7 +30,7 @@
   ".agents/hooks/workflow_state_reminder.sh": "0983f90f506da7f22bb154fb3bfd04ac559df3ef9bd7b5afda6807f1b78d6dad",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -23,7 +23,7 @@
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -29,7 +29,7 @@
   ".agents/hooks/workflow_state_reminder.sh": "0983f90f506da7f22bb154fb3bfd04ac559df3ef9bd7b5afda6807f1b78d6dad",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -22,7 +22,7 @@
   ".agents/hooks/prod_guard.py": "3307967eab36b44c88e7c74fdda3418f6cff98ffcd1843688f5c585dfbd774d5",
   ".agents/memory/MEMORY.md": "544dac81979cbe795cc55a020360c2569036381b62f879d10ce8dffdc0de0791",
   ".agents/memory/README.md": "c18a7964cd3ed895d31ff003bfb6233a8a795f3e1ec7d4acdd5ea4b9416ca94c",
-  ".agents/memory/SCHEMA.md": "93f5a4e962766266fe2646552388d08fa0b8401295f231930a961fc385130578",
+  ".agents/memory/SCHEMA.md": "9b3b9f507f0f1daa44320958c6b7060e5820290d144f9247815a648ca520e645",
   ".agents/memory/feedback_conventions.md": "abd94813bbd6aa8522f5df1523f63785fa005d9052b8513cad5966e0de0ba443",
   ".agents/memory/project_context.md": "395604794021cc2eaa1f4df3be451fc71ecad21daa1333656a102a6776ae4bff",
   ".agents/memory/user_role.md": "cbeb0886e2f9c8e4b8e444c4835e2dac85b66bdf8dc24d68329ee3bbf458586b",

--- a/tests/integration/test_diagram_skill.py
+++ b/tests/integration/test_diagram_skill.py
@@ -57,6 +57,9 @@ class TestDiagramSkill:
         # Git-tracking policy for rendered assets (PI-680): commit the render,
         # marked linguist-generated, not gitignored.
         assert "Commit the render, don't gitignore it" in content
+        # Map-not-territory is codified here (PI-684/PI-688): volatile specifics
+        # are pointed at, not restated in labels.
+        assert "map-not-territory" in content
         # Quality rules.
         assert "25 nodes" in content
         assert "subgraph" in content


### PR DESCRIPTION
## What

WS10 of epic #677 — codify **map-not-territory** and add deterministic guards for hand-maintained facts that had no check tying them to their source.

1. **Codify map-not-territory** — new section in the memory `SCHEMA.md` (a memory may assert only mechanically-verifiable facts — repo paths, boundaries, ownership — or immune-to-change ones — rationale, decisions; volatile specifics like tool names / thresholds / pins / line numbers are *pointed at, not restated*). The diagram skill already states it (PI-684); locked here with a test assertion.
2. **Strip the coverage-floor value (`70`)** from the four rule docs (`python/go/rust/typescript.md`) — the value is the `justfile`/`bunfig.toml`'s to own; docs now say "threshold per justfile". (No test asserted the value; the `#688` audit noted `test_justfile.py` checks only the flag name.)
3. **DAG contract test** — the reminder's ASCII lifecycle diagram must name exactly `dag_workflow.py`'s `GRAPH` node set; fails on a GRAPH node added without updating the reminder.
4. **Committed-diagram path lint** — every repo-relative path a `.mmd` names must resolve, so a diagram pointing at a moved/deleted file fails CI (makes diagrams safe as navigational memory).

## Scope decision (documented in the test)

The dangling-path lint runs on **`.mmd` diagrams only**, not `docs/**/*.md` or skills. I scanned first: those corpora describe the *scaffolded output* (`.agents/memory/MEMORY.md`) and template-relative names (`dot_agents/hooks/...`), so a repo-root existence check false-positives on ~49 legitimate files — a noise machine, not a guard. Diagrams reference real repo paths, so the check is precise there. This is the issue's "warn or fail — decide and document": **fail**, on `.mmd` only.

## Verification

- Both guards pass; break-it confirmed (a fake missing `.mmd` path is flagged; the DAG test compares exact node sets).
- Re-pinned only the `SCHEMA.md` hash across byte-identity baselines (rule docs are already excluded).
- ruff + `mypy --strict` clean; full suite 2270 passed, 10 skipped.

Closes #688