### PR TITLE
chore(PI-772): adopt ruff format gate on the scaffolder repo (reformat + enforce)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,10 @@ jobs:
       - name: Sync dev dependencies
         run: uv sync --group dev --locked
 
-      - name: Lint (ruff)
-        run: uv run ruff check .
+      - name: Lint (ruff check + format check)
+        # `just lint` runs `ruff check` AND `ruff format --check` (PI-772) — one
+        # callsite, so CI, pre-push (fast-ci) and local all enforce the same gate.
+        run: just lint
 
       - name: Typecheck (mypy --strict)
         run: just typecheck

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -94,7 +94,7 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 |---|---|---|---|---|
 | `ci-gate` aggregator | ✅ single required check | ✅ single required check | **keep** both | One gate, matrix-rename-robust. |
 | ruff `check` (lint + `S`/bandit) | ✅ blocking | ✅ blocking | **keep** both | Lint + in-linter SAST. |
-| ruff `format --check` | ✅ in `just lint` | ❌ (#726) | **promote** repo → add | Repo ships a format gate it doesn't run on itself. |
+| ruff `format --check` | ✅ in `just lint` | ✅ in `just lint` (PI-772) | **done** (promoted) | Repo now dogfoods the format gate it ships; CI's `checks` job runs `just lint` (check + format-check). |
 | mypy `--strict` | ✅ blocking | ✅ blocking | **keep** both | Type gate, dogfooded (#639). |
 | Test coverage floor | ✅ 70% blocking (×4 langs) | ✅ 85% nightly (PI-765) | **done** (promoted) | Gated in the nightly full-suite run (accurate single-process); 85% keeps headroom below ~92%. Per-PR shards stay ungated (a floor there needs a cross-shard combine for little gain). |
 | pip-audit (SCA) | ✅ blocking | ✅ blocking | **keep** both | Dependency CVE scan. |
@@ -109,9 +109,10 @@ Decision legend: **keep** (unchanged), **promote** (make stronger / adopt onto t
 
 ## The four known gaps — decisions
 
-1. **ruff format** (#726) — **promote**: add `ruff format --check .` to the repo's lint step.
-   A one-time repo-wide `ruff format .` reformat commit precedes the check (large mechanical
-   diff is expected). Follow-up PR under #751.
+1. **ruff format** — **done** (PI-772): the repo's `just lint` now runs `ruff format --check`
+   (a one-time `ruff format .` reformat preceded it), and CI's `checks` job invokes `just lint`,
+   so the repo dogfoods the format gate its python scaffold ships. (#726 was a separate
+   *template* audit — no format-*check* in some languages — already resolved by PR #728.)
 2. **Coverage floor** — **done** (PI-765): the repo is gated at **85%** via
    `--cov-fail-under=85` in the nightly full-suite run (`nightly.yml`), where coverage is
    measured accurately in one process. Per-PR CI shards the tests (PI-762), so each shard sees

--- a/justfile
+++ b/justfile
@@ -9,9 +9,12 @@ setup:
     git config core.hooksPath .githooks
     uv run python tools/sync_claude_dir.py
 
-# lint (docstring + complexity gates per pyproject.toml)
+# lint + format check (docstring + complexity gates per pyproject.toml). The
+# format check dogfoods the gate the template's python scaffold ships (PI-772),
+# so `ruff format .` is now the expected fix — no longer a footgun.
 lint:
     uv run ruff check .
+    uv run ruff format --check .
 
 # auto-format
 format:

--- a/src/project_init/__main__.py
+++ b/src/project_init/__main__.py
@@ -567,9 +567,7 @@ def _prompt_menu_index(question: str, count: int, *, default: int) -> int:
         choice = IntPrompt.ask(question, default=default)
         if 1 <= choice <= count:
             return choice
-        console.print(
-            f"[red]Invalid choice {choice}. Enter a number between 1 and {count}.[/red]"
-        )
+        console.print(f"[red]Invalid choice {choice}. Enter a number between 1 and {count}.[/red]")
 
 
 def _prompt_validated(label: str, *, default: str, flag: str, allow_empty: bool = False) -> str:
@@ -643,7 +641,7 @@ def _choose_mcps_interactive(catalog: list[dict[str, Any]]) -> list[dict[str, An
         "can call (Model Context Protocol):"
     )
     for i, m in enumerate(catalog, 1):
-        console.print(option_line(i, m['name'], m['description']))
+        console.print(option_line(i, m["name"], m["description"]))
     console.print()
 
     while True:
@@ -884,9 +882,7 @@ def _print_summary(
     # git repo; say so instead of scaffolding into a bare dir silently
     # (2026-07 QA). Checked structurally (.git up the tree — a valid dir, or a
     # file for worktrees/submodules) — the scaffolder never shells out to git.
-    git_missing = not any(
-        _is_git_marker(p / ".git") for p in (target, *target.resolve().parents)
-    )
+    git_missing = not any(_is_git_marker(p / ".git") for p in (target, *target.resolve().parents))
 
     # Off a TTY (piped/captured/CI) render plain, unwrapped text — no borders to
     # word-wrap mid-phrase, and nothing decorative to bloat a transcript.
@@ -1482,7 +1478,6 @@ def _resolve_iac_interactive(iac: str | None) -> str:
         try:
             return resolve_iac(iac)
         except ValueError as e:
-
             console.print(f"[red]{e}[/red]")
     return _choose_iac_interactive()
 
@@ -1536,7 +1531,6 @@ def _gather_mcps_interactive(cli_mcps: str, cli_browser: bool) -> list[dict[str,
         try:
             selected = _resolve_mcps_non_interactive(cli_mcps, cli_browser)
         except ValueError as e:
-
             console.print(f"[red]{e}[/red] — choose from the catalog instead.")
         else:
             # --mcps pins the catalog picks, but browser automation is its own
@@ -1745,7 +1739,6 @@ def _gather_inputs_interactive(  # noqa: PLR0913 — wizard gatherer; args map t
         try:
             agents = resolve_agents(cli_agents)
         except ValueError as e:
-
             console.print(f"[red]{e}[/red]")
             agents = _choose_agents_interactive()
     else:

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -78,7 +78,7 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
             "no longer resets a hand-set `memory.rag_endpoint`, preset control "
             "vars (governance/lifecycle/memory_stack) no longer leak into the "
             "template gates (so `remove governance` on a governed-preset project "
-            "now converges, and a preset's `lifecycle = \"none\"` renders "
+            'now converges, and a preset\'s `lifecycle = "none"` renders '
             "correctly), and the wizard honors `--agents`, re-prompts on a "
             "mistyped language/license instead of silently coercing to `none`, "
             "and still offers the browser concern when `--mcps` is passed. "

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -863,9 +863,7 @@ def _coerce_preset_var(value: object) -> str:
 # the .agents/observability/ layer stays absent — config.yaml would advertise a
 # retrieval surface the project never scaffolded. (multi_model deliberately stays
 # out: it has no base-template gate and its preset-var flow is intended, #252.)
-_PRESET_CONTROL_KEYS = frozenset(
-    {"memory_stack", "lifecycle", "governance", "observability"}
-)
+_PRESET_CONTROL_KEYS = frozenset({"memory_stack", "lifecycle", "governance", "observability"})
 
 
 def _apply_preset_vars(variables: dict[str, str], preset: dict[str, Any]) -> dict[str, str]:
@@ -1173,7 +1171,9 @@ def _generate_claude_projection(
     # it is our own generated projection: a real dir is rebuilt, and a stale
     # symlink / git-materialized symlink-file is removed with unlink().
     real_dir = claude_dir.is_dir() and not claude_dir.is_symlink()
-    user_config = claude_dir.is_symlink() or claude_dir.is_file() or (real_dir and any(claude_dir.iterdir()))
+    user_config = (
+        claude_dir.is_symlink() or claude_dir.is_file() or (real_dir and any(claude_dir.iterdir()))
+    )
     if first_scaffold and user_config:
         backup = _unique_backup_dir(claude_dir)
         claude_dir.rename(backup)  # rename moves a dir, symlink, or file alike

--- a/src/project_init/surfaces.py
+++ b/src/project_init/surfaces.py
@@ -38,9 +38,10 @@ def _guard_command(surface: str) -> str:
     then ``exec``s the guard so stdin (the tool-call JSON) is inherited.
     """
     return (
-        "sh -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && "
+        'sh -c \'cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && '
         f"exec .agents/hooks/_py.sh .agents/hooks/agent_guard_adapter.py {surface}'"
     )
+
 
 # --- canonical MCP rendering -------------------------------------------------
 
@@ -58,7 +59,9 @@ def mcp_server_specs(selected: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return out
 
 
-def render_mcp_json(servers: dict[str, dict[str, Any]], *, key: str, drop_type: bool = False) -> str:
+def render_mcp_json(
+    servers: dict[str, dict[str, Any]], *, key: str, drop_type: bool = False
+) -> str:
     """MCP config as JSON.
 
     ``key`` is the top-level wrapper: ``mcpServers`` (Claude root .mcp.json,
@@ -68,8 +71,7 @@ def render_mcp_json(servers: dict[str, dict[str, Any]], *, key: str, drop_type: 
     """
     if drop_type:
         servers = {
-            name: {k: v for k, v in spec.items() if k != "type"}
-            for name, spec in servers.items()
+            name: {k: v for k, v in spec.items() if k != "type"} for name, spec in servers.items()
         }
     return json.dumps({key: servers}, indent=2, sort_keys=True) + "\n"
 
@@ -139,9 +141,7 @@ def render_cursor_hooks() -> str:
     config = {
         "version": 1,
         "hooks": {
-            "beforeShellExecution": [
-                {"command": _guard_command("cursor"), "type": "command"}
-            ],
+            "beforeShellExecution": [{"command": _guard_command("cursor"), "type": "command"}],
         },
     }
     return json.dumps(config, indent=2, sort_keys=True) + "\n"
@@ -221,6 +221,7 @@ SURFACES: dict[str, dict[str, Any]] = {
         "mcp_render": ("json", "mcpServers", True),
     },
 }
+
 
 def render_mcp_for(kind_key: tuple[Any, ...], servers: dict[str, dict[str, Any]]) -> str:
     """Render MCP config for a ``(format, key[, drop_type])`` spec."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,4 +73,3 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         marker_name = _PATH_MARKERS.get(rel_path.parts[0])
         if marker_name:
             item.add_marker(getattr(pytest.mark, marker_name))
-

--- a/tests/contracts/test_agent_overlays.py
+++ b/tests/contracts/test_agent_overlays.py
@@ -216,7 +216,6 @@ class TestAntigravityOverlay:
         assert not (target / ".gemini-extension").exists()
         assert not (target / ".agents" / "scripts" / "setup_gemini.sh").exists()
 
-
     def test_scaffolds_agents_md(self, tmp_path: Path):
         target = _scaffold_agents(tmp_path / "p", "antigravity")
         agents_md = target / ".agents" / "AGENTS.md"

--- a/tests/contracts/test_agents_canonical.py
+++ b/tests/contracts/test_agents_canonical.py
@@ -31,7 +31,12 @@ class TestCanonicality:
         content = (target / "AGENTS.md").read_text()
         # "cannot fail" keys on the durable break-it rule, not a methodology name
         # that gets reworded (PI-745 changed "TDD" -> "Test-first for design").
-        for marker in ("Key rules for agents", "cannot fail", "GitHub workflow", "Skills (load on demand)"):
+        for marker in (
+            "Key rules for agents",
+            "cannot fail",
+            "GitHub workflow",
+            "Skills (load on demand)",
+        ):
             assert marker in content, f"AGENTS.md missing canonical content: {marker}"
 
     def test_claude_md_is_a_thin_redirect(self, target: Path):
@@ -128,8 +133,12 @@ class TestSkillNeutrality:
         # github_workflow moved to the lifecycle_fallback overlay (#476).
         gw = (
             Path(__file__).resolve().parents[2]
-            / "templates" / "lifecycle_fallback" / "dot_agents" / "skills"
-            / "github_workflow" / "SKILL.md"
+            / "templates"
+            / "lifecycle_fallback"
+            / "dot_agents"
+            / "skills"
+            / "github_workflow"
+            / "SKILL.md"
         )
         content = gw.read_text()
         frontmatter = content.split("---")[1]

--- a/tests/contracts/test_agents_template_sync.py
+++ b/tests/contracts/test_agents_template_sync.py
@@ -54,8 +54,11 @@ def test_committed_code_map_is_fresh(tmp_path: Path):
     committed = REPO_ROOT / ".agents" / "docs" / "CODE_MAP.md"
     assert committed.exists(), "run `just code-map` and commit .agents/docs/CODE_MAP.md"
     subprocess.run(
-        [sys.executable, str(REPO_ROOT / ".agents" / "scripts" / "gen_code_map.py"),
-         str(REPO_ROOT / "src")],
+        [
+            sys.executable,
+            str(REPO_ROOT / ".agents" / "scripts" / "gen_code_map.py"),
+            str(REPO_ROOT / "src"),
+        ],
         cwd=tmp_path,
         check=True,
         capture_output=True,

--- a/tests/contracts/test_benchmark_cost_latency.py
+++ b/tests/contracts/test_benchmark_cost_latency.py
@@ -16,15 +16,28 @@ from tools.benchmark.record import RunRecord
 
 def _record(model: str = "claude-opus-4-8", **tok) -> RunRecord:
     base = dict(
-        input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
     )
     base.update(tok)
     total = sum(base.values())
     return RunRecord(
-        task="feat", target="bare", run_index=0, model=model,
-        agents_version="v", session_id="", transcript_path="/t",
-        total_tokens=total, tool_calls=0, turns=0, wall_clock_s=None,
-        first_ts=None, last_ts=None, **base,
+        task="feat",
+        target="bare",
+        run_index=0,
+        model=model,
+        agents_version="v",
+        session_id="",
+        transcript_path="/t",
+        total_tokens=total,
+        tool_calls=0,
+        turns=0,
+        wall_clock_s=None,
+        first_ts=None,
+        last_ts=None,
+        **base,
     )
 
 
@@ -38,8 +51,9 @@ class TestCost:
     def test_cache_classes_priced_independently(self):
         prc = prices.load_prices()
         # 1M cache-read @ 0.5e-6 = $0.50; 1M cache-creation @ 6.25e-6 = $6.25.
-        rec = _record("claude-opus-4-8", cache_read_tokens=1_000_000,
-                      cache_creation_tokens=1_000_000)
+        rec = _record(
+            "claude-opus-4-8", cache_read_tokens=1_000_000, cache_creation_tokens=1_000_000
+        )
         assert prices.cost_for(rec, prc) == 6.75
 
     def test_apply_cost_sets_field_rounded(self):

--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -19,8 +19,12 @@ from tools.benchmark.record import RunRecord, read_records, write_records
 def _write_transcript(path: Path) -> None:
     """A small but representative Claude Code transcript."""
     entries = [
-        {"type": "user", "timestamp": "2026-06-23T10:00:00Z", "version": "2.1.181",
-         "message": {"content": "hi"}},
+        {
+            "type": "user",
+            "timestamp": "2026-06-23T10:00:00Z",
+            "version": "2.1.181",
+            "message": {"content": "hi"},
+        },
         {
             "type": "assistant",
             "timestamp": "2026-06-23T10:00:05Z",
@@ -46,8 +50,12 @@ def _write_transcript(path: Path) -> None:
             "version": "2.1.181",
             "message": {
                 "model": "claude-opus-4-8",
-                "usage": {"input_tokens": 20, "output_tokens": 10,
-                          "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 10,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                },
                 "content": [{"type": "text", "text": "done"}],
             },
         },
@@ -82,11 +90,23 @@ class TestTranscriptParse:
 class TestRecord:
     def test_jsonl_round_trip(self, tmp_path: Path):
         rec = RunRecord(
-            task="feat", target="bare", run_index=0, model="claude-opus-4-8",
-            agents_version="2.1.181", session_id="s1", transcript_path="/t.jsonl",
-            input_tokens=120, output_tokens=60, cache_read_tokens=800,
-            cache_creation_tokens=200, total_tokens=1180, tool_calls=2, turns=2,
-            wall_clock_s=9.0, first_ts="a", last_ts="b",
+            task="feat",
+            target="bare",
+            run_index=0,
+            model="claude-opus-4-8",
+            agents_version="2.1.181",
+            session_id="s1",
+            transcript_path="/t.jsonl",
+            input_tokens=120,
+            output_tokens=60,
+            cache_read_tokens=800,
+            cache_creation_tokens=200,
+            total_tokens=1180,
+            tool_calls=2,
+            turns=2,
+            wall_clock_s=9.0,
+            first_ts="a",
+            last_ts="b",
         )
         out = tmp_path / "records.jsonl"
         write_records([rec], out)
@@ -98,14 +118,28 @@ class TestRecord:
 
     def test_from_dict_tolerant(self):
         # Unknown keys ignored, missing optional keys default — forward/backward compat.
-        rec = RunRecord.from_dict({
-            "task": "qa", "target": "bare", "run_index": 1, "model": "m",
-            "agents_version": "v", "session_id": "", "transcript_path": "/t",
-            "input_tokens": 1, "output_tokens": 2, "cache_read_tokens": 3,
-            "cache_creation_tokens": 4, "total_tokens": 10, "tool_calls": 0, "turns": 1,
-            "wall_clock_s": None, "first_ts": None, "last_ts": None,
-            "future_field_from_a_later_issue": 123,  # ignored
-        })
+        rec = RunRecord.from_dict(
+            {
+                "task": "qa",
+                "target": "bare",
+                "run_index": 1,
+                "model": "m",
+                "agents_version": "v",
+                "session_id": "",
+                "transcript_path": "/t",
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_read_tokens": 3,
+                "cache_creation_tokens": 4,
+                "total_tokens": 10,
+                "tool_calls": 0,
+                "turns": 1,
+                "wall_clock_s": None,
+                "first_ts": None,
+                "last_ts": None,
+                "future_field_from_a_later_issue": 123,  # ignored
+            }
+        )
         assert rec.task == "qa" and rec.cost_usd is None
 
     def test_read_missing_file_is_empty(self, tmp_path: Path):
@@ -118,8 +152,12 @@ class TestBuildRecord:
         _write_transcript(tx)
         rec = harness.build_record(
             harness.RunContext(
-                task="feat", target="obsidian-only", run_index=2,
-                model="claude-opus-4-8", session_id="sess-1", wall_clock_s=12.3,
+                task="feat",
+                target="obsidian-only",
+                run_index=2,
+                model="claude-opus-4-8",
+                session_id="sess-1",
+                wall_clock_s=12.3,
             ),
             tx,
         )
@@ -217,13 +255,22 @@ class TestUnpricedWarning:
     def test_record_from_warns_on_unpriced_model(self, tmp_path: Path, capsys):
         """Both CLI paths must warn (not silently emit null cost) — Copilot review."""
         tx = tmp_path / "t.jsonl"
-        tx.write_text(json.dumps(
-            {"type": "assistant", "message": {"model": "gpt-4o", "usage": {}}}
-        ) + "\n")
-        rc = harness.main([
-            "record-from", "--task", "qa", "--target", "bare",
-            "--transcript", str(tx), "--out", str(tmp_path / "r.jsonl"),
-        ])
+        tx.write_text(
+            json.dumps({"type": "assistant", "message": {"model": "gpt-4o", "usage": {}}}) + "\n"
+        )
+        rc = harness.main(
+            [
+                "record-from",
+                "--task",
+                "qa",
+                "--target",
+                "bare",
+                "--transcript",
+                str(tx),
+                "--out",
+                str(tmp_path / "r.jsonl"),
+            ]
+        )
         assert rc == 0
         assert "no price row for model 'gpt-4o'" in capsys.readouterr().err
 

--- a/tests/contracts/test_benchmark_report.py
+++ b/tests/contracts/test_benchmark_report.py
@@ -15,11 +15,27 @@ from tools.benchmark.record import RunRecord, write_records
 def _rec(target: str, **over) -> RunRecord:
     """Build a RunRecord with sane defaults; `over` uses dataclass field names."""
     base = dict(
-        task="feat", target=target, run_index=0, model="claude-opus-4-8",
-        agents_version="v", session_id="", transcript_path="/t",
-        input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
-        total_tokens=0, tool_calls=0, turns=1, wall_clock_s=None, first_ts=None, last_ts=None,
-        cost_usd=None, success=None, first_try=None, rework_cycles=None,
+        task="feat",
+        target=target,
+        run_index=0,
+        model="claude-opus-4-8",
+        agents_version="v",
+        session_id="",
+        transcript_path="/t",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        total_tokens=0,
+        tool_calls=0,
+        turns=1,
+        wall_clock_s=None,
+        first_ts=None,
+        last_ts=None,
+        cost_usd=None,
+        success=None,
+        first_try=None,
+        rework_cycles=None,
     )
     base.update(over)
     return RunRecord(**base)
@@ -28,20 +44,68 @@ def _rec(target: str, **over) -> RunRecord:
 def _sample() -> list[RunRecord]:
     return [
         # bare: cheap, often wrong (1 of 2 passes, never first-try)
-        _rec("bare", run_index=0, cost_usd=0.10, total_tokens=1000, wall_clock_s=10.0,
-             success=False, first_try=False, rework_cycles=2),
-        _rec("bare", run_index=1, cost_usd=0.10, total_tokens=1000, wall_clock_s=12.0,
-             success=True, first_try=False, rework_cycles=1),
+        _rec(
+            "bare",
+            run_index=0,
+            cost_usd=0.10,
+            total_tokens=1000,
+            wall_clock_s=10.0,
+            success=False,
+            first_try=False,
+            rework_cycles=2,
+        ),
+        _rec(
+            "bare",
+            run_index=1,
+            cost_usd=0.10,
+            total_tokens=1000,
+            wall_clock_s=12.0,
+            success=True,
+            first_try=False,
+            rework_cycles=1,
+        ),
         # obsidian-only: pricier, more accurate (both pass first-try)
-        _rec("obsidian-only", run_index=0, cost_usd=0.15, total_tokens=1500, wall_clock_s=11.0,
-             success=True, first_try=True, rework_cycles=0),
-        _rec("obsidian-only", run_index=1, cost_usd=0.15, total_tokens=1500, wall_clock_s=13.0,
-             success=True, first_try=True, rework_cycles=0),
+        _rec(
+            "obsidian-only",
+            run_index=0,
+            cost_usd=0.15,
+            total_tokens=1500,
+            wall_clock_s=11.0,
+            success=True,
+            first_try=True,
+            rework_cycles=0,
+        ),
+        _rec(
+            "obsidian-only",
+            run_index=1,
+            cost_usd=0.15,
+            total_tokens=1500,
+            wall_clock_s=13.0,
+            success=True,
+            first_try=True,
+            rework_cycles=0,
+        ),
         # obsidian-graphify: priciest, no better accuracy → dominated
-        _rec("obsidian-graphify", run_index=0, cost_usd=0.20, total_tokens=2000, wall_clock_s=14.0,
-             success=True, first_try=True, rework_cycles=0),
-        _rec("obsidian-graphify", run_index=1, cost_usd=0.20, total_tokens=2000, wall_clock_s=15.0,
-             success=True, first_try=True, rework_cycles=0),
+        _rec(
+            "obsidian-graphify",
+            run_index=0,
+            cost_usd=0.20,
+            total_tokens=2000,
+            wall_clock_s=14.0,
+            success=True,
+            first_try=True,
+            rework_cycles=0,
+        ),
+        _rec(
+            "obsidian-graphify",
+            run_index=1,
+            cost_usd=0.20,
+            total_tokens=2000,
+            wall_clock_s=15.0,
+            success=True,
+            first_try=True,
+            rework_cycles=0,
+        ),
     ]
 
 
@@ -62,7 +126,9 @@ class TestAggregate:
         assert summ["bare"].first_try_rate == 0.0
 
     def test_noop_success_none_excluded_from_pass_rate(self):
-        recs = [_rec("bare", cost_usd=0.1, total_tokens=1, wall_clock_s=1.0)]  # success defaults None
+        recs = [
+            _rec("bare", cost_usd=0.1, total_tokens=1, wall_clock_s=1.0)
+        ]  # success defaults None
         assert report.aggregate(recs)["bare"].pass_rate is None
 
 
@@ -89,10 +155,12 @@ class TestParetoTiesAndIncomparable:
 
     def test_unpriced_target_is_incomparable_not_dominated(self):
         """A target missing a Pareto axis must not be labelled 'dominated' (Codex review)."""
-        summ = report.aggregate([
-            _rec("bare", cost_usd=0.10, total_tokens=100, success=True, first_try=True),
-            _rec("mystery", cost_usd=None, total_tokens=100, success=True, first_try=True),
-        ])
+        summ = report.aggregate(
+            [
+                _rec("bare", cost_usd=0.10, total_tokens=100, success=True, first_try=True),
+                _rec("mystery", cost_usd=None, total_tokens=100, success=True, first_try=True),
+            ]
+        )
         eff = report.pareto_efficient(summ)
         line = report.verdict(summ["bare"], summ["mystery"], eff)
         assert "incomparable" in line and "dominated" not in line

--- a/tests/contracts/test_benchmark_scoring.py
+++ b/tests/contracts/test_benchmark_scoring.py
@@ -86,8 +86,7 @@ class TestPytestArgv:
             "uv run pytest -q test_calc.py",
             ["test_calc.py::test_a", "test_calc.py::test_b"],
         )
-        assert argv == ["uv", "run", "pytest", "-q",
-                        "test_calc.py::test_a", "test_calc.py::test_b"]
+        assert argv == ["uv", "run", "pytest", "-q", "test_calc.py::test_a", "test_calc.py::test_b"]
 
     def test_no_nodes_runs_command_as_authored(self):
         argv = scoring._pytest_argv("uv run pytest -q test_slug.py", [])
@@ -123,12 +122,26 @@ class TestNoneCheck:
 
 class TestRework:
     def _transcript(self, path: Path, n_errors: int) -> None:
-        entries = [{"type": "assistant", "message": {"model": "m", "usage": {},
-                    "content": [{"type": "tool_use", "id": f"t{i}", "name": "Bash", "input": {}}]}}
-                   for i in range(n_errors)]
-        entries += [{"type": "user", "message": {"content": [
-            {"type": "tool_result", "tool_use_id": f"t{i}", "is_error": True}]}}
-            for i in range(n_errors)]
+        entries = [
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "m",
+                    "usage": {},
+                    "content": [{"type": "tool_use", "id": f"t{i}", "name": "Bash", "input": {}}],
+                },
+            }
+            for i in range(n_errors)
+        ]
+        entries += [
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": f"t{i}", "is_error": True}]
+                },
+            }
+            for i in range(n_errors)
+        ]
         path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
 
     def test_counts_error_tool_results(self, tmp_path: Path):
@@ -150,21 +163,38 @@ class TestScoreOrchestrator:
     def test_first_try_when_success_and_no_rework(self, tmp_path: Path):
         tx = tmp_path / "t.jsonl"
         tx.write_text(json.dumps({"type": "assistant", "message": {"model": "m"}}) + "\n")
-        s = scoring.score(load_task("qa"), target_dir=Path("."),
-                          transcript_path=tx, agent_output="see the justfile")
+        s = scoring.score(
+            load_task("qa"),
+            target_dir=Path("."),
+            transcript_path=tx,
+            agent_output="see the justfile",
+        )
         assert s.success is True and s.rework_cycles == 0 and s.first_try is True
 
     def test_not_first_try_when_rework(self, tmp_path: Path):
         tx = tmp_path / "t.jsonl"
         entries = [
-            {"type": "assistant", "message": {"model": "m", "content": [
-                {"type": "tool_use", "id": "t0", "name": "Bash", "input": {}}]}},
-            {"type": "user", "message": {"content": [
-                {"type": "tool_result", "tool_use_id": "t0", "is_error": True}]}},
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "m",
+                    "content": [{"type": "tool_use", "id": "t0", "name": "Bash", "input": {}}],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": "t0", "is_error": True}]
+                },
+            },
         ]
         tx.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
-        s = scoring.score(load_task("qa"), target_dir=Path("."),
-                          transcript_path=tx, agent_output="see the justfile")
+        s = scoring.score(
+            load_task("qa"),
+            target_dir=Path("."),
+            transcript_path=tx,
+            agent_output="see the justfile",
+        )
         assert s.success is True and s.rework_cycles == 1 and s.first_try is False
 
     def test_no_target_leaves_success_none(self, tmp_path: Path):

--- a/tests/contracts/test_capabilities.py
+++ b/tests/contracts/test_capabilities.py
@@ -40,9 +40,7 @@ def test_inventory_is_generated(tmp_path: Path):
 
 
 def test_options_reflect_choices(tmp_path: Path):
-    t = _scaffold(
-        tmp_path / "p", agents="claude,codex,cursor", installed_mcps="context7"
-    )
+    t = _scaffold(tmp_path / "p", agents="claude,codex,cursor", installed_mcps="context7")
     text = (t / _REL).read_text()
     assert "claude,codex,cursor" in text
     assert "| MCP servers | context7 |" in text
@@ -102,8 +100,12 @@ def test_mcp_section_empty_when_none(tmp_path: Path):
 def test_inventory_matches_canonical_render_no_drift(tmp_path: Path):
     """The written file equals render(variables) — single source of truth."""
     variables = make_variables(
-        plugin_mode="true", no_plugin="", codex="true", multi_agent="true",
-        agents="claude,codex", installed_mcps="context7",
+        plugin_mode="true",
+        no_plugin="",
+        codex="true",
+        multi_agent="true",
+        agents="claude,codex",
+        installed_mcps="context7",
     )
     t = _scaffold(tmp_path / "p", agents="claude,codex", installed_mcps="context7")
     assert (t / _REL).read_text() == capabilities.render(variables)

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -43,9 +43,7 @@ def _jobs_with_runs_on(text: str) -> dict[str, str]:
 class TestCiRunsOnEscapeHatch:
     def test_compute_jobs_use_the_variable(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        jobs = _jobs_with_runs_on(
-            (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
-        )
+        jobs = _jobs_with_runs_on((tmp_target / ".github" / "workflows" / "ci.yml").read_text())
         assert jobs, "no jobs parsed from ci.yml"
         for job, runs_on in jobs.items():
             if job == "scorecard":
@@ -80,9 +78,7 @@ class TestCiRunsOnEscapeHatch:
 
     def test_scorecard_stays_pinned_but_gate_follows(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        jobs = _jobs_with_runs_on(
-            (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
-        )
+        jobs = _jobs_with_runs_on((tmp_target / ".github" / "workflows" / "ci.yml").read_text())
         # scorecard: OSSF-hosted requirement; schedule-gated so it never
         # blocks a PR — safe to pin.
         if "scorecard" in jobs:
@@ -113,9 +109,7 @@ class TestCiRunsOnEscapeHatch:
         from tests.helpers import make_variables
 
         preset = load_preset("obsidian-only")
-        extra = overlay_layers(
-            [], no_plugin=True, memory_stack="obsidian-only", lifecycle=False
-        )
+        extra = overlay_layers([], no_plugin=True, memory_stack="obsidian-only", lifecycle=False)
         preset = {**preset, "layers": [*preset["layers"], *extra]}
         target = tmp_path / "p"
         scaffold(
@@ -144,9 +138,7 @@ class TestCiRunsOnEscapeHatch:
         ci = (tmp_target / ".github" / "workflows" / "ci.yml").read_text()
         # Executable lines only — the explanatory comment legitimately names
         # the failure mode ("pip install semgrep fails there").
-        runnable = [
-            ln for ln in ci.splitlines() if not ln.lstrip().startswith("#")
-        ]
+        runnable = [ln for ln in ci.splitlines() if not ln.lstrip().startswith("#")]
         assert not [ln for ln in runnable if "pip install" in ln], (
             "pip must not be executed in scaffolded CI"
         )

--- a/tests/contracts/test_deploy_overlay.py
+++ b/tests/contracts/test_deploy_overlay.py
@@ -70,7 +70,9 @@ class TestContainerDeploy:
 
     def test_fly_and_k8s_stubs(self, tmp_path: Path):
         assert "flyctl deploy" in _deploy_yml(_service_deploy(tmp_path / "f", "fly")).read_text()
-        assert "kubectl set image" in _deploy_yml(_service_deploy(tmp_path / "k", "k8s")).read_text()
+        assert (
+            "kubectl set image" in _deploy_yml(_service_deploy(tmp_path / "k", "k8s")).read_text()
+        )
 
     @pytest.mark.parametrize("deploy", ["cloud-run", "fly", "k8s"])
     def test_ship_stubs_use_project_slug(self, tmp_path: Path, deploy: str):
@@ -139,10 +141,10 @@ class TestDeployGateScripts:
 
     def test_gate_is_tiered(self, tmp_path: Path):
         text = _envprot(_service_deploy(tmp_path / "svc", "cloud-run")).read_text()
-        assert "prevent_self_review" in text          # org: hard human gate
+        assert "prevent_self_review" in text  # org: hard human gate
         assert "reviewers" in text
-        assert "wait_timer" in text                   # individual/standalone: advisory
-        assert "PUBLIC repo" in text                  # plan caveat documented
+        assert "wait_timer" in text  # individual/standalone: advisory
+        assert "PUBLIC repo" in text  # plan caveat documented
 
     def test_absent_for_registry_none_and_prototype(self, tmp_path: Path):
         reg = _service_deploy(tmp_path / "reg", "registry")

--- a/tests/contracts/test_dockerfile_lint.py
+++ b/tests/contracts/test_dockerfile_lint.py
@@ -81,13 +81,17 @@ class TestDockerfilePassesClean:
         assert "uv:latest" in dockerfile
         # The ignore directive must sit immediately above the COPY it applies to.
         lines = dockerfile.splitlines()
-        copy_idx = next(i for i, ln in enumerate(lines) if ln.startswith("COPY --from=ghcr.io/astral-sh/uv"))
+        copy_idx = next(
+            i for i, ln in enumerate(lines) if ln.startswith("COPY --from=ghcr.io/astral-sh/uv")
+        )
         assert lines[copy_idx - 1].strip() == "# hadolint ignore=DL3007"
 
     def test_rust_pipe_guarded(self, tmp_path: Path):
         dockerfile = (_service(tmp_path / "svc", "rust") / "Dockerfile").read_text()
         lines = dockerfile.splitlines()
-        run_idx = next(i for i, ln in enumerate(lines) if ln.startswith("RUN cargo build --release"))
+        run_idx = next(
+            i for i, ln in enumerate(lines) if ln.startswith("RUN cargo build --release")
+        )
         assert lines[run_idx - 1].strip() == "# hadolint ignore=DL4006"
 
     @pytest.mark.parametrize("language", ["node", "go"])

--- a/tests/contracts/test_docs_renovate.py
+++ b/tests/contracts/test_docs_renovate.py
@@ -20,7 +20,9 @@ from project_init.upgrade import _backfill_variables, _migrate_semantic_config
 from tests.helpers import make_variables, memory_preset
 
 
-def _inputs(*, want_docs: bool = True, renovate: bool = True, language: str = "python") -> ScaffoldInputs:
+def _inputs(
+    *, want_docs: bool = True, renovate: bool = True, language: str = "python"
+) -> ScaffoldInputs:
     return ScaffoldInputs(
         project_name="p",
         project_description="d",
@@ -77,12 +79,18 @@ class TestGating:
         assert _render_file("base/mkdocs.yml.tmpl", python="true", want_docs="true").strip()
         assert _render_file("base/mkdocs.yml.tmpl", python="true", want_docs="").strip() == ""
         # never forced on a non-python language, even with want_docs on.
-        assert _render_file("base/mkdocs.yml.tmpl", python="", node="true", want_docs="true").strip() == ""
+        assert (
+            _render_file("base/mkdocs.yml.tmpl", python="", node="true", want_docs="true").strip()
+            == ""
+        )
 
     def test_typedoc_node_plus_want_docs(self):
         assert _render_file("base/typedoc.json.tmpl", node="true", want_docs="true").strip()
         assert _render_file("base/typedoc.json.tmpl", node="true", want_docs="").strip() == ""
-        assert _render_file("base/typedoc.json.tmpl", node="", python="true", want_docs="true").strip() == ""
+        assert (
+            _render_file("base/typedoc.json.tmpl", node="", python="true", want_docs="true").strip()
+            == ""
+        )
 
     def test_renovate_gates_on_renovate(self):
         assert _render_file("base/renovate.json.tmpl", renovate="true").strip()
@@ -116,7 +124,9 @@ class TestGating:
 class TestScaffoldGating:
     def test_python_no_docs_omits_mkdocs(self, tmp_path: Path):
         target = tmp_path / "p"
-        scaffold(target, memory_preset("core"), make_variables(python="true", want_docs=""), strict=True)
+        scaffold(
+            target, memory_preset("core"), make_variables(python="true", want_docs=""), strict=True
+        )
         assert not (target / "mkdocs.yml").exists()
 
     def test_python_default_ships_mkdocs(self, tmp_path: Path):
@@ -131,7 +141,9 @@ class TestScaffoldGating:
 
     def test_no_docs_omits_docs_tree(self, tmp_path: Path):
         target = tmp_path / "p"
-        scaffold(target, memory_preset("core"), make_variables(python="true", want_docs=""), strict=True)
+        scaffold(
+            target, memory_preset("core"), make_variables(python="true", want_docs=""), strict=True
+        )
         assert not (target / "docs").exists()
 
     def test_default_ships_docs_tree(self, tmp_path: Path):
@@ -143,8 +155,19 @@ class TestScaffoldGating:
 
 def _scaffold_cli(target: Path, *extra: str) -> None:
     rc = main(
-        [str(target), "--non-interactive", "--preset", "core", "--name", "fx",
-         "--description", "d", "--language", "python", *extra]
+        [
+            str(target),
+            "--non-interactive",
+            "--preset",
+            "core",
+            "--name",
+            "fx",
+            "--description",
+            "d",
+            "--language",
+            "python",
+            *extra,
+        ]
     )
     assert rc == 0
 

--- a/tests/contracts/test_emission_hardening.py
+++ b/tests/contracts/test_emission_hardening.py
@@ -203,9 +203,7 @@ def test_canonical_hooks_warns_on_invalid_json(monkeypatch, capsys):
     """Invalid rendered settings.json means broken wiring, not zero hooks — it
     must warn on stderr (visible in CLI use, unlike warnings.warn) rather than
     silently return an empty inventory (2026-07 review)."""
-    monkeypatch.setattr(
-        "project_init.scaffold._render", lambda *a, **k: "{ not valid json,"
-    )
+    monkeypatch.setattr("project_init.scaffold._render", lambda *a, **k: "{ not valid json,")
     hooks = capabilities.canonical_hooks(make_variables())
     assert hooks == []
     assert "invalid JSON" in capsys.readouterr().err

--- a/tests/contracts/test_env_tooling.py
+++ b/tests/contracts/test_env_tooling.py
@@ -103,9 +103,7 @@ class TestVscodeOverlay:
         assert "anthropic.agents-code" in extensions["recommendations"]
 
     def test_go_recommends_go_extension(self, tmp_path: Path):
-        target = _scaffold_vscode(
-            tmp_path / "go", language="go", python="", go="true"
-        )
+        target = _scaffold_vscode(tmp_path / "go", language="go", python="", go="true")
         extensions = json.loads((target / ".vscode" / "extensions.json").read_text())
         assert "golang.go" in extensions["recommendations"]
         assert "charliermarsh.ruff" not in extensions["recommendations"]

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -30,7 +30,12 @@ from tests.workflow import (
 
 def _scaffold(target: Path, language: str = "python") -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
-    scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags), strict=True)
+    scaffold(
+        target,
+        load_preset("obsidian-only"),
+        make_variables(language=language, **flags),
+        strict=True,
+    )
     return target
 
 
@@ -133,7 +138,9 @@ class TestFuzzJob:
 
     @pytest.mark.parametrize("language", _LANGUAGES)
     def test_renders_cleanly(self, tmp_path: Path, language: str):
-        ci = (_scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml").read_text()
+        ci = (
+            _scaffold(tmp_path / language, language) / ".github" / "workflows" / "ci.yml"
+        ).read_text()
         assert "{{#if" not in ci and "{{/if" not in ci
 
 
@@ -147,8 +154,12 @@ class TestFuzzDocumented:
             ("rust", "rust.md", "proptest"),
         ],
     )
-    def test_rules_document_pattern(self, tmp_path: Path, language: str, rules_file: str, tool: str):
-        rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
+    def test_rules_document_pattern(
+        self, tmp_path: Path, language: str, rules_file: str, tool: str
+    ):
+        rules = (
+            _scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file
+        ).read_text()
         assert tool in rules
         # Explicitly scoped as pattern/tooling, not a blocking gate.
         assert "not** a blocking gate" in rules or "not a blocking gate" in rules
@@ -164,7 +175,9 @@ class TestFuzzDocumented:
         nothing at all — a doc restating a gate that does not exist as written is
         the map-not-territory failure (#688).
         """
-        rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
+        rules = (
+            _scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file
+        ).read_text()
         assert "**When it runs:**" in rules, f"{rules_file} does not say when fuzzing runs"
         assert "schedule-only (nightly)" in rules
         assert "never on a PR" in rules

--- a/tests/contracts/test_governance.py
+++ b/tests/contracts/test_governance.py
@@ -11,9 +11,7 @@ from project_init.scaffold import load_preset, scaffold
 from tests.helpers import make_variables
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_SETUP_GITHUB = (
-    _REPO_ROOT / "templates/lifecycle/dot_agents/scripts/setup_github.sh"
-)
+_SETUP_GITHUB = _REPO_ROOT / "templates/lifecycle/dot_agents/scripts/setup_github.sh"
 
 
 def _scaffold(target: Path, **overrides: str) -> Path:
@@ -41,9 +39,7 @@ class TestGovernanceFiles:
         content = (target / ".github" / "CODEOWNERS").read_text()
         assert "@your-org/backend" in content  # commented examples survive
         # No uncommented ownership line without an owner.
-        active = [
-            ln for ln in content.splitlines() if ln.strip() and not ln.startswith("#")
-        ]
+        active = [ln for ln in content.splitlines() if ln.strip() and not ln.startswith("#")]
         assert active == []
 
     def test_contributing_references_command_surface(self, tmp_path: Path):
@@ -56,8 +52,13 @@ class TestGovernanceFiles:
 
     def test_contributing_language_none_has_no_just(self, tmp_path: Path):
         target = _scaffold(
-            tmp_path / "p", language="none", python="", justfile="",
-            lint_command="", format_command="", test_command="",
+            tmp_path / "p",
+            language="none",
+            python="",
+            justfile="",
+            lint_command="",
+            format_command="",
+            test_command="",
         )
         content = (target / "CONTRIBUTING.md").read_text()
         assert "just --list" not in content

--- a/tests/contracts/test_governance_overlay.py
+++ b/tests/contracts/test_governance_overlay.py
@@ -64,9 +64,7 @@ class TestOverlayLayers:
         assert overlay_layers("claude", no_plugin=False, governance=False) == []
 
     def test_composes_with_agents_fallback_and_multi_model(self):
-        layers = overlay_layers(
-            "claude,codex", no_plugin=True, multi_model=True, governance=True
-        )
+        layers = overlay_layers("claude,codex", no_plugin=True, multi_model=True, governance=True)
         # Order is stable: fallback, agents, then the opt-in overlays.
         assert layers == ["fallback", "codex", "multi_model", "governance"]
 

--- a/tests/contracts/test_hook_portability.py
+++ b/tests/contracts/test_hook_portability.py
@@ -129,13 +129,7 @@ def test_lint_hooks_do_not_leak_ruff_stdout():
     diagnostics there, which would leak before the JSON and break consumers."""
     from pathlib import Path
 
-    root = (
-        Path(__file__).resolve().parents[2]
-        / "templates"
-        / "fallback"
-        / "dot_agents"
-        / "hooks"
-    )
+    root = Path(__file__).resolve().parents[2] / "templates" / "fallback" / "dot_agents" / "hooks"
     for name in ("pre_commit_gate.sh", "post_edit_lint.sh"):
         for line in (root / name).read_text().splitlines():
             s = line.strip()

--- a/tests/contracts/test_iac_overlay.py
+++ b/tests/contracts/test_iac_overlay.py
@@ -23,7 +23,14 @@ def _iac(target: Path) -> Path:
 class TestIacOverlayPresent:
     def test_hcl_skeleton_renders(self, tmp_path: Path):
         t = _iac(tmp_path / "p")
-        for f in ("versions.tf", "main.tf", "variables.tf", "outputs.tf", "backend.tf", "README.md"):
+        for f in (
+            "versions.tf",
+            "main.tf",
+            "variables.tf",
+            "outputs.tf",
+            "backend.tf",
+            "README.md",
+        ):
             assert (t / "infra" / f).is_file(), f"missing infra/{f}"
 
     def test_backend_is_commented_stub(self, tmp_path: Path):
@@ -31,7 +38,7 @@ class TestIacOverlayPresent:
         # Every backend line is commented — no uncommented backend/terraform block
         # anywhere, including the file's first line (column 0).
         assert 'backend "s3"' in backend
-        assert '# terraform {' in backend
+        assert "# terraform {" in backend
         for line in backend.splitlines():
             stripped = line.lstrip()
             assert not stripped.startswith("terraform {"), f"uncommented: {line!r}"
@@ -40,15 +47,17 @@ class TestIacOverlayPresent:
     def test_gitignore_keeps_lockfile_tracked(self, tmp_path: Path):
         gi = (_iac(tmp_path / "p") / "infra" / ".gitignore").read_text()
         assert "*.tfstate" in gi
-        assert ".terraform.lock.hcl" not in gi.replace("# NOT ignored: .terraform.lock.hcl is committed (provider checksum pinning).", "")
+        assert ".terraform.lock.hcl" not in gi.replace(
+            "# NOT ignored: .terraform.lock.hcl is committed (provider checksum pinning).", ""
+        )
 
     def test_workflow_uses_opentofu_and_gated_apply(self, tmp_path: Path):
         wf = (_iac(tmp_path / "p") / ".github" / "workflows" / "infra.yml").read_text()
         assert "opentofu/setup-opentofu" in wf
         assert "tofu plan" in wf and "tofu validate" in wf
-        assert "environment: infra-apply" in wf          # gated apply
-        assert "workflow_dispatch" in wf                  # manual, not on merge
-        assert "id-token: write" in wf                    # OIDC
+        assert "environment: infra-apply" in wf  # gated apply
+        assert "workflow_dispatch" in wf  # manual, not on merge
+        assert "id-token: write" in wf  # OIDC
 
     def test_infra_apply_gate_documented_as_advisory(self, tmp_path: Path):
         """#439: the infra-apply environment is referenced but no scaffolded

--- a/tests/contracts/test_image_scan.py
+++ b/tests/contracts/test_image_scan.py
@@ -73,7 +73,5 @@ class TestTrivyImageScanAbsent:
         assert "aquasecurity/trivy-action" not in ci
 
     def test_absent_for_library(self, tmp_path: Path):
-        ci = _ci(
-            _scaffold(tmp_path / "lib", delivery="library", delivery_library="true")
-        )
+        ci = _ci(_scaffold(tmp_path / "lib", delivery="library", delivery_library="true"))
         assert "aquasecurity/trivy-action" not in ci

--- a/tests/contracts/test_integrity.py
+++ b/tests/contracts/test_integrity.py
@@ -26,6 +26,7 @@ class TestScaffoldIntegrity:
         """{{var}} or {{#if var}} surviving means a template wasn't named .tmpl
         or a variable wasn't wired up in __main__.py."""
         import re
+
         # Match {{...}} but not ${{...}} (GitHub Actions expression syntax)
         placeholder_re = re.compile(r"(?<!\$)\{\{[^}]+\}\}")
         offenders: list[str] = []
@@ -45,9 +46,8 @@ class TestScaffoldIntegrity:
                     continue
                 for match in placeholder_re.finditer(text):
                     offenders.append(f"{f.relative_to(target)}: {match.group()}")
-        assert not offenders, (
-            "Unrendered placeholders survived scaffolding:\n  "
-            + "\n  ".join(offenders)
+        assert not offenders, "Unrendered placeholders survived scaffolding:\n  " + "\n  ".join(
+            offenders
         )
 
 
@@ -57,6 +57,7 @@ class TestStrictMode:
     def test_strict_raises_on_missing_variable(self, tmp_path: Path):
         """If a variable is missing from the dict, strict mode must raise."""
         from project_init.scaffold import TemplateRenderError
+
         target = tmp_path / "p"
         variables = make_variables()
         # Inject a stale variable into a template by hand: write a fake .tmpl
@@ -64,11 +65,10 @@ class TestStrictMode:
         # We achieve this via a custom template layer.
         fake_dir = tmp_path / "fake-layer"
         (fake_dir / "dot_agents").mkdir(parents=True)
-        (fake_dir / "dot_agents" / "stale.md.tmpl").write_text(
-            "value: {{undefined_variable_xyz}}"
-        )
+        (fake_dir / "dot_agents" / "stale.md.tmpl").write_text("value: {{undefined_variable_xyz}}")
         # Patch the templates dir for this test only.
         import project_init.scaffold as sm
+
         original = sm._TEMPLATES_DIR
         sm._TEMPLATES_DIR = fake_dir.parent
         try:
@@ -86,10 +86,9 @@ class TestStrictMode:
         target = tmp_path / "p"
         fake_dir = tmp_path / "data-layer"
         (fake_dir / "dot_agents").mkdir(parents=True)
-        (fake_dir / "dot_agents" / "about.md.tmpl").write_text(
-            "desc: {{description}}\n"
-        )
+        (fake_dir / "dot_agents" / "about.md.tmpl").write_text("desc: {{description}}\n")
         import project_init.scaffold as sm
+
         original = sm._TEMPLATES_DIR
         sm._TEMPLATES_DIR = fake_dir.parent
         try:
@@ -103,15 +102,15 @@ class TestStrictMode:
     def test_strict_target_untouched_on_validation_error(self, tmp_path: Path):
         """PI-21: strict mode must leave target untouched on validation error."""
         from project_init.scaffold import TemplateRenderError
+
         target = tmp_path / "p"
         variables = make_variables()
         # Create a broken layer that will fail strict validation.
         fake_dir = tmp_path / "broken-layer"
         (fake_dir / "dot_agents").mkdir(parents=True)
-        (fake_dir / "dot_agents" / "bad.md.tmpl").write_text(
-            "# Config\nvalue: {{undefined_var}}"
-        )
+        (fake_dir / "dot_agents" / "bad.md.tmpl").write_text("# Config\nvalue: {{undefined_var}}")
         import project_init.scaffold as sm
+
         original = sm._TEMPLATES_DIR
         sm._TEMPLATES_DIR = fake_dir.parent
         try:
@@ -164,22 +163,28 @@ class TestStrictMode:
         # Shipped templates pass strict mode (verified by other test), so just
         # assert the happy path: --strict succeeds on a known-good preset.
         from project_init.__main__ import main
+
         target = tmp_path / "p"
-        rc = main([
-            str(target), "--non-interactive",
-            "--preset", "obsidian-only",
-            "--name", "strict-test",
-            "--description", "test",
-            "--language", "python",
-            "--strict",
-        ])
+        rc = main(
+            [
+                str(target),
+                "--non-interactive",
+                "--preset",
+                "obsidian-only",
+                "--name",
+                "strict-test",
+                "--description",
+                "test",
+                "--language",
+                "python",
+                "--strict",
+            ]
+        )
         assert rc == 0
 
     def test_strict_mode_docs_describe_validated_merge(self):
         readme = Path("README.md").read_text(encoding="utf-8")
-        template_system = Path("docs/development/template-system.md").read_text(
-            encoding="utf-8"
-        )
+        template_system = Path("docs/development/template-system.md").read_text(encoding="utf-8")
 
         assert "validated scaffold files are merged into the target" in readme
         assert "strict mode is not a whole-directory replacement" in readme.lower()

--- a/tests/contracts/test_interpreter_portability.py
+++ b/tests/contracts/test_interpreter_portability.py
@@ -36,6 +36,7 @@ _MULTI_MODEL = (
     _REPO_ROOT / "templates" / "multi_model" / "dot_agents" / "scripts" / "setup_models.sh"
 )
 
+
 # Every shell script the scaffold ships that may invoke Python, except the
 # resolver itself (which legitimately names python3/python/uv).
 def _shell_scripts() -> list[Path]:

--- a/tests/contracts/test_license_scan.py
+++ b/tests/contracts/test_license_scan.py
@@ -20,7 +20,10 @@ from tests.workflow import job, load_workflow, needs, run_commands, steps
 def _scaffold(target: Path, language: str = "python", **overrides: str) -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
     scaffold(
-        target, load_preset("obsidian-only"), make_variables(language=language, **flags, **overrides), strict=True
+        target,
+        load_preset("obsidian-only"),
+        make_variables(language=language, **flags, **overrides),
+        strict=True,
     )
     return target
 
@@ -41,7 +44,9 @@ class TestLicenseScanJob:
 
     def test_non_blocking_not_in_ci_gate_needs(self, tmp_path: Path):
         wf = load_workflow(_scaffold(tmp_path / "p", "python"))
-        assert "license-scan" not in needs(wf, "ci-gate"), "license-scan must stay non-blocking initially"
+        assert "license-scan" not in needs(wf, "ci-gate"), (
+            "license-scan must stay non-blocking initially"
+        )
 
     @pytest.mark.parametrize(
         "language,tool",
@@ -98,7 +103,9 @@ class TestLicenseDocumented:
         [("python", "python.md"), ("node", "node.md"), ("go", "go.md"), ("rust", "rust.md")],
     )
     def test_rules_mention_license(self, tmp_path: Path, language: str, rules_file: str):
-        rules = (_scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file).read_text()
+        rules = (
+            _scaffold(tmp_path / language, language) / ".agents" / "rules" / rules_file
+        ).read_text()
         assert "license" in rules.lower()
 
 

--- a/tests/contracts/test_lifecycle_none.py
+++ b/tests/contracts/test_lifecycle_none.py
@@ -72,9 +72,12 @@ class TestLifecycleLayerDerivation:
 
     def test_lifecycle_precedes_agents(self):
         # base → fallback → lifecycle → lifecycle_fallback → agents.
-        assert overlay_layers(
-            "claude,codex", no_plugin=True, lifecycle=True
-        ) == ["fallback", "lifecycle", "lifecycle_fallback", "codex"]
+        assert overlay_layers("claude,codex", no_plugin=True, lifecycle=True) == [
+            "fallback",
+            "lifecycle",
+            "lifecycle_fallback",
+            "codex",
+        ]
 
 
 class TestVariableContract:
@@ -225,20 +228,36 @@ class TestLifecycleNoneScaffold:
         lifecycle-free scaffold didn't ship (Codex review, #482). Catches inline
         `code` references, not just markdown links."""
         names = [
-            "create_issue.sh", "start_issue.sh", "create_nojira_pr.sh", "promote_review.sh",
-            "monitor_pr.sh", "finish_pr.sh", "push_branch.sh", "setup_github.sh", "push_wiki.sh",
-            "dag_workflow.py", "board-automation", "issue-validation", "review-status",
-            "validate-pr", "project-init-upgrade",
-            "skills/create_issue", "skills/start_task", "skills/github_workflow",
-            "skills/request_review", "skills/audit",
+            "create_issue.sh",
+            "start_issue.sh",
+            "create_nojira_pr.sh",
+            "promote_review.sh",
+            "monitor_pr.sh",
+            "finish_pr.sh",
+            "push_branch.sh",
+            "setup_github.sh",
+            "push_wiki.sh",
+            "dag_workflow.py",
+            "board-automation",
+            "issue-validation",
+            "review-status",
+            "validate-pr",
+            "project-init-upgrade",
+            "skills/create_issue",
+            "skills/start_task",
+            "skills/github_workflow",
+            "skills/request_review",
+            "skills/audit",
         ]
         pat = re.compile("|".join(re.escape(n) for n in names))
         # The guard hooks and gh_host carry internal design comments that mention
         # dag_workflow.py / start_issue.sh as examples — not user-facing paths and
         # not present as wired hooks in a lifecycle-off scaffold. Allowed.
         allowed = {
-            ".agents/hooks/_usage_log.sh", ".agents/scripts/gh_host.sh",
-            ".claude/hooks/_usage_log.sh", ".claude/scripts/gh_host.sh",
+            ".agents/hooks/_usage_log.sh",
+            ".agents/scripts/gh_host.sh",
+            ".claude/hooks/_usage_log.sh",
+            ".claude/scripts/gh_host.sh",
         }
         offenders = {}
         for p in self.target.rglob("*"):
@@ -254,7 +273,9 @@ class TestLifecycleNoneScaffold:
             hits = sorted(set(pat.findall(text)))
             if hits:
                 offenders[rel] = hits
-        assert not offenders, f"dangling lifecycle references in lifecycle-free scaffold: {offenders}"
+        assert not offenders, (
+            f"dangling lifecycle references in lifecycle-free scaffold: {offenders}"
+        )
 
     def test_base_layer_intact(self):
         assert (self.target / "AGENTS.md").is_file()
@@ -268,7 +289,9 @@ class TestPluginSplit:
     def _settings(self, tmp_path: Path, lifecycle: str) -> dict:
         target = tmp_path / lifecycle
         preset = load_preset("obsidian-only")
-        extra = overlay_layers([], no_plugin=False, memory_stack="obsidian-only", lifecycle=lifecycle == "github")
+        extra = overlay_layers(
+            [], no_plugin=False, memory_stack="obsidian-only", lifecycle=lifecycle == "github"
+        )
         preset = {**preset, "layers": [*preset["layers"], *extra]}
         scaffold(target, preset, make_variables(lifecycle_tier=lifecycle), strict=True)
         return json.loads((target / ".agents" / "settings.json").read_text())

--- a/tests/contracts/test_lifecycle_script_hardening.py
+++ b/tests/contracts/test_lifecycle_script_hardening.py
@@ -43,9 +43,7 @@ class TestStartIssueErrorPath:
 class TestCreateIssueTempFile:
     def test_could_not_add_early_return_removes_temp_file(self):
         s = (_LIFECYCLE_SCRIPTS / "create_issue.sh").read_text()
-        block = re.search(
-            r"\n(.*\n)?\s*echo \"Warning: could not add", s
-        )
+        block = re.search(r"\n(.*\n)?\s*echo \"Warning: could not add", s)
         assert block, "could-not-add warning not found"
         assert 'rm -f "$pdata_file"' in block.group(0), (
             "the could-not-add early return must clean up the mktemp file "
@@ -241,9 +239,7 @@ class TestStartIssueWorktreeKey:
         srv = tmp_path / "srv"
         srv.mkdir()
         bare = srv / "widget.git"
-        subprocess.run(
-            ["git", "clone", "-q", "--bare", str(seed), str(bare)], check=True
-        )
+        subprocess.run(["git", "clone", "-q", "--bare", str(seed), str(bare)], check=True)
         wt = tmp_path / "widget-15-fix"
         subprocess.run(
             ["git", "--git-dir", str(bare), "worktree", "add", "-q", str(wt)],
@@ -280,7 +276,7 @@ class TestStartIssueSeedCommit:
         ):
             s = path.read_text()
             assert "_seed_base" in s, f"{path}: remote-base resolver missing"
-            assert 'refs/remotes/origin/$BASE_BRANCH' in s, (
+            assert "refs/remotes/origin/$BASE_BRANCH" in s, (
                 f"{path}: the seed decision must prefer the remote-tracking "
                 "base ref — the local base can lag behind what GitHub compares"
             )
@@ -308,9 +304,7 @@ class TestStartIssueSeedCommit:
         local-base comparison says 'has commits' (skip seed); the remote-base
         comparison correctly says 'level' (seed)."""
         s = (_LIFECYCLE_SCRIPTS / "start_issue.sh").read_text()
-        m = re.search(
-            r"^_seed_base\(\) \{\n.*?\n\}$", s, re.MULTILINE | re.DOTALL
-        )
+        m = re.search(r"^_seed_base\(\) \{\n.*?\n\}$", s, re.MULTILINE | re.DOTALL)
         assert m, "_seed_base not found"
         helper = m.group(0)
 
@@ -395,9 +389,7 @@ class TestMonitorPrMergeRetry:
                 and "--auto" not in ln
                 and not ln.lstrip().startswith("#")
             ]
-            assert not outside, (
-                f"{path}: single-shot merge outside _merge_with_retry: {outside}"
-            )
+            assert not outside, f"{path}: single-shot merge outside _merge_with_retry: {outside}"
 
     def _extract(self, script: Path, *names: str) -> str:
         s = script.read_text()
@@ -412,7 +404,9 @@ class TestMonitorPrMergeRetry:
             parts.append(m.group(0))
         return "\n".join(parts)
 
-    def _run_with_stub(self, tmp_path: Path, stub: str, script_tail: str) -> subprocess.CompletedProcess:
+    def _run_with_stub(
+        self, tmp_path: Path, stub: str, script_tail: str
+    ) -> subprocess.CompletedProcess:
         helpers = self._extract(
             _LIFECYCLE_SCRIPTS / "monitor_pr.sh",
             "_run_gh",
@@ -539,9 +533,7 @@ class TestMonitorPrLocalBranchCleanup:
         s = (_LIFECYCLE_SCRIPTS / "monitor_pr.sh").read_text()
         parts = []
         for name in ("_pr_is_merged", "_cleanup_local_branch"):
-            m = re.search(
-                rf"^{name}\(\) \{{\n.*?\n\}}$", s, re.MULTILINE | re.DOTALL
-            )
+            m = re.search(rf"^{name}\(\) \{{\n.*?\n\}}$", s, re.MULTILINE | re.DOTALL)
             assert m, f"{name} not found"
             parts.append(m.group(0))
         bin_dir = tmp_path / "bin"

--- a/tests/contracts/test_marketplace_source.py
+++ b/tests/contracts/test_marketplace_source.py
@@ -67,10 +67,7 @@ class TestSettingsRendersHostAwareSource:
 class TestPluginVersionInSync:
     def test_constant_matches_plugin_json(self):
         plugin_json = json.loads(
-            (
-                _REPO_ROOT
-                / "plugins/project-init-workflow/.agents-plugin/plugin.json"
-            ).read_text()
+            (_REPO_ROOT / "plugins/project-init-workflow/.agents-plugin/plugin.json").read_text()
         )
         assert __plugin_version__ == plugin_json["version"], (
             "__plugin_version__ must match the plugin manifest"

--- a/tests/contracts/test_memory_none.py
+++ b/tests/contracts/test_memory_none.py
@@ -65,9 +65,13 @@ class TestMemoryLayerDerivation:
 
     def test_memory_layers_precede_fallback_and_agents(self):
         # Historical order: base → auto → obsidian → graphify → fallback → agents.
-        assert overlay_layers(
-            "claude,codex", no_plugin=True, memory_stack="obsidian-graphify"
-        ) == ["auto", "obsidian", "graphify", "fallback", "codex"]
+        assert overlay_layers("claude,codex", no_plugin=True, memory_stack="obsidian-graphify") == [
+            "auto",
+            "obsidian",
+            "graphify",
+            "fallback",
+            "codex",
+        ]
 
 
 class TestVariableContract:
@@ -76,12 +80,22 @@ class TestVariableContract:
     @pytest.mark.parametrize("stack,mem,obs,gfy", CONTRACT)
     def test_build_variables(self, stack, mem, obs, gfy):
         v = _build_variables(load_preset("core"), _inputs(stack))
-        assert (v["memory_stack"], v["memory"], v["obsidian"], v["graphify"]) == (stack, mem, obs, gfy)
+        assert (v["memory_stack"], v["memory"], v["obsidian"], v["graphify"]) == (
+            stack,
+            mem,
+            obs,
+            gfy,
+        )
 
     @pytest.mark.parametrize("stack,mem,obs,gfy", CONTRACT)
     def test_backfill_variables(self, stack, mem, obs, gfy):
         v = _backfill_variables({"memory_stack": stack})
-        assert (v["memory_stack"], v["memory"], v["obsidian"], v["graphify"]) == (stack, mem, obs, gfy)
+        assert (v["memory_stack"], v["memory"], v["obsidian"], v["graphify"]) == (
+            stack,
+            mem,
+            obs,
+            gfy,
+        )
 
     def test_backfill_legacy_record_gains_memory_gate(self):
         # A pre-#466 record has memory_stack but no `memory` gate var; backfill
@@ -99,7 +113,8 @@ class TestVariableContract:
         assert preset_name == ("core" if stack == "none" else stack)
 
     @pytest.mark.parametrize(
-        "stack,tier", [("none", ""), ("auto", "0"), ("obsidian-only", "1"), ("obsidian-graphify", "2")]
+        "stack,tier",
+        [("none", ""), ("auto", "0"), ("obsidian-only", "1"), ("obsidian-graphify", "2")],
     )
     def test_memory_tier_parity(self, stack, tier):
         """`memory_tier` (#498) must be emitted identically by all three paths."""

--- a/tests/contracts/test_no_egress.py
+++ b/tests/contracts/test_no_egress.py
@@ -20,9 +20,7 @@ from tests.helpers import make_variables, memory_preset
 
 def _settings(tmp_path: Path, **overrides: str) -> dict:
     target = tmp_path / "p"
-    scaffold(
-        target, memory_preset("obsidian-only"), make_variables(**overrides), strict=True
-    )
+    scaffold(target, memory_preset("obsidian-only"), make_variables(**overrides), strict=True)
     return json.loads((target / ".agents" / "settings.json").read_text())
 
 

--- a/tests/contracts/test_observability_overlay.py
+++ b/tests/contracts/test_observability_overlay.py
@@ -108,7 +108,7 @@ class TestObservabilityOn:
             encoding="utf-8"
         )
         assert "candidates.extend(" in text
-        assert "shutil.which(\"git\")" in text
+        assert 'shutil.which("git")' in text
         assert "# noqa: S603" in text
 
 

--- a/tests/contracts/test_observability_report.py
+++ b/tests/contracts/test_observability_report.py
@@ -60,18 +60,45 @@ def _write_transcript(path: Path) -> None:
                     "cache_read_input_tokens": 8000,
                 },
                 "content": [
-                    {"type": "tool_use", "id": "t1", "name": "Skill", "input": {"skill": "github_workflow"}},
-                    {"type": "tool_use", "id": "t2", "name": "Task", "input": {"subagent_type": "Explore"}},
-                    {"type": "tool_use", "id": "t3", "name": "Bash", "input": {"command": _LEAK_COMMAND}},
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "Skill",
+                        "input": {"skill": "github_workflow"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "t2",
+                        "name": "Task",
+                        "input": {"subagent_type": "Explore"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "t3",
+                        "name": "Bash",
+                        "input": {"command": _LEAK_COMMAND},
+                    },
                     {"type": "tool_use", "id": "t4", "name": "mcp__ctx__query", "input": {}},
-                    {"type": "tool_use", "id": "t5", "name": "Write",
-                     "input": {"content": f"{_LEAK_FILE}\nline2\nline3"}},
-                    {"type": "tool_use", "id": "t6", "name": "Edit",
-                     "input": {"new_string": "a\nb"}},
+                    {
+                        "type": "tool_use",
+                        "id": "t5",
+                        "name": "Write",
+                        "input": {"content": f"{_LEAK_FILE}\nline2\nline3"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "t6",
+                        "name": "Edit",
+                        "input": {"new_string": "a\nb"},
+                    },
                     # Task with no subagent_type — its free-text description must
                     # NOT leak into the report (bucketed as "unknown").
-                    {"type": "tool_use", "id": "t7", "name": "Task",
-                     "input": {"description": _LEAK_PROMPT}},
+                    {
+                        "type": "tool_use",
+                        "id": "t7",
+                        "name": "Task",
+                        "input": {"description": _LEAK_PROMPT},
+                    },
                 ],
             },
         },
@@ -82,10 +109,18 @@ def _write_transcript(path: Path) -> None:
                     # List-form content (typed blocks) — exercises the block path
                     # of the context-volume counter (PI-655). The malformed
                     # non-string "text" block must count 0, not crash the report.
-                    {"type": "tool_result", "tool_use_id": "t1", "is_error": False,
-                     "content": [{"type": "text", "text": "ok"},
-                                 {"type": "text", "text": 123}]},
-                    {"type": "tool_result", "tool_use_id": "t3", "is_error": True, "content": "boom"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "is_error": False,
+                        "content": [{"type": "text", "text": "ok"}, {"type": "text", "text": 123}],
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t3",
+                        "is_error": True,
+                        "content": "boom",
+                    },
                 ]
             },
         },
@@ -154,9 +189,7 @@ class TestBuckets:
         mod = _load_report(_scaffold(tmp_path / "p"))
         tx = tmp_path / "t.jsonl"
         _write_transcript(tx)
-        found = mod.discover_transcript(
-            transcript=str(tx), session_id=None, project_dir=tmp_path
-        )
+        found = mod.discover_transcript(transcript=str(tx), session_id=None, project_dir=tmp_path)
         assert found == tx
 
     def test_non_numeric_token_field_does_not_crash(self, tmp_path: Path):
@@ -178,9 +211,7 @@ class TestBuckets:
             },
         }
         tx.write_text(json.dumps(entry) + "\n", encoding="utf-8")
-        report = mod.analyze(
-            mod.parse_transcript(tx), {}, {"commits": None, "merge_commits": None}
-        )
+        report = mod.analyze(mod.parse_transcript(tx), {}, {"commits": None, "merge_commits": None})
         model = report["cost"]["models"][0]
         assert model["input"] == 0  # bad value coerced, not raised
         assert model["cache_read"] == 8000  # good siblings still counted
@@ -190,9 +221,7 @@ class TestBuckets:
 
         mod = _load_report(_scaffold(tmp_path / "p"))
         with pytest.raises(FileNotFoundError, match="no transcript found|not found"):
-            mod.discover_transcript(
-                transcript=None, session_id=None, project_dir=tmp_path / "nope"
-            )
+            mod.discover_transcript(transcript=None, session_id=None, project_dir=tmp_path / "nope")
 
 
 class TestHtmlReport:
@@ -219,9 +248,7 @@ class TestHtmlReport:
         mod = _load_report(target)
         tx = tmp_path / "t.jsonl"
         _write_transcript(tx)
-        report = mod.analyze(
-            mod.parse_transcript(tx), {}, {"commits": 7, "merge_commits": 0}
-        )
+        report = mod.analyze(mod.parse_transcript(tx), {}, {"commits": 7, "merge_commits": 0})
         html = mod.render_html(report, tx)
         # Document is complete, not cut off mid-tag.
         assert html.rstrip().endswith("</html>")
@@ -263,7 +290,14 @@ class TestInvariants:
             elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
                 roots.add(node.module.split(".")[0])
         stdlib = {
-            "argparse", "json", "shutil", "subprocess", "sys", "html", "pathlib", "__future__",
+            "argparse",
+            "json",
+            "shutil",
+            "subprocess",
+            "sys",
+            "html",
+            "pathlib",
+            "__future__",
         }
         assert roots <= stdlib, f"non-stdlib imports: {roots - stdlib}"
 

--- a/tests/contracts/test_observability_self_log.py
+++ b/tests/contracts/test_observability_self_log.py
@@ -36,6 +36,7 @@ def _source_dir(hook: str) -> Path:
 def _plugin_dir(hook: str) -> Path:
     return _LIFECYCLE_PLUGIN_HOOKS if hook in _LIFECYCLE_HOOK_NAMES else _PLUGIN_HOOKS
 
+
 # The five always-on shell hooks that must self-log, with the (hook, event) each
 # should record.
 _WIRED_HOOKS = {
@@ -150,7 +151,7 @@ class TestHelperGating:
         command = 'echo "hello\nworld" && curl https://user:pass@example.com'
         quoted_decision = shlex.quote(decision)
         quoted_command = shlex.quote(command)
-        script = f". {shlex.quote(str(_HELPER))}\nusage_log pre_commit_gate PreToolUse \"\" {quoted_decision} {quoted_command}\n"
+        script = f'. {shlex.quote(str(_HELPER))}\nusage_log pre_commit_gate PreToolUse "" {quoted_decision} {quoted_command}\n'
         subprocess.run(
             ["bash", "-c", script],
             capture_output=True,
@@ -277,7 +278,10 @@ class TestPackageGuardSelfLog:
         assert rows[0]["command"] == "npm install totally-nonexistent-package-name-1234"
 
     def test_dormant_without_marker(self, tmp_path: Path):
-        payload = {"tool_input": {"command": "npm install totally-nonexistent-package-name-1234"}, "cwd": str(tmp_path)}
+        payload = {
+            "tool_input": {"command": "npm install totally-nonexistent-package-name-1234"},
+            "cwd": str(tmp_path),
+        }
         _, log = _run_package_guard(payload, tmp_path)
         assert not log.exists()
 

--- a/tests/contracts/test_package_guard.py
+++ b/tests/contracts/test_package_guard.py
@@ -215,9 +215,7 @@ class TestWiring:
         scaffold(tmp_target, fallback_preset(), fallback_variables(), strict=True)
         settings = json.loads((tmp_target / ".agents" / "settings.json").read_text())
         commands = [
-            h["command"]
-            for entry in settings["hooks"]["PreToolUse"]
-            for h in entry["hooks"]
+            h["command"] for entry in settings["hooks"]["PreToolUse"] for h in entry["hooks"]
         ]
         assert any("package_guard.py" in c for c in commands)
         assert (tmp_target / ".agents" / "hooks" / "package_guard.py").is_file()
@@ -227,9 +225,7 @@ class TestWiring:
             (_REPO_ROOT / "plugins/project-init-workflow/hooks/hooks.json").read_text()
         )
         commands = [
-            h["command"]
-            for entry in plugin_hooks["hooks"]["PreToolUse"]
-            for h in entry["hooks"]
+            h["command"] for entry in plugin_hooks["hooks"]["PreToolUse"] for h in entry["hooks"]
         ]
         assert any("package_guard.py" in c for c in commands)
         assert (_REPO_ROOT / "plugins/project-init-workflow/hooks/package_guard.py").is_file()

--- a/tests/contracts/test_plugin_marketplace.py
+++ b/tests/contracts/test_plugin_marketplace.py
@@ -37,9 +37,7 @@ class TestMarketplaceManifest:
 
 class TestPluginManifest:
     def test_plugin_json_valid(self):
-        manifest = json.loads(
-            (_PLUGIN_ROOT / ".agents-plugin" / "plugin.json").read_text()
-        )
+        manifest = json.loads((_PLUGIN_ROOT / ".agents-plugin" / "plugin.json").read_text())
         assert manifest["name"] == "project-init-workflow"
         assert re.match(r"^\d+\.\d+\.\d+$", manifest["version"])
         assert manifest["hooks"] == "./hooks/hooks.json"
@@ -68,9 +66,7 @@ class TestPluginManifest:
         lifecycle plugin supplies PreToolUse(guard) + UserPromptSubmit)."""
         plugin_events = set(
             json.loads((_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
-        ) | set(
-            json.loads((_LIFECYCLE_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
-        )
+        ) | set(json.loads((_LIFECYCLE_PLUGIN_ROOT / "hooks" / "hooks.json").read_text())["hooks"])
         template_settings = (_TEMPLATE_CLAUDE / "settings.json.tmpl").read_text()
         template_events = set(
             re.findall(

--- a/tests/contracts/test_portability_hardening.py
+++ b/tests/contracts/test_portability_hardening.py
@@ -92,9 +92,21 @@ def test_audit_stat_guidance_is_portable():
         # copies (codex/antigravity) still carry it via the sync, now gated as
         # SKILL.md.tmpl ({{#if lifecycle}}, PI-537 #5) — the wrapped body keeps
         # the portable stat guidance.
-        _REPO_ROOT / "templates" / "lifecycle_fallback" / "dot_agents" / "skills" / "audit" / "SKILL.md",
+        _REPO_ROOT
+        / "templates"
+        / "lifecycle_fallback"
+        / "dot_agents"
+        / "skills"
+        / "audit"
+        / "SKILL.md",
         _REPO_ROOT / "templates" / "codex" / "dot_agents" / "skills" / "audit" / "SKILL.md.tmpl",
-        _REPO_ROOT / "templates" / "antigravity" / "dot_agents" / "skills" / "audit" / "SKILL.md.tmpl",
+        _REPO_ROOT
+        / "templates"
+        / "antigravity"
+        / "dot_agents"
+        / "skills"
+        / "audit"
+        / "SKILL.md.tmpl",
     ):
         text = mirror.read_text()
         assert "stat -f '%Lp'" in text, f"{mirror}: missing BSD/macOS stat fallback"

--- a/tests/contracts/test_post_edit_lint_typecheck.py
+++ b/tests/contracts/test_post_edit_lint_typecheck.py
@@ -48,7 +48,9 @@ def _project(tmp_path: Path) -> Path:
     (tmp_path / "mypy.ini").write_text("[mypy]\nstrict = True\n")
     src = tmp_path / "src"
     src.mkdir()
-    (src / "bad.py").write_text('def add(a: int, b: int) -> int:\n    return a + b\n\nadd("x", "y")\n')
+    (src / "bad.py").write_text(
+        'def add(a: int, b: int) -> int:\n    return a + b\n\nadd("x", "y")\n'
+    )
     return tmp_path
 
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -109,9 +109,7 @@ class TestVerdicts:
     def test_allowlist_suppresses_flag(self, tmp_path: Path):
         config = tmp_path / ".agents" / "config.yaml"
         config.parent.mkdir(parents=True)
-        config.write_text(
-            'safety:\n  allow: ["kubectl delete .* --context kind-dev"]\n'
-        )
+        config.write_text('safety:\n  allow: ["kubectl delete .* --context kind-dev"]\n')
         command = "kubectl delete pod web --context kind-dev"
         assert _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path) is None
         # Same verb without the allowed context is still blocked.
@@ -135,9 +133,7 @@ class TestVerdicts:
         — the old parser silently dropped it to []."""
         config = tmp_path / ".agents" / "config.yaml"
         config.parent.mkdir(parents=True)
-        config.write_text(
-            'safety:\n  allow:\n    - "kubectl delete .* --context kind-dev"\n'
-        )
+        config.write_text('safety:\n  allow:\n    - "kubectl delete .* --context kind-dev"\n')
         command = "kubectl delete pod web --context kind-dev"
         assert _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path) is None
         # A verb not on the list is still blocked.
@@ -190,9 +186,7 @@ class TestVerdicts:
         config = tmp_path / ".agents" / "config.yaml"
         config.parent.mkdir(parents=True)
         config.write_text("safety:\n  allow: [broken json\n")
-        verdict = _run_hook(
-            _payload("terraform destroy", "bypassPermissions", tmp_path), tmp_path
-        )
+        verdict = _run_hook(_payload("terraform destroy", "bypassPermissions", tmp_path), tmp_path)
         assert verdict is not None, "broken allowlist must not disable the guard"
 
     def test_scalar_inline_allow_does_not_overpermit(self, tmp_path: Path):
@@ -202,9 +196,7 @@ class TestVerdicts:
         config = tmp_path / ".agents" / "config.yaml"
         config.parent.mkdir(parents=True)
         config.write_text('safety:\n  allow: "terraform destroy"\n')
-        verdict = _run_hook(
-            _payload("terraform destroy", "bypassPermissions", tmp_path), tmp_path
-        )
+        verdict = _run_hook(_payload("terraform destroy", "bypassPermissions", tmp_path), tmp_path)
         assert verdict is not None, "a scalar allow must not disable the guard"
 
 
@@ -218,9 +210,7 @@ class TestWiring:
         scaffold(target, fallback_preset(), fallback_variables(), strict=True)
         settings = json.loads((target / ".agents" / "settings.json").read_text())
         commands = [
-            h["command"]
-            for entry in settings["hooks"]["PreToolUse"]
-            for h in entry["hooks"]
+            h["command"] for entry in settings["hooks"]["PreToolUse"] for h in entry["hooks"]
         ]
         assert any("prod_guard.py" in c for c in commands)
         assert (target / ".agents" / "hooks" / "prod_guard.py").is_file()
@@ -237,9 +227,7 @@ class TestWiring:
             (_REPO_ROOT / "plugins/project-init-workflow/hooks/hooks.json").read_text()
         )
         commands = [
-            h["command"]
-            for entry in plugin_hooks["hooks"]["PreToolUse"]
-            for h in entry["hooks"]
+            h["command"] for entry in plugin_hooks["hooks"]["PreToolUse"] for h in entry["hooks"]
         ]
         assert any("prod_guard.py" in c for c in commands)
 

--- a/tests/contracts/test_provenance.py
+++ b/tests/contracts/test_provenance.py
@@ -21,7 +21,9 @@ def _scaffold(target: Path, **overrides: str) -> Path:
 
 def _library(target: Path, language: str = "python") -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
-    return _scaffold(target, delivery="library", delivery_library="true", language=language, **flags)
+    return _scaffold(
+        target, delivery="library", delivery_library="true", language=language, **flags
+    )
 
 
 def _service_deploy(target: Path, deploy: str) -> Path:
@@ -66,7 +68,9 @@ class TestReleaseArtifactProvenance:
 
 class TestContainerImageProvenance:
     def test_deploy_attests_image_digest(self, tmp_path: Path):
-        deploy = (_service_deploy(tmp_path / "svc", "cloud-run") / ".github" / "workflows" / "deploy.yml").read_text()
+        deploy = (
+            _service_deploy(tmp_path / "svc", "cloud-run") / ".github" / "workflows" / "deploy.yml"
+        ).read_text()
         assert "actions/attest-build-provenance" in deploy
         assert "subject-digest: ${{ steps.build.outputs.digest }}" in deploy
         assert "push-to-registry: true" in deploy
@@ -74,7 +78,12 @@ class TestContainerImageProvenance:
         assert "attestations: write" in deploy
 
     def test_registry_publish_attests_image_digest(self, tmp_path: Path):
-        reg = (_service_deploy(tmp_path / "reg", "registry") / ".github" / "workflows" / "registry-publish.yml").read_text()
+        reg = (
+            _service_deploy(tmp_path / "reg", "registry")
+            / ".github"
+            / "workflows"
+            / "registry-publish.yml"
+        ).read_text()
         assert "actions/attest-build-provenance" in reg
         # The build step needs an id so its digest output can be referenced.
         assert "id: build" in reg
@@ -84,5 +93,7 @@ class TestContainerImageProvenance:
         assert "attestations: write" in reg
 
     def test_renders_cleanly(self, tmp_path: Path):
-        deploy = (_service_deploy(tmp_path / "svc", "fly") / ".github" / "workflows" / "deploy.yml").read_text()
+        deploy = (
+            _service_deploy(tmp_path / "svc", "fly") / ".github" / "workflows" / "deploy.yml"
+        ).read_text()
         assert "{{#if" not in deploy and "{{/if" not in deploy

--- a/tests/contracts/test_quality_toolchain.py
+++ b/tests/contracts/test_quality_toolchain.py
@@ -829,6 +829,7 @@ class TestTypecheckParity:
         assert 'find . -name "*.go"' in recipe
         assert "nothing to type-check" in recipe
 
+
 class TestTypeScriptSecurityGate:
     """PI-729: TS had no blocking security lint; semgrep was its only SAST, non-blocking.
 

--- a/tests/contracts/test_renovate.py
+++ b/tests/contracts/test_renovate.py
@@ -61,9 +61,7 @@ class TestRepoRenovateConfig:
         unpinned ref at author time.
         """
         config = json.loads((_REPO_ROOT / "renovate.json").read_text())
-        regex_managers = [
-            m for m in config["customManagers"] if m["customType"] == "regex"
-        ]
+        regex_managers = [m for m in config["customManagers"] if m["customType"] == "regex"]
         assert regex_managers, "regex custom manager for workflow templates missing"
         manager = regex_managers[0]
         assert manager["datasourceTemplate"] == "github-tags"

--- a/tests/contracts/test_repo_ci_python_matrix.py
+++ b/tests/contracts/test_repo_ci_python_matrix.py
@@ -36,7 +36,9 @@ def _nightly_matrix_pythons() -> list[str]:
     nightly = load_workflow(_ROOT, "nightly.yml")
     matrix = job(nightly, "full-matrix-tests").get("strategy", {}).get("matrix", {})
     versions = matrix.get("python-version")
-    assert isinstance(versions, list), "nightly full-matrix-tests has no python-version matrix (#638)"
+    assert isinstance(versions, list), (
+        "nightly full-matrix-tests has no python-version matrix (#638)"
+    )
     return sorted(str(v) for v in versions)
 
 
@@ -69,7 +71,9 @@ def test_tests_are_sharded_into_parallel_jobs():
     assert shards == [1, 2, 3, 4], f"test job must shard [1, 2, 3, 4], got {shards!r}"
     run = " ".join(str(s.get("run", "")) for s in steps(test_job))
     assert "--splits" in run and "--group" in run, "test job must run pytest --splits/--group"
-    assert "-n auto" not in run, "shards run serially (no xdist) — that is what makes them race-free"
+    assert "-n auto" not in run, (
+        "shards run serially (no xdist) — that is what makes them race-free"
+    )
 
 
 def test_semgrep_and_license_scan_are_advisory():
@@ -84,4 +88,6 @@ def test_semgrep_and_license_scan_are_advisory():
     assert "license-scan" in jobs, "license-scan job missing from ci.yml"
     gate_needs = needs(wf, "ci-gate")
     assert "semgrep" not in gate_needs, "semgrep must stay advisory (not in ci-gate.needs)"
-    assert "license-scan" not in gate_needs, "license-scan must stay advisory (not in ci-gate.needs)"
+    assert "license-scan" not in gate_needs, (
+        "license-scan must stay advisory (not in ci-gate.needs)"
+    )

--- a/tests/contracts/test_repo_ci_python_matrix.py
+++ b/tests/contracts/test_repo_ci_python_matrix.py
@@ -76,6 +76,18 @@ def test_tests_are_sharded_into_parallel_jobs():
     )
 
 
+def test_repo_lint_gate_includes_ruff_format_check():
+    """PI-772: the repo dogfoods the ruff-format gate its python scaffold ships.
+    `just lint` runs `ruff format --check` (not just `ruff check`), and CI's
+    `checks` job invokes `just lint` (single callsite), so an unformatted file
+    fails CI here the same way it does in a generated project.
+    """
+    justfile = (_ROOT / "justfile").read_text(encoding="utf-8")
+    assert "ruff format --check ." in justfile, "`just lint` must run `ruff format --check`"
+    checks_run = " ".join(str(s.get("run", "")) for s in steps(job(load_workflow(_ROOT), "checks")))
+    assert "just lint" in checks_run, "CI `checks` job must run `just lint` (which format-checks)"
+
+
 def test_semgrep_and_license_scan_are_advisory():
     """PI-769: semgrep + license-scan run on the repo (security-scan parity) but
     are ADVISORY — present as jobs, deliberately NOT in ci-gate's needs. They fail

--- a/tests/contracts/test_repo_validate_pr.py
+++ b/tests/contracts/test_repo_validate_pr.py
@@ -36,9 +36,7 @@ fi
 
 def _run(title: str, body: str, branch: str = "") -> subprocess.CompletedProcess:
     env = {**os.environ, "PR_TITLE": title, "PR_BODY": body, "PR_BRANCH": branch}
-    return subprocess.run(
-        ["bash", "-c", _CHECK], env=env, capture_output=True, text=True
-    )
+    return subprocess.run(["bash", "-c", _CHECK], env=env, capture_output=True, text=True)
 
 
 def test_workflow_keeps_the_key_match_check():

--- a/tests/contracts/test_sbom.py
+++ b/tests/contracts/test_sbom.py
@@ -22,7 +22,9 @@ def _scaffold(target: Path, **overrides: str) -> Path:
 
 def _library(target: Path, language: str) -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
-    return _scaffold(target, delivery="library", delivery_library="true", language=language, **flags)
+    return _scaffold(
+        target, delivery="library", delivery_library="true", language=language, **flags
+    )
 
 
 def _release(target: Path) -> str:
@@ -77,8 +79,12 @@ class TestSbomRecipe:
         ],
     )
     def test_sbom_recipe_present(self, tmp_path: Path, language: str, needle: str):
-        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
-        justfile = (_scaffold(tmp_path / language, language=language, **flags) / "justfile").read_text()
+        flags = {
+            lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")
+        }
+        justfile = (
+            _scaffold(tmp_path / language, language=language, **flags) / "justfile"
+        ).read_text()
         assert "sbom:" in justfile
         assert needle in justfile
 
@@ -94,7 +100,9 @@ class TestSbomDocumented:
         [("python", "python.md"), ("node", "node.md"), ("go", "go.md"), ("rust", "rust.md")],
     )
     def test_rules_mention_sbom(self, tmp_path: Path, language: str, rules_file: str):
-        flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
+        flags = {
+            lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")
+        }
         target = _scaffold(tmp_path / language, language=language, **flags)
         rules = (target / ".agents" / "rules" / rules_file).read_text()
         assert "sbom" in rules.lower() or "cyclonedx" in rules.lower()

--- a/tests/contracts/test_scaffold_graphify.py
+++ b/tests/contracts/test_scaffold_graphify.py
@@ -39,9 +39,7 @@ class TestScaffoldGraphify:
         assert "setup_graphify.sh" in rule
 
     def test_guide_documents_workflow(self):
-        guide = (
-            self.target / ".agents" / "docs" / "guides" / "using-graphify.md"
-        ).read_text()
+        guide = (self.target / ".agents" / "docs" / "guides" / "using-graphify.md").read_text()
         assert "--obsidian" in guide
         assert "setup_graphify.sh" in guide
 

--- a/tests/contracts/test_scaffold_obsidian.py
+++ b/tests/contracts/test_scaffold_obsidian.py
@@ -215,9 +215,7 @@ class TestScaffoldObsidianOnly:
         assert seed_idx < pr_idx, "seed must precede gh pr create"
         # A plain --allow-empty would capture staged work — it must not be
         # invoked (a comment may still reference it to explain the choice).
-        command_lines = [
-            ln for ln in content.splitlines() if not ln.lstrip().startswith("#")
-        ]
+        command_lines = [ln for ln in content.splitlines() if not ln.lstrip().startswith("#")]
         assert not any("git commit --allow-empty" in ln for ln in command_lines), (
             "seed must not use `git commit --allow-empty` (captures staged work)"
         )
@@ -311,6 +309,7 @@ class TestScaffoldObsidianOnly:
 
     def test_settings_json_has_autocompact(self):
         import json
+
         settings = self.target / ".agents" / "settings.json"
         data = json.loads(settings.read_text())
         assert data.get("env", {}).get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE") == "70"

--- a/tests/contracts/test_scaffold_ruff_gate.py
+++ b/tests/contracts/test_scaffold_ruff_gate.py
@@ -35,6 +35,5 @@ def test_scaffolded_agents_dir_passes_its_own_ruff_gate(tmp_target: Path):
         timeout=120,
     )
     assert result.returncode == 0, (
-        "fresh scaffold fails its own ruff gate:\n"
-        f"{result.stdout}\n{result.stderr}"
+        f"fresh scaffold fails its own ruff gate:\n{result.stdout}\n{result.stderr}"
     )

--- a/tests/contracts/test_scorecard.py
+++ b/tests/contracts/test_scorecard.py
@@ -20,7 +20,12 @@ from tests.workflow import job, load_workflow, needs, schedule_crons
 
 def _scaffold_language(target: Path, language: str) -> Path:
     flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go", "rust")}
-    scaffold(target, load_preset("obsidian-only"), make_variables(language=language, **flags), strict=True)
+    scaffold(
+        target,
+        load_preset("obsidian-only"),
+        make_variables(language=language, **flags),
+        strict=True,
+    )
     return target
 
 

--- a/tests/contracts/test_session_bootstrap.py
+++ b/tests/contracts/test_session_bootstrap.py
@@ -64,9 +64,7 @@ class TestDevcontainerOverlay:
         self, tmp_path: Path, language: str, marker: str, absent: str
     ):
         flags = {lang: "true" if lang == language else "" for lang in ("python", "node", "go")}
-        target = _scaffold(
-            tmp_path / language, devcontainer="true", language=language, **flags
-        )
+        target = _scaffold(tmp_path / language, devcontainer="true", language=language, **flags)
         script = (target / ".devcontainer" / "post-create.sh").read_text()
         assert marker in script
         assert absent not in script
@@ -75,8 +73,11 @@ class TestDevcontainerOverlay:
 
     def test_go_uses_official_feature(self, tmp_path: Path):
         target = _scaffold(
-            tmp_path / "go", devcontainer="true",
-            language="go", python="", go="true",
+            tmp_path / "go",
+            devcontainer="true",
+            language="go",
+            python="",
+            go="true",
         )
         config = json.loads((target / ".devcontainer" / "devcontainer.json").read_text())
         assert "ghcr.io/devcontainers/features/go:1" in config.get("features", {})

--- a/tests/contracts/test_skill_index.py
+++ b/tests/contracts/test_skill_index.py
@@ -27,9 +27,7 @@ class TestSkillIndex:
                 continue
             if skill_dir.name not in index_text:
                 missing.append(skill_dir.name)
-        assert not missing, (
-            "Skill directories not referenced in INDEX.md: " + ", ".join(missing)
-        )
+        assert not missing, "Skill directories not referenced in INDEX.md: " + ", ".join(missing)
 
     def test_this_repos_own_index_covers_every_skill_dir(self):
         """PI-686: the template INDEX was guarded; this repo's own INDEX was not.

--- a/tests/contracts/test_surface_emission.py
+++ b/tests/contracts/test_surface_emission.py
@@ -55,17 +55,13 @@ def test_emitted_content_matches_canonical_source(tmp_path: Path):
     would render — so editing a renderer without regenerating can't pass."""
     agents = ["claude", "codex", "cursor", "antigravity", "vscode"]
     servers = servers_for_ids(["context7"])
-    t = _scaffold(
-        tmp_path / "p", agents=",".join(agents), installed_mcps="context7"
-    )
+    t = _scaffold(tmp_path / "p", agents=",".join(agents), installed_mcps="context7")
     for rel, content in surfaces.planned_files(agents, servers).items():
         assert (t / rel).read_text() == content, f"{rel} drifted from canonical source"
 
 
 def test_mcp_schemas_per_surface(tmp_path: Path):
-    t = _scaffold(
-        tmp_path / "p", agents="claude,cursor,vscode", installed_mcps="context7"
-    )
+    t = _scaffold(tmp_path / "p", agents="claude,cursor,vscode", installed_mcps="context7")
     assert "mcpServers" in json.loads((t / ".mcp.json").read_text())
     assert "mcpServers" in json.loads((t / ".cursor/mcp.json").read_text())
     assert "servers" in json.loads((t / ".vscode/mcp.json").read_text())

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -74,9 +74,11 @@ class TestTemplateIdentifiers:
     def _scaffold(self, tmp_target: Path):
         self.target = tmp_target
         preset = fallback_preset()
-        scaffold(tmp_target, preset, fallback_variables(
-            project_init_url="https://github.com/example/project-init"
-        ))
+        scaffold(
+            tmp_target,
+            preset,
+            fallback_variables(project_init_url="https://github.com/example/project-init"),
+        )
 
     def test_claude_md_redirects_to_agents(self):
         """PI-136: AGENTS.md is canonical; CLAUDE.md is the redirect."""
@@ -157,9 +159,7 @@ class TestScaffoldGitHubFiles:
         # error-suppression substring anywhere in the file (brittle to harmless
         # whitespace/formatting changes): locate the multi-line `gh api graphql`
         # command substitution and capture it through the line that closes it.
-        starts = [
-            i for i, line in enumerate(lines) if line.lstrip().startswith("PROJECT_DATA=")
-        ]
+        starts = [i for i, line in enumerate(lines) if line.lstrip().startswith("PROJECT_DATA=")]
         assert starts, "board-automation.yml must assign PROJECT_DATA from a gh query"
         start = starts[0]
         ends = [i for i, line in enumerate(lines[start:], start) if "|| true" in line]
@@ -438,9 +438,7 @@ class TestPythonMatrixResolution:
         """Pull the heredoc'd Python between `<<'PY'` and its `PY` terminator."""
         lines = ci_yaml.splitlines()
         start = next(i for i, ln in enumerate(lines) if ln.rstrip().endswith("<<'PY'"))
-        end = next(
-            i for i, ln in enumerate(lines[start + 1 :], start + 1) if ln.strip() == "PY"
-        )
+        end = next(i for i, ln in enumerate(lines[start + 1 :], start + 1) if ln.strip() == "PY")
         return textwrap.dedent("\n".join(lines[start + 1 : end]))
 
     def _resolve(self, requires_python, tmp_path, monkeypatch) -> list[str]:
@@ -457,9 +455,7 @@ class TestPythonMatrixResolution:
         monkeypatch.chdir(proj)
         monkeypatch.setenv("GITHUB_OUTPUT", str(out))
         exec(compile(self.resolver, "<ci-resolver>", "exec"), {})  # noqa: S102
-        line = next(
-            ln for ln in out.read_text().splitlines() if ln.startswith("versions=")
-        )
+        line = next(ln for ln in out.read_text().splitlines() if ln.startswith("versions="))
         return json.loads(line.split("=", 1)[1])
 
     def test_floor_excludes_lower_versions(self, tmp_path, monkeypatch):

--- a/tests/contracts/test_third_party_pin_contract.py
+++ b/tests/contracts/test_third_party_pin_contract.py
@@ -103,4 +103,4 @@ def test_every_manifest_tool_declares_where_its_pin_lives():
             assert path.is_file(), f"{tool_id}: used_in path does not exist: {rel}"
             assert f'{tool["version_var"]}="{tool["pinned"]}"' in path.read_text(
                 encoding="utf-8"
-            ), f"{tool_id}: {rel} does not carry {tool['version_var']}=\"{tool['pinned']}\""
+            ), f'{tool_id}: {rel} does not carry {tool["version_var"]}="{tool["pinned"]}"'

--- a/tests/contracts/test_tool_output_compressor.py
+++ b/tests/contracts/test_tool_output_compressor.py
@@ -105,15 +105,11 @@ class TestCompressorBehavior:
         assert "updatedToolOutput" in result.stdout
 
     def test_env_disable(self):
-        result = self._run(
-            json.dumps(_payload("git diff")), {"PI_COMPRESS_TOOL_OUTPUT": "0"}
-        )
+        result = self._run(json.dumps(_payload("git diff")), {"PI_COMPRESS_TOOL_OUTPUT": "0"})
         assert result.stdout == ""
 
     def test_threshold_is_env_overridable(self):
-        result = self._run(
-            json.dumps(_payload("git diff")), {"PI_COMPRESS_MIN_CHARS": "100000"}
-        )
+        result = self._run(json.dumps(_payload("git diff")), {"PI_COMPRESS_MIN_CHARS": "100000"})
         assert result.stdout == ""
 
     def test_fails_open_on_garbage_stdin(self):

--- a/tests/integration/test_checkpoint_skill.py
+++ b/tests/integration/test_checkpoint_skill.py
@@ -18,9 +18,7 @@ from tests.helpers import fallback_preset, fallback_variables
 class TestCheckpointSkill:
     def test_present_and_default_on_no_plugin(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        content = (
-            tmp_target / ".agents" / "skills" / "checkpoint" / "SKILL.md"
-        ).read_text()
+        content = (tmp_target / ".agents" / "skills" / "checkpoint" / "SKILL.md").read_text()
         assert "name: checkpoint" in content
         assert "user-invocable: true" in content
         # The handoff structure is prescribed, not improvised.
@@ -38,9 +36,7 @@ class TestCheckpointSkill:
     def test_checkpoint_path_is_gitignored(self, tmp_target: Path):
         """The scaffold's .gitignore must make the handoff file uncommittable."""
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        subprocess.run(
-            ["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True
-        )
+        subprocess.run(["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True)
         checkpoint = tmp_target / ".agents" / "tmp" / "checkpoint.md"
         checkpoint.parent.mkdir(parents=True)
         checkpoint.write_text("# Checkpoint\nsession state\n")

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -334,7 +334,7 @@ class TestCLI:
             ]
         )
         assert rc == 0
-        assert 'Vy\'s tool' in (target / ".agents" / "config.yaml").read_text()
+        assert "Vy's tool" in (target / ".agents" / "config.yaml").read_text()
 
     def test_target_mkdir_oserror_reported_cleanly(self, tmp_path: Path, monkeypatch):
         """A mkdir OSError (e.g. PermissionError on a read-only parent) must surface

--- a/tests/integration/test_code_map.py
+++ b/tests/integration/test_code_map.py
@@ -78,9 +78,9 @@ class TestGeneratorOutput:
         src.mkdir()
         (src / "widget.py").write_text(
             '"""Widget module — does widget things."""\n\n'
-            "def public_fn():\n    \"\"\"Do a public thing.\"\"\"\n\n"
-            "def _private():\n    \"\"\"Hidden.\"\"\"\n\n"
-            "class Gadget:\n    \"\"\"A gadget.\"\"\"\n",
+            'def public_fn():\n    """Do a public thing."""\n\n'
+            'def _private():\n    """Hidden."""\n\n'
+            'class Gadget:\n    """A gadget."""\n',
             encoding="utf-8",
         )
         out = self._run(target, src)

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -41,7 +41,9 @@ def _require_tool(name: str) -> None:
     if shutil.which(name):
         return
     if os.environ.get("CI"):
-        pytest.fail(f"{name} is not on PATH — CI must install it (ci.yml) or this gate tests nothing (#737).")
+        pytest.fail(
+            f"{name} is not on PATH — CI must install it (ci.yml) or this gate tests nothing (#737)."
+        )
     pytest.skip(f"{name} not available — install it to run this gate locally")
 
 
@@ -111,9 +113,7 @@ def test_pre_commit_gate_autofixes_staged_shell(tmp_path: Path):
     subprocess.run(["git", "add", "messy.sh"], cwd=target, check=True)
 
     payload = json.dumps({"tool_input": {"command": "git commit -m x"}})
-    subprocess.run(
-        ["bash", str(hook)], input=payload, cwd=target, capture_output=True, text=True
-    )
+    subprocess.run(["bash", str(hook)], input=payload, cwd=target, capture_output=True, text=True)
 
     # The working-tree file was reformatted in place …
     assert bad.read_text() != original, "pre_commit_gate did not shfmt the staged shell file"
@@ -160,7 +160,7 @@ def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
     hook = target / ".github" / "hooks" / "pre-commit"
     # Replace the scaffolded justfile with a sentinel lint recipe.
     (target / "justfile").write_text(
-        'lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n'
+        "lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n"
     )
 
     subprocess.run(["git", "init", "-q"], cwd=target, check=True)
@@ -178,7 +178,9 @@ def test_git_pre_commit_lints_the_index_not_the_worktree(tmp_path: Path):
     result = subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
 
     # The staged (index) content is BAD, so the hook must block the commit …
-    assert result.returncode != 0, "pre-commit passed on a staged lint error hidden by an unstaged fix"
+    assert result.returncode != 0, (
+        "pre-commit passed on a staged lint error hidden by an unstaged fix"
+    )
     # … and the developer's unstaged fix must be restored intact afterward.
     assert (target / "x.txt").read_text() == "GOOD\n", "unstaged changes were not restored"
 
@@ -190,7 +192,7 @@ def test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index(tmp_path: Path):
     scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
     hook = target / ".github" / "hooks" / "pre-commit"
     (target / "justfile").write_text(
-        'lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n'
+        "lint:\n    #!/usr/bin/env bash\n    if grep -q BAD x.txt; then exit 1; fi\n"
     )
     subprocess.run(["git", "init", "-q"], cwd=target, check=True)
     subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)

--- a/tests/integration/test_consent.py
+++ b/tests/integration/test_consent.py
@@ -24,9 +24,7 @@ from tests.helpers import make_variables, memory_preset
 
 
 def _declined(target: Path) -> dict:
-    m = re.search(
-        r"declined_additions:\s*(\{.*\})", (target / ".agents/config.yaml").read_text()
-    )
+    m = re.search(r"declined_additions:\s*(\{.*\})", (target / ".agents/config.yaml").read_text())
     return json.loads(m.group(1)) if m else {}
 
 

--- a/tests/integration/test_dag_workflow.py
+++ b/tests/integration/test_dag_workflow.py
@@ -216,9 +216,7 @@ class TestGuardSteering:
         (tmp_path / ".agents" / "scripts" / "monitor_pr.sh").write_text("#!/bin/sh\nexit 0\n")
         subdir = tmp_path / "src" / "pkg"
         subdir.mkdir(parents=True)
-        out = _run_guard_hook(
-            hook, {"tool_input": {"command": "gh pr merge 42"}}, cwd=subdir
-        )
+        out = _run_guard_hook(hook, {"tool_input": {"command": "gh pr merge 42"}}, cwd=subdir)
         assert _denied(out)
         assert "monitor_pr.sh" in _deny_reason(out)
 
@@ -437,9 +435,7 @@ class TestPrereqWalk:
     def test_blocks_when_review_pending(self, dag, monkeypatch):
         for node in dag.GRAPH:
             monkeypatch.setitem(dag.CHECKS, node, lambda: (True, "ok"))
-        monkeypatch.setitem(
-            dag.CHECKS, "review.approved", lambda: (False, "review pending")
-        )
+        monkeypatch.setitem(dag.CHECKS, "review.approved", lambda: (False, "review pending"))
         ok, reason = dag.prereqs_satisfied("pr.merged")
         assert not ok
         assert "review.approved" in reason
@@ -454,9 +450,7 @@ class TestPrereqWalk:
             monkeypatch.setitem(dag.CHECKS, node, lambda: (True, "ok"))
         # branch.pushed fails — pr.opened should fail because of it,
         # and pr.merged should report the branch.pushed failure transitively.
-        monkeypatch.setitem(
-            dag.CHECKS, "branch.pushed", lambda: (False, "no remote branch")
-        )
+        monkeypatch.setitem(dag.CHECKS, "branch.pushed", lambda: (False, "no remote branch"))
         ok, reason = dag.prereqs_satisfied("pr.merged")
         assert not ok
         assert "branch.pushed" in reason
@@ -570,8 +564,11 @@ class TestSubcommands:
     def test_create_pr_nojira_rejects_bad_branch(self, tmp_path: Path):
         # Use a branch arg that doesn't match the type/* convention.
         proc = self._run(
-            "create-pr-nojira", "feat", "Some title",
-            "--branch", "no-prefix-here",
+            "create-pr-nojira",
+            "feat",
+            "Some title",
+            "--branch",
+            "no-prefix-here",
             cwd=tmp_path,
         )
         assert proc.returncode == 1
@@ -595,7 +592,9 @@ class TestSlugify:
 class TestScriptShims:
     """The bash lifecycle scripts are now thin shims around dag_workflow.py."""
 
-    @pytest.mark.parametrize("name", ["push_branch.sh", "promote_review.sh", "finish_pr.sh", "create_nojira_pr.sh"])
+    @pytest.mark.parametrize(
+        "name", ["push_branch.sh", "promote_review.sh", "finish_pr.sh", "create_nojira_pr.sh"]
+    )
     def test_source_script_is_shim(self, name: str):
         # Since PI-685 the repo's shims are synced verbatim from
         # templates/lifecycle, so they carry the PI-361 _py.sh resolver form.
@@ -607,7 +606,9 @@ class TestScriptShims:
         # Each shim should be tiny.
         assert len(text.splitlines()) <= 6
 
-    @pytest.mark.parametrize("name", ["push_branch.sh", "promote_review.sh", "finish_pr.sh", "create_nojira_pr.sh"])
+    @pytest.mark.parametrize(
+        "name", ["push_branch.sh", "promote_review.sh", "finish_pr.sh", "create_nojira_pr.sh"]
+    )
     def test_template_script_is_shim(self, name: str):
         path = REPO_ROOT / "templates" / "lifecycle" / "dot_agents" / "scripts" / name
         assert path.is_file()
@@ -683,7 +684,9 @@ class TestPushForceWithLease:
 
         proc = subprocess.run(
             [sys.executable, str(SOURCE_HOOK), "push", "feat/x", "0"],
-            cwd=work, capture_output=True, text=True,
+            cwd=work,
+            capture_output=True,
+            text=True,
         )
         assert proc.returncode == 0, proc.stderr
 
@@ -691,14 +694,18 @@ class TestPushForceWithLease:
         subprocess.run([*env_git, "commit", "-q", "--amend", "-m", "feat: one v2"], check=True)
         proc = subprocess.run(
             [sys.executable, str(SOURCE_HOOK), "push", "feat/x", "0"],
-            cwd=work, capture_output=True, text=True,
+            cwd=work,
+            capture_output=True,
+            text=True,
         )
         assert proc.returncode == 1
 
         # ...and --force-with-lease must succeed.
         proc = subprocess.run(
             [sys.executable, str(SOURCE_HOOK), "push", "feat/x", "0", "--force-with-lease"],
-            cwd=work, capture_output=True, text=True,
+            cwd=work,
+            capture_output=True,
+            text=True,
         )
         assert proc.returncode == 0, proc.stderr
 
@@ -713,7 +720,8 @@ class TestFinishBranchGuard:
         # PR #99's head is feat/PI-99-x, but a different branch is checked out.
         monkeypatch.setattr(mod, "_current_branch", lambda: "chore/PI-50-other")
         monkeypatch.setattr(
-            mod, "_gh",
+            mod,
+            "_gh",
             lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
         )
         pushed: list = []
@@ -729,7 +737,8 @@ class TestFinishBranchGuard:
         mod = _load_module(SOURCE_HOOK)
         monkeypatch.setattr(mod, "_current_branch", lambda: None)
         monkeypatch.setattr(
-            mod, "_gh",
+            mod,
+            "_gh",
             lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
         )
         pushed: list = []
@@ -744,7 +753,8 @@ class TestFinishBranchGuard:
         mod = _load_module(SOURCE_HOOK)
         monkeypatch.setattr(mod, "_current_branch", lambda: "feat/PI-99-x")
         monkeypatch.setattr(
-            mod, "_gh",
+            mod,
+            "_gh",
             lambda args: (0, "feat/PI-99-x\n") if "headRefName" in args else (0, ""),
         )
         pushed: list = []
@@ -770,7 +780,8 @@ class TestCiGreenStatusContext:
     @staticmethod
     def _rollup(dag, monkeypatch, entries):
         monkeypatch.setattr(
-            dag, "_gh",
+            dag,
+            "_gh",
             lambda args: (0, json.dumps({"number": 7, "statusCheckRollup": entries})),
         )
 
@@ -794,7 +805,8 @@ class TestCiGreenStatusContext:
 
     def test_mixed_green_checkrun_and_status_context(self, dag, monkeypatch):
         self._rollup(
-            dag, monkeypatch,
+            dag,
+            monkeypatch,
             [
                 {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
                 {"context": "vercel", "state": "SUCCESS"},

--- a/tests/integration/test_diagram_skill.py
+++ b/tests/integration/test_diagram_skill.py
@@ -16,18 +16,14 @@ from tests.helpers import fallback_preset, fallback_variables
 class TestDiagramSkill:
     def test_present_and_default_on_no_plugin(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        content = (
-            tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md"
-        ).read_text()
+        content = (tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md").read_text()
         assert "name: diagram" in content
         assert "user-invocable: true" in content
         assert len(content.splitlines()) < 500
 
     def test_body_covers_the_method(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        content = (
-            tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md"
-        ).read_text()
+        content = (tmp_target / ".agents" / "skills" / "diagram" / "SKILL.md").read_text()
         # Notation table with the mermaid diagram types + dense-graph escape.
         assert "erDiagram" in content
         assert "sequenceDiagram" in content

--- a/tests/integration/test_gitignore_scaffold.py
+++ b/tests/integration/test_gitignore_scaffold.py
@@ -72,7 +72,9 @@ def test_codex_wiring_is_trackable(tmp_path: Path):
     target = tmp_path / "proj"
     assert _scaffold(target, "--agents", "claude,codex", "--mcps", "context7") == 0
     subprocess.run(["git", "init", "-q"], cwd=target, check=True)
-    codex_files = [p.relative_to(target).as_posix() for p in target.rglob(".codex/*") if p.is_file()]
+    codex_files = [
+        p.relative_to(target).as_posix() for p in target.rglob(".codex/*") if p.is_file()
+    ]
     assert codex_files, "expected .codex/ config to be emitted"
     assert not _ignored(target, codex_files)
 

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -217,9 +217,7 @@ class TestInstallHooks:
 
     def test_installs_all_enforcement_hooks(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        subprocess.run(
-            ["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True
-        )
+        subprocess.run(["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True)
         result = subprocess.run(
             ["bash", str(tmp_target / ".agents" / "scripts" / "install_hooks.sh")],
             cwd=tmp_target,
@@ -236,9 +234,7 @@ class TestInstallHooks:
         """PI-204: when .git/hooks/<hook> is a symlink (e.g. a hooks manager),
         install must replace the link, not write through to its referent."""
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        subprocess.run(
-            ["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True
-        )
+        subprocess.run(["git", "init", "-q"], cwd=tmp_target, check=True, capture_output=True)
         referent = tmp_target / "shared-pre-commit"
         referent.write_text("USER SHARED HOOK - DO NOT CLOBBER\n")
         dst = tmp_target / ".git" / "hooks" / "pre-commit"
@@ -306,7 +302,4 @@ class TestShellLineEndings:
             data = sh.read_bytes()
             if b"\r\n" in data:
                 offenders.append(str(sh.relative_to(repo_root)))
-        assert not offenders, (
-            "Shell scripts with CRLF line endings:\n  "
-            + "\n  ".join(offenders)
-        )
+        assert not offenders, "Shell scripts with CRLF line endings:\n  " + "\n  ".join(offenders)

--- a/tests/integration/test_install_script.py
+++ b/tests/integration/test_install_script.py
@@ -16,9 +16,7 @@ _INSTALL_SH = _REPO_ROOT / "install.sh"
 
 
 def test_install_sh_syntax_is_valid():
-    result = subprocess.run(
-        ["bash", "-n", str(_INSTALL_SH)], capture_output=True, text=True
-    )
+    result = subprocess.run(["bash", "-n", str(_INSTALL_SH)], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
 
 
@@ -35,9 +33,7 @@ def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
     (bindir / "uv").chmod(0o755)
     git_stub = bindir / "git"
     git_stub.write_text(
-        "#!/usr/bin/env bash\n"
-        'if [ "$1" = clone ]; then mkdir -p "${@: -1}/.git"; fi\n'
-        "exit 0\n"
+        '#!/usr/bin/env bash\nif [ "$1" = clone ]; then mkdir -p "${@: -1}/.git"; fi\nexit 0\n'
     )
     git_stub.chmod(0o755)
 
@@ -47,9 +43,7 @@ def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
         "PROJECT_INIT_REF": "main",  # short-circuits the network ref resolution
         "PROJECT_INIT_HOME": str(tmp_path / "install"),
     }
-    result = subprocess.run(
-        ["bash", str(_INSTALL_SH)], capture_output=True, text=True, env=env
-    )
+    result = subprocess.run(["bash", str(_INSTALL_SH)], capture_output=True, text=True, env=env)
     assert result.returncode == 0, result.stdout + result.stderr
     # The clone branch must have run (not the "update existing clone" path).
     assert (tmp_path / "install" / ".git").is_dir(), "install.sh must clone into INSTALL_DIR"

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -20,9 +20,7 @@ class TestIssueMetadataScaffold:
         scaffold(tmp_target, preset, fallback_variables())
 
     def test_issue_template_config_disables_blank_issues(self):
-        content = (
-            self.target / ".github" / "ISSUE_TEMPLATE" / "config.yml"
-        ).read_text()
+        content = (self.target / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text()
         assert "blank_issues_enabled: false" in content
 
     def test_issue_forms_have_shared_metadata_fields(self):
@@ -53,15 +51,13 @@ class TestIssueMetadataScaffold:
         assert "labeled, unlabeled" in content
         assert "Agent ready" in content
         assert "Confidence" in content
-        assert "gh label create \"status:needs-info\"" in content
+        assert 'gh label create "status:needs-info"' in content
 
     def test_issue_validation_auto_ensures_type_label_from_body(self):
         """A missing type label is derived from the body '- Type:' (or '### Type'),
         created if absent, and applied — so MCP/API-created issues (which can't set
         Project fields or create labels) still get a valid type label."""
-        content = (
-            self.target / ".github" / "workflows" / "issue-validation.yml"
-        ).read_text()
+        content = (self.target / ".github" / "workflows" / "issue-validation.yml").read_text()
         assert "map_type_label" in content
         assert "parse_type_from_body" in content
         # Derives from either body shape.
@@ -75,9 +71,7 @@ class TestIssueMetadataScaffold:
         assert '--add-label "$label"' in content
 
     def test_board_automation_syncs_metadata_fields(self):
-        content = (
-            self.target / ".github" / "workflows" / "board-automation.yml"
-        ).read_text()
+        content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
         assert "PROJECT_TOKEN" in content
         assert "addProjectV2ItemById" in content
         assert "updateProjectV2ItemFieldValue" in content
@@ -97,9 +91,7 @@ class TestIssueMetadataScaffold:
         """Board fields populate whether the body uses issue-form '### Heading'
         blocks or create_issue.sh / MCP-API '- Field: value' bullets. A single
         dual-format parse_body_field handles all fields (incl. Area)."""
-        content = (
-            self.target / ".github" / "workflows" / "board-automation.yml"
-        ).read_text()
+        content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
         # Bullet form: "- Field: value" (case-insensitive sed).
         assert "-[[:space:]]*${heading}:" in content
         # Heading form: "### Field".
@@ -268,9 +260,7 @@ class TestCreateIssueSkill:
         assert "create_issue" in content
 
     def test_start_task_delegates_issue_creation_to_skill(self):
-        content = (
-            self.target / ".agents" / "skills" / "start_task" / "SKILL.md"
-        ).read_text()
+        content = (self.target / ".agents" / "skills" / "start_task" / "SKILL.md").read_text()
         assert "`create_issue` skill" in content, "must delegate to the create_issue skill"
 
     def test_nojira_pr_script_scaffolded(self):
@@ -376,9 +366,7 @@ class TestGitHubWorkflowHooks:
     def test_settings_wire_workflow_hooks(self):
         data = json.loads((self.target / ".agents" / "settings.json").read_text())
         pre_commands = [
-            hook["command"]
-            for group in data["hooks"]["PreToolUse"]
-            for hook in group["hooks"]
+            hook["command"] for group in data["hooks"]["PreToolUse"] for hook in group["hooks"]
         ]
         assert any("github_command_guard.sh" in command for command in pre_commands)
         assert "UserPromptSubmit" in data["hooks"]
@@ -395,9 +383,7 @@ class TestGitHubWorkflowHooks:
         assert "--no-review" in content
 
     def test_github_workflow_skill_documents_nonzero_monitor_exit(self):
-        content = (
-            self.target / ".agents" / "skills" / "github_workflow" / "SKILL.md"
-        ).read_text()
+        content = (self.target / ".agents" / "skills" / "github_workflow" / "SKILL.md").read_text()
         assert "exits **1** for CI or merge failures" in content
         assert "Do not report a PR as merged unless the script exits 0" in content
 

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -117,7 +117,9 @@ class TestOldRecordUpgrade:
         recorded = json.loads(m.group(2))
         for k in ("lifecycle", "lifecycle_tier", "lifecycle_off"):
             recorded.pop(k, None)
-        text = text[: m.start()] + m.group(1) + json.dumps(recorded, sort_keys=True) + text[m.end() :]
+        text = (
+            text[: m.start()] + m.group(1) + json.dumps(recorded, sort_keys=True) + text[m.end() :]
+        )
         config.write_text(text)
 
         capsys.readouterr()

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -38,9 +38,7 @@ esac
 class TestLocalCiSkill:
     def test_present_with_the_method(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        content = (
-            tmp_target / ".agents" / "skills" / "local_ci" / "SKILL.md"
-        ).read_text()
+        content = (tmp_target / ".agents" / "skills" / "local_ci" / "SKILL.md").read_text()
         assert "name: local_ci" in content
         assert "user-invocable: true" in content
         # Diagnosis before action.

--- a/tests/integration/test_memory_backends.py
+++ b/tests/integration/test_memory_backends.py
@@ -139,7 +139,9 @@ class TestOldRecordUpgrade:
         assert m
         recorded = json.loads(m.group(2))
         recorded.pop("memory", None)
-        text = text[: m.start()] + m.group(1) + json.dumps(recorded, sort_keys=True) + text[m.end() :]
+        text = (
+            text[: m.start()] + m.group(1) + json.dumps(recorded, sort_keys=True) + text[m.end() :]
+        )
         config.write_text(text)
 
         capsys.readouterr()

--- a/tests/integration/test_memory_starters.py
+++ b/tests/integration/test_memory_starters.py
@@ -298,9 +298,20 @@ class TestLintMemoryScript:
             ["git", "-C", str(self.target), "add", "-A"], capture_output=True, check=True
         )
         subprocess.run(
-            ["git", "-C", str(self.target), "-c", "user.email=t@t", "-c", "user.name=t",
-             "commit", "-qm", "seed"],
-            capture_output=True, check=True,
+            [
+                "git",
+                "-C",
+                str(self.target),
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-qm",
+                "seed",
+            ],
+            capture_output=True,
+            check=True,
         )
         script = self.target / ".agents" / "scripts" / "lint_memory.sh"
         result = subprocess.run(

--- a/tests/integration/test_monitor_ci_timeout.py
+++ b/tests/integration/test_monitor_ci_timeout.py
@@ -53,9 +53,7 @@ def test_pi_ci_timeout_override_respected(tmp_target: Path, tmp_path: Path):
     assert "within 900s" not in result.stdout
 
 
-def test_invalid_pi_ci_timeout_fails_closed_with_clear_message(
-    tmp_target: Path, tmp_path: Path
-):
+def test_invalid_pi_ci_timeout_fails_closed_with_clear_message(tmp_target: Path, tmp_path: Path):
     scaffold(tmp_target, fallback_preset(), fallback_variables())
     script = tmp_target / ".agents" / "scripts" / "monitor_pr.sh"
     env = os.environ.copy()

--- a/tests/integration/test_monitor_head_sync.py
+++ b/tests/integration/test_monitor_head_sync.py
@@ -84,12 +84,8 @@ def _run(tmp_target: Path, tmp_path: Path, api_sha: str, **overrides: str):
     )
 
 
-def test_stale_api_head_never_reaches_the_check_verdict(
-    tmp_target: Path, tmp_path: Path
-):
-    result = _run(
-        tmp_target, tmp_path, api_sha=_OLD_SHA, PI_HEAD_SYNC_TIMEOUT="10"
-    )
+def test_stale_api_head_never_reaches_the_check_verdict(tmp_target: Path, tmp_path: Path):
+    result = _run(tmp_target, tmp_path, api_sha=_OLD_SHA, PI_HEAD_SYNC_TIMEOUT="10")
     assert result.returncode == 1
     assert "Refusing to judge check results" in result.stderr
     assert _OLD_SHA in result.stderr and _NEW_SHA in result.stderr
@@ -97,9 +93,7 @@ def test_stale_api_head_never_reaches_the_check_verdict(
     assert "CI failed" not in result.stdout
 
 
-def test_synced_api_head_passes_through_to_the_check_verdict(
-    tmp_target: Path, tmp_path: Path
-):
+def test_synced_api_head_passes_through_to_the_check_verdict(tmp_target: Path, tmp_path: Path):
     result = _run(tmp_target, tmp_path, api_sha=_NEW_SHA)
     assert result.returncode == 1
     assert "CI failed on PR #1" in result.stdout
@@ -120,17 +114,13 @@ def test_cross_repo_pr_skips_the_gate(tmp_target: Path, tmp_path: Path):
     `feature`, and the gate would wait out its timeout against a SHA from the
     wrong repository. Skip instead of guessing (PR #712 review).
     """
-    result = _run(
-        tmp_target, tmp_path, api_sha=_OLD_SHA, PI_TEST_CROSS_REPO="true"
-    )
+    result = _run(tmp_target, tmp_path, api_sha=_OLD_SHA, PI_TEST_CROSS_REPO="true")
     assert result.returncode == 1
     assert "CI failed on PR #1" in result.stdout
     assert "Refusing to judge check results" not in result.stderr
 
 
 def test_invalid_head_sync_timeout_fails_closed(tmp_target: Path, tmp_path: Path):
-    result = _run(
-        tmp_target, tmp_path, api_sha=_NEW_SHA, PI_HEAD_SYNC_TIMEOUT="soon"
-    )
+    result = _run(tmp_target, tmp_path, api_sha=_NEW_SHA, PI_HEAD_SYNC_TIMEOUT="soon")
     assert result.returncode == 2
     assert "non-negative integer" in result.stderr

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -22,7 +22,9 @@ def _human_section(config_text: str) -> str:
 
 class TestMarketplaceVarsIncludeHost:
     def test_host_is_derived(self):
-        assert marketplace_source_vars("https://github.com/o/r")["project_init_host"] == "github.com"
+        assert (
+            marketplace_source_vars("https://github.com/o/r")["project_init_host"] == "github.com"
+        )
         assert (
             marketplace_source_vars("https://ghes.example.com/o/r")["project_init_host"]
             == "ghes.example.com"

--- a/tests/integration/test_overwrite_protection.py
+++ b/tests/integration/test_overwrite_protection.py
@@ -278,9 +278,7 @@ class TestFileDirCollision:
         (target / "CLAUDE.md").mkdir()
         conflicts: list[tuple[Path, Path]] = []
 
-        scaffold(
-            target, fallback_preset(), fallback_variables(), strict=True, conflicts=conflicts
-        )
+        scaffold(target, fallback_preset(), fallback_variables(), strict=True, conflicts=conflicts)
 
         assert (target / "CLAUDE.md").is_dir()
         assert (target / "CLAUDE.md.new").is_file()

--- a/tests/integration/test_python_floor.py
+++ b/tests/integration/test_python_floor.py
@@ -24,6 +24,7 @@ agents: claude
 
     assert variables["python_floor"] == "3.13", "Should extract 3.13 from ^3.13"
 
+
 def test_poetry_python_floor_extracted_during_build_variables(tmp_path: Path):
 
     pyproject = tmp_path / "pyproject.toml"
@@ -35,7 +36,28 @@ python = "~=3.14"
     import subprocess
     import sys
 
-    subprocess.run([sys.executable, "-m", "project_init", str(tmp_path), "--name", "foo", "--preset", "core", "--agents", "claude", "--description", "test", "--language", "python", "--non-interactive"], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "project_init",
+            str(tmp_path),
+            "--name",
+            "foo",
+            "--preset",
+            "core",
+            "--agents",
+            "claude",
+            "--description",
+            "test",
+            "--language",
+            "python",
+            "--non-interactive",
+        ],
+        check=True,
+    )
 
     mypy = tmp_path / "mypy.ini"
-    assert "python_version = 3.14" in mypy.read_text(), "mypy.ini must use 3.14 extracted from ~=3.14"
+    assert "python_version = 3.14" in mypy.read_text(), (
+        "mypy.ini must use 3.14 extracted from ~=3.14"
+    )

--- a/tests/integration/test_python_version_pins.py
+++ b/tests/integration/test_python_version_pins.py
@@ -200,9 +200,7 @@ def test_wizard_drops_python_version_when_the_language_is_not_python(monkeypatch
     assert "--python-version 3.13 ignored" in capsys.readouterr().out
 
 
-def test_wizard_does_not_ask_when_pyproject_already_declares_a_floor(
-    monkeypatch, tmp_path: Path
-):
+def test_wizard_does_not_ask_when_pyproject_already_declares_a_floor(monkeypatch, tmp_path: Path):
     """requires-python is the source of truth; asking would invite a contradiction."""
     (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.12"\n')
     inputs, seen = _wizard(monkeypatch, ["proj", "desc", "python", "", "none"], target=tmp_path)

--- a/tests/integration/test_report_upstream_issue_skill.py
+++ b/tests/integration/test_report_upstream_issue_skill.py
@@ -20,13 +20,7 @@ class TestReportUpstreamIssueSkill:
         """--no-plugin copies the skill in as a real .agents/skills file, on by
         default (no opt-in flag), with the required frontmatter."""
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        skill = (
-            tmp_target
-            / ".agents"
-            / "skills"
-            / "report_upstream_issue"
-            / "SKILL.md"
-        )
+        skill = tmp_target / ".agents" / "skills" / "report_upstream_issue" / "SKILL.md"
         content = skill.read_text()
         assert "name: report_upstream_issue" in content
         assert "when_to_use:" in content
@@ -56,11 +50,7 @@ class TestReportUpstreamIssueSkill:
     def test_body_classifies_and_routes_upstream(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
         content = (
-            tmp_target
-            / ".agents"
-            / "skills"
-            / "report_upstream_issue"
-            / "SKILL.md"
+            tmp_target / ".agents" / "skills" / "report_upstream_issue" / "SKILL.md"
         ).read_text()
         # Classification: project-level vs tooling/scaffolding.
         assert "Classify" in content

--- a/tests/integration/test_review_gate.py
+++ b/tests/integration/test_review_gate.py
@@ -145,9 +145,7 @@ def test_unresolved_comments_open_a_review_cycle_instead_of_merging(
     assert "Merged" not in result.stdout
 
 
-def test_reviewed_with_no_open_comments_merges_without_override(
-    tmp_target: Path, tmp_path: Path
-):
+def test_reviewed_with_no_open_comments_merges_without_override(tmp_target: Path, tmp_path: Path):
     result = _run_monitor(tmp_target, tmp_path, reviews="1", unresolved="0")
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Merged PR #1" in result.stdout

--- a/tests/integration/test_rust_lint_scope.py
+++ b/tests/integration/test_rust_lint_scope.py
@@ -53,7 +53,7 @@ pytestmark = [
     pytest.mark.slow,
 ]
 
-_CLEAN_LIB = '//! Probe.\n\n/// Adds two numbers.\n#[must_use]\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n'
+_CLEAN_LIB = "//! Probe.\n\n/// Adds two numbers.\n#[must_use]\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n"
 _CLEAN_TEST = "#[test]\nfn t() {\n    assert_eq!(probe::add(1, 2), 3);\n}\n"
 # A type error, not a style nit: `&str` where `i32` is required.
 _BROKEN_TEST = '#[test]\nfn t() {\n    let x: i32 = "not an integer";\n    assert_eq!(probe::add(1, 2), x);\n}\n'

--- a/tests/integration/test_session_cold_start.py
+++ b/tests/integration/test_session_cold_start.py
@@ -21,9 +21,7 @@ _STAMP = ".agents/.session_setup_stamp"
 def _scaffold_python(target: Path) -> Path:
     scaffold(target, fallback_preset(), fallback_variables(), strict=True)
     # A scaffolded *user* project has its own dependency manifest.
-    (target / "pyproject.toml").write_text(
-        '[project]\nname = "fixture"\nversion = "0"\n'
-    )
+    (target / "pyproject.toml").write_text('[project]\nname = "fixture"\nversion = "0"\n')
     return target
 
 
@@ -84,9 +82,7 @@ class TestColdAndWarmStart:
         bin_dir = _make_shim_bin(tmp_path, target)
         assert _run_hook(target, bin_dir).returncode == 0
 
-        (target / "pyproject.toml").write_text(
-            '[project]\nname = "fixture"\nversion = "1"\n'
-        )
+        (target / "pyproject.toml").write_text('[project]\nname = "fixture"\nversion = "1"\n')
         assert _run_hook(target, bin_dir).returncode == 0
         calls = (tmp_path / "just-calls.log").read_text().splitlines()
         assert calls == ["setup", "setup"], "changed manifest must re-bootstrap"
@@ -112,8 +108,12 @@ class TestColdAndWarmStart:
             target,
             fallback_preset(),
             fallback_variables(
-                language="none", python="", justfile="",
-                lint_command="", format_command="", test_command="",
+                language="none",
+                python="",
+                justfile="",
+                lint_command="",
+                format_command="",
+                test_command="",
             ),
             strict=True,
         )
@@ -129,9 +129,7 @@ class TestColdAndWarmStart:
         target = _scaffold_python(tmp_path / "p")
         bin_dir = _make_shim_bin(tmp_path, target)
         (bin_dir / "just").write_text(
-            "#!/bin/bash\n"
-            'if [ "$1" = "--show" ]; then exit 0; fi\n'
-            "exit 1\n"
+            '#!/bin/bash\nif [ "$1" = "--show" ]; then exit 0; fi\nexit 1\n'
         )
 
         result = _run_hook(target, bin_dir)

--- a/tests/integration/test_shell_lint_gate.py
+++ b/tests/integration/test_shell_lint_gate.py
@@ -93,9 +93,7 @@ def test_emitted_claude_scripts_are_shfmt_clean(tmp_target: Path):
 
     dirty = []
     for p in scripts:
-        result = subprocess.run(
-            [shfmt, "-d", "-i", "2", str(p)], capture_output=True, text=True
-        )
+        result = subprocess.run([shfmt, "-d", "-i", "2", str(p)], capture_output=True, text=True)
         if result.stdout.strip() or result.returncode != 0:
             dirty.append(f"{p.relative_to(tmp_target)}:\n{result.stdout}{result.stderr}")
     assert not dirty, "emitted .agents scripts fail `shfmt -d -i 2`:\n" + "\n".join(dirty)

--- a/tests/integration/test_token_efficiency_skill.py
+++ b/tests/integration/test_token_efficiency_skill.py
@@ -27,9 +27,7 @@ class TestTokenEfficiencySkill:
 
     def test_body_covers_input_and_output_side(self, tmp_target: Path):
         scaffold(tmp_target, fallback_preset(), fallback_variables())
-        content = (
-            tmp_target / ".agents" / "skills" / "token_efficiency" / "SKILL.md"
-        ).read_text()
+        content = (tmp_target / ".agents" / "skills" / "token_efficiency" / "SKILL.md").read_text()
         # Input side: filter before ingest, ranged reads, delegated sweeps.
         assert "test-quick" in content
         assert "tail -n 40" in content

--- a/tests/integration/test_ts_security_gate.py
+++ b/tests/integration/test_ts_security_gate.py
@@ -51,6 +51,7 @@ def _require_bun() -> None:
         )
     pytest.skip(f"{message} — install bun to run the TS toolchain gate locally")
 
+
 _INSECURE = """/** Runs user code. */
 export function run(userInput: string): unknown {
   return eval(userInput);
@@ -92,7 +93,9 @@ def test_dev_deps_match_the_scaffolded_setup_recipe(tmp_path: Path):
     from project_init.scaffold import scaffold as _scaffold
 
     target = tmp_path / "n"
-    _scaffold(target, fallback_preset(), fallback_variables(language="node", node="true", python=""))
+    _scaffold(
+        target, fallback_preset(), fallback_variables(language="node", node="true", python="")
+    )
     setup = (target / "justfile").read_text(encoding="utf-8").split("\nsetup:", 1)[1]
     setup = setup.split("\n\n", 1)[0]
     command = " ".join(

--- a/tests/smoke/test_packaging.py
+++ b/tests/smoke/test_packaging.py
@@ -67,6 +67,7 @@ class TestInstalledWheel:
         # PI-144: the installed release artifact must report its version —
         # this is what install pinning and the upgrade path key off.
         import tomllib
+
         pkg_version = tomllib.loads(
             (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
         )["project"]["version"]
@@ -79,12 +80,17 @@ class TestInstalledWheel:
         # Scaffold using the installed binary, with --strict.
         result = subprocess.run(
             [
-                str(venv_bin), str(scaffold_target),
+                str(venv_bin),
+                str(scaffold_target),
                 "--non-interactive",
-                "--preset", "obsidian-only",
-                "--name", "wheel-smoke",
-                "--description", "test",
-                "--language", "python",
+                "--preset",
+                "obsidian-only",
+                "--name",
+                "wheel-smoke",
+                "--description",
+                "test",
+                "--language",
+                "python",
                 "--no-plugin",
                 "--strict",
             ],
@@ -93,8 +99,7 @@ class TestInstalledWheel:
             timeout=60,
         )
         assert result.returncode == 0, (
-            f"installed binary failed:\nSTDOUT: {result.stdout}\n"
-            f"STDERR: {result.stderr}"
+            f"installed binary failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )
 
         # Essentials present.
@@ -108,6 +113,4 @@ class TestInstalledWheel:
         ]:
             hook_path = scaffold_target / ".agents" / "hooks" / hook
             assert hook_path.is_file()
-            assert hook_path.stat().st_mode & 0o111, (
-                f"{hook} lost executable bit"
-            )
+            assert hook_path.stat().st_mode & 0o111, f"{hook} lost executable bit"

--- a/tests/unit/test_audit_fixes.py
+++ b/tests/unit/test_audit_fixes.py
@@ -141,18 +141,8 @@ class TestCarryRagEndpoint:
     memory.rag_endpoint — the template always renders it empty and
     setup_rag.sh explicitly instructs the user to set it (2026-07 review)."""
 
-    _OLD = (
-        "memory:\n"
-        "  tier: 3\n"
-        '  rag_endpoint: "ccc mcp"  # user-set per setup_rag.sh\n'
-        "\n"
-    )
-    _NEW = (
-        "memory:\n"
-        "  tier: 3\n"
-        "  rag_endpoint:        # tier 3: set after running setup_rag.sh\n"
-        "\n"
-    )
+    _OLD = 'memory:\n  tier: 3\n  rag_endpoint: "ccc mcp"  # user-set per setup_rag.sh\n\n'
+    _NEW = "memory:\n  tier: 3\n  rag_endpoint:        # tier 3: set after running setup_rag.sh\n\n"
 
     def test_user_value_survives_the_splice(self):
         out = _carry_rag_endpoint(self._OLD, self._NEW)
@@ -190,9 +180,7 @@ class TestWizardHonorsMcpsFlag:
         assert offered, "browser concern must still be offered (ADR-023)"
 
     def test_cli_mcps_browser_prompt_accept_adds_playwright(self, monkeypatch):
-        monkeypatch.setattr(
-            "project_init.__main__._choose_browser_interactive", lambda: True
-        )
+        monkeypatch.setattr("project_init.__main__._choose_browser_interactive", lambda: True)
         selected = _gather_mcps_interactive("context7", False)
         assert [m["id"] for m in selected] == ["context7", "playwright"]
 
@@ -226,7 +214,9 @@ class TestRunCommandModuleName:
     def test_render_empty_slug_falls_back(self):
         from project_init.__main__ import render_run_command
 
-        assert render_run_command("uv run python -m {project_slug}", "") == "uv run python -m my_app"
+        assert (
+            render_run_command("uv run python -m {project_slug}", "") == "uv run python -m my_app"
+        )
 
     def test_upgrade_paths_call_the_shared_renderer(self):
         # Both upgrade backfill sites assign run_command via the shared renderer,

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -31,9 +31,15 @@ def test_render_presets_plain_lists_every_preset(capsys) -> None:
     """Off a TTY the table degrades to a plain numbered list of all presets."""
     presets = [
         {"name": "core", "description": "no memory", "vars": {"memory_stack": "none"}},
-        {"name": "obsidian-only", "description": "vault only", "vars": {"memory_stack": "obsidian-only"}},
+        {
+            "name": "obsidian-only",
+            "description": "vault only",
+            "vars": {"memory_stack": "obsidian-only"},
+        },
     ]
-    pc.render_presets(presets, default_idx=2, memory_by_name={"core": "none", "obsidian-only": "obsidian-only"})
+    pc.render_presets(
+        presets, default_idx=2, memory_by_name={"core": "none", "obsidian-only": "obsidian-only"}
+    )
     out = capsys.readouterr().out
     assert "Available presets" in out
     assert "core" in out and "obsidian-only" in out
@@ -70,7 +76,9 @@ def test_render_presets_shows_resolved_inherited_memory(monkeypatch, capsys) -> 
 
 def test_render_presets_handles_missing_memory(capsys) -> None:
     """A preset absent from the resolved map shows a dash, not a KeyError."""
-    pc.render_presets([{"name": "x", "description": "d", "vars": {}}], default_idx=1, memory_by_name={})
+    pc.render_presets(
+        [{"name": "x", "description": "d", "vars": {}}], default_idx=1, memory_by_name={}
+    )
     assert "x" in capsys.readouterr().out
 
 

--- a/tests/unit/test_mcps.py
+++ b/tests/unit/test_mcps.py
@@ -10,6 +10,7 @@ class TestMCPs:
 
     def test_catalog_has_required_keys(self):
         from project_init.mcps import MCP_CATALOG
+
         for m in MCP_CATALOG:
             assert "id" in m
             assert "name" in m
@@ -18,6 +19,7 @@ class TestMCPs:
 
     def test_catalog_contains_core_mcps(self):
         from project_init.mcps import MCP_CATALOG
+
         ids = {m["id"] for m in MCP_CATALOG}
         # Linear, GitHub, Filesystem removed (PI-25/PI-26): CLI alternatives cover all needs
         assert "context7" in ids
@@ -28,15 +30,18 @@ class TestMCPs:
     def test_no_db_catalog(self):
         """PI-387: postgres/sqlite DB MCPs removed (archived + unpatched CVEs)."""
         import project_init.mcps as mcps
+
         assert not hasattr(mcps, "DB_CATALOG")
 
     def test_playwright_mcp_defined(self):
         from project_init.mcps import PLAYWRIGHT_MCP
+
         assert PLAYWRIGHT_MCP["id"] == "playwright"
         assert "command" in PLAYWRIGHT_MCP
 
     def test_no_npx_in_any_command(self):
         from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP
+
         all_commands = [m["command"] for m in MCP_CATALOG] + [PLAYWRIGHT_MCP["command"]]
         for cmd in all_commands:
             assert "npx" not in cmd, f"npx found in command: {cmd}"
@@ -46,6 +51,7 @@ class TestMCPs:
         """Stdio entries use `bunx` with the `--` separator (PI-387); HTTP entries
         use `--transport http` instead (PI-397)."""
         from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP
+
         for entry in [*MCP_CATALOG, PLAYWRIGHT_MCP]:
             cmd = entry["command"]
             if "url" in entry.get("server", {}):  # HTTP/remote entry
@@ -58,6 +64,7 @@ class TestMCPs:
         """PI-397: an HTTP/streamable catalog entry for cloud surfaces (web/mobile
         can't run stdio); never SSE."""
         from project_init.mcps import MCP_CATALOG
+
         http = [m for m in MCP_CATALOG if m["server"].get("type") == "http"]
         assert http, "expected at least one HTTP MCP catalog entry"
         for m in http:
@@ -66,30 +73,36 @@ class TestMCPs:
 
     def test_format_installed_mcps_empty(self):
         from project_init.mcps import format_installed_mcps
+
         assert format_installed_mcps([]) == "none"
 
     def test_format_installed_mcps_single(self):
         from project_init.mcps import MCP_CATALOG, format_installed_mcps
+
         context7 = next(m for m in MCP_CATALOG if m["id"] == "context7")
         assert format_installed_mcps([context7]) == "context7"
 
     def test_format_installed_mcps_multiple(self):
         from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, format_installed_mcps
+
         subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), PLAYWRIGHT_MCP]
         result = format_installed_mcps(subset)
         assert "context7" in result and "playwright" in result
 
     def test_format_installed_mcps_yaml_empty(self):
         from project_init.mcps import format_installed_mcps_yaml
+
         assert format_installed_mcps_yaml([]) == "[]"
 
     def test_format_installed_mcps_yaml_single(self):
         from project_init.mcps import MCP_CATALOG, format_installed_mcps_yaml
+
         context7 = next(m for m in MCP_CATALOG if m["id"] == "context7")
         assert format_installed_mcps_yaml([context7]) == '["context7"]'
 
     def test_format_installed_mcps_yaml_multiple(self):
         from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, format_installed_mcps_yaml
+
         subset = [next(m for m in MCP_CATALOG if m["id"] == "context7"), PLAYWRIGHT_MCP]
         result = format_installed_mcps_yaml(subset)
         assert result.startswith("[") and result.endswith("]")
@@ -101,15 +114,24 @@ class TestMCPsNonInteractive:
 
     def test_mcps_flag_context7(self, tmp_path: Path):
         from project_init.__main__ import main
+
         target = tmp_path / "p"
-        rc = main([
-            str(target), "--non-interactive",
-            "--preset", "obsidian-only",
-            "--name", "mcp-test",
-            "--description", "test",
-            "--language", "python",
-            "--mcps", "context7",
-        ])
+        rc = main(
+            [
+                str(target),
+                "--non-interactive",
+                "--preset",
+                "obsidian-only",
+                "--name",
+                "mcp-test",
+                "--description",
+                "test",
+                "--language",
+                "python",
+                "--mcps",
+                "context7",
+            ]
+        )
         assert rc == 0
         config = (target / ".agents" / "config.yaml").read_text()
         assert "context7" in config
@@ -117,36 +139,68 @@ class TestMCPsNonInteractive:
     def test_db_flag_removed(self):
         """PI-387: --db is gone; passing it must be a CLI error."""
         from project_init.__main__ import main
+
         with pytest.raises(SystemExit):
-            main(["x", "--non-interactive", "--preset", "obsidian-only",
-                   "--name", "n", "--description", "d", "--language", "python",
-                   "--db", "postgres"])
+            main(
+                [
+                    "x",
+                    "--non-interactive",
+                    "--preset",
+                    "obsidian-only",
+                    "--name",
+                    "n",
+                    "--description",
+                    "d",
+                    "--language",
+                    "python",
+                    "--db",
+                    "postgres",
+                ]
+            )
 
     def test_browser_flag_adds_playwright(self, tmp_path: Path):
         from project_init.__main__ import main
+
         target = tmp_path / "p"
-        rc = main([
-            str(target), "--non-interactive",
-            "--preset", "obsidian-only",
-            "--name", "browser-test",
-            "--description", "test",
-            "--language", "python",
-            "--browser",
-        ])
+        rc = main(
+            [
+                str(target),
+                "--non-interactive",
+                "--preset",
+                "obsidian-only",
+                "--name",
+                "browser-test",
+                "--description",
+                "test",
+                "--language",
+                "python",
+                "--browser",
+            ]
+        )
         assert rc == 0
-        config = (target / ".clone" / "config.yaml") if False else (target / ".agents" / "config.yaml")
+        config = (
+            (target / ".clone" / "config.yaml") if False else (target / ".agents" / "config.yaml")
+        )
         assert "playwright" in config.read_text()
 
     def test_no_mcps_gives_none(self, tmp_path: Path):
         from project_init.__main__ import main
+
         target = tmp_path / "p"
-        rc = main([
-            str(target), "--non-interactive",
-            "--preset", "obsidian-only",
-            "--name", "empty-test",
-            "--description", "test",
-            "--language", "python",
-        ])
+        rc = main(
+            [
+                str(target),
+                "--non-interactive",
+                "--preset",
+                "obsidian-only",
+                "--name",
+                "empty-test",
+                "--description",
+                "test",
+                "--language",
+                "python",
+            ]
+        )
         assert rc == 0
         config = (target / ".agents" / "config.yaml").read_text()
         assert "installed: []" in config
@@ -154,45 +208,66 @@ class TestMCPsNonInteractive:
     def test_unknown_mcp_id_is_rejected(self, tmp_path: Path):
         """Silently ignoring typos hides real bugs — unknown IDs must error out."""
         from project_init.__main__ import main
+
         target = tmp_path / "p"
         with pytest.raises(SystemExit):
-            main([
-                str(target), "--non-interactive",
-                "--preset", "obsidian-only",
-                "--name", "bad-mcp-test",
-                "--description", "test",
-                "--language", "python",
-                "--mcps", "nonexistent,anotherunknown",
-            ])
+            main(
+                [
+                    str(target),
+                    "--non-interactive",
+                    "--preset",
+                    "obsidian-only",
+                    "--name",
+                    "bad-mcp-test",
+                    "--description",
+                    "test",
+                    "--language",
+                    "python",
+                    "--mcps",
+                    "nonexistent,anotherunknown",
+                ]
+            )
 
     def test_unknown_preset_does_not_create_target_dir(self, tmp_path: Path):
         """A typo in --preset must fail BEFORE the target directory is created."""
         from project_init.__main__ import main
+
         target = tmp_path / "should-not-exist"
         with pytest.raises(SystemExit):
-            main([
-                str(target), "--non-interactive",
-                "--preset", "definitely-not-a-real-preset",
-                "--name", "x",
-                "--description", "x",
-            ])
-        assert not target.exists(), (
-            f"target dir {target} was created despite invalid preset"
-        )
+            main(
+                [
+                    str(target),
+                    "--non-interactive",
+                    "--preset",
+                    "definitely-not-a-real-preset",
+                    "--name",
+                    "x",
+                    "--description",
+                    "x",
+                ]
+            )
+        assert not target.exists(), f"target dir {target} was created despite invalid preset"
 
     def test_unknown_mcp_id_does_not_create_target_dir(self, tmp_path: Path):
         """An invalid MCP id must fail BEFORE the target directory is created. PI-20."""
         from project_init.__main__ import main
+
         target = tmp_path / "should-not-exist"
         with pytest.raises(SystemExit):
-            main([
-                str(target), "--non-interactive",
-                "--preset", "obsidian-only",
-                "--name", "test",
-                "--description", "test",
-                "--language", "python",
-                "--mcps", "fakeone,anotherunknown",
-            ])
-        assert not target.exists(), (
-            f"target dir {target} was created despite invalid MCP id"
-        )
+            main(
+                [
+                    str(target),
+                    "--non-interactive",
+                    "--preset",
+                    "obsidian-only",
+                    "--name",
+                    "test",
+                    "--description",
+                    "test",
+                    "--language",
+                    "python",
+                    "--mcps",
+                    "fakeone,anotherunknown",
+                ]
+            )
+        assert not target.exists(), f"target dir {target} was created despite invalid MCP id"

--- a/tests/unit/test_render_nesting.py
+++ b/tests/unit/test_render_nesting.py
@@ -58,9 +58,7 @@ class TestNestedConditionals:
 
         fake_dir = tmp_path / "mismatch-layer"
         (fake_dir / "dot_agents").mkdir(parents=True)
-        (fake_dir / "dot_agents" / "typo.md.tmpl").write_text(
-            "{{#if python}}body{{/if node}}\n"
-        )
+        (fake_dir / "dot_agents" / "typo.md.tmpl").write_text("{{#if python}}body{{/if node}}\n")
         original = sm._TEMPLATES_DIR
         sm._TEMPLATES_DIR = fake_dir.parent
         try:

--- a/tests/unit/test_scaffold_inputs.py
+++ b/tests/unit/test_scaffold_inputs.py
@@ -15,8 +15,17 @@ def test_resolve_inputs_returns_named_record():
     parser = _build_parser()
     args = parser.parse_args(
         [
-            "x", "--non-interactive", "--preset", "obsidian-only",
-            "--name", "demo", "--description", "d", "--language", "python", "--no-plugin",
+            "x",
+            "--non-interactive",
+            "--preset",
+            "obsidian-only",
+            "--name",
+            "demo",
+            "--description",
+            "d",
+            "--language",
+            "python",
+            "--no-plugin",
         ]
     )
     inputs = _resolve_inputs(args, parser, Path("x"))
@@ -36,7 +45,17 @@ def test_resolve_inputs_none_when_interactive():
 
 def test_scaffold_inputs_is_frozen():
     si = ScaffoldInputs(
-        "n", "d", "python", [], "", "none", False, False, False, ["claude"], False,
+        "n",
+        "d",
+        "python",
+        [],
+        "",
+        "none",
+        False,
+        False,
+        False,
+        ["claude"],
+        False,
         "individual",
     )
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -91,7 +110,9 @@ class TestDeliveryModel:
         from tests.helpers import make_variables
 
         target = tmp_path / "p"
-        scaffold(target, load_preset("obsidian-only"), make_variables(delivery="library"), strict=True)
+        scaffold(
+            target, load_preset("obsidian-only"), make_variables(delivery="library"), strict=True
+        )
         config = (target / ".agents" / "config.yaml").read_text()
         assert "delivery: library" in config
 

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -134,9 +134,7 @@ def test_amp_junie_not_experimental():
 
 def test_planned_files_for_selection():
     servers = servers_for_ids(["context7"])
-    files = surfaces.planned_files(
-        ["claude", "cursor", "antigravity", "vscode", "codex"], servers
-    )
+    files = surfaces.planned_files(["claude", "cursor", "antigravity", "vscode", "codex"], servers)
     assert set(files) >= {
         ".mcp.json",
         ".cursor/hooks.json",

--- a/tests/workflow.py
+++ b/tests/workflow.py
@@ -81,7 +81,9 @@ def needs(workflow: dict, name: str) -> list[str]:
     review).
     """
     raw = job(workflow, name).get("needs") or []
-    assert isinstance(raw, (str, list)), f"`needs:` on `{name}` is neither str nor list: {type(raw).__name__}"
+    assert isinstance(raw, (str, list)), (
+        f"`needs:` on `{name}` is neither str nor list: {type(raw).__name__}"
+    )
     return [raw] if isinstance(raw, str) else list(raw)
 
 

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -115,7 +115,10 @@ _AUTH_ENV_VARS = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
 
 def auth_available(config_dir: Path) -> bool:
     """True if the run can authenticate: an API key / OAuth token in env, or seeded creds."""
-    return any(os.environ.get(v) for v in _AUTH_ENV_VARS) or (config_dir / ".credentials.json").is_file()
+    return (
+        any(os.environ.get(v) for v in _AUTH_ENV_VARS)
+        or (config_dir / ".credentials.json").is_file()
+    )
 
 
 # --- target setup (testable — no agent) -----------------------------------
@@ -440,9 +443,13 @@ def main(argv: list[str] | None = None) -> int:
         help="scaffolded preset to compare against bare (repeatable)",
     )
     run.add_argument("--model", default=_DEFAULT_MODEL)
-    run.add_argument("--repeats", type=int, default=5, help="repeats per (task,target) for variance")
+    run.add_argument(
+        "--repeats", type=int, default=5, help="repeats per (task,target) for variance"
+    )
     run.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
-    run.add_argument("--prices", help="price table JSON (default: tools/benchmark/model_prices.json)")
+    run.add_argument(
+        "--prices", help="price table JSON (default: tools/benchmark/model_prices.json)"
+    )
     run.set_defaults(func=_cmd_run)
 
     rec = sub.add_parser("record-from", help="normalize an existing transcript (no agent)")
@@ -454,7 +461,9 @@ def main(argv: list[str] | None = None) -> int:
     rec.add_argument("--model", default="", help="override; default = transcript's model")
     rec.add_argument("--run-index", type=int, default=0, dest="run_index")
     rec.add_argument("--out", help="output JSONL (default: tools/benchmark/results/records.jsonl)")
-    rec.add_argument("--prices", help="price table JSON (default: tools/benchmark/model_prices.json)")
+    rec.add_argument(
+        "--prices", help="price table JSON (default: tools/benchmark/model_prices.json)"
+    )
     rec.set_defaults(func=_cmd_record_from)
 
     args = parser.parse_args(argv)

--- a/tools/benchmark/report.py
+++ b/tools/benchmark/report.py
@@ -82,7 +82,9 @@ def aggregate(records: list[RunRecord]) -> dict[str, Summary]:
             wall_clock_p99=lat["p99"],
             pass_rate=_rate(scored),  # _rate returns None on empty
             first_try_rate=_rate(first_tries),
-            mean_rework=_mean([float(r.rework_cycles) for r in recs if r.rework_cycles is not None]),
+            mean_rework=_mean(
+                [float(r.rework_cycles) for r in recs if r.rework_cycles is not None]
+            ),
             mean_tool_calls=_mean([float(r.tool_calls) for r in recs]),
         )
     return out
@@ -188,10 +190,14 @@ def fixed_overhead(target_dir: Path) -> list[tuple[str, int]]:
     for name in _OVERHEAD_CANDIDATES:
         path = target_dir / name
         if path.is_file():
-            rows.append((name, len(path.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN))
+            rows.append(
+                (name, len(path.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN)
+            )
     for skill in sorted((target_dir / ".agents" / "skills").glob("*/SKILL.md")):
         rel = skill.relative_to(target_dir)
-        rows.append((str(rel), len(skill.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN))
+        rows.append(
+            (str(rel), len(skill.read_text(encoding="utf-8", errors="replace")) // _CHARS_PER_TOKEN)
+        )
     rows.sort(key=lambda r: -r[1])
     return rows
 
@@ -207,7 +213,18 @@ def _render_comparison(console, order: list[Summary], efficient: set[str]) -> No
     from rich.table import Table
 
     table = Table(title="Cost–benefit: bare vs scaffolded")
-    for col in ("Target", "n", "$", "Tokens", "P50 s", "Pass%", "First-try%", "Rework", "Tools", ""):
+    for col in (
+        "Target",
+        "n",
+        "$",
+        "Tokens",
+        "P50 s",
+        "Pass%",
+        "First-try%",
+        "Rework",
+        "Tools",
+        "",
+    ):
         table.add_column(col)
     for s in order:
         table.add_row(

--- a/tools/check_third_party_updates.py
+++ b/tools/check_third_party_updates.py
@@ -146,7 +146,10 @@ def apply(tool_id: str, version: str, *, manifest_path: Path = MANIFEST) -> list
     # missing version_var fails fast and never leaves a half-applied lockstep
     # bump on disk (2026-07 review).
     pending: list[tuple[Path, str]] = [
-        (manifest_path, _replace_in_toml(manifest_path.read_text(encoding="utf-8"), tool_id, version))
+        (
+            manifest_path,
+            _replace_in_toml(manifest_path.read_text(encoding="utf-8"), tool_id, version),
+        )
     ]
     var = tool.get("version_var")
     if var:

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -258,7 +258,9 @@ def _check() -> int:
                 shutil.copytree(snapshot / str(i), root)
     if drifted:
         sys.stderr.write(
-            "plugin payload is out of sync — run `just sync-plugin`:\n  " + "\n  ".join(drifted) + "\n"
+            "plugin payload is out of sync — run `just sync-plugin`:\n  "
+            + "\n  ".join(drifted)
+            + "\n"
         )
         return 1
     sys.stdout.write("plugin payload is in sync\n")


### PR DESCRIPTION
## Summary

The repo linted with `ruff check` but never `ruff format` — 97 files were unformatted, and it shipped a `ruff format --check` gate to every generated python project without running it on itself. This adopts it.

**Two commits:**
1. `ruff format .` — the one-time mechanical reformat (97 files). Semantically neutral: `ruff check` clean, full suite green unchanged.
2. Enforce: `just lint` now runs `ruff check` + `ruff format --check`; CI's `checks` job invokes `just lint` (single callsite), so CI, pre-push (`fast-ci`) and local all enforce the same gate.

**Break-it verified**: a badly-formatted file fails the gate; clean after removal.

## Note on #726
`#726` turned out to be a *template* audit (no format-*check* in some scaffolded languages) — already resolved by PR #728 (verified: python/rust/go/node all gate; docs corrected). This PR closes the separate *repo-parity* gap #726 was mis-cited for in `quality-gates.md`, which is now corrected. `quality-gates.md` marks the ruff-format gap done.

- `test_repo_ci_python_matrix`: guards that `just lint` format-checks and CI runs it.
- Full suite green (2288); actionlint + mkdocs clean.

Closes #772