### PR TITLE
feat(PI-767): add gitleaks pre-commit secret scan to the repo

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# pre-commit gate for the project-init repo itself (dogfood).
+#
+# Scans STAGED changes for secrets with gitleaks before the commit is written —
+# the local half of the secret-scan CI runs on full history (ADR-007 posture:
+# the git hook is fast local feedback, CI is the hard backstop). Fail-OPEN when
+# gitleaks is absent so a missing tool never blocks a commit; bypassable in an
+# emergency with `git commit --no-verify`.
+#
+# Enabled by `just setup` (git config core.hooksPath .githooks). Mirrors the
+# gitleaks half of the richer pre-commit the scaffolder ships
+# (templates/base/dot_github/hooks/pre-commit); the `just lint` half is omitted
+# here because this repo lints at pre-push (fast-ci) instead.
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "WARNING: gitleaks not installed — skipping local secret scan." >&2
+  echo "  CI still scans full history; install for fast local feedback:" >&2
+  echo "    https://github.com/gitleaks/gitleaks#installing" >&2
+  exit 0
+fi
+
+exec gitleaks git --pre-commit --staged --redact --no-banner --verbose

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -98,7 +98,7 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 | mypy `--strict` | ✅ blocking | ✅ blocking | **keep** both | Type gate, dogfooded (#639). |
 | Test coverage floor | ✅ 70% blocking (×4 langs) | ✅ 85% nightly (PI-765) | **done** (promoted) | Gated in the nightly full-suite run (accurate single-process); 85% keeps headroom below ~92%. Per-PR shards stay ungated (a floor there needs a cross-shard combine for little gain). |
 | pip-audit (SCA) | ✅ blocking | ✅ blocking | **keep** both | Dependency CVE scan. |
-| gitleaks secret-scan | ✅ blocking | ✅ blocking | **keep** both | Full-history secret scan. |
+| gitleaks secret-scan | ✅ CI + pre-commit | ✅ CI + pre-commit (PI-767) | **keep** both | CI scans full history (blocking); a git pre-commit hook scans the staged diff locally (fail-open). The repo previously scanned only in CI — the local half was the parity gap. |
 | wheel-smoke | — (repo-specific) | ✅ blocking | **keep** repo | Proves the built wheel scaffolds; no template analogue. |
 | semgrep SAST | ✅ advisory | ❌ | **promote** repo → advisory | Semantic SAST; advisory until calibrated, matching the template. |
 | license-scan | ✅ advisory | ❌ | **promote** repo → advisory | Deny GPL/AGPL; advisory while the deny-list is calibrated. |

--- a/tests/integration/test_repo_pre_commit_hook.py
+++ b/tests/integration/test_repo_pre_commit_hook.py
@@ -1,0 +1,43 @@
+"""PI-767: the repo's own pre-commit hook scans staged changes for secrets with
+gitleaks — the local half of the CI secret-scan (ADR-007). This closed the parity
+gap the quality-gate audit flagged: the repo had NO local secret scan (secrets
+were caught only in CI), while the scaffolder ships a gitleaks pre-commit to every
+generated project.
+
+Guarded structurally + for fail-open behaviour WITHOUT requiring gitleaks on PATH
+(in CI gitleaks is a Docker action, not a CLI), so this stays a real gate rather
+than a skipped one (#733).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_HOOK = Path(__file__).resolve().parents[2] / ".githooks" / "pre-commit"
+_BASH = shutil.which("bash")
+
+
+def test_pre_commit_hook_exists_and_is_executable():
+    assert _HOOK.is_file(), "repo .githooks/pre-commit is missing"
+    assert _HOOK.stat().st_mode & 0o111, "pre-commit hook must be executable to run"
+
+
+def test_pre_commit_runs_gitleaks_staged_scan():
+    body = _HOOK.read_text(encoding="utf-8")
+    # Scans the STAGED diff (not history) — the point of a pre-commit gate.
+    assert "gitleaks git --pre-commit --staged" in body
+
+
+def test_pre_commit_fails_open_when_gitleaks_absent(tmp_path: Path):
+    # Empty PATH → gitleaks not found → the hook must exit 0 (CI stays the hard
+    # backstop); a missing tool must never block a commit. bash is invoked by
+    # absolute path so the restricted PATH doesn't hide the interpreter itself.
+    env = {**os.environ, "PATH": str(tmp_path)}
+    result = subprocess.run(
+        [_BASH, str(_HOOK)], env=env, cwd=str(tmp_path), capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"hook must fail-open when gitleaks absent: {result.stderr}"
+    assert "gitleaks not installed" in result.stderr


### PR DESCRIPTION
## Summary

Closes a security parity gap from the quality-gate audit: the repo scanned secrets **only in CI** (full-history job), while the scaffolder ships a gitleaks **pre-commit** to every generated project. A committed secret was caught only after a push. This adds the local half.

- **`.githooks/pre-commit`**: gitleaks staged-diff scan; **fail-open** if gitleaks is absent (CI stays the backstop); bypassable with `--no-verify`. Mirrors the gitleaks half of the template's pre-commit (the `just lint` half is omitted — this repo lints at pre-push via `fast-ci`).
- **Functionally verified**: blocks a staged private key (exit 1, "leaks found: 1"), allows clean content, fail-opens with gitleaks absent. This commit itself was scanned by the new hook (dogfooded).
- **`test_repo_pre_commit_hook`**: structural + fail-open guards that need no gitleaks on PATH (it's a Docker action in CI, not a CLI) — so it's a real gate, not a skipped one (#733).
- `quality-gates.md`: gitleaks row now records CI + pre-commit for both surfaces.

Full suite green (2286); mkdocs clean.

Closes #767