### PR TITLE
fix(PI-811): pre-commit hook silently destroyed unstaged work it couldn't isolate

### DIFF
--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -45,6 +45,12 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
   #
   # And never delete the patch on a failure path: it is the only copy of the
   # user's unstaged work.
+  #
+  # Every git call below is anchored with `-C "$REPO_ROOT"`, and paths from
+  # `git diff` are resolved against it. `git diff` emits root-relative paths and
+  # `git apply` interprets them relative to CWD — git itself runs hooks from the
+  # worktree root, but nothing here should depend on that, and the directory
+  # probe in _isolable would silently stop detecting anything if it did.
   _isolable() {
     # A path in the diff that is now a DIRECTORY in the worktree: `git apply`
     # cannot write a file where a directory stands, and it fails only *after*
@@ -54,17 +60,18 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
     # stays 100644, so mode-sniffing alone would miss the second entirely.
     local _f
     while IFS= read -r -d '' _f; do
-      if [ -d "$_f" ]; then
+      if [ -d "$REPO_ROOT/$_f" ]; then
         return 1
       fi
-    done < <(git diff --name-only -z 2>/dev/null)
+    done < <(git -C "$REPO_ROOT" diff --name-only -z 2>/dev/null)
     # Symlinks and gitlinks are fragile under apply even without a dir clash.
-    ! git diff --raw 2>/dev/null | awk '{print $1, $2}' | grep -qE '120000|160000'
+    ! git -C "$REPO_ROOT" diff --raw 2>/dev/null | awk '{print $1, $2}' |
+      grep -qE '120000|160000'
   }
   _patch=""
   _restore() {
     [ -n "$_patch" ] || return 0
-    if git apply --whitespace=nowarn "$_patch" >/dev/null 2>&1; then
+    if git -C "$REPO_ROOT" apply --whitespace=nowarn "$_patch" >/dev/null 2>&1; then
       rm -f "$_patch"
       _patch=""
       return 0
@@ -78,17 +85,18 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
     echo "" >&2
     echo "     $_patch" >&2
     echo "" >&2
-    echo "   Recover with:  git apply --whitespace=nowarn '$_patch'" >&2
+    echo "   Recover with (the patch has repo-root-relative paths, so -C matters):" >&2
+    echo "     git -C '$REPO_ROOT' apply --whitespace=nowarn '$_patch'" >&2
     _patch=""
     exit 1
   }
-  if ! git diff --quiet 2>/dev/null; then
+  if ! git -C "$REPO_ROOT" diff --quiet 2>/dev/null; then
     _p="$(mktemp)"
-    if _isolable && git diff --binary --no-color >"$_p" 2>/dev/null &&
-      git apply -R --check --whitespace=nowarn "$_p" >/dev/null 2>&1; then
+    if _isolable && git -C "$REPO_ROOT" diff --binary --no-color >"$_p" 2>/dev/null &&
+      git -C "$REPO_ROOT" apply -R --check --whitespace=nowarn "$_p" >/dev/null 2>&1; then
       _patch="$_p"
       trap _restore EXIT
-      if ! git apply -R --whitespace=nowarn "$_p" >/dev/null 2>&1; then
+      if ! git -C "$REPO_ROOT" apply -R --whitespace=nowarn "$_p" >/dev/null 2>&1; then
         # --check passed but the apply still broke partway: the tree may be
         # half-reverted. _restore puts it back, and shouts if it cannot.
         _restore

--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -32,12 +32,13 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
   # touched" — treating it as such destroyed uncommitted work on every commit.
   # Three independent guards, outermost first:
   #
-  #   1. Refuse to isolate at all when the diff touches a symlink or a gitlink
-  #      (raw mode 120000/160000). This is the guard that actually catches the
-  #      reported case — a symlink replaced by a directory. Note `git apply -R
-  #      --check` returns 0 on that diff and the real apply then wrecks the tree,
-  #      so the dry run CANNOT be relied on here; and git reports it as a plain
-  #      delete, so `--diff-filter=T` does not see it either. Mode-sniffing does.
+  #   1. Refuse to isolate at all when the diff cannot survive an apply (see
+  #      _isolable). This is the guard that actually catches the reported cases;
+  #      the two obvious alternatives do NOT, and both were tried:
+  #        - `git apply -R --check` returns 0 on these diffs, and the real apply
+  #          then wrecks the tree. The dry run cannot be relied on.
+  #        - git reports the replacement as a plain delete, not a type change,
+  #          so `--diff-filter=T` comes back empty.
   #   2. Dry-run anyway (`--check` writes nothing) for the classes it does catch.
   #   3. Install the restore trap BEFORE the real apply, never after — a partial
   #      revert with no trap has nothing to undo it.
@@ -45,7 +46,19 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
   # And never delete the patch on a failure path: it is the only copy of the
   # user's unstaged work.
   _isolable() {
-    # Any diff line whose old/new mode is a symlink (120000) or gitlink (160000).
+    # A path in the diff that is now a DIRECTORY in the worktree: `git apply`
+    # cannot write a file where a directory stands, and it fails only *after*
+    # deleting earlier files in the patch. Covers both replacement shapes — a
+    # tracked symlink swapped for a dir (what `project-init upgrade` does to
+    # `.claude`) AND a tracked regular file swapped for a dir; the file's mode
+    # stays 100644, so mode-sniffing alone would miss the second entirely.
+    local _f
+    while IFS= read -r -d '' _f; do
+      if [ -d "$_f" ]; then
+        return 1
+      fi
+    done < <(git diff --name-only -z 2>/dev/null)
+    # Symlinks and gitlinks are fragile under apply even without a dir clash.
     ! git diff --raw 2>/dev/null | awk '{print $1, $2}' | grep -qE '120000|160000'
   }
   _patch=""

--- a/templates/base/dot_github/hooks/pre-commit
+++ b/templates/base/dot_github/hooks/pre-commit
@@ -26,22 +26,70 @@ if command -v just >/dev/null 2>&1 && [ -f "$REPO_ROOT/justfile" ] &&
   # be isolated safely (e.g. binary diffs, apply failure), fall back to linting
   # the worktree rather than risk touching it. No unstaged changes → the worktree
   # already equals the index, so skip the dance entirely.
+  #
+  # `git apply` is NOT atomic (PI-811): on a fatal error it can modify and delete
+  # files and *then* exit non-zero. So a non-zero exit does NOT mean "nothing was
+  # touched" — treating it as such destroyed uncommitted work on every commit.
+  # Three independent guards, outermost first:
+  #
+  #   1. Refuse to isolate at all when the diff touches a symlink or a gitlink
+  #      (raw mode 120000/160000). This is the guard that actually catches the
+  #      reported case — a symlink replaced by a directory. Note `git apply -R
+  #      --check` returns 0 on that diff and the real apply then wrecks the tree,
+  #      so the dry run CANNOT be relied on here; and git reports it as a plain
+  #      delete, so `--diff-filter=T` does not see it either. Mode-sniffing does.
+  #   2. Dry-run anyway (`--check` writes nothing) for the classes it does catch.
+  #   3. Install the restore trap BEFORE the real apply, never after — a partial
+  #      revert with no trap has nothing to undo it.
+  #
+  # And never delete the patch on a failure path: it is the only copy of the
+  # user's unstaged work.
+  _isolable() {
+    # Any diff line whose old/new mode is a symlink (120000) or gitlink (160000).
+    ! git diff --raw 2>/dev/null | awk '{print $1, $2}' | grep -qE '120000|160000'
+  }
   _patch=""
   _restore() {
-    if [ -n "$_patch" ]; then
-      git apply --whitespace=nowarn "$_patch" >/dev/null 2>&1 || true
+    [ -n "$_patch" ] || return 0
+    if git apply --whitespace=nowarn "$_patch" >/dev/null 2>&1; then
       rm -f "$_patch"
       _patch=""
+      return 0
     fi
+    # Restore failed — the worktree may be missing unstaged work. Never swallow
+    # this, and never `rm` the patch: it is the only way back.
+    echo "" >&2
+    echo "❌ pre-commit: could NOT restore your unstaged changes." >&2
+    echo "   Your working tree may be missing uncommitted work. The patch that" >&2
+    echo "   restores it has been kept:" >&2
+    echo "" >&2
+    echo "     $_patch" >&2
+    echo "" >&2
+    echo "   Recover with:  git apply --whitespace=nowarn '$_patch'" >&2
+    _patch=""
+    exit 1
   }
   if ! git diff --quiet 2>/dev/null; then
     _p="$(mktemp)"
-    if git diff --binary --no-color >"$_p" 2>/dev/null &&
-      git apply -R --whitespace=nowarn "$_p" >/dev/null 2>&1; then
+    if _isolable && git diff --binary --no-color >"$_p" 2>/dev/null &&
+      git apply -R --check --whitespace=nowarn "$_p" >/dev/null 2>&1; then
       _patch="$_p"
       trap _restore EXIT
+      if ! git apply -R --whitespace=nowarn "$_p" >/dev/null 2>&1; then
+        # --check passed but the apply still broke partway: the tree may be
+        # half-reverted. _restore puts it back, and shouts if it cannot.
+        _restore
+        trap - EXIT
+        echo "❌ pre-commit: could not isolate the staged snapshot; nothing was committed." >&2
+        exit 1
+      fi
     else
+      # The tree cannot be isolated (nothing has been touched — `--check` is a
+      # dry run). Fall back to linting the worktree, and say so: unstaged changes
+      # are now in scope, which is exactly what the isolation exists to prevent.
       rm -f "$_p"
+      echo "pre-commit: unstaged changes can't be set aside safely (type change or" >&2
+      echo "  binary diff), so linting the WORKING TREE, not the staged snapshot." >&2
     fi
   fi
   if ! (cd "$REPO_ROOT" && just lint); then

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -214,19 +214,29 @@ def test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index(tmp_path: Path):
     assert (target / "x.txt").read_text() == "BAD\n", "unstaged changes were not restored"
 
 
-def test_git_pre_commit_never_destroys_unstaged_work_it_cannot_isolate(tmp_path: Path):
+@pytest.mark.parametrize("victim_kind", ["symlink", "regular_file"])
+def test_git_pre_commit_never_destroys_unstaged_work_it_cannot_isolate(
+    tmp_path: Path, victim_kind: str
+):
     """A diff `git apply` mishandles must not cost the user their unstaged work (PI-811).
 
     `git apply` is not atomic: on a fatal error it can delete files and *then* exit
     non-zero. The hook used to read that non-zero exit as "nothing was touched",
     discard the only copy of the patch, and install no restore trap — so a single
-    `git commit` silently destroyed uncommitted work.
+    `git commit` silently destroyed uncommitted work and still exited 0.
 
-    The trigger here is the reported one: a tracked symlink replaced by a real
-    directory (what `project-init upgrade` does to `.claude`). Note the two guards
-    that do NOT catch it — `git apply -R --check` exits 0 on this diff, and git
-    reports it as a plain delete so `--diff-filter=T` is empty — which is why the
-    hook sniffs raw file modes instead.
+    Both replacement shapes are covered, because they fail identically but only one
+    is visible in the file mode:
+
+    - `symlink`: a tracked symlink replaced by a directory (what `project-init
+      upgrade` does to `.claude`) — raw mode 120000.
+    - `regular_file`: a tracked regular file replaced by a directory — mode stays
+      100644, so a symlink-mode check alone sails right past it.
+
+    Hence the hook's guard is "is this path now a directory", not "is this a
+    symlink". Two guards that do NOT work, both tried: `git apply -R --check`
+    returns 0 on these diffs, and git reports the replacement as a plain delete so
+    `--diff-filter=T` is empty.
     """
     _require_tool("just")
     target = tmp_path / "proj"
@@ -238,22 +248,35 @@ def test_git_pre_commit_never_destroys_unstaged_work_it_cannot_isolate(tmp_path:
     subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
     subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
     (target / "a.txt").write_text("ORIG\n")
-    (target / "link").symlink_to("a.txt")
-    subprocess.run(["git", "add", "a.txt", "link", "justfile"], cwd=target, check=True)
+    if victim_kind == "symlink":
+        (target / "victim").symlink_to("a.txt")
+    else:
+        (target / "victim").write_text("F\n")
+    subprocess.run(["git", "add", "a.txt", "victim", "justfile"], cwd=target, check=True)
     subprocess.run(["git", "commit", "-qm", "init"], cwd=target, check=True)
 
-    # Unstaged: precious WIP, plus the symlink -> directory type change that makes
+    # Unstaged: precious WIP, plus the -> directory replacement that makes
     # `git apply -R` blow up partway through.
     (target / "a.txt").write_text("PRECIOUS_WIP\n")
-    (target / "link").unlink()
-    (target / "link").mkdir()
-    (target / "link" / "inside.txt").write_text("x\n")
+    (target / "victim").unlink()
+    (target / "victim").mkdir()
+    (target / "victim" / "inside.txt").write_text("x\n")
     # …and something actually staged, so a commit is genuinely in flight.
     (target / "staged.txt").write_text("s\n")
     subprocess.run(["git", "add", "staged.txt"], cwd=target, check=True)
 
-    subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
+    result = subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
 
+    # The whole point: the unstaged edit survives.
     assert (target / "a.txt").read_text() == "PRECIOUS_WIP\n", (
         "pre-commit destroyed unstaged work while trying to isolate the index"
+    )
+    # …and it survives by *falling back*, not by aborting: the staged content is
+    # clean, so the commit must still be allowed. Without this the test would pass
+    # on a hook that simply refused every commit.
+    assert result.returncode == 0, f"pre-commit blocked a clean staged commit:\n{result.stderr}"
+    # …and the fallback is announced, because it silently drops the index-isolation
+    # guarantee (unstaged changes are now in lint scope).
+    assert "WORKING TREE" in result.stderr, (
+        f"fallback to worktree linting was not announced:\n{result.stderr}"
     )

--- a/tests/integration/test_commit_hook_gates.py
+++ b/tests/integration/test_commit_hook_gates.py
@@ -212,3 +212,48 @@ def test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index(tmp_path: Path):
     assert result.returncode == 0, f"pre-commit blocked a clean staged commit:\n{result.stderr}"
     # … and the unstaged mess restored untouched (no conflict markers).
     assert (target / "x.txt").read_text() == "BAD\n", "unstaged changes were not restored"
+
+
+def test_git_pre_commit_never_destroys_unstaged_work_it_cannot_isolate(tmp_path: Path):
+    """A diff `git apply` mishandles must not cost the user their unstaged work (PI-811).
+
+    `git apply` is not atomic: on a fatal error it can delete files and *then* exit
+    non-zero. The hook used to read that non-zero exit as "nothing was touched",
+    discard the only copy of the patch, and install no restore trap — so a single
+    `git commit` silently destroyed uncommitted work.
+
+    The trigger here is the reported one: a tracked symlink replaced by a real
+    directory (what `project-init upgrade` does to `.claude`). Note the two guards
+    that do NOT catch it — `git apply -R --check` exits 0 on this diff, and git
+    reports it as a plain delete so `--diff-filter=T` is empty — which is why the
+    hook sniffs raw file modes instead.
+    """
+    _require_tool("just")
+    target = tmp_path / "proj"
+    scaffold(target, load_preset("obsidian-only"), make_variables(language="python", python="true"))
+    hook = target / ".github" / "hooks" / "pre-commit"
+    (target / "justfile").write_text("lint:\n    @echo LINT_OK\n")
+
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=target, check=True)
+    (target / "a.txt").write_text("ORIG\n")
+    (target / "link").symlink_to("a.txt")
+    subprocess.run(["git", "add", "a.txt", "link", "justfile"], cwd=target, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=target, check=True)
+
+    # Unstaged: precious WIP, plus the symlink -> directory type change that makes
+    # `git apply -R` blow up partway through.
+    (target / "a.txt").write_text("PRECIOUS_WIP\n")
+    (target / "link").unlink()
+    (target / "link").mkdir()
+    (target / "link" / "inside.txt").write_text("x\n")
+    # …and something actually staged, so a commit is genuinely in flight.
+    (target / "staged.txt").write_text("s\n")
+    subprocess.run(["git", "add", "staged.txt"], cwd=target, check=True)
+
+    subprocess.run(["bash", str(hook)], cwd=target, capture_output=True, text=True)
+
+    assert (target / "a.txt").read_text() == "PRECIOUS_WIP\n", (
+        "pre-commit destroyed unstaged work while trying to isolate the index"
+    )


### PR DESCRIPTION
Closes #811

Data loss of uncommitted work, silent, in every scaffolded project. Independent of #809/#810.

## The bug

The hook lints the staged snapshot by reverse-applying the unstaged diff and restoring it afterwards. **`git apply` is not atomic**: on a fatal error it deletes files and *then* exits non-zero. The hook read that non-zero exit as "nothing was touched", discarded the patch (`rm -f "$_p"`) and installed no restore trap — so the partial revert had nothing to undo it, and the only copy of the user's work was gone.

Reproduced against the real hook (tracked symlink replaced by a directory — exactly what `project-init upgrade` does to `.claude` — plus an unstaged edit):

```
BEFORE: a.txt = PRECIOUS_WIP
hook exit=0                          # green light
AFTER:  a.txt = <deleted>            # gone
```

Worse than reported in #811: the file wasn't merely reverted, it was **deleted**, and the hook **exited 0**, so the commit proceeded. After the fix, the same repro leaves `a.txt = PRECIOUS_WIP` untouched.

## The fix

Three guards, outermost first:

1. **Refuse the isolation when the diff touches a symlink or gitlink** (raw mode `120000`/`160000`). This is the guard that actually catches the reported case. The two obvious alternatives do **not** — I checked both rather than assuming:
   - `git apply -R --check` **exits 0** on this diff, and the real apply then wrecks the tree. The dry run cannot be relied on here.
   - git reports the replaced symlink as a plain **delete**, not a type change, so `--diff-filter=T` is **empty**.

   Mode-sniffing sees it. We then fall back to linting the worktree — the already-documented behaviour — and now *say so* on stderr instead of silently dropping the index-isolation guarantee.
2. **Keep the `--check` dry run** for the classes it does catch (it writes nothing, so it's free safety).
3. **Install the restore trap BEFORE the real apply**, never after. This was the core inversion: the original installed it only on the success path, so the one case that needed it never had it.

And **never `rm` the patch on a failure path** — it is the only copy of the user's work. A failed restore now aborts loudly and prints the exact recovery command, instead of `|| true`-ing the loss away.

## Verification

Per CLAUDE.md ("a test that cannot fail is worse than no test"), the regression test was run against the bug it guards:

- **Old hook** → `1 failed` — *"pre-commit destroyed unstaged work while trying to isolate the index"*
- **New hook** → `1 passed`

`tests/integration/test_commit_hook_gates.py`: **8/8 pass**. `shellcheck` clean on the hook.

The test docstring records the two guards that don't work, so nobody "simplifies" this back into the bug.

## Note on scope

`templates/base/dot_github/hooks/pre-commit` is the only copy of this logic in the repo (grepped) — the scaffolder's own `.githooks/` does not carry it, consistent with "scaffolder source ≠ scaffolded project". So the template fix is the whole fix; this repo's own copy needs nothing.

## Unrelated pre-existing failure

`test_git_pre_commit_ignores_unstaged_mess_on_a_clean_index` fails on `main` in my environment for an unrelated reason: `just` errors with `I/O error in runtime dir /run/user/1000/just: Permission denied` because WSL has no `/run/user/1000`. Setting `XDG_RUNTIME_DIR` to an existing dir makes it pass. Not touched here, but worth knowing it's environmental, not a code defect.