### PR TITLE
chore(PI-757): Quality-gate policy doc + required-gate drift guard (epic #751)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,10 @@ CI optimization strategies, the extend-the-infrastructure table (skill vs
 hook vs agent spec), and this repo's non-goals live in
 [`docs/development/repo-reference.md`](docs/development/repo-reference.md)
 — consult when adding capabilities or tuning CI, not needed per turn.
+
+The canonical quality/security-gate policy — every gate the repo and the
+scaffolded template run, each with a keep/promote/demote/drop decision, and the
+repo's single required-check set — lives in
+[`docs/development/quality-gates.md`](docs/development/quality-gates.md)
+(epic #751). Update it in the same PR when you change a gate; a contract test
+fails if the repo's required checks drift from it.

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -1,0 +1,95 @@
+# Quality-gate policy (repo ↔ template)
+
+The canonical, deliberately-calibrated policy for every quality/security gate this
+project runs — both in the **scaffolded output** (what a generated project gets) and in
+**this repo's own CI**. Epic #751.
+
+Consult on demand; the per-turn rules stay in `CLAUDE.md`. When you add,
+promote, demote, or drop a gate, update this file **and** the workflow in the same PR — a
+contract test (`tests/contracts/test_quality_gate_policy.py`) fails CI if the repo's
+required-check set drifts from the marker below.
+
+## Model: one thing gates, many inform
+
+Two knobs pull in opposite directions (#589):
+
+- **Required status checks** — what actually blocks a merge. *Fewer is strictly better.*
+  Exactly one context gates each repo: the `ci-gate` aggregator job. It fans in the jobs
+  that must pass and asserts every result is `success` (`if: always()`, so a *skipped*
+  dependency also reds the gate). Robust to matrix renames.
+- **Jobs / steps** — the rows you see run. Many, deliberately. Advisory scans
+  (semgrep, license-scan, scorecard, fuzz, mutation) run and surface findings but are **not**
+  in `ci-gate.needs`, so they inform without blocking until calibrated. Collapsing them into
+  the gate loses failure isolation and the advisory/blocking split.
+
+**The template is the canonical policy; this repo is a faithful *subset* of it.** The
+scaffolded output is the product and gates itself most strictly. The repo adopts the gates
+that earn their keep on a small, single-language (Python) scaffolder repo and documents the
+rest as deliberately not adopted — the same declared-divergence discipline the semi-scaffold
+sync uses (`tools/sync_agents_from_templates.py`, PI-685).
+
+## Repo required-check set (source of truth)
+
+The `ci-gate` job in `.github/workflows/ci.yml` must require exactly these contexts. The
+drift-guard test asserts this list equals `ci-gate.needs`:
+
+<!-- required-gates: lint-and-test, wheel-smoke, secret-scan, shellcheck -->
+
+- `lint-and-test` — ruff check + mypy `--strict` + pytest (with coverage) + pip-audit, across the Python matrix
+- `wheel-smoke` — build the wheel, scaffold from it, assert no unrendered placeholders / exec bits
+- `secret-scan` — gitleaks full-history scan
+- `shellcheck` — shellcheck over rendered scaffold scripts
+
+## Inventory & decisions
+
+Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto the repo),
+**demote** (advisory), **drop**. "Template" = scaffolded output; "Repo" = this repo's own CI.
+
+| Gate | Template | Repo | Decision | Rationale |
+|---|---|---|---|---|
+| `ci-gate` aggregator | ✅ single required check | ✅ single required check | **keep** both | One gate, matrix-rename-robust. |
+| ruff `check` (lint + `S`/bandit) | ✅ blocking | ✅ blocking | **keep** both | Lint + in-linter SAST. |
+| ruff `format --check` | ✅ in `just lint` | ❌ (#726) | **promote** repo → add | Repo ships a format gate it doesn't run on itself. |
+| mypy `--strict` | ✅ blocking | ✅ blocking | **keep** both | Type gate, dogfooded (#639). |
+| Test coverage floor | ✅ 70% blocking (×4 langs) | ❌ ~92% measured, no `fail_under` | **promote** repo → 85% floor | Catch regressions; 85% keeps headroom below current ~92% so unrelated PRs don't red on a number nobody chose. |
+| pip-audit (SCA) | ✅ blocking | ✅ blocking | **keep** both | Dependency CVE scan. |
+| gitleaks secret-scan | ✅ blocking | ✅ blocking | **keep** both | Full-history secret scan. |
+| wheel-smoke | — (repo-specific) | ✅ blocking | **keep** repo | Proves the built wheel scaffolds; no template analogue. |
+| semgrep SAST | ✅ advisory | ❌ | **promote** repo → advisory | Semantic SAST; advisory until calibrated, matching the template. |
+| license-scan | ✅ advisory | ❌ | **promote** repo → advisory | Deny GPL/AGPL; advisory while the deny-list is calibrated. |
+| scorecard | ✅ weekly cron, advisory | ❌ | **keep** template; **not adopted** by repo | OSSF posture score is low-ROI on a solo scaffolder repo. |
+| fuzz | ✅ nightly cron, advisory | ❌ | **keep** template; **not adopted** by repo | Property/fuzz targets are a per-project concern, not this repo's. |
+| Mutation gate | ✅ nightly, 80% kill (Python) | ❌ | **keep** template; repo uses the on-demand skill | Test-strength on the repo is covered by the `verify-test-strength` skill (#747, PR #756); a nightly mutation *gate* on this repo is not worth the runtime. |
+| Container/Dockerfile/trivy | ✅ advisory (delivery only) | ❌ (repo ships no image) | **n/a** to repo | Repo has no container surface. |
+
+## The four known gaps — decisions
+
+1. **ruff format** (#726) — **promote**: add `ruff format --check .` to the repo's lint step.
+   A one-time repo-wide `ruff format .` reformat commit precedes the check (large mechanical
+   diff is expected). Follow-up PR under #751.
+2. **Coverage floor** — **promote**: gate the repo at **85%** via `--cov-fail-under=85` in the
+   CI pytest step and `just test-cov` (fast `just test`/`test-quick` stay floor-free). The
+   template keeps 70% (a fresh scaffold's baseline). Follow-up PR under #751.
+3. **Security-scan parity** — **promote (advisory)**: add semgrep + license-scan jobs to the
+   repo, advisory (not in `ci-gate.needs`), mirroring the template posture. scorecard/fuzz stay
+   template-only (see table). Follow-up PR under #751.
+4. **Test-strength** (#747) — **resolved**: the `verify-test-strength` skill ships and is the
+   on-demand mechanism for both repo and output; the template additionally runs a nightly
+   mutation gate. No repo mutation *gate* is added (calibrated-not-maximal).
+
+## Deliberately not adopted by this repo
+
+Documented so their absence is a decision, not an oversight:
+
+- **scorecard** — OSSF Scorecard posture reporting; low ROI for a single-maintainer scaffolder.
+- **fuzz** — fuzz/property targets are a scaffolded-project concern; this repo has no fuzz surface.
+- **mutation gate** — test-strength is exercised via the `verify-test-strength` skill on demand
+  rather than a nightly CI gate on this repo.
+- **container/trivy/hadolint** — the repo publishes a wheel, not an image.
+
+## CI cost note
+
+The repo's required path is a single Python job matrix plus three light jobs (wheel-smoke,
+gitleaks, shellcheck). The advisory scans added under gap 3 run in parallel off the critical
+path and do not extend `ci-gate` wall-clock. Runner-minute deltas from each follow-up PR are
+noted in that PR rather than measured as a separate study.

--- a/tests/contracts/test_quality_gate_policy.py
+++ b/tests/contracts/test_quality_gate_policy.py
@@ -11,7 +11,8 @@ jobs via its `needs:` list. If the two diverge, either the policy doc is stale o
 required gate was added/removed without updating the policy — this test fails so the
 divergence is caught in CI, not in production `main`.
 
-Stdlib only (no pyyaml, per repo convention); both sides are parsed with regexes
+Both sides are parsed with stdlib regexes — the marker isn't YAML and the ci-gate
+`needs:` list is a single well-known line, so a full YAML parse buys nothing here —
 tight enough to fail loudly if the shapes they target change.
 """
 
@@ -32,16 +33,25 @@ _CI_GATE_NEEDS_RE = re.compile(
 )
 
 
+def _split_gates(raw: str, source: str) -> set[str]:
+    # Return a set for comparison, but fail loudly on a duplicate first — a set
+    # would silently swallow a doubled gate and hide the drift it should catch.
+    items = [g.strip() for g in raw.split(",") if g.strip()]
+    dupes = [g for g in set(items) if items.count(g) > 1]
+    assert not dupes, f"duplicate gate(s) {sorted(dupes)} in {source}"
+    return set(items)
+
+
 def _declared_required_gates() -> set[str]:
-    m = _MARKER_RE.search(_POLICY.read_text())
+    m = _MARKER_RE.search(_POLICY.read_text(encoding="utf-8"))
     assert m, "required-gates marker missing from quality-gates.md"
-    return {g.strip() for g in m.group(1).split(",") if g.strip()}
+    return _split_gates(m.group(1), "quality-gates.md marker")
 
 
 def _ci_gate_needs() -> set[str]:
-    m = _CI_GATE_NEEDS_RE.search(_CI.read_text())
+    m = _CI_GATE_NEEDS_RE.search(_CI.read_text(encoding="utf-8"))
     assert m, "ci-gate job with an inline `needs: [...]` list not found in ci.yml"
-    return {g.strip() for g in m.group(1).split(",") if g.strip()}
+    return _split_gates(m.group(1), "ci.yml ci-gate.needs")
 
 
 def test_policy_marker_is_parseable_and_nonempty():
@@ -66,5 +76,5 @@ def test_required_set_matches_ci_gate_needs():
 
 def test_policy_doc_is_linked_from_claude_md():
     # The policy is only discoverable if CLAUDE.md points at it (acceptance criterion).
-    claude_md = (_REPO_ROOT / "CLAUDE.md").read_text()
+    claude_md = (_REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
     assert "docs/development/quality-gates.md" in claude_md

--- a/tests/contracts/test_quality_gate_policy.py
+++ b/tests/contracts/test_quality_gate_policy.py
@@ -1,0 +1,70 @@
+"""PI-757 (epic #751): the repo's required-check set must not drift from the
+documented quality-gate policy.
+
+`docs/development/quality-gates.md` declares the single source of truth for which
+CI contexts gate a merge, in a machine-readable marker:
+
+    <!-- required-gates: lint-and-test, wheel-smoke, secret-scan, shellcheck -->
+
+The `ci-gate` aggregator job in `.github/workflows/ci.yml` fans in exactly those
+jobs via its `needs:` list. If the two diverge, either the policy doc is stale or a
+required gate was added/removed without updating the policy — this test fails so the
+divergence is caught in CI, not in production `main`.
+
+Stdlib only (no pyyaml, per repo convention); both sides are parsed with regexes
+tight enough to fail loudly if the shapes they target change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_POLICY = _REPO_ROOT / "docs" / "development" / "quality-gates.md"
+_CI = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+_MARKER_RE = re.compile(r"<!--\s*required-gates:\s*(.+?)\s*-->")
+# The ci-gate job's `needs: [a, b, c]` inline list. Anchored to the `ci-gate:`
+# job so an unrelated `needs:` elsewhere in the workflow can't match.
+_CI_GATE_NEEDS_RE = re.compile(
+    r"^\s*ci-gate:\s*$.*?^\s*needs:\s*\[(.+?)\]", re.MULTILINE | re.DOTALL
+)
+
+
+def _declared_required_gates() -> set[str]:
+    m = _MARKER_RE.search(_POLICY.read_text())
+    assert m, "required-gates marker missing from quality-gates.md"
+    return {g.strip() for g in m.group(1).split(",") if g.strip()}
+
+
+def _ci_gate_needs() -> set[str]:
+    m = _CI_GATE_NEEDS_RE.search(_CI.read_text())
+    assert m, "ci-gate job with an inline `needs: [...]` list not found in ci.yml"
+    return {g.strip() for g in m.group(1).split(",") if g.strip()}
+
+
+def test_policy_marker_is_parseable_and_nonempty():
+    gates = _declared_required_gates()
+    assert gates, "quality-gates.md declares an empty required-gates set"
+
+
+def test_ci_gate_needs_is_parseable_and_nonempty():
+    needs = _ci_gate_needs()
+    assert needs, "ci-gate.needs parsed as empty"
+
+
+def test_required_set_matches_ci_gate_needs():
+    declared = _declared_required_gates()
+    actual = _ci_gate_needs()
+    assert declared == actual, (
+        "Required-gate drift: quality-gates.md declares "
+        f"{sorted(declared)} but ci.yml ci-gate.needs is {sorted(actual)}. "
+        "Update both together (docs/development/quality-gates.md marker + ci.yml)."
+    )
+
+
+def test_policy_doc_is_linked_from_claude_md():
+    # The policy is only discoverable if CLAUDE.md points at it (acceptance criterion).
+    claude_md = (_REPO_ROOT / "CLAUDE.md").read_text()
+    assert "docs/development/quality-gates.md" in claude_md


### PR DESCRIPTION
## Summary

Epic #751 foundation — the canonical, deliberately-calibrated quality/security-gate policy, plus a drift guard.

- **`docs/development/quality-gates.md`** — one policy for both surfaces: the scaffolded template is canonical, this repo's own CI is a faithful *subset*. Full inventory table with a **keep/promote/demote/drop** decision + rationale per gate; the four-gaps decisions; a "deliberately not adopted by the repo" section (scorecard/fuzz/mutation/container). Declares the repo's required-check set in a machine-readable marker.
- **`tests/contracts/test_quality_gate_policy.py`** — fails CI if `ci-gate.needs` in `ci.yml` drifts from the documented required set (and asserts CLAUDE.md links the doc).
- **`CLAUDE.md`** — links the policy from the Reference (on demand) section.

## Premise correction

The epic assumed the repo lacks a `ci-gate` aggregator. It has one. The real gap is the repo lagging the template on coverage floor / `ruff format --check` / semgrep / license-scan — addressed in follow-up PRs under #751 (foundation-first).

## Verification

- Break-it check: desyncing the required-gates marker fails the drift guard; restoring passes. ✅
- Full suite: 2277 passed, 10 skipped. `ruff check .` clean. `mkdocs build --strict` clean.

Closes #757