### PR TITLE
feat(PI-765): gate repo coverage at 85% (nightly full-suite run)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,11 @@ jobs:
       - name: Sync dev dependencies
         run: uv sync --group dev --locked
 
-      - name: Tests (full suite, with coverage)
+      - name: Tests (full suite, coverage gated at 85%)
         # Serial, whole suite, one process — accurate coverage without a
-        # cross-shard combine. Coverage is reported (#636), not gated here.
-        run: uv run pytest --tb=short -q --cov --cov-report=term-missing
+        # cross-shard combine, so it can carry the floor. 85% is deliberately
+        # below the current ~92% (PI-765): it catches a real regression without
+        # blocking an unrelated PR on a number nobody chose. The gate lives in the
+        # nightly run (not per-PR) because per-PR tests are sharded — each shard
+        # sees only a slice, and a cross-shard combine would add cost for no gain.
+        run: uv run pytest --tb=short -q --cov --cov-report=term-missing --cov-fail-under=85

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -96,7 +96,7 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 | ruff `check` (lint + `S`/bandit) | ✅ blocking | ✅ blocking | **keep** both | Lint + in-linter SAST. |
 | ruff `format --check` | ✅ in `just lint` | ❌ (#726) | **promote** repo → add | Repo ships a format gate it doesn't run on itself. |
 | mypy `--strict` | ✅ blocking | ✅ blocking | **keep** both | Type gate, dogfooded (#639). |
-| Test coverage floor | ✅ 70% blocking (×4 langs) | ❌ ~92% measured, no `fail_under` | **promote** repo → 85% floor | Catch regressions; 85% keeps headroom below current ~92% so unrelated PRs don't red on a number nobody chose. |
+| Test coverage floor | ✅ 70% blocking (×4 langs) | ✅ 85% nightly (PI-765) | **done** (promoted) | Gated in the nightly full-suite run (accurate single-process); 85% keeps headroom below ~92%. Per-PR shards stay ungated (a floor there needs a cross-shard combine for little gain). |
 | pip-audit (SCA) | ✅ blocking | ✅ blocking | **keep** both | Dependency CVE scan. |
 | gitleaks secret-scan | ✅ blocking | ✅ blocking | **keep** both | Full-history secret scan. |
 | wheel-smoke | — (repo-specific) | ✅ blocking | **keep** repo | Proves the built wheel scaffolds; no template analogue. |
@@ -112,9 +112,11 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 1. **ruff format** (#726) — **promote**: add `ruff format --check .` to the repo's lint step.
    A one-time repo-wide `ruff format .` reformat commit precedes the check (large mechanical
    diff is expected). Follow-up PR under #751.
-2. **Coverage floor** — **promote**: gate the repo at **85%** via `--cov-fail-under=85` in the
-   CI pytest step and `just test-cov` (fast `just test`/`test-quick` stay floor-free). The
-   template keeps 70% (a fresh scaffold's baseline). Follow-up PR under #751.
+2. **Coverage floor** — **done** (PI-765): the repo is gated at **85%** via
+   `--cov-fail-under=85` in the nightly full-suite run (`nightly.yml`), where coverage is
+   measured accurately in one process. Per-PR CI shards the tests (PI-762), so each shard sees
+   only a slice — a per-PR floor would need a cross-shard combine for little benefit. The
+   template keeps its per-language 70% (a fresh scaffold's baseline).
 3. **Security-scan parity** — **promote (advisory)**: add semgrep + license-scan jobs to the
    repo, advisory (not in `ci-gate.needs`), mirroring the template posture. scorecard/fuzz stay
    template-only (see table). Follow-up PR under #751.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,12 @@ markers = [
     "slow: needs a non-python toolchain (bun, cargo); skipped where absent",
 ]
 
-# Coverage (#636): drift VISIBILITY, not a gate. No `fail_under` — a hard floor
-# would block unrelated PRs on a number nobody chose, and this repo's real
-# coverage contract is "every templates/ change gets a test", which no percentage
-# can express. Deliberately not wired into `just test-quick`: that recipe is the
+# Coverage (#636): drift visibility per-PR, a regression floor nightly. There is
+# no `fail_under` HERE — the floor lives in the nightly workflow's pytest
+# invocation (`--cov-fail-under=85`, PI-765), not in this config, so per-PR runs
+# (and `just test-cov`) stay ungated while the nightly full-suite run catches a
+# real drop. 85% is below the current ~92% so it never blocks a PR on a number
+# nobody chose. Deliberately not wired into `just test-quick`: that recipe is the
 # fail-fast iterate loop, and coverage costs a measurable slice of its runtime.
 [tool.coverage.run]
 source = ["src/project_init"]

--- a/tests/contracts/test_coverage_config.py
+++ b/tests/contracts/test_coverage_config.py
@@ -81,20 +81,22 @@ def test_no_conftest_env_hook_is_needed():
     assert "COVERAGE_PROCESS_START" not in body
 
 
-def test_ci_reports_coverage_without_gating_on_it():
-    """Coverage is measured in the nightly full-suite run, not per-PR (PI-762).
+def test_coverage_measured_per_pr_visibility_gated_nightly():
+    """Coverage is measured in the nightly full-suite run, gated at 85% (PI-765).
 
     Per-PR CI shards the tests across parallel jobs for speed (ci.yml `test`
-    job) — each shard sees only a slice, so per-PR coverage would need a
-    cross-shard combine for no gating benefit. The nightly full-suite run
-    (nightly.yml) measures coverage accurately in one process. Bare `--cov` is
-    deliberate: scope lives in [tool.coverage.run] source (pytest-cov does not
-    rewrite it when `--cov` is valueless). No `--cov-fail-under` anywhere —
-    coverage is drift visibility (#636), not a gate.
+    job) — each shard sees only a slice, so a per-PR floor would need a
+    cross-shard combine for little benefit. The nightly full-suite run
+    (nightly.yml) measures coverage accurately in one process and carries the 85%
+    regression floor. Bare `--cov` is deliberate: scope lives in
+    [tool.coverage.run] source (pytest-cov does not rewrite it when `--cov` is
+    valueless). Per-PR runs stay ungated (`--cov-fail-under` absent from ci.yml).
     """
     nightly = (_ROOT / ".github" / "workflows" / "nightly.yml").read_text(encoding="utf-8")
     assert "--cov" in nightly
-    assert "--cov-fail-under" not in nightly
-    # Per-PR CI shards without coverage — no combine step to maintain.
+    # The 85% regression floor lives in the nightly full-suite run (PI-765),
+    # where coverage is measured accurately in one process.
+    assert "--cov-fail-under=85" in nightly
+    # Per-PR CI shards without coverage — no floor, no combine step to maintain.
     ci = (_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     assert "--cov-fail-under" not in ci


### PR DESCRIPTION
## Summary

Closes the coverage-floor gap from epic #751. The repo measured ~92% coverage but never gated it. Since per-PR CI now shards the tests (PI-762) — each shard sees only a slice — the floor lives in the **nightly full-suite run** (`nightly.yml`), where coverage is measured accurately in one process.

- `nightly.yml`: `--cov-fail-under=85`. **Verified active**: `Required test coverage of 85% reached. Total coverage: 91.66%`. 85% is below current ~92% so it catches a real regression without blocking a PR on a number nobody chose.
- `pyproject.toml`: the "no fail_under" comment now describes the nightly floor.
- `test_coverage_config`: asserts the 85% floor is in `nightly.yml` and absent from `ci.yml` (per-PR shards stay ungated).
- `quality-gates.md`: coverage-floor gap marked **done**.

Full suite green (2283); actionlint + mkdocs clean.

Closes #765