### PR TITLE
feat(PI-747): verify-test-strength skill: agentic mutation loop to prove guards can fail

### DIFF
--- a/plugins/project-init-workflow/.agents-plugin/plugin.json
+++ b/plugins/project-init-workflow/.agents-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/skills/verify-test-strength/SKILL.md
+++ b/plugins/project-init-workflow/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/plugins/project-init-workflow/skills/verify-test-strength/SKILL.md
+++ b/plugins/project-init-workflow/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.0.1"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.agents-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.6.0"
+__plugin_version__ = "0.7.0"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/amp/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/amp/dot_agents/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/templates/amp/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/amp/dot_agents/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/templates/antigravity/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/templates/antigravity/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/templates/base/dot_agents/project-init.md.tmpl
+++ b/templates/base/dot_agents/project-init.md.tmpl
@@ -36,6 +36,7 @@ Scaffolded with [project-init]({{project_init_url}}) on {{created_date}}.
 | Skill | `token_efficiency` | token-frugal working habits for long coding/debugging sessions |
 | Skill | `checkpoint` | checkpoint-and-clear session handoff (gitignored) |
 | Skill | `diagram` | draw/iterate diagrams (Mermaid-first, committed source) |
+| Skill | `verify-test-strength` | mutation-test a load-bearing test until survivors are killed |
 | Skill | `local_ci` | Actions minutes lockout → self-hosted runner escape hatch |
 | Skill | `add_hook` | add a new deterministic hook |
 | Skill | `add_command` | add a new slash command |

--- a/templates/base/dot_agents/skills/README.md.tmpl
+++ b/templates/base/dot_agents/skills/README.md.tmpl
@@ -13,6 +13,7 @@ Each skill is a directory `.agents/skills/<name>/SKILL.md`. See [`INDEX.md`](IND
 | `token_efficiency` | Long coding/debugging session — token-frugal habits for tool output, reads, and responses |
 | `checkpoint` | Long session — write a gitignored handoff, /clear, resume cheap |
 | `diagram` | Draw architecture/code/idea diagrams as version-controlled Mermaid source |
+| `verify-test-strength` | After a load-bearing test — mutation-test it and strengthen until survivors are killed |
 | `local_ci` | Actions billing lockout — diagnose and move CI to a self-hosted runner |
 | `add_hook` | When you need a new deterministic hook (safety, lint, logging) |
 | `add_command` | When you need a new slash command for a recurring workflow |

--- a/templates/codex/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/codex/dot_agents/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/templates/codex/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/codex/dot_agents/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/templates/fallback/dot_agents/skills/INDEX.md.tmpl
+++ b/templates/fallback/dot_agents/skills/INDEX.md.tmpl
@@ -16,6 +16,7 @@ Load the relevant skill file when the trigger applies. Do not load all skills at
 {{/if memory}}| Work token-efficiently in a long session | `.agents/skills/token_efficiency/SKILL.md` |
 | Checkpoint a long session (save state, /clear, resume) | `.agents/skills/checkpoint/SKILL.md` |
 | Draw/iterate on architecture, code, or idea diagrams | `.agents/skills/diagram/SKILL.md` |
+| Prove a load-bearing test can actually fail (mutation loop) | `.agents/skills/verify-test-strength/SKILL.md` |
 | CI won't start / out of Actions minutes | `.agents/skills/local_ci/SKILL.md` |
 | Record an architectural decision (ADR) | `.agents/skills/add_adr/SKILL.md` |
 | Report / file a bug or issue | `.agents/skills/report_upstream_issue/SKILL.md` |

--- a/templates/fallback/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/fallback/dot_agents/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/templates/fallback/dot_agents/skills/verify-test-strength/SKILL.md
+++ b/templates/fallback/dot_agents/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/templates/junie/dot_junie/skills/verify-test-strength/SKILL.md
+++ b/templates/junie/dot_junie/skills/verify-test-strength/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify-test-strength
+description: Prove a load-bearing test can actually fail — run mutation testing on a target module, then iteratively strengthen its tests until surviving mutants are killed. The automated form of the break-it discipline, for guards that must not silently pass.
+when_to_use: Use on a LOAD-BEARING test after writing or changing it — a contract test, guard hook, invariant check, or anything whose green must mean something. Trigger on "prove this test can fail", "is this test vacuous", "strengthen these tests", "mutation test this", "harden the guard", or right after adding a test you're about to rely on. NOT for the whole suite (it is expensive) and NOT for throwaway tests.
+user-invocable: true
+---
+
+# verify-test-strength — make green mean something
+
+A passing test proves nothing until you've seen it fail for the right reason.
+Coverage is cheap and lies: an LLM-written suite can hit 100% coverage at ~4%
+mutation score — it *executes* the code without *asserting* on it. The fix is a
+**mutation-feedback loop**, not a one-off "try to break it": mutate the code,
+see which mutants the tests fail to catch, strengthen the tests to catch them,
+repeat. Static "write fault-detecting tests" guidance is the floor; the measured
+gain comes from iterating on real survivors.
+
+**Use this selectively.** The loop costs meaningfully more tokens and time than a
+normal test run, so reach for it on the tests that *matter* — the contract test
+guarding an invariant, the security/guard hook, the parser everything depends on
+— not on every test. For a quick change with no load-bearing test, the plain
+break-it rule (change the thing, watch the test fail, restore) is enough.
+
+## 1. Scope it
+
+Name the **one module (or a few functions) under test** and **its test file**.
+Mutation testing is slow and noisy at scale, so a tight scope is what makes it
+usable. Point the mutation tool at deterministic, pure-logic code — skip I/O,
+network, template rendering, and hooks, where mutants are dominated by
+false-equivalents.
+
+## 2. Run the mutation tool
+
+Only meaningful where a mutation runner is wired for the language:
+
+| Language | Tool | Wired? |
+|---|---|---|
+| **Python** | `mutmut` — `just test-mutation` | ✅ shipped |
+| Node/TS | StrykerJS | not scaffolded yet — fall back to §5 |
+| Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
+| Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
+
+For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
+module, then `just test-mutation`. It reports **surviving mutants** — code
+changes the tests did NOT catch. Each survivor is a hole in the suite.
+
+If the language has no wired mutation tool, say so plainly and drop to §5 (the
+manual loop) — do not pretend a score exists.
+
+## 3. Kill the survivors, one at a time
+
+For each surviving mutant:
+
+1. Read the mutation — what did it change (a `>` to `>=`, a `+` to `-`, a
+   returned value, a dropped call)?
+2. Ask: **what real behaviour would that break, and why didn't a test notice?**
+3. Add or strengthen a test that FAILS on the mutant and passes on the original.
+   Assert on the *behaviour the mutant changed*, not on incidental output.
+4. Prefer strengthening an existing test's assertions over adding a near-duplicate.
+
+Re-run the mutation tool. Repeat. Convergence is typically ~4 rounds — if the
+kill-rate stops improving, stop; grinding further mostly hits equivalent mutants.
+
+## 4. Report honestly — never force green
+
+Some survivors can't (or shouldn't) be killed:
+
+- **Equivalent mutants** — the change doesn't alter observable behaviour. Note
+  and move on; don't contort a test to "kill" a no-op.
+- **Dead code** — nothing can reach the mutated line. That's a *finding*: the
+  branch is a candidate for deletion, not a test to add.
+- **Genuinely untestable** — a defensive `assert`/`raise` for an invariant the
+  types already guarantee.
+
+List the survivors you did not kill and WHY. A truthful "3 killed, 1 equivalent,
+1 is dead code — delete it" is the deliverable. Forcing a green score by writing
+a test that asserts the mutant's own behaviour is worse than the original hole.
+
+## 5. No mutation tool? Manual break-it loop
+
+Where no runner is wired, do the loop by hand on the load-bearing test:
+
+1. In the code under test, deliberately break the exact thing the test claims to
+   guard (flip a comparison, drop a guard clause, return a wrong constant).
+2. Run the test. It **must** fail — if it passes, the test is vacuous; fix the
+   assertion, not the code.
+3. Restore the code; confirm green.
+4. Repeat for each distinct thing the test claims to protect.
+
+State in the PR that you did this and what you flipped — the same evidence the
+mutation loop produces, just hand-rolled.

--- a/templates/junie/dot_junie/skills/verify-test-strength/SKILL.md
+++ b/templates/junie/dot_junie/skills/verify-test-strength/SKILL.md
@@ -40,9 +40,17 @@ Only meaningful where a mutation runner is wired for the language:
 | Rust | `cargo-mutants` | not scaffolded yet — fall back to §5 |
 | Go | `gremlins` / `go-mutesting` | not scaffolded yet — fall back to §5 |
 
-For Python: scope `[tool.mutmut] source_paths` in `pyproject.toml` to the target
-module, then `just test-mutation`. It reports **surviving mutants** — code
-changes the tests did NOT catch. Each survivor is a hole in the suite.
+For Python, target the run **without committing a narrower config**. The
+nightly CI `mutation-tests` job reads `[tool.mutmut] source_paths` from
+`pyproject.toml`, so committing a scoped-down `source_paths` silently shrinks
+CI's mutation coverage to your one module. Instead:
+
+- run mutmut with a per-run path filter — `uv run --with mutmut mutmut run <path/to/module>` — leaving the committed config alone, **or**
+- temporarily narrow `source_paths` and **restore it before committing**.
+
+`just test-mutation` runs the full configured scope (what CI runs). Either way,
+mutmut reports **surviving mutants** — code changes the tests did NOT catch.
+Each survivor is a hole in the suite.
 
 If the language has no wired mutation tool, say so plainly and drop to §5 (the
 manual loop) — do not pretend a score exists.

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -240,6 +240,8 @@ _ADDED_SINCE_BASELINE = {
     # PI-665: diagram skill (collaborative Mermaid-first diagramming);
     # INDEX/README/project-init.md rows already excluded above
     ".agents/skills/diagram/SKILL.md",
+    # PI-747: verify-test-strength skill (mutation-feedback loop)
+    ".agents/skills/verify-test-strength/SKILL.md",
     # PI-671: local_ci skill (Actions billing-lockout escape hatch)
     ".agents/skills/local_ci/SKILL.md",
     # #605: Guards log the governance signal (decision + command)

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -225,6 +225,8 @@ _ADDED_SINCE_BASELINE = {
     # PI-665: diagram skill (collaborative Mermaid-first diagramming);
     # INDEX/README/project-init.md rows already excluded above
     ".agents/skills/diagram/SKILL.md",
+    # PI-747: verify-test-strength skill (mutation-feedback loop)
+    ".agents/skills/verify-test-strength/SKILL.md",
     # PI-671: local_ci skill (Actions billing-lockout escape hatch)
     ".agents/skills/local_ci/SKILL.md",
     # #605: Guards log the governance signal (decision + command)

--- a/tests/integration/test_verify_test_strength_skill.py
+++ b/tests/integration/test_verify_test_strength_skill.py
@@ -1,0 +1,54 @@
+"""PI-747: the verify-test-strength skill — mutation-feedback loop.
+
+The automated form of the break-it discipline: run the project's mutation tool
+on a load-bearing test, then strengthen the test until survivors are killed.
+Ships default-on (like diagram); invoked selectively, Python-gated to mutmut.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+
+class TestVerifyTestStrengthSkill:
+    def test_present_and_default_on_no_plugin(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (
+            tmp_target / ".agents" / "skills" / "verify-test-strength" / "SKILL.md"
+        ).read_text()
+        assert "name: verify-test-strength" in content
+        assert "user-invocable: true" in content
+        assert len(content.splitlines()) < 500
+
+    def test_body_covers_the_method(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (
+            tmp_target / ".agents" / "skills" / "verify-test-strength" / "SKILL.md"
+        ).read_text()
+        # It is a mutation-feedback LOOP, not a one-off — coverage lies.
+        assert "mutation" in content.lower()
+        assert "surviving mutant" in content or "survivors" in content
+        # Python is wired via mutmut / just test-mutation; other langs are not.
+        assert "mutmut" in content
+        assert "just test-mutation" in content
+        assert "StrykerJS" in content  # named but flagged not-scaffolded
+        # Selective by design — it's expensive, not a whole-suite run.
+        assert "selectively" in content.lower() or "Use this selectively" in content
+        # Honest reporting: don't force green; equivalent mutants / dead code.
+        assert "equivalent" in content.lower()
+        assert "dead code" in content.lower()
+        assert "never force green" in content.lower() or "force green" in content.lower()
+        # Manual fallback where no mutation tool is wired.
+        assert "manual" in content.lower()
+
+    def test_listed_in_skill_tables(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        for rel in (
+            ".agents/skills/INDEX.md",
+            ".agents/skills/README.md",
+            ".agents/project-init.md",
+        ):
+            assert "verify-test-strength" in (tmp_target / rel).read_text(), rel


### PR DESCRIPTION
## What

A new default-on, user-invocable **`verify-test-strength`** skill: the automated form of the break-it discipline. Given a load-bearing test, it runs the project's mutation tool, surfaces surviving mutants, and drives the agent to strengthen tests until they're killed — because coverage is cheap and lies (an LLM suite can hit 100% coverage at ~4% mutation score).

Motivated by #743/#745 (the *instruction-level* floor) + the literature: the measured gain comes from the **iterative mutation loop**, not a one-off "try to break it". This session is the same finding lived out — the vacuity bug recurred 5× and was caught only by the manual loop.

## The skill

- Scope to one module + its test → run mutation tool → kill survivors one at a time (assert on the behaviour the mutant changed) → re-run (~4 rounds).
- **Python-gated** to `mutmut` / `just test-mutation` (the only wired runner). Names StrykerJS / cargo-mutants / gremlins but flags them **not-scaffolded** and drops to a manual break-it loop rather than faking a score.
- **Honest reporting**: equivalent mutants, dead code (a finding, not a forced test), genuinely-untestable branches — reported, never forced green.
- **Selective** by design (the loop is ~32% more tokens) — load-bearing guards, not the whole suite.

## Decisions (from #747's "decision needed" section)

Python-only PoC now · dedicated skill (not folded into `/verify`) · manual/selective invocation. Per-language mutation recipes (Node/Rust/Go) remain a separate prerequisite for cross-language coverage — the skill is language-gated to where a runner is actually wired.

## Wiring

Auto-synced to the plugin + 4 per-surface copies (`sync_plugin.py` globs skills). Registered in INDEX / README / project-init tables; plugin `0.6.0 → 0.7.0`; new SKILL.md added to both byte-identity `_ADDED_SINCE_BASELINE` sets.

## Verification

- New content test (present + default-on, method coverage, listed in the 3 tables).
- ruff + `mypy --strict` clean; full suite **2273 passed**, 10 skipped.

Closes #747