### PR TITLE
feat(PI-759): lighter pre-push gate (both surfaces); CI parallelization deferred to #762

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,30 +1,31 @@
 #!/usr/bin/env bash
 # pre-push gate for the project-init repo itself (dogfood).
 #
-# Runs the SAME `just ci` (lint + tests) that CI runs, before the push leaves
-# the machine — so nothing red reaches a PR and the push→CI-fail→fix→re-push
-# loop is caught locally. This is the local↔CI parity gate whose absence let a
-# fresh-scaffold lint failure ship (the scaffolder's CI caught it only after a
-# push, and even then incompletely).
+# Runs the fast local gate `just fast-check` (lint + parallel tests) before the
+# push leaves the machine — so the common break (a failing test or lint error)
+# is caught locally instead of via the push→CI-fail→fix→re-push loop. It is
+# deliberately lighter than the full `just ci`: typecheck + audit run in CI,
+# which stays the hard backstop, so we don't re-run the whole gate on every push
+# (PI-759).
 #
 # Enabled automatically by `just setup` (git config core.hooksPath .githooks).
 # Bypass in an emergency with: git push --no-verify
 set -euo pipefail
 
 if command -v just >/dev/null 2>&1; then
-  # `just ci` tests the working tree, but the push ships the committed tree.
-  # Skip (fail-open) on a dirty worktree rather than test a tree that isn't what
-  # gets pushed — a WIP fix could mask a failure, or unrelated WIP fail a clean
-  # push. CI stays the backstop.
+  # `just fast-check` tests the working tree, but the push ships the committed
+  # tree. Skip (fail-open) on a dirty worktree rather than test a tree that isn't
+  # what gets pushed — a WIP fix could mask a failure, or unrelated WIP fail a
+  # clean push. CI stays the backstop.
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    echo "pre-push: working tree is dirty — skipping the 'just ci' gate" >&2
+    echo "pre-push: working tree is dirty — skipping the 'just fast-check' gate" >&2
     echo "  (it would test the worktree, not the commit being pushed)." >&2
     echo "  Commit or stash your changes to run the gate before pushing." >&2
   else
-    echo "pre-push: running 'just ci' (lint + tests)…"
-    if ! just ci; then
+    echo "pre-push: running 'just fast-check' (lint + tests)…"
+    if ! just fast-check; then
       echo ""
-      echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+      echo "❌ pre-push: 'just fast-check' failed — fix the errors above before pushing."
       echo "   (bypass in an emergency with: git push --no-verify)"
       exit 1
     fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # pre-push gate for the project-init repo itself (dogfood).
 #
-# Runs the fast local gate `just fast-check` (lint + parallel tests) before the
+# Runs the fast local gate `just fast-ci` (lint + parallel tests) before the
 # push leaves the machine — so the common break (a failing test or lint error)
 # is caught locally instead of via the push→CI-fail→fix→re-push loop. It is
 # deliberately lighter than the full `just ci`: typecheck + audit run in CI,
@@ -12,24 +12,24 @@
 # Bypass in an emergency with: git push --no-verify
 set -euo pipefail
 
-if command -v just >/dev/null 2>&1 && just --show fast-check >/dev/null 2>&1; then
-  # `just fast-check` tests the working tree, but the push ships the committed
+if command -v just >/dev/null 2>&1 && just --show fast-ci >/dev/null 2>&1; then
+  # `just fast-ci` tests the working tree, but the push ships the committed
   # tree. Skip (fail-open) on a dirty worktree rather than test a tree that isn't
   # what gets pushed — a WIP fix could mask a failure, or unrelated WIP fail a
   # clean push. CI stays the backstop.
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    echo "pre-push: working tree is dirty — skipping the 'just fast-check' gate" >&2
+    echo "pre-push: working tree is dirty — skipping the 'just fast-ci' gate" >&2
     echo "  (it would test the worktree, not the commit being pushed)." >&2
     echo "  Commit or stash your changes to run the gate before pushing." >&2
   else
-    echo "pre-push: running 'just fast-check' (lint + tests)…"
-    if ! just fast-check; then
+    echo "pre-push: running 'just fast-ci' (lint + tests)…"
+    if ! just fast-ci; then
       echo ""
-      echo "❌ pre-push: 'just fast-check' failed — fix the errors above before pushing."
+      echo "❌ pre-push: 'just fast-ci' failed — fix the errors above before pushing."
       echo "   (bypass in an emergency with: git push --no-verify)"
       exit 1
     fi
   fi
 else
-  echo "pre-push: 'just'/the 'fast-check' recipe not available — skipping local gate (CI still runs)." >&2
+  echo "pre-push: 'just'/the 'fast-ci' recipe not available — skipping local gate (CI still runs)." >&2
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,7 +12,7 @@
 # Bypass in an emergency with: git push --no-verify
 set -euo pipefail
 
-if command -v just >/dev/null 2>&1; then
+if command -v just >/dev/null 2>&1 && just --show fast-check >/dev/null 2>&1; then
   # `just fast-check` tests the working tree, but the push ships the committed
   # tree. Skip (fail-open) on a dirty worktree rather than test a tree that isn't
   # what gets pushed — a WIP fix could mask a failure, or unrelated WIP fail a
@@ -31,5 +31,5 @@ if command -v just >/dev/null 2>&1; then
     fi
   fi
 else
-  echo "pre-push: 'just' not found — skipping local CI gate (CI still runs)." >&2
+  echo "pre-push: 'just'/the 'fast-check' recipe not available — skipping local gate (CI still runs)." >&2
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,13 @@ jobs:
         run: just typecheck
 
       - name: Tests (pytest)
-        # Serial execution avoids xdist cross-test interference in upgrade
-        # drift checks while preserving the same assertions CI enforces.
+        # Parallel execution (xdist) is the CI wall-clock long pole's fix (PI-759):
+        # the upgrade drift checks that once forced serial were isolated (#668),
+        # so `-n auto` runs green and roughly halves this step. pytest-cov combines
+        # the per-worker data files (coverage `parallel = true`).
         # --cov reports coverage (#636) without gating on it: no fail_under, so
         # a dip is visible in the log and never blocks an unrelated PR.
-        run: uv run pytest --tb=short -q --cov --cov-report=term-missing
+        run: uv run pytest -n auto --tb=short -q --cov --cov-report=term-missing
 
       # Dependency vulnerability scan (#637). gitleaks (secret-scan job) catches
       # committed secrets; nothing else here catches a correctly-spelled dep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,16 @@ jobs:
         run: just typecheck
 
       - name: Tests (pytest)
-        # Parallel execution (xdist) is the CI wall-clock long pole's fix (PI-759):
-        # the upgrade drift checks that once forced serial were isolated (#668),
-        # so `-n auto` runs green and roughly halves this step. pytest-cov combines
-        # the per-worker data files (coverage `parallel = true`).
+        # Serial in CI, deliberately (PI-759/PI-762). Parallel (`-n auto`) cut this
+        # step ~5m→~2m, but surfaced a rare cross-test interference under CI's
+        # worker scheduling (a memory-lint test read a wrong/corrupt tree) that
+        # local runs did not reproduce. CI must stay deterministic — a flaky red on
+        # an unrelated PR costs more than the minutes saved — so parallelizing CI
+        # safely (root-cause the interference, or split tests into parallel jobs)
+        # is tracked in PI-762. `just test` runs `-n auto` locally for dev speed.
         # --cov reports coverage (#636) without gating on it: no fail_under, so
         # a dip is visible in the log and never blocks an unrelated PR.
-        run: uv run pytest -n auto --tb=short -q --cov --cov-report=term-missing
+        run: uv run pytest --tb=short -q --cov --cov-report=term-missing
 
       # Dependency vulnerability scan (#637). gitleaks (secret-scan job) catches
       # committed secrets; nothing else here catches a correctly-spelled dep

--- a/justfile
+++ b/justfile
@@ -23,19 +23,19 @@ format:
 typecheck:
     uv run --with "mypy>=1.10" --with pip mypy --install-types --non-interactive src/
 
-# The suite is xdist-safe: the upgrade drift checks that once forced serial
-# execution were isolated (#668 frozen-templates fixture), so `-n auto` runs
-# green and roughly halves wall-clock.
+# Parallel locally for dev-loop speed (~halves wall-clock). CI runs this suite
+# SERIALLY on purpose — a rare cross-test interference surfaces under parallel
+# scheduling (PI-762); a local flake is low-stakes (re-run), but CI must stay
+# deterministic. Remove `-n auto` here too if a local flake ever bites.
 # run the test suite in parallel (xdist)
 test:
     uv run pytest -n auto --tb=short -q
 
 # Coverage (#636) is drift visibility, no floor. Kept off `just test` so the
-# default loop stays fast; CI runs this one. pytest-cov combines the per-worker
-# data files (coverage `parallel = true`).
-# run the test suite in parallel with a coverage report
+# default loop stays fast; CI runs this one (serially — see `test`).
+# run the test suite with a coverage report
 test-cov:
-    uv run pytest -n auto --tb=short -q --cov --cov-report=term-missing
+    uv run pytest --tb=short -q --cov --cov-report=term-missing
 
 # fast iterate loop — stop at first failure, minimal output. Use while
 # debugging to keep test noise out of agent context; run `just test` for the

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 # in the tools and their configs, never in this file.
 
 # install/sync dev dependencies + enable the local pre-push gate (dogfood).
-# core.hooksPath points git at .githooks/, so `just fast-check` runs before every push.
+# core.hooksPath points git at .githooks/, so `just fast-ci` runs before every push.
 setup:
     uv sync --group dev
     git config core.hooksPath .githooks
@@ -68,7 +68,7 @@ ci: lint typecheck test audit
 # backstop, so we don't re-run the whole gate before every push (PI-759). Keeps
 # the push→CI loop fast while still catching the common break (a failing test).
 # fast local gate for the pre-push hook: lint + parallel tests
-fast-check: lint test
+fast-ci: lint test
 
 # sync the plugin payload from templates (PI-129)
 sync-plugin:

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@
 # `just --list` shows every recipe. Recipes are thin wrappers — logic lives
 # in the tools and their configs, never in this file.
 
-# install/sync dev dependencies + enable the local pre-push CI gate (dogfood).
-# core.hooksPath points git at .githooks/, so `just ci` runs before every push.
+# install/sync dev dependencies + enable the local pre-push gate (dogfood).
+# core.hooksPath points git at .githooks/, so `just fast-check` runs before every push.
 setup:
     uv sync --group dev
     git config core.hooksPath .githooks
@@ -23,14 +23,19 @@ format:
 typecheck:
     uv run --with "mypy>=1.10" --with pip mypy --install-types --non-interactive src/
 
-# run the test suite
+# The suite is xdist-safe: the upgrade drift checks that once forced serial
+# execution were isolated (#668 frozen-templates fixture), so `-n auto` runs
+# green and roughly halves wall-clock.
+# run the test suite in parallel (xdist)
 test:
-    uv run pytest --tb=short -q
+    uv run pytest -n auto --tb=short -q
 
-# run the test suite with a coverage report (#636) — drift visibility, no floor.
-# Kept off `just test` so the default loop stays fast; CI runs this one.
+# Coverage (#636) is drift visibility, no floor. Kept off `just test` so the
+# default loop stays fast; CI runs this one. pytest-cov combines the per-worker
+# data files (coverage `parallel = true`).
+# run the test suite in parallel with a coverage report
 test-cov:
-    uv run pytest --tb=short -q --cov --cov-report=term-missing
+    uv run pytest -n auto --tb=short -q --cov --cov-report=term-missing
 
 # fast iterate loop — stop at first failure, minimal output. Use while
 # debugging to keep test noise out of agent context; run `just test` for the
@@ -56,8 +61,14 @@ docs:
 audit:
     uv run --all-extras --with pip-audit pip-audit
 
-# what CI runs
+# what CI runs (the full gate)
 ci: lint typecheck test audit
+
+# Deliberately lighter than `ci` — no typecheck/audit here; CI is the full
+# backstop, so we don't re-run the whole gate before every push (PI-759). Keeps
+# the push→CI loop fast while still catching the common break (a failing test).
+# fast local gate for the pre-push hook: lint + parallel tests
+fast-check: lint test
 
 # sync the plugin payload from templates (PI-129)
 sync-plugin:

--- a/templates/base/dot_github/hooks/pre-push.tmpl
+++ b/templates/base/dot_github/hooks/pre-push.tmpl
@@ -62,8 +62,10 @@ while read -r _ local_sha remote_ref _; do
 # so this catches the common break (a failing test or lint error) without
 # duplicating the whole suite on every push. Only fires for a real branch push
 # (not tag/delete). Fail-CLOSED when `just`/the recipe are present (block the
-# push, bypassable with `git push --no-verify`); fail-open when the toolchain is
-# absent — CI stays the hard backstop.
+# push, bypassable with `git push --no-verify`); fail-open when `just` or the
+# `fast-check` recipe is absent — CI stays the hard backstop. (If `just` and the
+# recipe are present but a language tool is missing, the recipe itself decides:
+# the day-one guards skip cleanly, a genuinely missing linter fails closed.)
 if [[ "$PUSHING_BRANCH" == "1" ]]; then
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
   if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&

--- a/templates/base/dot_github/hooks/pre-push.tmpl
+++ b/templates/base/dot_github/hooks/pre-push.tmpl
@@ -56,31 +56,33 @@ while read -r _ local_sha remote_ref _; do
   fi
 {{/if lifecycle}}done
 
-# Full CI gate before the push leaves the machine: run the SAME `just ci`
-# (lint + full test suite) that CI runs, so nothing red reaches a PR and the
-# push→CI-fail→fix→re-push loop is caught locally instead. Only fires for a
-# real branch push (not tag/delete). Fail-CLOSED when `just`/the recipe are
-# present (block the push, bypassable with `git push --no-verify`); fail-open
-# when the toolchain is absent — CI stays the hard backstop.
+# Fast local gate before the push leaves the machine: run `just fast-check`
+# (lint + parallel tests) — deliberately lighter than the full `just ci` so the
+# push stays fast. CI re-runs the full gate (typecheck/coverage/audit + more),
+# so this catches the common break (a failing test or lint error) without
+# duplicating the whole suite on every push. Only fires for a real branch push
+# (not tag/delete). Fail-CLOSED when `just`/the recipe are present (block the
+# push, bypassable with `git push --no-verify`); fail-open when the toolchain is
+# absent — CI stays the hard backstop.
 if [[ "$PUSHING_BRANCH" == "1" ]]; then
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
   if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
-    (cd "$REPO_ROOT" && just --show ci >/dev/null 2>&1); then
-    # `just ci` runs against the working tree, but the push ships the committed
-    # tree. If the worktree is dirty (uncommitted changes or untracked files),
-    # testing it would give a false result either way — a WIP fix could hide a
-    # failure in the pushed commit, or unrelated WIP could fail a clean push.
-    # So skip the gate (fail-open) with a clear nudge instead of testing a tree
-    # that isn't what's being pushed; CI stays the backstop.
+    (cd "$REPO_ROOT" && just --show fast-check >/dev/null 2>&1); then
+    # `just fast-check` runs against the working tree, but the push ships the
+    # committed tree. If the worktree is dirty (uncommitted changes or untracked
+    # files), testing it would give a false result either way — a WIP fix could
+    # hide a failure in the pushed commit, or unrelated WIP could fail a clean
+    # push. So skip the gate (fail-open) with a clear nudge instead of testing a
+    # tree that isn't what's being pushed; CI stays the backstop.
     if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-      echo "pre-push: working tree is dirty — skipping the 'just ci' gate" >&2
+      echo "pre-push: working tree is dirty — skipping the 'just fast-check' gate" >&2
       echo "  (it would test the worktree, not the commit being pushed)." >&2
       echo "  Commit or stash your changes to run the gate before pushing." >&2
     else
-      echo "pre-push: running 'just ci' (lint + tests) before push…"
-      if ! (cd "$REPO_ROOT" && just ci); then
+      echo "pre-push: running 'just fast-check' (lint + tests) before push…"
+      if ! (cd "$REPO_ROOT" && just fast-check); then
         echo ""
-        echo "❌ pre-push: 'just ci' failed — fix the errors above before pushing."
+        echo "❌ pre-push: 'just fast-check' failed — fix the errors above before pushing."
         echo "   (bypass in an emergency with: git push --no-verify)"
         exit 1
       fi

--- a/templates/base/dot_github/hooks/pre-push.tmpl
+++ b/templates/base/dot_github/hooks/pre-push.tmpl
@@ -56,35 +56,35 @@ while read -r _ local_sha remote_ref _; do
   fi
 {{/if lifecycle}}done
 
-# Fast local gate before the push leaves the machine: run `just fast-check`
+# Fast local gate before the push leaves the machine: run `just fast-ci`
 # (lint + parallel tests) — deliberately lighter than the full `just ci` so the
 # push stays fast. CI re-runs the full gate (typecheck/coverage/audit + more),
 # so this catches the common break (a failing test or lint error) without
 # duplicating the whole suite on every push. Only fires for a real branch push
 # (not tag/delete). Fail-CLOSED when `just`/the recipe are present (block the
 # push, bypassable with `git push --no-verify`); fail-open when `just` or the
-# `fast-check` recipe is absent — CI stays the hard backstop. (If `just` and the
+# `fast-ci` recipe is absent — CI stays the hard backstop. (If `just` and the
 # recipe are present but a language tool is missing, the recipe itself decides:
 # the day-one guards skip cleanly, a genuinely missing linter fails closed.)
 if [[ "$PUSHING_BRANCH" == "1" ]]; then
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "$0")/../.." && pwd))"
   if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
-    (cd "$REPO_ROOT" && just --show fast-check >/dev/null 2>&1); then
-    # `just fast-check` runs against the working tree, but the push ships the
+    (cd "$REPO_ROOT" && just --show fast-ci >/dev/null 2>&1); then
+    # `just fast-ci` runs against the working tree, but the push ships the
     # committed tree. If the worktree is dirty (uncommitted changes or untracked
     # files), testing it would give a false result either way — a WIP fix could
     # hide a failure in the pushed commit, or unrelated WIP could fail a clean
     # push. So skip the gate (fail-open) with a clear nudge instead of testing a
     # tree that isn't what's being pushed; CI stays the backstop.
     if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-      echo "pre-push: working tree is dirty — skipping the 'just fast-check' gate" >&2
+      echo "pre-push: working tree is dirty — skipping the 'just fast-ci' gate" >&2
       echo "  (it would test the worktree, not the commit being pushed)." >&2
       echo "  Commit or stash your changes to run the gate before pushing." >&2
     else
-      echo "pre-push: running 'just fast-check' (lint + tests) before push…"
-      if ! (cd "$REPO_ROOT" && just fast-check); then
+      echo "pre-push: running 'just fast-ci' (lint + tests) before push…"
+      if ! (cd "$REPO_ROOT" && just fast-ci); then
         echo ""
-        echo "❌ pre-push: 'just fast-check' failed — fix the errors above before pushing."
+        echo "❌ pre-push: 'just fast-ci' failed — fix the errors above before pushing."
         echo "   (bypass in an emergency with: git push --no-verify)"
         exit 1
       fi

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -89,7 +89,7 @@ ci: setup lint typecheck test-cov audit
 
 # fast local gate for the pre-push hook: lint + parallel tests (CI is the full
 # backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
-fast-check: lint test
+fast-ci: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -192,7 +192,7 @@ ci: setup lint typecheck test audit
 
 # fast local gate for the pre-push hook: lint + parallel tests (CI is the full
 # backstop, so pre-push stays fast and doesn't re-run typecheck/audit)
-fast-check: lint test
+fast-ci: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -289,7 +289,7 @@ ci: lint typecheck test-cov audit
 
 # fast local gate for the pre-push hook: lint + parallel tests (CI is the full
 # backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
-fast-check: lint test
+fast-ci: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -400,7 +400,7 @@ ci: lint typecheck test-cov audit
 
 # fast local gate for the pre-push hook: lint + parallel tests (CI is the full
 # backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
-fast-check: lint test
+fast-ci: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md

--- a/templates/base/justfile.tmpl
+++ b/templates/base/justfile.tmpl
@@ -84,8 +84,12 @@ license:
 fuzz:
     uv run --with hypothesis --with pytest-xdist pytest -n auto --tb=short -q
 
-# what CI runs
+# what CI runs (the full gate)
 ci: setup lint typecheck test-cov audit
+
+# fast local gate for the pre-push hook: lint + parallel tests (CI is the full
+# backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
+fast-check: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -183,8 +187,12 @@ fuzz:
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
-# what CI runs
+# what CI runs (the full gate)
 ci: setup lint typecheck test audit
+
+# fast local gate for the pre-push hook: lint + parallel tests (CI is the full
+# backstop, so pre-push stays fast and doesn't re-run typecheck/audit)
+fast-check: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -276,8 +284,12 @@ fuzz:
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
-# what CI runs
+# what CI runs (the full gate)
 ci: lint typecheck test-cov audit
+
+# fast local gate for the pre-push hook: lint + parallel tests (CI is the full
+# backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
+fast-check: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md
@@ -383,8 +395,12 @@ fuzz:
 scan:
     gitleaks git --pre-commit --staged --redact --no-banner --verbose
 
-# what CI runs
+# what CI runs (the full gate)
 ci: lint typecheck test-cov audit
+
+# fast local gate for the pre-push hook: lint + parallel tests (CI is the full
+# backstop, so pre-push stays fast and doesn't re-run typecheck/coverage/audit)
+fast-check: lint test
 
 # route CI to a self-hosted runner when Actions minutes run out (PI-666);
 # requires a registered runner — see .agents/docs/guides/self-hosted-ci-runner.md

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -94,6 +94,19 @@ class TestJustfilePerLanguage:
         text = (target / "justfile").read_text()
         assert re.search(r"^ci: setup lint typecheck test-cov audit\s*$", text, re.MULTILINE)
 
+    @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
+    def test_fast_check_is_lighter_than_ci(self, tmp_path: Path, language):
+        """PI-759: every language ships a `fast-check: lint test` recipe for the
+        pre-push hook — the fast local gate. It must be strictly lighter than
+        `ci` (no typecheck/audit/coverage), so pushing stays fast while CI runs
+        the full gate. The pre-push hook invokes exactly this recipe.
+        """
+        target = _scaffold_language(tmp_path / language, language)
+        text = (target / "justfile").read_text()
+        assert re.search(r"^fast-check: lint test\s*$", text, re.MULTILINE)
+        # Guard against silently promoting it back to the heavy gate.
+        assert not re.search(r"^fast-check:.*\b(typecheck|audit|test-cov)\b", text, re.MULTILINE)
+
     def test_node_ci_recipe_includes_typecheck(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "node")
         text = (target / "justfile").read_text()

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -104,8 +104,13 @@ class TestJustfilePerLanguage:
         target = _scaffold_language(tmp_path / language, language)
         text = (target / "justfile").read_text()
         assert re.search(r"^fast-check: lint test\s*$", text, re.MULTILINE)
-        # Guard against silently promoting it back to the heavy gate.
+        # Guard against silently promoting it back to the heavy gate — on the
+        # header line...
         assert not re.search(r"^fast-check:.*\b(typecheck|audit|test-cov)\b", text, re.MULTILINE)
+        # ...and in a body: `fast-check` must stay dependency-only, so a stray
+        # `just typecheck`/`audit` line can't sneak the heavy gate back in
+        # while the header still reads `lint test` (Copilot review, PR #760).
+        assert _recipe_body(text, "fast-check").strip() == ""
 
     def test_node_ci_recipe_includes_typecheck(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "node")

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -95,7 +95,7 @@ class TestJustfilePerLanguage:
         assert re.search(r"^ci: setup lint typecheck test-cov audit\s*$", text, re.MULTILINE)
 
     @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
-    def test_fast_check_is_lighter_than_ci(self, tmp_path: Path, language):
+    def test_fast_ci_is_lighter_than_ci(self, tmp_path: Path, language):
         """PI-759: every language ships a `fast-ci: lint test` recipe for the
         pre-push hook — the fast local gate. It must be strictly lighter than
         `ci` (no typecheck/audit/coverage), so pushing stays fast while CI runs

--- a/tests/contracts/test_justfile.py
+++ b/tests/contracts/test_justfile.py
@@ -96,21 +96,21 @@ class TestJustfilePerLanguage:
 
     @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
     def test_fast_check_is_lighter_than_ci(self, tmp_path: Path, language):
-        """PI-759: every language ships a `fast-check: lint test` recipe for the
+        """PI-759: every language ships a `fast-ci: lint test` recipe for the
         pre-push hook — the fast local gate. It must be strictly lighter than
         `ci` (no typecheck/audit/coverage), so pushing stays fast while CI runs
         the full gate. The pre-push hook invokes exactly this recipe.
         """
         target = _scaffold_language(tmp_path / language, language)
         text = (target / "justfile").read_text()
-        assert re.search(r"^fast-check: lint test\s*$", text, re.MULTILINE)
+        assert re.search(r"^fast-ci: lint test\s*$", text, re.MULTILINE)
         # Guard against silently promoting it back to the heavy gate — on the
         # header line...
-        assert not re.search(r"^fast-check:.*\b(typecheck|audit|test-cov)\b", text, re.MULTILINE)
-        # ...and in a body: `fast-check` must stay dependency-only, so a stray
+        assert not re.search(r"^fast-ci:.*\b(typecheck|audit|test-cov)\b", text, re.MULTILINE)
+        # ...and in a body: `fast-ci` must stay dependency-only, so a stray
         # `just typecheck`/`audit` line can't sneak the heavy gate back in
         # while the header still reads `lint test` (Copilot review, PR #760).
-        assert _recipe_body(text, "fast-check").strip() == ""
+        assert _recipe_body(text, "fast-ci").strip() == ""
 
     def test_node_ci_recipe_includes_typecheck(self, tmp_path: Path):
         target = _scaffold_language(tmp_path / "n", "node")

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -5,7 +5,7 @@ Three layers, each closing a gap the others leave:
 - **git `pre-commit`** now runs `just lint` (not only gitleaks), so a *human*
   committing from a terminal/IDE is held to the same static gate as CI — the
   Claude `pre_commit_gate.sh` only fires for agent-driven commits.
-- **git `pre-push`** runs the fast `just fast-check` (lint + parallel tests), so
+- **git `pre-push`** runs the fast `just fast-ci` (lint + parallel tests), so
   the common break is caught locally without re-running the full `just ci` (CI's
   job) before every push (PI-759).
 - **`pre_commit_gate.sh`** (the agent commit gate) gained a per-file shell block
@@ -68,13 +68,13 @@ def test_git_pre_commit_runs_lint_and_keeps_secret_scan(tmp_target: Path):
     assert "gitleaks" in pre_commit
 
 
-def test_git_pre_push_runs_fast_check(tmp_target: Path):
+def test_git_pre_push_runs_fast_ci(tmp_target: Path):
     _, pre_push = _git_hooks(tmp_target)
-    # The gate command is the lighter `just fast-check` (lint + parallel tests),
+    # The gate command is the lighter `just fast-ci` (lint + parallel tests),
     # not the full `just ci` — CI is the full backstop (PI-759). Assert the actual
     # invocation, not a substring that also appears in the explanatory comment.
-    assert "just fast-check" in pre_push
-    assert "just --show fast-check" in pre_push
+    assert "just fast-ci" in pre_push
+    assert "just --show fast-ci" in pre_push
     # Only for a real branch push, and still bypassable in an emergency.
     assert "PUSHING_BRANCH" in pre_push
     assert "--no-verify" in pre_push

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -5,8 +5,9 @@ Three layers, each closing a gap the others leave:
 - **git `pre-commit`** now runs `just lint` (not only gitleaks), so a *human*
   committing from a terminal/IDE is held to the same static gate as CI — the
   Claude `pre_commit_gate.sh` only fires for agent-driven commits.
-- **git `pre-push`** now runs `just ci`, so the push→CI-fail→fix→re-push loop is
-  caught locally.
+- **git `pre-push`** runs the fast `just fast-check` (lint + parallel tests), so
+  the common break is caught locally without re-running the full `just ci` (CI's
+  job) before every push (PI-759).
 - **`pre_commit_gate.sh`** (the agent commit gate) gained a per-file shell block
   so staged `.sh` files are `shfmt`/`shellcheck`'d even when `just` is absent.
 
@@ -67,9 +68,13 @@ def test_git_pre_commit_runs_lint_and_keeps_secret_scan(tmp_target: Path):
     assert "gitleaks" in pre_commit
 
 
-def test_git_pre_push_runs_ci(tmp_target: Path):
+def test_git_pre_push_runs_fast_check(tmp_target: Path):
     _, pre_push = _git_hooks(tmp_target)
-    assert "just ci" in pre_push
+    # The gate command is the lighter `just fast-check` (lint + parallel tests),
+    # not the full `just ci` — CI is the full backstop (PI-759). Assert the actual
+    # invocation, not a substring that also appears in the explanatory comment.
+    assert "just fast-check" in pre_push
+    assert "just --show fast-check" in pre_push
     # Only for a real branch push, and still bypassable in an emergency.
     assert "PUSHING_BRANCH" in pre_push
     assert "--no-verify" in pre_push

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -163,12 +163,12 @@ class TestPrePushLifecycleGate:
         self.target = tmp_target
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         self.hook = self.target / ".github" / "hooks" / "pre-push"
-        # Neutralize the hook's `just ci` gate: the hook runs from pytest's
-        # cwd (this repo), so with a real `just` on PATH and a CLEAN worktree
-        # the gate would run THIS repo's full suite — which re-runs this test,
+        # Neutralize the hook's `just fast-check` gate: the hook runs from
+        # pytest's cwd (this repo), so with a real `just` on PATH and a CLEAN
+        # worktree the gate would run THIS repo's suite — which re-runs this test,
         # recursively, forever (PI-649 discovery; only the branch-naming rules
         # are under test here). A stub `just` that exits nonzero makes the
-        # gate's `just --show ci` probe fail → deterministic fail-open.
+        # gate's `just --show fast-check` probe fail → deterministic fail-open.
         stub_bin = tmp_path / "stub-bin"
         stub_bin.mkdir(exist_ok=True)
         stub = stub_bin / "just"

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -163,12 +163,12 @@ class TestPrePushLifecycleGate:
         self.target = tmp_target
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         self.hook = self.target / ".github" / "hooks" / "pre-push"
-        # Neutralize the hook's `just fast-check` gate: the hook runs from
+        # Neutralize the hook's `just fast-ci` gate: the hook runs from
         # pytest's cwd (this repo), so with a real `just` on PATH and a CLEAN
         # worktree the gate would run THIS repo's suite — which re-runs this test,
         # recursively, forever (PI-649 discovery; only the branch-naming rules
         # are under test here). A stub `just` that exits nonzero makes the
-        # gate's `just --show fast-check` probe fail → deterministic fail-open.
+        # gate's `just --show fast-ci` probe fail → deterministic fail-open.
         stub_bin = tmp_path / "stub-bin"
         stub_bin.mkdir(exist_ok=True)
         stub = stub_bin / "just"


### PR DESCRIPTION
## Summary

Reduces the local push cost now; defers the CI wall-clock win because parallelizing surfaced a real (rare) test interference.

### Ships: lighter pre-push (both surfaces) — deterministic
The pre-push hook re-ran the **full** `just ci` before every push, duplicating what CI is about to do. New **`fast-ci: lint test`** recipe (no typecheck/coverage/audit) becomes the pre-push gate in both `.githooks/pre-push` (repo) and `pre-push.tmpl` (scaffolded output). CI stays the full backstop → fast push→CI loop, nothing dropped. Security stays cheap-and-local (gitleaks pre-commit untouched).

### Deferred: CI pytest parallelization → #762
`-n auto` **proved the win** on this PR's first CI run — the Tests step dropped **5m08s → 2m06s**. But that same run **failed once**: `test_lint_passes_on_clean_scaffold` read a wrong/corrupt tree under CI's worker scheduling — the exact cross-test interference the original serial comment named (this suite has known coupling; see the `_frozen_templates` session fixture). Local `-n auto` and `-n 4` did **not** reproduce it, so it can't be root-caused/isolated safely here. Shipping nondeterministic CI would cause flaky reds on unrelated PRs — the opposite of faster time-to-merge. CI reverts to **serial**; `just test` keeps `-n auto` for local dev speed. Parallelizing CI safely (root-cause, or split into parallel *jobs*) is #762.

## Tests
- New parametrized `test_fast_check_is_lighter_than_ci` (python/node/go/rust).
- Tightened `test_git_pre_push_runs_fast_ci` to assert the real `just fast-check` invocation (the old `just ci` substring assertion now only matches a comment — it would have passed for the wrong reason).
- shellcheck clean on both hooks.

## Scope
Epic #751. Matrix→nightly (cost) = #761. Safe CI parallelization = #762.

Closes #759