### PR TITLE
feat(PI-762): shard CI tests into parallel jobs (race-free, ~4x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  lint-and-test:
-    name: Lint and test
+  # Fast static gates across the full support window (#638) — cheap, so all three
+  # versions run per PR. Tests are NOT here: they are sharded into parallel jobs
+  # below (PI-762), and the full-matrix TEST run is nightly (nightly.yml). A
+  # version-specific test break is therefore caught within a day rather than
+  # per-PR — the deliberate speed/coverage trade of epic #751.
+  checks:
+    name: Lint, typecheck, audit
     runs-on: ubuntu-24.04
-    # Test across the full declared support window (#638). pyproject sets
-    # requires-python >=3.11 with 3.11-3.13 classifiers, but this job used to pin
-    # only 3.12 — a break on 3.11 or 3.13 would ship uncaught. The matrix must
-    # stay in sync with the classifiers; tests/contracts/test_repo_ci_python_matrix.py
-    # fails CI if they drift. Matrixing renames the check to "Lint and test
-    # (3.xx)", which is why "CI gate" (below) is the single required context, not
-    # this job — see its comment.
     strategy:
       fail-fast: false
       matrix:
@@ -44,41 +42,6 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: ${{ matrix.python-version }}
 
-      # shellcheck ships preinstalled on ubuntu-24.04; shfmt does not. The
-      # scaffolded-output lint guard (test_shell_lint_gate.py) skips when its
-      # tool is absent, so without this step the shfmt guard would silently
-      # no-op in CI — a green check that tested nothing. Pinned + checksum-
-      # verified, mirroring the install the scaffolded ci.yml.tmpl ships.
-      - name: Install shfmt
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          tmp="$(mktemp -d)"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
-          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
-          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
-          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      # Same reasoning as shfmt above. test_ts_security_gate.py is the only test
-      # that RUNS the scaffolded TypeScript toolchain rather than asserting the
-      # text of eslint.config.mjs — and text assertions are what let #732 (an
-      # unpinned typescript resolving to 7.x, crashing eslint) ship. Without bun
-      # that gate skips, and a skipped test is not a gate (#733). The test does
-      # `bun add` against the npm registry; that network hop is ~3s warm and is
-      # the only thing between a broken TS toolchain and a green merge, so it
-      # runs on every PR rather than nightly.
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
-        with:
-          bun-version: latest
-
-      # Same reasoning again (#737). The two git pre-commit hook tests in
-      # test_commit_hook_gates.py drive the real hook, which shells out to
-      # `just lint` — the hook's two most interesting behaviours (block a bad
-      # STAGED commit; do NOT block a good staged commit when the worktree is
-      # dirty) were never exercised in CI because `just` was absent and the
-      # tests skipped. Pinned to the same SHA the scaffolded ci.yml.tmpl uses.
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
 
@@ -91,30 +54,71 @@ jobs:
       - name: Typecheck (mypy --strict)
         run: just typecheck
 
-      - name: Tests (pytest)
-        # Serial in CI, deliberately (PI-759/PI-762). Parallel (`-n auto`) cut this
-        # step ~5m→~2m, but surfaced a rare cross-test interference under CI's
-        # worker scheduling (a memory-lint test read a wrong/corrupt tree) that
-        # local runs did not reproduce. CI must stay deterministic — a flaky red on
-        # an unrelated PR costs more than the minutes saved — so parallelizing CI
-        # safely (root-cause the interference, or split tests into parallel jobs)
-        # is tracked in PI-762. `just test` runs `-n auto` locally for dev speed.
-        # --cov reports coverage (#636) without gating on it: no fail_under, so
-        # a dip is visible in the log and never blocks an unrelated PR.
-        run: uv run pytest --tb=short -q --cov --cov-report=term-missing
-
       # Dependency vulnerability scan (#637). gitleaks (secret-scan job) catches
       # committed secrets; nothing else here catches a correctly-spelled dep
       # already in uv.lock with a known CVE. pip-audit is pulled in ephemerally
-      # via `uv run --with`, the same pattern the scaffolded ci.yml.tmpl uses —
-      # no dev-dependency to forget. Mirrors the template's `just audit` step.
+      # via `uv run --with`, the same pattern the scaffolded ci.yml.tmpl uses.
       - name: Dependency vulnerability scan (pip-audit)
         run: just audit
+
+  # Tests, sharded into parallel jobs with pytest-split (PI-762). Each shard is a
+  # separate SERIAL process, so the xdist in-process interference that once forced
+  # serial CI (#668/PI-759) cannot occur — deterministic AND ~4x faster wall-clock
+  # than one serial run. Single Python version per PR (the full matrix runs
+  # nightly). The shfmt/bun/just toolchain is installed because several tests
+  # DRIVE the scaffolded toolchain rather than asserting text (ts/hook gates,
+  # #732/#733/#737) — without it they skip, and a skipped test is not a gate.
+  test:
+    name: Tests (shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          version: "0.11.7"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.11"
+
+      - name: Install shfmt
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tmp="$(mktemp -d)"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
+          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
+          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
+          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+
+      - name: Sync dev dependencies
+        run: uv sync --group dev --locked
+
+      - name: Tests (pytest, shard ${{ matrix.shard }})
+        # pytest-split partitions the suite deterministically; --splits/--group
+        # select this shard. Serial within the shard (no -n) — that is what makes
+        # it race-free. Coverage is measured in the nightly full-suite run
+        # (nightly.yml), not here, so a shard needs no combine step.
+        run: uv run pytest --splits 4 --group ${{ matrix.shard }} --tb=short -q
 
   wheel-smoke:
     name: Wheel smoke test
     runs-on: ubuntu-24.04
-    needs: lint-and-test
+    needs: checks
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
@@ -365,13 +369,15 @@ jobs:
   # own CI was behind its own product).
   #
   # needs = only jobs that ALWAYS run: a skipped need counts as not-success and
-  # would red the gate. wheel-smoke skips only when lint-and-test fails (gate
-  # should be red then anyway); the conditional portability jobs are deliberately
-  # out (they skip on non-shell PRs and were never required contexts).
+  # would red the gate. `checks` and `test` (all 4 shards) always run; wheel-smoke
+  # skips only when `checks` fails (gate should be red then anyway); the
+  # conditional portability jobs are deliberately out (they skip on non-shell PRs
+  # and were never required contexts). The nightly full-matrix test job is not a
+  # merge gate (it runs on schedule only, in nightly.yml).
   ci-gate:
     name: CI gate
     runs-on: ubuntu-24.04
-    needs: [lint-and-test, wheel-smoke, secret-scan, shellcheck]
+    needs: [checks, test, wheel-smoke, secret-scan, shellcheck]
     if: always()
     steps:
       - name: Require all upstream jobs to succeed

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,66 @@
+name: Nightly
+
+# The full Python support-window test run (PI-762). Per-PR CI (ci.yml) shards the
+# tests on a single version for fast, race-free feedback; this job runs the WHOLE
+# suite on EVERY supported version once a day, so a version-specific break is
+# caught within a day. It also measures coverage in one process (accurate, no
+# shard-combine). Not a merge gate — it informs, it doesn't block.
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  full-matrix-tests:
+    name: Tests (full suite, ${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      # Must stay in sync with pyproject's requires-python classifiers;
+      # tests/contracts/test_repo_ci_python_matrix.py fails CI if they drift.
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          version: "0.11.7"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install shfmt
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tmp="$(mktemp -d)"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
+          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
+          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
+          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+
+      - name: Sync dev dependencies
+        run: uv sync --group dev --locked
+
+      - name: Tests (full suite, with coverage)
+        # Serial, whole suite, one process — accurate coverage without a
+        # cross-shard combine. Coverage is reported (#636), not gated here.
+        run: uv run pytest --tb=short -q --cov --cov-report=term-missing

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -33,9 +33,10 @@ sync uses (`tools/sync_agents_from_templates.py`, PI-685).
 The `ci-gate` job in `.github/workflows/ci.yml` must require exactly these contexts. The
 drift-guard test asserts this list equals `ci-gate.needs`:
 
-<!-- required-gates: lint-and-test, wheel-smoke, secret-scan, shellcheck -->
+<!-- required-gates: checks, test, wheel-smoke, secret-scan, shellcheck -->
 
-- `lint-and-test` — ruff check + mypy `--strict` + pytest (with coverage) + pip-audit, across the Python matrix
+- `checks` — ruff check + mypy `--strict` + pip-audit, across the full Python matrix
+- `test` — the suite sharded into 4 parallel jobs (pytest-split), single Python version per PR; the full matrix runs nightly (PI-762, `nightly.yml`)
 - `wheel-smoke` — build the wheel, scaffold from it, assert no unrendered placeholders / exec bits
 - `secret-scan` — gitleaks full-history scan
 - `shellcheck` — shellcheck over rendered scaffold scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     # `patch = ["subprocess"]` in [tool.coverage.run] landed in coverage 7.10.
     "coverage>=7.10",
     "pytest-xdist>=3.0",
+    # Deterministic, race-free CI test sharding across parallel jobs (PI-762):
+    # each shard is a separate serial process, so the xdist in-process
+    # interference (#668/PI-759) cannot occur. `just test` still uses xdist locally.
+    "pytest-split>=0.8",
     # Workflow-schema gate (#719): an invalid trigger made GitHub reject a whole
     # workflow file at load time. Declared here so tests/integration/
     # test_workflow_lint_gate.py never silently skips.

--- a/tests/contracts/test_coverage_config.py
+++ b/tests/contracts/test_coverage_config.py
@@ -82,15 +82,19 @@ def test_no_conftest_env_hook_is_needed():
 
 
 def test_ci_reports_coverage_without_gating_on_it():
-    """Bare `--cov` is deliberate: scope lives in [tool.coverage.run] source.
+    """Coverage is measured in the nightly full-suite run, not per-PR (PI-762).
 
-    pytest-cov 7 does not rewrite the configured source when `--cov` is passed
-    without a value — measured, the report covers 10 `src/project_init` files and
-    no `tests/` or `tools/` rows. Repeating the path in the justfile and the
-    workflow would just be two more places to drift from the config (PR #718
-    review). `test_coverage_measures_the_package_with_branch_coverage` pins the
-    source that makes this safe.
+    Per-PR CI shards the tests across parallel jobs for speed (ci.yml `test`
+    job) — each shard sees only a slice, so per-PR coverage would need a
+    cross-shard combine for no gating benefit. The nightly full-suite run
+    (nightly.yml) measures coverage accurately in one process. Bare `--cov` is
+    deliberate: scope lives in [tool.coverage.run] source (pytest-cov does not
+    rewrite it when `--cov` is valueless). No `--cov-fail-under` anywhere —
+    coverage is drift visibility (#636), not a gate.
     """
+    nightly = (_ROOT / ".github" / "workflows" / "nightly.yml").read_text(encoding="utf-8")
+    assert "--cov" in nightly
+    assert "--cov-fail-under" not in nightly
+    # Per-PR CI shards without coverage — no combine step to maintain.
     ci = (_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "--cov" in ci
     assert "--cov-fail-under" not in ci

--- a/tests/contracts/test_quality_gate_policy.py
+++ b/tests/contracts/test_quality_gate_policy.py
@@ -4,7 +4,7 @@ documented quality-gate policy.
 `docs/development/quality-gates.md` declares the single source of truth for which
 CI contexts gate a merge, in a machine-readable marker:
 
-    <!-- required-gates: lint-and-test, wheel-smoke, secret-scan, shellcheck -->
+    <!-- required-gates: checks, test, wheel-smoke, secret-scan, shellcheck -->
 
 The `ci-gate` aggregator job in `.github/workflows/ci.yml` fans in exactly those
 jobs via its `needs:` list. If the two diverge, either the policy doc is stale or a

--- a/tests/contracts/test_repo_ci_python_matrix.py
+++ b/tests/contracts/test_repo_ci_python_matrix.py
@@ -1,8 +1,10 @@
 """#638: this repo's own CI must test every Python it declares support for.
 
-pyproject sets requires-python >=3.11 with 3.11-3.13 classifiers, but ci.yml's
-lint-and-test job pinned only 3.12 — a break on 3.11 or 3.13 would ship uncaught.
-This guard fails if the CI matrix and the declared classifiers drift.
+pyproject sets requires-python >=3.11 with 3.11-3.13 classifiers. Per-PR CI shards
+the tests on a single version for speed (PI-762); the FULL suite runs on every
+declared version nightly (`nightly.yml`). This guard fails if that nightly matrix
+and the declared classifiers drift, so a version the project claims to support
+can't silently go untested.
 
 Distinct from tests/contracts/test_python_version_set.py, which guards the
 *scaffolded template's* matrix against the CLI's SUPPORTED_PYTHON_VERSIONS. This
@@ -15,7 +17,7 @@ import re
 import tomllib
 from pathlib import Path
 
-from tests.workflow import job, load_workflow, needs
+from tests.workflow import job, load_workflow, needs, steps
 
 _ROOT = Path(__file__).resolve().parents[2]
 
@@ -30,26 +32,41 @@ def _classifier_pythons() -> list[str]:
     )
 
 
-def _matrix_pythons() -> list[str]:
-    matrix = job(load_workflow(_ROOT), "lint-and-test").get("strategy", {}).get("matrix", {})
+def _nightly_matrix_pythons() -> list[str]:
+    nightly = load_workflow(_ROOT, "nightly.yml")
+    matrix = job(nightly, "full-matrix-tests").get("strategy", {}).get("matrix", {})
     versions = matrix.get("python-version")
-    assert isinstance(versions, list), "lint-and-test has no python-version matrix (#638)"
+    assert isinstance(versions, list), "nightly full-matrix-tests has no python-version matrix (#638)"
     return sorted(str(v) for v in versions)
 
 
-def test_ci_matrix_matches_declared_classifiers():
-    assert _matrix_pythons() == _classifier_pythons(), (
-        "ci.yml lint-and-test matrix and pyproject Python classifiers drifted — "
-        "keep them equal (#638)"
+def test_nightly_matrix_matches_declared_classifiers():
+    assert _nightly_matrix_pythons() == _classifier_pythons(), (
+        "nightly.yml full-matrix-tests matrix and pyproject Python classifiers "
+        "drifted — keep them equal so every supported version is tested (#638)"
     )
 
 
-def test_ci_gate_depends_on_the_matrixed_job():
-    """The matrix renames "Lint and test" to "Lint and test (3.xx)", so branch
-    protection requires "CI gate" instead. That gate is only meaningful if it
-    actually depends on the matrixed job — else a green gate could mask a red run.
+def test_ci_gate_depends_on_the_test_and_checks_jobs():
+    """Per-PR CI splits into `checks` (matrixed lint/typecheck/audit) and `test`
+    (4 sharded jobs). Both matrix/shard-expand their check names, so branch
+    protection requires "CI gate" instead — which is only meaningful if it
+    actually depends on both, else a green gate could mask a red run.
     """
-    assert "lint-and-test" in needs(load_workflow(_ROOT), "ci-gate"), (
-        "ci-gate must `needs: lint-and-test` — it is the required check standing "
-        "in for the matrixed job (#638)"
-    )
+    ci_gate_needs = needs(load_workflow(_ROOT), "ci-gate")
+    assert "test" in ci_gate_needs, "ci-gate must `needs: test` (the sharded test jobs)"
+    assert "checks" in ci_gate_needs, "ci-gate must `needs: checks` (lint/typecheck/audit)"
+
+
+def test_tests_are_sharded_into_parallel_jobs():
+    """PI-762: the per-PR `test` job shards via pytest-split — each shard is a
+    serial process (race-free) and the shards run in parallel. Guard the
+    mechanism so a refactor can't silently collapse it back to one serial run
+    (which would reintroduce the ~5-minute long pole) or to xdist (the race).
+    """
+    test_job = job(load_workflow(_ROOT), "test")
+    shards = test_job.get("strategy", {}).get("matrix", {}).get("shard")
+    assert shards == [1, 2, 3, 4], f"test job must shard [1, 2, 3, 4], got {shards!r}"
+    run = " ".join(str(s.get("run", "")) for s in steps(test_job))
+    assert "--splits" in run and "--group" in run, "test job must run pytest --splits/--group"
+    assert "-n auto" not in run, "shards run serially (no xdist) — that is what makes them race-free"

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ dev = [
     { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "ruff" },
@@ -592,6 +593,7 @@ dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-split", specifier = ">=0.8" },
     { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = ">=0.4" },
@@ -647,6 +649,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The safe fix for the CI wall-clock long pole (~5-min serial pytest). xdist cut it to ~2 min but surfaced a rare, nondeterministic cross-test interference under CI scheduling (PI-759) — unshippable. **Sharding** sidesteps it entirely: `pytest-split` partitions the suite across 4 parallel jobs, each a **separate serial process**, so the in-process xdist race cannot occur. Deterministic *and* ~4× faster.

## Changes
- **`ci.yml`**: `lint-and-test` → `checks` (ruff + mypy + audit, 3-version matrix) + `test` (4 shards, single version per PR, `pytest --splits 4 --group N`). `ci-gate.needs = [checks, test, wheel-smoke, secret-scan, shellcheck]`; `wheel-smoke` needs `checks`.
- **`nightly.yml`** (new): the full support-window matrix runs the WHOLE suite on every version once a day — a version-specific break is caught within a day (the deliberate speed/coverage trade) — and measures coverage in one process (no cross-shard combine).
- `pytest-split` dev dep. `just test` keeps `-n auto` locally.
- `quality-gates.md`: required-gates marker updated (the #758 drift guard enforces it).
- Tests: matrix guard now targets `nightly.yml`; new guards that ci-gate needs `checks`+`test` and that the `test` job actually shards (no silent un-shard, no xdist).

## Validation
- Locally: `pytest --splits 4` partitions the suite completely (4×573 = 2292); a shard runs green serially in ~18s. On CI, 4 shards in parallel should take the ~5-min step to ~1–1.5 min.
- actionlint (workflow-lint gate) passes on both `ci.yml` and `nightly.yml`; full suite green (2283).

## Scope
Repo-only (the template already runs `pytest -n auto`; scaffolded projects don't have this repo's specific interference). Template matrix→nightly is #761. Coverage now measured nightly; the 85% floor (follow-up) will gate there.

Closes #762