### PR TITLE
feat(PI-769): semgrep + license-scan advisory jobs on repo CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,58 @@ jobs:
           printf '%s\n' "${files[@]}"
           uvx --from 'shellcheck-py==0.11.0.1' shellcheck --severity=warning "${files[@]}"
 
+  # Semantic security scan (semgrep) over the scaffolder's own src/. ADVISORY —
+  # deliberately NOT in ci-gate's needs (security-scan parity, PI-769) while the
+  # ruleset is calibrated; the step still fails on a finding so it stays visible.
+  # Mirrors the scaffolded semgrep job the product ships.
+  semgrep:
+    name: Semgrep (semantic security scan)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          # Full history: --baseline-commit (PR-only, below) needs the base
+          # commit reachable.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Run Semgrep
+        env:
+          SEMGREP_ENABLE_VERSION_CHECK: "0"
+        run: |
+          SEMGREP="uvx semgrep@1.168.0"
+          RULESETS="--config p/secrets --config p/owasp-top-ten --config p/python"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            $SEMGREP scan --error --metrics=off $RULESETS \
+              --baseline-commit "${{ github.event.pull_request.base.sha }}"
+          else
+            $SEMGREP scan --error --metrics=off $RULESETS
+          fi
+
+  # Dependency license compliance (#579): flag copyleft (GPL/AGPL) deps.
+  # ADVISORY — not in ci-gate's needs — while the deny-list is calibrated. The
+  # deny-list lives in the justfile's `license` recipe. Mirrors the template.
+  license-scan:
+    name: Dependency license scan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+
+      - name: License scan (pip-licenses)
+        run: just license
+
   # PI-363 Layer 3 gate: only spend the 10x-billed macOS minutes when shell or
   # template files actually change. Ordinary PRs skip the macOS job entirely.
   changes:

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -100,8 +100,8 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 | pip-audit (SCA) | ✅ blocking | ✅ blocking | **keep** both | Dependency CVE scan. |
 | gitleaks secret-scan | ✅ CI + pre-commit | ✅ CI + pre-commit (PI-767) | **keep** both | CI scans full history (blocking); a git pre-commit hook scans the staged diff locally (fail-open). The repo previously scanned only in CI — the local half was the parity gap. |
 | wheel-smoke | — (repo-specific) | ✅ blocking | **keep** repo | Proves the built wheel scaffolds; no template analogue. |
-| semgrep SAST | ✅ advisory | ❌ | **promote** repo → advisory | Semantic SAST; advisory until calibrated, matching the template. |
-| license-scan | ✅ advisory | ❌ | **promote** repo → advisory | Deny GPL/AGPL; advisory while the deny-list is calibrated. |
+| semgrep SAST | ✅ advisory | ✅ advisory (PI-769) | **done** (promoted) | Semantic SAST over the scaffolder's `src/`; advisory (not in ci-gate) until calibrated, matching the template. |
+| license-scan | ✅ advisory | ✅ advisory (PI-769) | **done** (promoted) | Deny GPL/AGPL via `just license`; advisory while the deny-list is calibrated. |
 | scorecard | ✅ weekly cron, advisory | ❌ | **keep** template; **not adopted** by repo | OSSF posture score is low-ROI on a solo scaffolder repo. |
 | fuzz | ✅ nightly cron, advisory | ❌ | **keep** template; **not adopted** by repo | Property/fuzz targets are a per-project concern, not this repo's. |
 | Mutation gate | ✅ nightly, 80% kill (Python) | ❌ | **keep** template; repo uses the on-demand skill | Test-strength on the repo is covered by the `verify-test-strength` skill (#747, PR #756); a nightly mutation *gate* on this repo is not worth the runtime. |
@@ -117,9 +117,10 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
    measured accurately in one process. Per-PR CI shards the tests (PI-762), so each shard sees
    only a slice — a per-PR floor would need a cross-shard combine for little benefit. The
    template keeps its per-language 70% (a fresh scaffold's baseline).
-3. **Security-scan parity** — **promote (advisory)**: add semgrep + license-scan jobs to the
-   repo, advisory (not in `ci-gate.needs`), mirroring the template posture. scorecard/fuzz stay
-   template-only (see table). Follow-up PR under #751.
+3. **Security-scan parity** — **done** (PI-769 semgrep + license-scan; PI-767 gitleaks
+   pre-commit): the repo now runs semgrep + license-scan as advisory jobs (not in
+   `ci-gate.needs`), plus a local gitleaks pre-commit. scorecard/fuzz stay template-only (see
+   table).
 4. **Test-strength** (#747) — **resolved**: the `verify-test-strength` skill ships and is the
    on-demand mechanism for both repo and output; the template additionally runs a nightly
    mutation gate. No repo mutation *gate* is added (calibrated-not-maximal).

--- a/justfile
+++ b/justfile
@@ -61,6 +61,12 @@ docs:
 audit:
     uv run --all-extras --with pip-audit pip-audit
 
+# dependency license compliance scan (#579) — fail on copyleft (GPL/AGPL; also
+# LGPL, since --partial-match is substring-based). Advisory in CI (not in
+# ci-gate), matching the template's rollout. Mirrors the scaffolded `just license`.
+license:
+    uv run --with pip-licenses pip-licenses --from=mixed --fail-on "GPL;AGPL" --partial-match
+
 # what CI runs (the full gate)
 ci: lint typecheck test audit
 

--- a/tests/contracts/test_repo_ci_python_matrix.py
+++ b/tests/contracts/test_repo_ci_python_matrix.py
@@ -70,3 +70,18 @@ def test_tests_are_sharded_into_parallel_jobs():
     run = " ".join(str(s.get("run", "")) for s in steps(test_job))
     assert "--splits" in run and "--group" in run, "test job must run pytest --splits/--group"
     assert "-n auto" not in run, "shards run serially (no xdist) — that is what makes them race-free"
+
+
+def test_semgrep_and_license_scan_are_advisory():
+    """PI-769: semgrep + license-scan run on the repo (security-scan parity) but
+    are ADVISORY — present as jobs, deliberately NOT in ci-gate's needs. They fail
+    their own step so a finding is visible, but don't block a merge while the
+    ruleset / deny-list is calibrated (the same rollout the template uses).
+    """
+    wf = load_workflow(_ROOT)
+    jobs = wf.get("jobs", {})
+    assert "semgrep" in jobs, "semgrep job missing from ci.yml"
+    assert "license-scan" in jobs, "license-scan job missing from ci.yml"
+    gate_needs = needs(wf, "ci-gate")
+    assert "semgrep" not in gate_needs, "semgrep must stay advisory (not in ci-gate.needs)"
+    assert "license-scan" not in gate_needs, "license-scan must stay advisory (not in ci-gate.needs)"


### PR DESCRIPTION
## Summary

Security-scan parity (epic #751): the repo ran only ruff-S / gitleaks / pip-audit; the template also ships semgrep (SAST) and license-scan. This adds both to the repo, **advisory** — deliberately NOT in `ci-gate.needs` — so they surface findings without blocking a merge while the ruleset / deny-list is calibrated (the template's own rollout).

- **`ci.yml`**: `semgrep` job (`uvx semgrep@1.168.0`, `p/secrets` + `p/owasp-top-ten` + `p/python`, `--baseline-commit` on PRs) and `license-scan` job (`just license`).
- **`justfile`**: `license` recipe (pip-licenses, fail on GPL/AGPL) — verified the repo's deps are all MIT/Apache, so it passes clean.
- **`test_repo_ci_python_matrix`**: guards that both jobs exist AND stay out of `ci-gate.needs` (advisory).
- `quality-gates.md`: security-scan-parity gap marked **done** (with the PI-767 gitleaks pre-commit).

actionlint + full suite green (2287). Advisory jobs don't gate `ci-gate`, so a finding shows red on its own job without blocking the merge — the intended "visible but non-blocking" posture.

Closes #769