### PR TITLE
fix(PI-802): benchmark harness looks for Claude creds in ~/.agents, not ~/.claude — blocks subscription-auth measurement

### DIFF
--- a/tests/contracts/test_benchmark_harness.py
+++ b/tests/contracts/test_benchmark_harness.py
@@ -290,7 +290,25 @@ class TestAuth:
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
         assert harness.default_config_dir() == tmp_path / "cfg"
         monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
-        assert harness.default_config_dir() == Path.home() / ".agents"
+        # PI-802: the default is Claude Code's real config dir (~/.claude), where
+        # the subscription/OAuth credentials live — NOT ~/.agents.
+        assert harness.default_config_dir() == Path.home() / ".claude"
+
+    def test_default_config_dir_finds_existing_login(self, tmp_path: Path, monkeypatch):
+        """With no env override, the resolver points at a real ~/.claude login.
+
+        Regression guard for PI-802: the harness must locate credentials Claude
+        Code actually wrote, so `run` authenticates off a Pro/Max login instead
+        of falsely reporting "not authenticated".
+        """
+        fake_home = tmp_path / "home"
+        (fake_home / ".claude").mkdir(parents=True)
+        (fake_home / ".claude" / ".credentials.json").write_text("{}", encoding="utf-8")
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        resolved = harness.default_config_dir()
+        assert (resolved / ".credentials.json").is_file()
+        assert resolved == fake_home / ".claude"
 
     def test_seed_credentials_copies_subscription_token(self, tmp_path: Path):
         source = tmp_path / "real"

--- a/tools/benchmark/harness.py
+++ b/tools/benchmark/harness.py
@@ -82,10 +82,13 @@ def transcript_path_for(config_dir: Path, target_dir: Path, session_id: str) -> 
 def default_config_dir() -> Path:
     """The user's real Claude config dir — where OAuth/subscription creds live.
 
-    Honors ``CLAUDE_CONFIG_DIR`` (matching Claude Code), else ``~/.agents``.
+    Honors ``CLAUDE_CONFIG_DIR`` (matching Claude Code), else ``~/.claude`` —
+    Claude Code's real default config dir, where the subscription/OAuth
+    ``.credentials.json`` is written (NOT ``~/.agents``, which is a project's
+    scaffolded tree, not the user's Claude config; PI-802).
     """
     env = os.environ.get("CLAUDE_CONFIG_DIR")
-    return Path(env) if env else Path.home() / ".agents"
+    return Path(env) if env else Path.home() / ".claude"
 
 
 def seed_credentials(config_dir: Path, source: Path | None = None) -> bool:
@@ -109,7 +112,7 @@ def seed_credentials(config_dir: Path, source: Path | None = None) -> bool:
 
 
 # Env vars Claude Code honors for non-interactive auth — both take precedence
-# over stored credentials, so either is sufficient (https://code.agents.com/docs/en/env-vars).
+# over stored credentials, so either is sufficient (https://code.claude.com/docs/en/env-vars).
 _AUTH_ENV_VARS = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
 
 


### PR DESCRIPTION
Closes #802