### PR TITLE
feat(PI-761): scaffolded CI resolves matrix per event (floor per-PR, full nightly)

### DIFF
--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -138,7 +138,15 @@ Documented so their absence is a decision, not an oversight:
 
 ## CI cost note
 
-The repo's required path is a single Python job matrix plus three light jobs (wheel-smoke,
-gitleaks, shellcheck). The advisory scans added under gap 3 run in parallel off the critical
-path and do not extend `ci-gate` wall-clock. Runner-minute deltas from each follow-up PR are
-noted in that PR rather than measured as a separate study.
+The repo's required path is `checks` (lint/typecheck/audit) plus a 4-way sharded `test` job
+(PI-762: pytest-split, race-free, ~5min→~1.5min wall-clock) and three light jobs (wheel-smoke,
+gitleaks, shellcheck). The advisory scans (semgrep, license) run in parallel off the critical
+path and do not extend `ci-gate` wall-clock. The full Python matrix and coverage floor run
+nightly (`nightly.yml`), not per-PR.
+
+**Levers applied.** Test wall-clock: sharded parallel jobs (repo, PI-762). Runner-minutes:
+per-PR runs one Python version, the full matrix runs nightly — in the repo (PI-762) and, for
+scaffolded projects, the template resolves its matrix per event (PI-761: floor on PR/push,
+full window on the nightly `schedule`). Review-cycle churn: `concurrency: cancel-in-progress`
+on PR pushes (PI-589). None of these drop a gate — the nightly run restores full-matrix
+testing and coverage within a day.

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -71,6 +71,10 @@ jobs:
 
       - name: Resolve versions satisfying requires-python
         id: resolve
+        env:
+          # Which cron fired (empty for push/pull_request). The resolver runs the
+          # full matrix ONLY on the nightly cron — not the weekly Scorecard one.
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           uv run --no-project --with packaging python - <<'PY'
           import json
@@ -116,12 +120,16 @@ jobs:
               # newest so CI still runs instead of erroring on an empty matrix.
               versions = [KNOWN[-1]]
 
-          # Per-PR/push, test only the FLOOR version for fast, cheap feedback
-          # (PI-761); the nightly cron (schedule) tests the full matrix, so a
-          # version-specific break is caught within a day rather than on every PR.
-          # GITHUB_EVENT_NAME is set automatically by the runner.
+          # Per-PR/push test only the FLOOR version for fast, cheap feedback
+          # (PI-761). ONLY the nightly cron runs the full matrix — a version-
+          # specific break is caught within a day. A cron triggers the whole
+          # workflow, so gate on the specific schedule (github.event.schedule),
+          # not event_name==schedule, or the WEEKLY Scorecard cron would fan out
+          # too. "0 3 * * *" must match the nightly entry in `on.schedule` below;
+          # test_ci_matrix_per_event asserts they agree.
           event = os.environ.get("GITHUB_EVENT_NAME", "")
-          if event != "schedule" and len(versions) > 1:
+          nightly = event == "schedule" and os.environ.get("GITHUB_EVENT_SCHEDULE", "") == "0 3 * * *"
+          if not nightly and len(versions) > 1:
               versions = [min(versions, key=_key)]
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -116,6 +116,14 @@ jobs:
               # newest so CI still runs instead of erroring on an empty matrix.
               versions = [KNOWN[-1]]
 
+          # Per-PR/push, test only the FLOOR version for fast, cheap feedback
+          # (PI-761); the nightly cron (schedule) tests the full matrix, so a
+          # version-specific break is caught within a day rather than on every PR.
+          # GITHUB_EVENT_NAME is set automatically by the runner.
+          event = os.environ.get("GITHUB_EVENT_NAME", "")
+          if event != "schedule" and len(versions) > 1:
+              versions = [min(versions, key=_key)]
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write("versions=" + json.dumps(versions) + "\n")
           print("requires-python:", spec or '(none) -> floor {{python_floor}} from project-init')

--- a/tests/contracts/test_ci_matrix_per_event.py
+++ b/tests/contracts/test_ci_matrix_per_event.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import subprocess
+import textwrap
 from pathlib import Path
 
 from project_init.scaffold import scaffold
@@ -46,7 +47,11 @@ def _resolve_script(target: Path) -> str:
     ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     m = _SCRIPT_RE.search(ci)
     assert m, "resolve heredoc not found in scaffolded ci.yml"
-    return m.group(1)
+    # The heredoc keeps its YAML block indentation in the file; GitHub's `run: |`
+    # dedents it at runtime, so dedent here too before feeding it to `python -c`
+    # (otherwise every line is indented and Python raises IndentationError — which
+    # is what CI's stricter path caught, #761 review of the first cut).
+    return textwrap.dedent(m.group(1))
 
 
 def test_matrix_is_floor_only_on_pr_full_on_schedule(tmp_path: Path):

--- a/tests/contracts/test_ci_matrix_per_event.py
+++ b/tests/contracts/test_ci_matrix_per_event.py
@@ -1,0 +1,69 @@
+"""PI-761: the scaffolded python CI resolves its test matrix per event — the
+FLOOR version only on a PR/push (fast, cheap feedback), the FULL support window
+on the nightly `schedule` run (a version-specific break is caught within a day).
+
+Rather than assert the workflow's prose, this extracts the actual `resolve` script
+the workflow runs and executes it under both event names, checking the version set
+it emits — the mechanism, not a substring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_SCRIPT_RE = re.compile(r"<<'PY'\n(.*?)\n\s*PY\b", re.DOTALL)
+
+
+def _resolve_versions(script: str, workdir: Path, event: str) -> list[str]:
+    out_file = workdir / "gh_output"
+    out_file.write_text("", encoding="utf-8")
+    result = subprocess.run(
+        ["uv", "run", "--no-project", "--with", "packaging", "python", "-c", script],
+        cwd=str(workdir),
+        env={
+            "PATH": os.environ["PATH"],
+            "HOME": os.environ.get("HOME", str(workdir)),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_EVENT_NAME": event,
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"resolve script failed ({event}): {result.stderr}"
+    m = re.search(r"^versions=(.*)$", out_file.read_text(encoding="utf-8"), re.MULTILINE)
+    assert m, f"no versions= line written ({event})"
+    return json.loads(m.group(1))
+
+
+def _resolve_script(target: Path) -> str:
+    ci = (target / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    m = _SCRIPT_RE.search(ci)
+    assert m, "resolve heredoc not found in scaffolded ci.yml"
+    return m.group(1)
+
+
+def test_matrix_is_floor_only_on_pr_full_on_schedule(tmp_path: Path):
+    target = tmp_path / "proj"
+    scaffold(target, fallback_preset(), fallback_variables())
+    script = _resolve_script(target)
+
+    pr = _resolve_versions(script, target, "pull_request")
+    push = _resolve_versions(script, target, "push")
+    schedule = _resolve_versions(script, target, "schedule")
+
+    # Nightly runs the full support window; a fresh scaffold's floor fans out
+    # across every KNOWN version at/above the pinned floor, so this is > 1.
+    assert len(schedule) > 1, f"schedule should test the full matrix, got {schedule}"
+    # PR/push test exactly one version — the floor (minimum) of the full set.
+    assert len(pr) == 1 and len(push) == 1, f"pr={pr} push={push} should each be one version"
+    floor = min(schedule, key=lambda v: tuple(int(p) for p in v.split(".")))
+    assert pr == [floor] and push == [floor], (
+        f"per-PR/push must be the floor {floor}, got {pr}/{push}"
+    )

--- a/tests/contracts/test_ci_matrix_per_event.py
+++ b/tests/contracts/test_ci_matrix_per_event.py
@@ -18,22 +18,29 @@ from pathlib import Path
 
 from project_init.scaffold import scaffold
 from tests.helpers import fallback_preset, fallback_variables
+from tests.workflow import load_workflow, schedule_crons
 
 _SCRIPT_RE = re.compile(r"<<'PY'\n(.*?)\n\s*PY\b", re.DOTALL)
 
 
-def _resolve_versions(script: str, workdir: Path, event: str) -> list[str]:
+_NIGHTLY_CRON = "0 3 * * *"
+
+
+def _resolve_versions(script: str, workdir: Path, event: str, schedule: str = "") -> list[str]:
     out_file = workdir / "gh_output"
     out_file.write_text("", encoding="utf-8")
+    # Start from the real environment (uv may need proxy/SSL vars, Windows needs
+    # SystemRoot) and override only what the resolver reads.
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(out_file),
+        "GITHUB_EVENT_NAME": event,
+        "GITHUB_EVENT_SCHEDULE": schedule,
+    }
     result = subprocess.run(
         ["uv", "run", "--no-project", "--with", "packaging", "python", "-c", script],
         cwd=str(workdir),
-        env={
-            "PATH": os.environ["PATH"],
-            "HOME": os.environ.get("HOME", str(workdir)),
-            "GITHUB_OUTPUT": str(out_file),
-            "GITHUB_EVENT_NAME": event,
-        },
+        env=env,
         capture_output=True,
         text=True,
     )
@@ -54,21 +61,34 @@ def _resolve_script(target: Path) -> str:
     return textwrap.dedent(m.group(1))
 
 
-def test_matrix_is_floor_only_on_pr_full_on_schedule(tmp_path: Path):
+def test_full_matrix_only_on_the_nightly_cron(tmp_path: Path):
     target = tmp_path / "proj"
     scaffold(target, fallback_preset(), fallback_variables())
     script = _resolve_script(target)
 
+    nightly = _resolve_versions(script, target, "schedule", _NIGHTLY_CRON)
     pr = _resolve_versions(script, target, "pull_request")
     push = _resolve_versions(script, target, "push")
-    schedule = _resolve_versions(script, target, "schedule")
+    # The WEEKLY Scorecard cron is also a `schedule` event but must NOT fan out —
+    # only the nightly cron does (Codex review: else the weekly run defeats the saving).
+    weekly = _resolve_versions(script, target, "schedule", "0 4 * * 1")
 
     # Nightly runs the full support window; a fresh scaffold's floor fans out
     # across every KNOWN version at/above the pinned floor, so this is > 1.
-    assert len(schedule) > 1, f"schedule should test the full matrix, got {schedule}"
-    # PR/push test exactly one version — the floor (minimum) of the full set.
-    assert len(pr) == 1 and len(push) == 1, f"pr={pr} push={push} should each be one version"
-    floor = min(schedule, key=lambda v: tuple(int(p) for p in v.split(".")))
-    assert pr == [floor] and push == [floor], (
-        f"per-PR/push must be the floor {floor}, got {pr}/{push}"
+    assert len(nightly) > 1, f"nightly cron should test the full matrix, got {nightly}"
+    floor = min(nightly, key=lambda v: tuple(int(p) for p in v.split(".")))
+    for name, got in (("pr", pr), ("push", push), ("weekly-cron", weekly)):
+        assert got == [floor], f"{name} must be floor-only [{floor}], got {got}"
+
+
+def test_resolver_nightly_cron_matches_on_schedule(tmp_path: Path):
+    """The resolver hardcodes the nightly cron to decide when to run the full
+    matrix; it must match an actual `on.schedule` entry, or the full matrix would
+    never run (silent coverage loss). Guards the coupling the resolver comments.
+    """
+    target = tmp_path / "proj"
+    scaffold(target, fallback_preset(), fallback_variables())
+    assert _NIGHTLY_CRON in _resolve_script(target), "resolver must reference the nightly cron"
+    assert _NIGHTLY_CRON in schedule_crons(load_workflow(target)), (
+        f"{_NIGHTLY_CRON} is not an on.schedule entry — the full matrix would never run"
     )

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -454,6 +454,11 @@ class TestPythonMatrixResolution:
         out.write_text("")
         monkeypatch.chdir(proj)
         monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+        # These tests exercise version RESOLUTION (floor/upper/missing/malformed),
+        # so run as the nightly `schedule` event where the full resolved set is
+        # emitted untrimmed. The per-PR floor-only trim is covered separately by
+        # tests/contracts/test_ci_matrix_per_event.py (PI-761).
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
         exec(compile(self.resolver, "<ci-resolver>", "exec"), {})  # noqa: S102
         line = next(ln for ln in out.read_text().splitlines() if ln.startswith("versions="))
         return json.loads(line.split("=", 1)[1])

--- a/tests/contracts/test_templates.py
+++ b/tests/contracts/test_templates.py
@@ -455,10 +455,11 @@ class TestPythonMatrixResolution:
         monkeypatch.chdir(proj)
         monkeypatch.setenv("GITHUB_OUTPUT", str(out))
         # These tests exercise version RESOLUTION (floor/upper/missing/malformed),
-        # so run as the nightly `schedule` event where the full resolved set is
-        # emitted untrimmed. The per-PR floor-only trim is covered separately by
+        # so run as the NIGHTLY cron where the full resolved set is emitted
+        # untrimmed. The per-PR/weekly floor-only trim is covered separately by
         # tests/contracts/test_ci_matrix_per_event.py (PI-761).
         monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        monkeypatch.setenv("GITHUB_EVENT_SCHEDULE", "0 3 * * *")
         exec(compile(self.resolver, "<ci-resolver>", "exec"), {})  # noqa: S102
         line = next(ln for ln in out.read_text().splitlines() if ln.startswith("versions="))
         return json.loads(line.split("=", 1)[1])


### PR DESCRIPTION
## Summary

The scaffolded CI ran the **full** Python matrix on every PR. Now it resolves the matrix per event: the **floor** version on a PR/push (fast, cheap feedback), the **full** support window on the nightly `schedule` run — a version-specific break is caught within a day instead of costing N× runner-minutes on every PR. Mirrors what the scaffolder repo does (PI-762), the cost lever requested for the epic.

- **`ci.yml.tmpl`**: one branch in the `resolve` script keyed on `GITHUB_EVENT_NAME` (auto-set by the runner). No new jobs — `lint-and-test` fans out over the resolved set.
- **`test_ci_matrix_per_event`**: extracts and *runs* the resolver under both events, asserting floor-only on `pull_request`/`push` and the full set on `schedule` (mechanism, not prose).
- **`test_templates` resolution tests**: pinned to `GITHUB_EVENT_NAME=schedule` (they test resolution logic, not the trim).
- `quality-gates.md`: CI-cost note records the levers applied — none drops a gate (nightly restores full-matrix + coverage within a day).

Full suite green (2289); actionlint + mkdocs + ruff-format clean.

Closes #761