### PR TITLE
feat(PI-545): colorize the unified diff in upgrade/add/remove reports

### DIFF
--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from rich.console import Console
+    from rich.text import Text
 
 from project_init.scaffold import (
     _ALWAYS_OVERWRITE,
@@ -868,6 +869,35 @@ def _unified_diff(rel: Path, old: bytes, new: bytes) -> str:
     )
 
 
+def _colorize_diff(diff: str) -> Text:
+    """A unified-diff string as a rich ``Text`` with +/-/@@ lines styled (#545).
+
+    Added lines are green, removed red, hunk headers (``@@``) cyan, and the
+    file-header lines (``---``/``+++``) bold. Returning a ``Text`` (not markup)
+    means diff content is treated literally — a ``[red]`` inside a changed line
+    is never mis-parsed — which is why the old plain path passed
+    ``markup=False``. Colour degrades automatically: a plain ``Console()``
+    drops styling when the sink is not a TTY or ``NO_COLOR`` is set, so piped
+    and CI output stay clean.
+    """
+    from rich.text import Text
+
+    text = Text()
+    for line in diff.splitlines(keepends=True):
+        if line.startswith("+++") or line.startswith("---"):
+            style = "bold"
+        elif line.startswith("+"):
+            style = "green"
+        elif line.startswith("-"):
+            style = "red"
+        elif line.startswith("@@"):
+            style = "cyan"
+        else:
+            style = ""
+        text.append(line, style=style)
+    return text
+
+
 def _render_staging(
     preset_name: str, variables: dict[str, str], staging: Path, detect_root: Path | None = None
 ) -> list[Path]:
@@ -1277,7 +1307,7 @@ def _print_report(report: DriftReport, applied: bool) -> None:
         diff = report.diffs.get(rel)
         if diff:
             console.print(f"\n[bold]--- drift: {rel} ---[/bold]")
-            console.print(diff, markup=False, highlight=False)
+            console.print(_colorize_diff(diff))
 
     if not applied:
         console.print("\nRun [bold]project-init upgrade --apply[/bold] to apply.")
@@ -1666,7 +1696,7 @@ def _show_interactive_diff(console: Console, report: DriftReport, rel: Path) -> 
     """Print the drift (and any merge result) for one file during the walk."""
     diff = report.diffs.get(rel)
     if diff:
-        console.print(diff, markup=False, highlight=False)
+        console.print(_colorize_diff(diff))
     merged = report.merge_results.get(rel)
     if merged is not None:
         console.print(f"\n[dim]--- 3-way merge result for {rel} ---[/dim]")

--- a/tests/integration/test_upgrade_diff_color.py
+++ b/tests/integration/test_upgrade_diff_color.py
@@ -1,0 +1,105 @@
+"""#545: colorized unified diff in the upgrade/add/remove drift report.
+
+`_colorize_diff` styles +/-/@@ lines; rich strips the colour on a non-TTY or
+under NO_COLOR. Assertions target the diff *content* (after stripping ANSI), not
+the escape codes, except where the presence/absence of colour is the point.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rich.console import Console
+
+from project_init.__main__ import main
+from project_init.upgrade import _colorize_diff, run_upgrade
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def _render(diff: str, *, color: bool) -> str:
+    """Render a diff through a rich Console with colour forced on or off."""
+    console = Console(
+        force_terminal=True if color else None,
+        no_color=not color,
+        width=200,
+    )
+    with console.capture() as cap:
+        console.print(_colorize_diff(diff))
+    return cap.get()
+
+
+_SAMPLE = (
+    "--- current/CLAUDE.md\n"
+    "+++ upgrade/CLAUDE.md\n"
+    "@@ -1,3 +1,3 @@\n"
+    " unchanged context line\n"
+    "-old project tagline\n"
+    "+new project tagline\n"
+)
+
+
+def test_content_preserved_after_stripping_ansi() -> None:
+    out = _strip(_render(_SAMPLE, color=True))
+    # Every diff line's text survives colouring — assert on content, not codes.
+    assert "-old project tagline" in out
+    assert "+new project tagline" in out
+    assert "@@ -1,3 +1,3 @@" in out
+    assert "unchanged context line" in out
+
+
+def test_color_emits_ansi_for_changed_lines() -> None:
+    out = _render(_SAMPLE, color=True)
+    assert "\x1b[" in out  # styling present on a colour-capable sink
+
+
+def test_no_color_env_falls_back_to_plain() -> None:
+    out = _render(_SAMPLE, color=False)
+    assert "\x1b[" not in out  # NO_COLOR / non-TTY → clean plain text
+    assert "+new project tagline" in out
+
+
+def test_added_and_removed_get_distinct_styles() -> None:
+    # The added line carries a green code and the removed a red one, so a reader
+    # can tell them apart — the whole point of the feature.
+    added = _render("+brand new line\n", color=True)
+    removed = _render("-deleted line\n", color=True)
+    assert "32m" in added  # ANSI green
+    assert "31m" in removed  # ANSI red
+
+
+def _scaffold(target: Path) -> None:
+    rc = main(
+        [
+            str(target),
+            "--preset",
+            "obsidian-only",
+            "--non-interactive",
+            "--name",
+            "diff-color-fixture",
+            "--description",
+            "Diff color test",
+            "--language",
+            "python",
+        ]
+    )
+    assert rc == 0
+
+
+def test_real_drift_shows_changed_line(tmp_path: Path, capsys) -> None:
+    # End-to-end: a one-line edit to a managed file must surface that line in the
+    # drift report's diff body (content assertion, ANSI stripped).
+    _scaffold(tmp_path)
+    claude_md = tmp_path / "CLAUDE.md"
+    original = claude_md.read_text()
+    marker = "ZZZ_UNIQUE_DRIFT_MARKER_545"
+    claude_md.write_text(original.replace("\n", f" {marker}\n", 1))
+
+    run_upgrade(tmp_path, apply=False)
+    out = _strip(capsys.readouterr().out)
+    assert marker in out  # the drifted line appears in the rendered diff


### PR DESCRIPTION
## What

`project-init upgrade` / `add` / `remove` already generate real unified diffs (`_unified_diff`) and print them through a `rich` Console, but both sites printed them plain (`markup=False, highlight=False`). This colorizes them: a new `_colorize_diff` renders the diff as a `rich.Text` with **added lines green, removed red, hunk headers (`@@`) cyan, and file headers (`---`/`+++`) bold**, wired into both the drift report and the interactive per-file (`-i`) diff.

## Safety / degradation

- Returns a `Text` (not markup), so diff **content is treated literally** — a `[red]` or other bracket inside a changed line is never mis-parsed as rich markup. This is why the old plain path passed `markup=False`; the `Text` representation preserves that guarantee.
- Color **degrades automatically**: a plain `Console()` drops styling when the sink is not a TTY or `NO_COLOR` is set, so piped and CI output stay clean plain text. No new dependency (`rich` was already in).
- Scope is `src/` only (the scaffolder's own CLI) — no `templates/` change, so scaffolded projects are unaffected.

## Testing

`tests/integration/test_upgrade_diff_color.py`:
- diff **content survives** after stripping ANSI (assert on text, not codes)
- color **is emitted** on a color-capable sink and **absent** under `NO_COLOR`/non-TTY
- added vs removed get **distinct** styles (green `32m` / red `31m`)
- a real end-to-end one-line drift surfaces the changed line in the report

Full suite green (2308 passed); lint + `mypy --strict` clean.

Closes #545

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1
