### PR TITLE
chore(PI-589): CI clustering policy + concurrency-cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ permissions:
 # Cancel a superseded run when a new commit is pushed to the SAME pull request
 # (PI-589). Review cycles re-push often; finishing an obsolete run just burns
 # runner-minutes. Gated to pull_request events so a `main` push is never
-# cancelled — same schedule-safe form the template ships.
+# cancelled. `github.event_name` is in the group key so push and PR runs never
+# share a group — same schedule-safe form the template ships.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: read
 
-# Cancel a superseded run when a new commit is pushed to the same ref (PI-589).
-# Review cycles re-push often; without this, every push leaves its predecessor
-# running to completion, burning runner-minutes on results nobody will read.
-# Keyed by workflow + ref; `main` pushes are not grouped with any PR's ref.
+# Cancel a superseded run when a new commit is pushed to the SAME pull request
+# (PI-589). Review cycles re-push often; finishing an obsolete run just burns
+# runner-minutes. Gated to pull_request events so a `main` push is never
+# cancelled — same schedule-safe form the template ships.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run when a new commit is pushed to the same ref (PI-589).
+# Review cycles re-push often; without this, every push leaves its predecessor
+# running to completion, burning runner-minutes on results nobody will read.
+# Keyed by workflow + ref; `main` pushes are not grouped with any PR's ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-test:
     name: Lint and test

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -63,6 +63,14 @@ render separately) and it widens the permission scope (board/review jobs need
 `projects`/`statuses` write), entangles triggers, and enlarges the blast radius
 of a single YAML error (#719).
 
+**Supersedes the original #589 proposal.** #589 first suggested regrouping jobs
+into ~3 workflow files to get GitHub checks-UI headings. That's the "merge the
+workflow files" move above — investigating it showed it doesn't reduce the visible
+rows and costs permission scope + trigger clarity, so we deliberately *don't* do
+it. Closing #589 with this policy is the reasoned resolution, not a dropped
+requirement: the cognitive-load goal is met by the one-required-gate model plus
+the drift guard, without the file reshuffle.
+
 **Adopted low-risk wins (both surfaces):** `concurrency: cancel-in-progress` on
 `ci.yml` — a new PR push cancels the superseded run, saving runner-minutes on
 review-cycle churn. Gated to `pull_request` events (`cancel-in-progress: ${{

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -40,6 +40,37 @@ drift-guard test asserts this list equals `ci-gate.needs`:
 - `secret-scan` — gitleaks full-history scan
 - `shellcheck` — shellcheck over rendered scaffold scripts
 
+## CI clustering policy (jobs & workflows) — #589
+
+"Consolidate the checks" splits into two things that pull opposite ways; only one
+is worth doing.
+
+**DO — one required check.** The `ci-gate` aggregator is the endorsed cluster:
+many jobs run and show individually, exactly one context (`ci-gate`) gates the
+merge. Already in place. This is the whole of "reduce what blocks a merge."
+
+**DON'T — merge jobs into one mega-job.** Collapsing `lint-and-test` /
+`secret-scan` / `shellcheck` / `wheel-smoke` into a single job is a regression:
+- kills parallelism (they run concurrently on separate runners; serialized, wall-clock = sum, not max — directly fights time-to-merge),
+- can't span OSes (`macos-portability`/`windows-portability` need their own runners),
+- loses failure isolation (one red X instead of "gitleaks vs shellcheck"),
+- loses per-piece conditional/scheduled triggers,
+- a flaky step re-runs the whole blob (no per-job re-run).
+
+**DON'T — merge the workflow files.** Folding `validate-pr` / `review-status` /
+`board-automation` into `ci.yml` doesn't reduce the visible rows (jobs still
+render separately) and it widens the permission scope (board/review jobs need
+`projects`/`statuses` write), entangles triggers, and enlarges the blast radius
+of a single YAML error (#719).
+
+**Adopted low-risk wins:** `concurrency: cancel-in-progress` on `ci.yml` (a new
+push cancels the superseded run — saves runner-minutes on review-cycle churn).
+
+**Considered, not adopted — a composite "setup" action.** The only step repeated
+across jobs is `Install uv` (5×, identical pinned SHA); renovate keeps those pins
+in sync automatically, so extracting a composite action adds indirection for
+negligible DRY gain. Revisit if per-job setup grows.
+
 ## Inventory & decisions
 
 Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto the repo),

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -63,8 +63,12 @@ render separately) and it widens the permission scope (board/review jobs need
 `projects`/`statuses` write), entangles triggers, and enlarges the blast radius
 of a single YAML error (#719).
 
-**Adopted low-risk wins:** `concurrency: cancel-in-progress` on `ci.yml` (a new
-push cancels the superseded run — saves runner-minutes on review-cycle churn).
+**Adopted low-risk wins (both surfaces):** `concurrency: cancel-in-progress` on
+`ci.yml` — a new PR push cancels the superseded run, saving runner-minutes on
+review-cycle churn. Gated to `pull_request` events (`cancel-in-progress: ${{
+github.event_name == 'pull_request' }}`) so scheduled (nightly/weekly) and
+base-branch-push runs are never cancelled — schedule-safe, so the template ships
+the same form.
 
 **Considered, not adopted — a composite "setup" action.** The only step repeated
 across jobs is `Install uv` (5×, identical pinned SHA); renovate keeps those pins

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -73,10 +73,11 @@ the drift guard, without the file reshuffle.
 
 **Adopted low-risk wins (both surfaces):** `concurrency: cancel-in-progress` on
 `ci.yml` — a new PR push cancels the superseded run, saving runner-minutes on
-review-cycle churn. Gated to `pull_request` events (`cancel-in-progress: ${{
-github.event_name == 'pull_request' }}`) so scheduled (nightly/weekly) and
-base-branch-push runs are never cancelled — schedule-safe, so the template ships
-the same form.
+review-cycle churn. `cancel-in-progress` is gated to pull-request events (its
+value is `${{ github.event_name == 'pull_request' }}`), so scheduled
+(nightly/weekly) and base-branch-push runs are never cancelled — schedule-safe,
+so the template ships the same form. The group key includes `github.event_name`
+so push/schedule/PR runs don't share a group and serialize.
 
 **Considered, not adopted — a composite "setup" action.** The only step repeated
 across jobs is `Install uv` (5×, identical pinned SHA); renovate keeps those pins

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -39,9 +39,12 @@ permissions:
 # (PI-589) — review cycles re-push often, and finishing an obsolete run just
 # burns runner-minutes. `cancel-in-progress` is gated to pull_request events, so
 # scheduled (nightly fuzz/mutation, weekly scorecard) and {{base_branch}}-push
-# runs are NEVER cancelled — they always complete.
+# runs are NEVER cancelled — they always complete. `github.event_name` is in the
+# group key so those non-PR runs don't share a group (they'd otherwise serialize:
+# a long nightly on {{base_branch}} would make a {{base_branch}} push CI queue
+# behind it).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -35,6 +35,15 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel a superseded run when a new commit is pushed to the SAME pull request
+# (PI-589) — review cycles re-push often, and finishing an obsolete run just
+# burns runner-minutes. `cancel-in-progress` is gated to pull_request events, so
+# scheduled (nightly fuzz/mutation, weekly scorecard) and {{base_branch}}-push
+# runs are NEVER cancelled — they always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 {{#if python}}
   # PI-214: derive the test matrix from requires-python at runtime, so the

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -51,6 +51,19 @@ class TestCiRunsOnEscapeHatch:
                 continue
             assert _EXPR in runs_on, f"{job} should read CI_RUNS_ON: {runs_on}"
 
+    def test_concurrency_cancels_only_pull_requests(self, tmp_target: Path):
+        """PI-589: the scaffolded ci.yml cancels a superseded PR run to save
+        runner-minutes, but ONLY for pull_request events — a nightly/weekly cron
+        or a base-branch push must never be cancelled mid-flight. A bare
+        `cancel-in-progress: true` would kill scheduled fuzz/mutation/scorecard
+        runs, so the gate on `github.event_name == 'pull_request'` is load-bearing.
+        """
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        text = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
+        assert "concurrency:" in text
+        assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in text
+        assert "cancel-in-progress: true" not in text
+
     def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         jobs = _jobs_with_runs_on(

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -70,12 +70,12 @@ class TestCiRunsOnEscapeHatch:
         # (which would cancel scheduled fuzz/mutation/scorecard runs) fails.
         assert cip is not True, "cancel-in-progress must be pull_request-gated, not a bare true"
         assert cip == "${{ github.event_name == 'pull_request' }}"
-        # The group must include github.event_name so push/schedule/PR runs get
-        # distinct groups — otherwise a long nightly on the base branch and a
-        # base-branch push would share a group and serialize. Lock it in.
-        assert "github.event_name" in str(concurrency.get("group", "")), (
-            "concurrency.group must include github.event_name to avoid "
-            "push/schedule runs serializing behind each other"
+        # Lock the exact group shape: github.ref keeps distinct PRs in distinct
+        # groups (so they don't cancel each other), and github.event_name keeps
+        # push/schedule/PR runs from sharing a group and serializing. Asserting
+        # the whole string catches any of the three being dropped in a refactor.
+        assert concurrency.get("group") == (
+            "${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}"
         )
 
     def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from project_init.scaffold import scaffold
 from tests.helpers import fallback_preset, fallback_variables
+from tests.workflow import load_workflow
 
 _EXPR = "${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}"
 
@@ -59,10 +60,15 @@ class TestCiRunsOnEscapeHatch:
         runs, so the gate on `github.event_name == 'pull_request'` is load-bearing.
         """
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        text = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
-        assert "concurrency:" in text
-        assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in text
-        assert "cancel-in-progress: true" not in text
+        concurrency = load_workflow(tmp_target).get("concurrency")
+        assert isinstance(concurrency, dict), "ci.yml has no concurrency block"
+        cip = concurrency["cancel-in-progress"]
+        # yaml parses a bare `true` to the boolean True; the gated expression
+        # parses to its string. Assert structurally so a comment mentioning
+        # "cancel-in-progress: true" can't fool the check, and a real bare-true
+        # (which would cancel scheduled fuzz/mutation/scorecard runs) fails.
+        assert cip is not True, "cancel-in-progress must be pull_request-gated, not a bare true"
+        assert cip == "${{ github.event_name == 'pull_request' }}"
 
     def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -62,6 +62,7 @@ class TestCiRunsOnEscapeHatch:
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         concurrency = load_workflow(tmp_target).get("concurrency")
         assert isinstance(concurrency, dict), "ci.yml has no concurrency block"
+        assert "cancel-in-progress" in concurrency, "concurrency block omits cancel-in-progress"
         cip = concurrency["cancel-in-progress"]
         # yaml parses a bare `true` to the boolean True; the gated expression
         # parses to its string. Assert structurally so a comment mentioning

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -70,6 +70,13 @@ class TestCiRunsOnEscapeHatch:
         # (which would cancel scheduled fuzz/mutation/scorecard runs) fails.
         assert cip is not True, "cancel-in-progress must be pull_request-gated, not a bare true"
         assert cip == "${{ github.event_name == 'pull_request' }}"
+        # The group must include github.event_name so push/schedule/PR runs get
+        # distinct groups — otherwise a long nightly on the base branch and a
+        # base-branch push would share a group and serialize. Lock it in.
+        assert "github.event_name" in str(concurrency.get("group", "")), (
+            "concurrency.group must include github.event_name to avoid "
+            "push/schedule runs serializing behind each other"
+        )
 
     def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())


### PR DESCRIPTION
## Summary

Consolidates the CI check surface **deliberately** — the honest conclusion of #589 is that the high-value cluster already exists, and the tempting ones are traps.

- **`quality-gates.md` — new "CI clustering policy" section:**
  - **DO** one required check (`ci-gate`) — already in place; this is the whole of "reduce what blocks a merge."
  - **DON'T** merge jobs into a mega-job — kills parallelism (wall-clock = sum not max), can't span OSes, loses failure isolation + conditional/scheduled triggers + per-job re-run.
  - **DON'T** merge workflow files — doesn't reduce rows, widens permission scope (board/review need write), enlarges YAML blast radius (#719).
  - Composite "setup" action: **considered, not adopted** — only `Install uv` repeats (5×) and renovate keeps those pins in sync, so it's indirection for negligible gain.
- **`ci.yml` — `concurrency: cancel-in-progress`:** a new push cancels the superseded run, saving runner-minutes on review-cycle churn (the one low-risk consolidation win).

## Why not more
Mega-job / file-merge consolidation trades away parallelism, isolation, and least-privilege for cosmetics — and mega-job makes CI *slower*, against the epic's time-to-merge goal. Documented so nobody "tidies" the parallelism away later; the drift guard from #758 keeps the required-check set honest.

## Verification
mkdocs `--strict`, workflow-lint gate, drift guard, full suite (2281 passed).

Closes #589