### PR TITLE
fix(PI-813): upgrade could not upgrade any pre-v1.0.1 scaffold

### DIFF
--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -142,6 +142,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 - `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.
+- `def upgrade_base_path` — Locate the merge-base sidecar, tolerating the pre-PI-606 ``.claude/`` home.
 - `def read_base` — Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``.
 - `def write_base` — Persist the ``{rel: rendered-text}`` merge base sidecar (sorted, pretty).
 - `def write_scaffold_record` — Append/replace the scaffold record block in .agents/config.yaml.

--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -139,6 +139,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 
 `project-init upgrade` — re-render from recorded config with a drift report.
 
+- `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.
 - `def read_base` — Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -142,6 +142,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 - `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.
+- `def upgrade_base_path` — Locate the merge-base sidecar, tolerating the pre-PI-606 ``.claude/`` home.
 - `def read_base` — Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``.
 - `def write_base` — Persist the ``{rel: rendered-text}`` merge base sidecar (sorted, pretty).
 - `def write_scaffold_record` — Append/replace the scaffold record block in .agents/config.yaml.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -139,6 +139,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 
 `project-init upgrade` — re-render from recorded config with a drift report.
 
+- `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.
 - `def read_base` — Return the recorded ``{rel: rendered-text}`` merge base, or ``{}``.

--- a/src/project_init/doctor.py
+++ b/src/project_init/doctor.py
@@ -56,7 +56,6 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
     without re-reading the file.
     """
     from project_init.upgrade import (
-        _CONFIG_REL,
         UpgradeError,
         _backfill_variables,
         _migrate_agents,
@@ -65,14 +64,17 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
     )
 
     # Tolerates the pre-PI-606 `.claude/config.yaml` location, or doctor would
-    # report a legacy scaffold as "never scaffolded" too (PI-813).
+    # report a legacy scaffold as "never scaffolded" too (PI-813). Messages below
+    # name the path actually read — printing the canonical path while reading the
+    # legacy one produced diagnostics that pointed at the wrong file.
     config = scaffold_record_path(target)
+    shown = config.relative_to(target) if config.is_relative_to(target) else config
     if not config.is_file():
         return (
             Check(
                 "FAIL",
                 "scaffold record",
-                f"{_CONFIG_REL} not found",
+                f"{shown} not found",
                 hint="this directory was not scaffolded by project-init (or the record was deleted)",
             ),
             None,
@@ -81,7 +83,7 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
         text = config.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return (
-            Check("FAIL", "scaffold record", f"cannot read {_CONFIG_REL}: {exc}"),
+            Check("FAIL", "scaffold record", f"cannot read {shown}: {exc}"),
             None,
         )
     try:
@@ -101,7 +103,7 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
             Check(
                 "WARN",
                 "scaffold record",
-                f"{_CONFIG_REL} has no scaffold-record marker (pre-record or hand-edited)",
+                f"{shown} has no scaffold-record marker (pre-record or hand-edited)",
                 hint="run `project-init upgrade` to reconcile, or restore from git",
             ),
             None,
@@ -113,7 +115,7 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
     # and false-FAIL a valid copied-hooks project (Codex review). The backfill
     # defaults such records to no_plugin, which is what pre-plugin scaffolds were.
     variables = _migrate_agents(_backfill_variables(variables))
-    return Check("PASS", "scaffold record", f"{_CONFIG_REL} records preset {_preset!r}"), variables
+    return Check("PASS", "scaffold record", f"{shown} records preset {_preset!r}"), variables
 
 
 def check_settings_json(target: Path) -> tuple[Check, dict[str, Any] | None]:

--- a/src/project_init/doctor.py
+++ b/src/project_init/doctor.py
@@ -61,9 +61,12 @@ def check_scaffold_record(target: Path) -> tuple[Check, dict[str, str] | None]:
         _backfill_variables,
         _migrate_agents,
         _parse_record_block,
+        scaffold_record_path,
     )
 
-    config = target / _CONFIG_REL
+    # Tolerates the pre-PI-606 `.claude/config.yaml` location, or doctor would
+    # report a legacy scaffold as "never scaffolded" too (PI-813).
+    config = scaffold_record_path(target)
     if not config.is_file():
         return (
             Check(

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -83,24 +83,38 @@ def _is_sibling(rel: Path) -> bool:
     return bool(_SIBLING_RE.search(rel.name))
 
 
-def _relocate_legacy_record(target: Path) -> bool:
-    """Move a pre-PI-606 ``.claude/config.yaml`` record to ``.agents/`` (PI-813).
+def _relocate_legacy_state(target: Path) -> list[str]:
+    """Move a pre-PI-606 project's scaffold state into ``.agents/`` (PI-813).
 
-    ``config.yaml`` is deliberately excluded from the managed drift set — it is the
-    hand-editable record the scaffolder owns — so the re-render never recreates it
-    at the new path on its own. Without an explicit move a legacy project would
-    upgrade every file *except* the record that identifies it, leave the record
-    behind in ``.claude/``, and come back legacy on the next run.
+    Both files are excluded from the managed drift set — the record because it is
+    the hand-editable file the scaffolder owns, the sidecar because it is internal
+    — so a re-render never recreates either at the new path. Without an explicit
+    move a legacy project would upgrade every file *except* the two that describe
+    it, and come back legacy on the next run.
 
-    Returns True when a record was moved.
+    The sidecar matters as much as the record: ``read_base`` treats a missing
+    sidecar as "no base recorded", so leaving it in ``.claude/`` degrades every
+    3-way merge into a conflict without a word of warning.
+
+    Returns the relative paths moved (empty when there is nothing to migrate).
     """
-    canonical = target / _CONFIG_REL
-    legacy = target / _LEGACY_CONFIG_REL
-    if canonical.exists() or not legacy.exists():
-        return False
-    canonical.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(legacy), str(canonical))
-    return True
+    moved: list[str] = []
+    for legacy_rel, canonical_rel in (
+        (_LEGACY_CONFIG_REL, _CONFIG_REL),
+        (_LEGACY_BASE_REL, _BASE_REL),
+    ):
+        legacy, canonical = target / legacy_rel, target / canonical_rel
+        if canonical.exists() or not legacy.exists():
+            continue
+        try:
+            canonical.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(legacy), str(canonical))
+        except OSError as exc:
+            # Abort loudly rather than half-migrate and traceback mid-upgrade.
+            msg = f"cannot migrate {legacy_rel} to {canonical_rel}: {exc}"
+            raise UpgradeError(msg) from exc
+        moved.append(f"{legacy_rel} → {canonical_rel}")
+    return moved
 
 
 def scaffold_record_path(target: Path) -> Path:
@@ -112,9 +126,11 @@ def scaffold_record_path(target: Path) -> Path:
     record and declared them never scaffolded, so the one upgrade that most needed
     to run was the only one that could not (PI-813).
 
-    `--apply` re-renders the record at the canonical `.agents/` path, so a legacy
-    project migrates itself on its next upgrade. When neither exists, the canonical
-    path is returned so the error names the location a current project should have.
+    This resolver only *reads*. The record is excluded from the managed drift set,
+    so a re-render never recreates it at the new path — `--apply` migrates it with
+    an explicit move (`_relocate_legacy_state`). When neither path exists, the
+    canonical one is returned so the error names the location a current project
+    should have.
     """
     current = target / _CONFIG_REL
     if current.exists():
@@ -248,6 +264,25 @@ _hash_bytes = hash_bytes
 # (#241). Text only — files that don't decode as UTF-8 are omitted and fall back
 # to the ``.new`` sibling path on conflict.
 _BASE_REL = Path(".agents/.upgrade-base.json")
+# The sidecar's pre-PI-606 home, alongside the legacy record (PI-813).
+_LEGACY_BASE_REL = Path(".claude/.upgrade-base.json")
+
+
+def upgrade_base_path(target: Path) -> Path:
+    """Locate the merge-base sidecar, tolerating the pre-PI-606 ``.claude/`` home.
+
+    Reading only the new path made a legacy project's sidecar invisible, and
+    ``read_base`` swallows that as a plain missing file — so every 3-way merge
+    silently lost its base and every user edit degraded into a conflict. The
+    failure is invisible precisely because the sidecar is optional (PI-813).
+    """
+    current = target / _BASE_REL
+    if current.exists():
+        return current
+    legacy = target / _LEGACY_BASE_REL
+    if legacy.exists():
+        return legacy
+    return current
 
 
 def read_base(target: Path) -> dict[str, str]:
@@ -257,7 +292,7 @@ def read_base(target: Path) -> dict[str, str]:
     out — a corrupted entry must not later reach the merge engine as a non-text
     base and crash the upgrade (#240 review).
     """
-    path = target / _BASE_REL
+    path = upgrade_base_path(target)
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -838,6 +873,11 @@ def read_scaffold_record(target: Path) -> tuple[str, dict[str, str], dict[str, s
         # A non-UTF-8 config.yaml would otherwise surface as a raw traceback,
         # since run_upgrade only catches UpgradeError (2026-07 review).
         msg = f"{config_path} is not valid UTF-8 — cannot read the scaffold record ({exc})."
+        raise UpgradeError(msg) from exc
+    except OSError as exc:
+        # Unreadable for any other reason (permissions, a directory at the path):
+        # same treatment, or it escapes run_upgrade's handler as a raw traceback.
+        msg = f"{config_path} cannot be read — cannot load the scaffold record ({exc})."
         raise UpgradeError(msg) from exc
     parsed = _parse_record_block(text)
     if parsed is not None:
@@ -1821,16 +1861,16 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
         # Run apply even with zero file drift: the config version line and the
         # scaffold record must still refresh to the current tool version.
         if apply:
-            # Before apply_drift rewrites the record: a legacy project's record is
-            # still in .claude/, and apply_drift only updates it at the canonical
-            # path (PI-813).
-            if _relocate_legacy_record(target):
+            # Migrate a legacy project's record + merge-base sidecar into .agents/
+            # before apply_drift writes through them (PI-813). Deliberately inside
+            # the apply branch and after the addition gate: a gated run applies
+            # nothing, so it must not move the user's files either. Once consent is
+            # given the run reaches here and migrates. read_base() above already
+            # resolves the legacy sidecar, so the merge base is correct either way.
+            for moved in _relocate_legacy_state(target):
                 from rich.console import Console
 
-                Console().print(
-                    "[green]migrated scaffold record[/green] "
-                    ".claude/config.yaml → .agents/config.yaml"
-                )
+                Console().print(f"[green]migrated[/green] {moved}")
             suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
             report.new = [rel for rel in report.new if rel not in suppressed]
             # Per-file interactive walk (#245): drop the files the user skips so

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -70,6 +70,9 @@ from project_init.scaffold import (
 )
 
 _CONFIG_REL = Path(".agents/config.yaml")
+# Where the record lived before the `.claude/` -> `.agents/` rename (PI-606),
+# which shipped in v1.0.1. Scaffolds from v1.0.0 and earlier still keep it there.
+_LEGACY_CONFIG_REL = Path(".claude/config.yaml")
 _VERSION_LINE_RE = re.compile(r"^(\s*project_init_version:\s*).*$", re.MULTILINE)
 # A never-clobber sibling: `<file>.new` or `<file>.new.N` (see scaffold._new_sibling).
 _SIBLING_RE = re.compile(r"\.new(\.\d+)?$")
@@ -78,6 +81,48 @@ _SIBLING_RE = re.compile(r"\.new(\.\d+)?$")
 def _is_sibling(rel: Path) -> bool:
     """True if *rel* is a `.new`/`.new.N` overwrite-protection sibling (PI-535)."""
     return bool(_SIBLING_RE.search(rel.name))
+
+
+def _relocate_legacy_record(target: Path) -> bool:
+    """Move a pre-PI-606 ``.claude/config.yaml`` record to ``.agents/`` (PI-813).
+
+    ``config.yaml`` is deliberately excluded from the managed drift set — it is the
+    hand-editable record the scaffolder owns — so the re-render never recreates it
+    at the new path on its own. Without an explicit move a legacy project would
+    upgrade every file *except* the record that identifies it, leave the record
+    behind in ``.claude/``, and come back legacy on the next run.
+
+    Returns True when a record was moved.
+    """
+    canonical = target / _CONFIG_REL
+    legacy = target / _LEGACY_CONFIG_REL
+    if canonical.exists() or not legacy.exists():
+        return False
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(legacy), str(canonical))
+    return True
+
+
+def scaffold_record_path(target: Path) -> Path:
+    """Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
+
+    The `.claude/` -> `.agents/` rename shipped in v1.0.1, moving the record from
+    `.claude/config.yaml` to `.agents/config.yaml`. Reading only the new path
+    stranded every scaffold from v1.0.0 and earlier: `upgrade` could not find their
+    record and declared them never scaffolded, so the one upgrade that most needed
+    to run was the only one that could not (PI-813).
+
+    `--apply` re-renders the record at the canonical `.agents/` path, so a legacy
+    project migrates itself on its next upgrade. When neither exists, the canonical
+    path is returned so the error names the location a current project should have.
+    """
+    current = target / _CONFIG_REL
+    if current.exists():
+        return current
+    legacy = target / _LEGACY_CONFIG_REL
+    if legacy.exists():
+        return legacy
+    return current
 
 
 # Variables that pre-record config files cannot recover; filled with the
@@ -224,7 +269,7 @@ def read_base(target: Path) -> dict[str, str]:
 
 def write_base(target: Path, base: dict[str, str]) -> None:
     """Persist the ``{rel: rendered-text}`` merge base sidecar (sorted, pretty)."""
-    if not (target / _CONFIG_REL).exists():
+    if not scaffold_record_path(target).exists():
         return  # not a scaffolded project — nothing to anchor the base to
     path = target / _BASE_REL
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -780,7 +825,7 @@ def _migrate_agents(variables: dict[str, str]) -> dict[str, str]:
 
 def read_scaffold_record(target: Path) -> tuple[str, dict[str, str], dict[str, str], bool]:
     """Return (preset_name, variables, manifest, migrated) for *target*."""
-    config_path = target / _CONFIG_REL
+    config_path = scaffold_record_path(target)
     if not config_path.exists():
         msg = (
             f"{config_path} not found — this directory was not scaffolded by "
@@ -1776,6 +1821,16 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
         # Run apply even with zero file drift: the config version line and the
         # scaffold record must still refresh to the current tool version.
         if apply:
+            # Before apply_drift rewrites the record: a legacy project's record is
+            # still in .claude/, and apply_drift only updates it at the canonical
+            # path (PI-813).
+            if _relocate_legacy_record(target):
+                from rich.console import Console
+
+                Console().print(
+                    "[green]migrated scaffold record[/green] "
+                    ".claude/config.yaml → .agents/config.yaml"
+                )
             suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
             report.new = [rel for rel in report.new if rel not in suppressed]
             # Per-file interactive walk (#245): drop the files the user skips so

--- a/tests/integration/test_upgrade_edges.py
+++ b/tests/integration/test_upgrade_edges.py
@@ -9,7 +9,13 @@ from pathlib import Path
 import pytest
 
 from project_init.__main__ import main
-from project_init.upgrade import UpgradeError, _three_way_merge, read_scaffold_record, run_upgrade
+from project_init.upgrade import (
+    UpgradeError,
+    _three_way_merge,
+    read_base,
+    read_scaffold_record,
+    run_upgrade,
+)
 
 _CONFIG = Path(".agents/config.yaml")
 
@@ -150,3 +156,24 @@ class TestLegacyClaudeRecordLocation:
         assert (target / _CONFIG).is_file(), "upgrade --apply must migrate the record to .agents/"
         preset, _variables, _manifest, _migrated = read_scaffold_record(target)
         assert preset == "obsidian-only", "the migrated record must survive the move intact"
+
+    def test_merge_base_sidecar_is_found_and_migrated(self, tmp_path: Path):
+        """The sidecar must migrate too, or every 3-way merge silently loses its base.
+
+        `read_base` treats a missing sidecar as "no base recorded" and returns {} —
+        so leaving it behind in `.claude/` degrades every user edit into a conflict
+        with no error at all. The failure is invisible precisely because the sidecar
+        is optional (PI-813 review, Codex).
+        """
+        target = self._legacy_scaffold(tmp_path)
+        # Move the sidecar back to its pre-PI-606 home too, as a real v1.0.0 has it.
+        legacy_base = target / ".claude" / ".upgrade-base.json"
+        canonical_base = target / ".agents" / ".upgrade-base.json"
+        legacy_base.write_bytes(canonical_base.read_bytes())
+        canonical_base.unlink()
+
+        # Read it where it actually lives — this returned {} before the fix.
+        assert read_base(target), "legacy merge base was invisible — every merge loses its base"
+
+        run_upgrade(target, apply=True)
+        assert canonical_base.is_file(), "upgrade --apply must migrate the merge-base sidecar"

--- a/tests/integration/test_upgrade_edges.py
+++ b/tests/integration/test_upgrade_edges.py
@@ -103,3 +103,50 @@ class TestCrlfPreservation:
         merged, clean = _three_way_merge(base, ours, theirs)
         assert clean
         assert "\r" not in merged
+
+
+class TestLegacyClaudeRecordLocation:
+    """A pre-v1.0.1 scaffold keeps its record at `.claude/config.yaml` (PI-813).
+
+    The `.claude/` -> `.agents/` rename (PI-606) shipped in v1.0.1 and moved the
+    scaffold record. `upgrade` read only the new path, so every project scaffolded
+    at v1.0.0 or earlier was told it "was not scaffolded by project-init" and could
+    never be upgraded — the migration the tool exists to perform was the one
+    operation it refused to do.
+    """
+
+    def _legacy_scaffold(self, tmp_path: Path) -> Path:
+        """Scaffold, then move the record back to where v1.0.0 put it."""
+        target = tmp_path / "proj"
+        _scaffold(target)
+        legacy = target / ".claude" / "config.yaml"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_bytes((target / _CONFIG).read_bytes())
+        (target / _CONFIG).unlink()
+        return target
+
+    def test_record_is_found_at_the_legacy_path(self, tmp_path: Path):
+        target = self._legacy_scaffold(tmp_path)
+        preset, variables, _manifest, _migrated = read_scaffold_record(target)
+        assert preset == "obsidian-only"
+        assert variables["project_name"] == "edge"
+
+    def test_upgrade_runs_instead_of_claiming_the_project_was_never_scaffolded(
+        self, tmp_path: Path
+    ):
+        target = self._legacy_scaffold(tmp_path)
+        # The bug: this raised UpgradeError("… was not scaffolded by project-init").
+        run_upgrade(target, apply=False)
+
+    def test_apply_relocates_the_record_to_the_canonical_path(self, tmp_path: Path):
+        target = self._legacy_scaffold(tmp_path)
+        # A real v1.0.0 project has drift by definition; this synthetic one is
+        # rendered from current templates, so give it some — otherwise `--apply`
+        # correctly re-renders nothing and the record never moves.
+        (target / ".agents" / "rules" / "hooks.md").unlink()
+
+        run_upgrade(target, apply=True)
+
+        assert (target / _CONFIG).is_file(), "upgrade --apply must migrate the record to .agents/"
+        preset, _variables, _manifest, _migrated = read_scaffold_record(target)
+        assert preset == "obsidian-only", "the migrated record must survive the move intact"


### PR DESCRIPTION
Closes #813

`project-init upgrade` refused to run on any project scaffolded at **v1.0.0 or earlier**, telling the user their project was never scaffolded:

```
error: .../.agents/config.yaml not found — this directory was not scaffolded by
project-init (or the record was deleted).
```

It *was* scaffolded. The record is just at the old path.

## Cause

The `.claude/` → `.agents/` rename (PI-606, `f375ca2`) moved the scaffold record and shipped in **v1.0.1**. `upgrade.py` hardcoded `_CONFIG_REL = Path(".agents/config.yaml")` with no fallback, so a v1.0.0 project — record at `.claude/config.yaml` — could not be found.

So **the upgrade that most needs to run is the one upgrade that cannot**: the one that migrates a legacy project onto the new layout. And the error blames the user's directory rather than the missing migration path. `doctor` returned the same false "not scaffolded" verdict.

The existing "migration" code (`_migrate_semantic_config`, the `migrated` flag) handles a config that lost its JSON *record block* — nothing handled a config that *moved*.

## Fix — two parts, and the second is the one that's easy to miss

1. **Resolve the record through a fallback** (`scaffold_record_path`): `.agents/config.yaml`, else the legacy `.claude/config.yaml`. Wired into `upgrade` **and** `doctor`. When neither exists, the error still names the canonical path, so a genuinely un-scaffolded directory reports sensibly.

2. **Relocate the record on `--apply`.** `config.yaml` is deliberately excluded from the managed drift set — it's the hand-editable record the scaffolder owns — so the re-render *never* recreates it at the new path. Without an explicit move, `--apply` would upgrade every file **except** the record identifying the project, leave it behind in `.claude/`, and the project would come back legacy on the next run.

   I only found this because the relocation test still failed after part 1 landed. Fixing the lookup alone looks like it works — the upgrade runs, files change, it prints success — and quietly leaves the project un-migrated.

## Verification

Per CLAUDE.md, the tests were checked against the bug they guard. All three fail on the unfixed code with the real error:

```
E  project_init.upgrade.UpgradeError: .../.agents/config.yaml not found —
   this directory was not scaffolded by project-init (or the record was deleted).
```

and pass after. They cover: the record is found at the legacy path; `upgrade` runs instead of claiming the project was never scaffolded; and `--apply` relocates the record to `.agents/` with its contents intact.

Full suite: **2391 passed**, 1 pre-existing environment-only failure unrelated to this change (`just` needs `XDG_RUNTIME_DIR`; see #812's note). `ruff` clean, `mypy --strict` clean, `CODE_MAP.md` regenerated for the new public function.

## Found while

Upgrading a real v1.0.0 project (`projects-orchestrator`, scaffolded 2026-06-28) after #810/#812 — the third defect in that chain, after the plugins loading zero hooks and the pre-commit hook destroying unstaged work.