### PR TITLE
feat(PI-777): auto-apply area:<slug> labels from the issue body Area field

### DIFF
--- a/templates/lifecycle/dot_agents/docs/guides/issue-metadata.md
+++ b/templates/lifecycle/dot_agents/docs/guides/issue-metadata.md
@@ -10,7 +10,7 @@ Use labels for values that workflows and project boards can read.
 - Priority labels: `priority:high`, `priority:medium`, `priority:low`
 - Size labels: `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
 - Scale labels: `scale:epic` (a large parent initiative) or `scale:task` (a focused leaf — the default). Keep an epic's child tickets `scale:task` and sized `S`/`M`, so PRs and agent context stay small.
-- Area labels are repository-specific. Use existing labels only; do not invent new area labels from agent context.
+- Area labels (`area:<slug>`) are derived automatically: the issue-validation workflow reads the body's `Area` field and applies an `area:<slug>` label (comma-separated areas each get one, e.g. `Area: ci, templates` → `area:ci` + `area:templates`), creating the label if missing. So set the `Area` field rather than hand-crafting the label — that keeps the subsystem facet consistent for click-to-filter. Reuse an existing area slug when one fits instead of coining a near-duplicate.
 
 `create_issue.sh` creates missing priority, size, and scale labels when the token has permission. If label creation fails, the issue is still created and the value remains in the markdown body.
 

--- a/templates/lifecycle/dot_github/workflows/issue-validation.yml
+++ b/templates/lifecycle/dot_github/workflows/issue-validation.yml
@@ -89,6 +89,46 @@ jobs:
             fi
           }
 
+          # Dual-format body field reader (bullet "- Field: value" wins, else the
+          # "### Field" heading block) — the same parser board-automation.yml uses.
+          parse_body_field() {
+            local heading="$1" body="$2" val
+            val=$(printf '%s\n' "$body" \
+              | sed -n "s/^[[:space:]]*-[[:space:]]*${heading}:[[:space:]]*//Ip" \
+              | head -1 | sed 's/[[:space:]]*$//')
+            if [ -n "$val" ]; then
+              printf '%s\n' "$val"
+              return 0
+            fi
+            printf '%s\n' "$body" | awk -v h="$heading" '
+              BEGIN { in_section = 0 }
+              $0 ~ "^[[:space:]]*###[[:space:]]+" h "[[:space:]]*$" { in_section = 1; next }
+              in_section && /^[[:space:]]*$/ { next }
+              in_section { sub(/[[:space:]]*$/, ""); print; exit }
+            '
+          }
+
+          # Turn the body's free-text Area value into facetable area:<slug>
+          # label(s) so issues are filterable by subsystem in the UI, mirroring the
+          # type-label derivation above. Comma-separated areas each get a label.
+          # Best-effort and non-blocking — the Area *value* is already required by
+          # has_body_value "Area"; this only adds the click-to-filter convenience.
+          apply_area_labels() {
+            local raw slug
+            raw=$(parse_body_field "Area" "$ISSUE_BODY")
+            case "$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')" in
+            "" | unset) return ;;
+            esac
+            printf '%s\n' "$raw" | tr ',' '\n' | while IFS= read -r part; do
+              slug=$(printf '%s' "$part" | tr '[:upper:]' '[:lower:]' \
+                | sed 's/[^a-z0-9]\{1,\}/-/g; s/^-//; s/-$//')
+              [ -z "$slug" ] && continue
+              gh label create "area:$slug" --color "1d76db" --description "Affected area / component" 2>/dev/null || true
+              gh issue edit "$ISSUE_NUMBER" --add-label "area:$slug" >/dev/null 2>&1 \
+                && echo "Applied area label 'area:$slug'."
+            done
+          }
+
           has_body_value "Priority"
           has_body_value "Area"
           has_body_value "Size"
@@ -100,6 +140,7 @@ jobs:
           has_body_value "Confidence"
           has_body_value "Definition of Done"
           has_type_label
+          apply_area_labels
 
           if [ "${#missing[@]}" -gt 0 ]; then
             gh label create "status:needs-info" --color "d93f0b" --description "Issue is missing required planning metadata" 2>/dev/null || true

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -208,7 +208,9 @@ _GENERATED = {".agents/CAPABILITIES.md"}
 #   • board-automation.yml / issue-validation.yml — self-populating board
 #     metadata: dual-format ("### Heading" + "- Field: value") body parsing so
 #     issues created outside the web form still populate all board fields, plus
-#     auto-ensuring the type label from the body "- Type:" for MCP/API issues
+#     auto-ensuring the type label from the body "- Type:" for MCP/API issues,
+#     and (PI-777 area labels) deriving area:<slug> label(s) from the body Area
+#     field for click-to-filter; issue-metadata.md documents the derivation
 #   • skills/report_upstream_issue/SKILL.md + skills/INDEX.md — new default-on
 #     skill that routes tooling/scaffolding bugs upstream to project-init; only
 #     the --no-plugin combos copy the skill in (plugin mode ships it via the
@@ -260,6 +262,7 @@ _ADDED_SINCE_BASELINE = {
     ".agents/scripts/create_issue.sh",
     ".github/workflows/board-automation.yml",
     ".github/workflows/issue-validation.yml",
+    ".agents/docs/guides/issue-metadata.md",
     ".agents/config.yaml",
     ".agents/hooks/session_setup.sh",
     "mypy.ini",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -196,7 +196,9 @@ _GENERATED = {".agents/CAPABILITIES.md"}
 #     against PyPI/npm/crates.io), wired into settings.json and documented (#564)
 #     memory-move content change
 #   • issue-validation.yml — self-populating board metadata: auto-ensures the
-#     type label from the body "- Type:" for MCP/API-created issues
+#     type label from the body "- Type:" for MCP/API-created issues, and derives
+#     area:<slug> label(s) from the body Area field (PI-777); issue-metadata.md
+#     documents that derivation
 #   • report_upstream_issue skill (SKILL.md + INDEX/README/project-init.md rows)
 #     — new default-on skill routing tooling bugs upstream to project-init
 #   • token_efficiency skill (PI-647) — new default-on skill with token-frugal
@@ -240,6 +242,7 @@ _ADDED_SINCE_BASELINE = {
     ".agents/scripts/create_issue.sh",
     ".github/workflows/board-automation.yml",
     ".github/workflows/issue-validation.yml",
+    ".agents/docs/guides/issue-metadata.md",
     # #629: workflow actions pinned to commit SHAs so a fresh scaffold no longer
     # trips its own Semgrep mutable-action-tag gate. ci.yml/board-automation.yml
     # already excluded above; project-init-upgrade.yml is the remaining drift.

--- a/tests/integration/test_issue_metadata_workflow.py
+++ b/tests/integration/test_issue_metadata_workflow.py
@@ -70,6 +70,54 @@ class TestIssueMetadataScaffold:
         assert 'gh label create "$label"' in content
         assert '--add-label "$label"' in content
 
+    def test_issue_validation_derives_area_labels(self):
+        """The free-text Area value is turned into facetable area:<slug> label(s)
+        for click-to-filter, comma-separated areas each get one, and it is
+        best-effort (never blocks — the Area value itself is already required)."""
+        content = (self.target / ".github" / "workflows" / "issue-validation.yml").read_text()
+        assert "apply_area_labels" in content
+        assert "apply_area_labels\n" in content  # actually called, not just defined
+        assert 'parse_body_field "Area"' in content
+        assert 'gh label create "area:$slug"' in content
+        assert '--add-label "area:$slug"' in content
+        # Comma-split so "ci, templates" becomes two labels.
+        assert 'tr "," ' in content or "tr ',' " in content
+
+    def test_area_label_slugification_executes(self, tmp_path: Path):
+        """Run the *shipped* parse_body_field/apply_area_labels against sample
+        bodies with a mocked gh — proves the slug logic, comma-split, and
+        unset/empty skips actually work, not just that the text is present."""
+        import re
+        import textwrap
+
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("bash not available")
+        wf = (self.target / ".github" / "workflows" / "issue-validation.yml").read_text()
+        # Extract the two real functions (contiguous block) from the shipped file,
+        # so this exercises the shipped code — not a copy that could drift green.
+        start = wf.index("# Dual-format body field reader")
+        end = wf.index('has_body_value "Priority"')
+        block = textwrap.dedent(wf[start:end])
+
+        # The shipped code sends gh output to /dev/null and echoes
+        # "Applied area label 'area:<slug>'." on a successful add — so mock gh to
+        # just succeed and parse that real output line.
+        harness = (
+            "set -euo pipefail\n"
+            "ISSUE_NUMBER=1\n"
+            "gh() { return 0; }\n" + block + "\n"
+            'ISSUE_BODY="- Area: CI, Scaffold Engine"; apply_area_labels\n'
+            'ISSUE_BODY="### Area\n\nlifecycle\n"; apply_area_labels\n'
+            'ISSUE_BODY="- Area: unset"; apply_area_labels\n'
+            'ISSUE_BODY="- Priority: high"; apply_area_labels\n'
+        )
+        out = subprocess.run(
+            [bash, "-c", harness], capture_output=True, text=True, check=True
+        ).stdout
+        labels = re.findall(r"Applied area label '(area:[a-z0-9-]+)'", out)
+        assert labels == ["area:ci", "area:scaffold-engine", "area:lifecycle"], labels
+
     def test_board_automation_syncs_metadata_fields(self):
         content = (self.target / ".github" / "workflows" / "board-automation.yml").read_text()
         assert "PROJECT_TOKEN" in content
@@ -114,6 +162,11 @@ class TestIssueMetadataScaffold:
         content = doc.read_text()
         assert "GitHub labels" in content
         assert "markdown body" in content
+        # The area-label auto-derivation is documented so agents set the Area
+        # field rather than hand-crafting labels (excluded from byte-identity, so
+        # this is the content guard for that doc line).
+        assert "area:<slug>" in content
+        assert "click-to-filter" in content
 
     def test_setup_github_script_created(self):
         script = self.target / ".agents" / "scripts" / "setup_github.sh"


### PR DESCRIPTION
## What

The lifecycle `issue-validation.yml` workflow already **requires** an `Area` value in the issue body — but leaves it as free text. That's searchable (`in:body`) yet not *facetable*. This extends the workflow's existing type-label derivation with an `apply_area_labels` step that turns the body's Area value into **`area:<slug>` label(s)** for click-to-filter, reusing the canonical dual-format `parse_body_field` (bullet `- Area: value` **or** `### Area` heading).

- Comma-separated areas each become their own label: `Area: ci, templates` → `area:ci` + `area:templates`.
- Slugified (lowercased, non-alphanumeric → `-`); the label is created if missing (mirrors how the type label is auto-created).
- **Best-effort and non-blocking** — the Area *value* is already a required field, so this only adds the label convenience; it never fails the validation.

## Why this and nothing more

Checking the premise first: scaffolded projects **already** ship a blocking issue-metadata validator (requires Area + 9 other fields), `blank_issues_enabled: false`, and auto-derived type labels. The only real gap was that Area was enforced-as-present but never facetable. This ~20-line extension closes exactly that gap with zero new author burden — no new taxonomy, no template-field change.

## Scope

Ships to `templates/` (the product). This repo does **not** run `issue-validation.yml` on itself (documented divergence — the repo is a subset of the template policy), so no repo copy changes. `issue-metadata.md` is updated to document the derivation so agents set the `Area` field instead of hand-crafting labels.

## Testing

- Content assertions that the derivation/call/label-apply are present.
- An **execution test** that extracts and runs the *shipped* `parse_body_field`/`apply_area_labels` against sample bodies (both body forms, comma-split → two labels, unset/empty → skip) with a mocked `gh`. Verified non-vacuous: it **fails** when the comma-split is removed from the workflow, passes when restored.
- Both lifecycle + memory byte-identity baselines exclude the intentionally-edited guide (same mechanism as `issue-validation.yml` itself); its new content is guarded by a doc-content assertion instead.
- `shellcheck -S warning` clean on the workflow's run block; full suite green (2310 passed).

Closes #777

https://claude.ai/code/session_01MrhsgXgLxVzvwSX4pWu9o1
