### PR TITLE
chore: release 1.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.1
+version: 1.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.1"
+version = "1.1.2"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -18,12 +18,12 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
     "1.1.2": {
         "summary": (
             "Three fixes, all of which failed silently in 1.1.x. (1) Both plugins "
-            "were un-installable and loaded ZERO hooks: the marketplace manifests "
+            "were uninstallable and loaded ZERO hooks: the marketplace manifests "
             "sat at `.agents-plugin/`, which Claude Code never reads, and each "
             "plugin.json redeclared the standard hooks file so the client rejected "
             "it as a duplicate. Plugin-first scaffolds take their hooks only from "
             "the plugin, so they ran with no commit gate, no lint-on-edit and no "
-            "prod guard — while `rules/hooks.md` said the hooks were firing "
+            "prod guard — while `.agents/rules/hooks.md` said the hooks were firing "
             "(#810). (2) The git `pre-commit` hook DESTROYED UNSTAGED WORK: "
             "`git apply` is not atomic, and the hook read its non-zero exit as "
             "'nothing was touched', so a single commit could delete uncommitted "

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,32 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "1.1.2": {
+        "summary": (
+            "Three fixes, all of which failed silently in 1.1.x. (1) Both plugins "
+            "were un-installable and loaded ZERO hooks: the marketplace manifests "
+            "sat at `.agents-plugin/`, which Claude Code never reads, and each "
+            "plugin.json redeclared the standard hooks file so the client rejected "
+            "it as a duplicate. Plugin-first scaffolds take their hooks only from "
+            "the plugin, so they ran with no commit gate, no lint-on-edit and no "
+            "prod guard — while `rules/hooks.md` said the hooks were firing "
+            "(#810). (2) The git `pre-commit` hook DESTROYED UNSTAGED WORK: "
+            "`git apply` is not atomic, and the hook read its non-zero exit as "
+            "'nothing was touched', so a single commit could delete uncommitted "
+            "files and still exit 0 (#812). (3) `upgrade` refused to run on any "
+            "pre-v1.0.1 scaffold, reporting it as never scaffolded (#814)."
+        ),
+        "action_required": (
+            "Run `.agents/scripts/install_hooks.sh` after upgrading. The git hooks "
+            "are COPIED into `.git/hooks/` at install time, so upgrading the "
+            "template does NOT replace the copy you are running — without this "
+            "step you keep the pre-commit hook that destroys unstaged work, while "
+            "believing 1.1.2 fixed it. Also re-add the plugin marketplace "
+            "(`claude plugin marketplace add <your project-init repo>`) if you "
+            "tried before 1.1.2 and it failed: every install attempt against the "
+            "old manifests errored out."
+        ),
+    },
     "1.0.2": {
         "summary": (
             "TypeScript projects gain a BLOCKING security lint "

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Bump `pyproject.toml`, `__init__.py`, `CITATION.cff`, `uv.lock` to **1.1.2**.

## Why this release matters

Three fixes are merged to `main` but **unreleased**. PyPI 1.1.1 still ships all three, so anyone running `uv tool install project-init` today gets:

| | Bug in 1.1.1 |
|---|---|
| **#810** (PI-809) | Both plugins un-installable, and loaded **zero hooks**. Manifests sat at `.agents-plugin/` (never read by the client), and each `plugin.json` redeclared the standard hooks file so it was rejected as a duplicate. Since the ADR-010 cutover, plugin-first scaffolds get their hooks *only* from the plugin — so they ran with **no hooks at all**, while `rules/hooks.md` insisted the hooks were firing. |
| **#812** (PI-811) | The scaffolded git `pre-commit` hook **silently destroyed unstaged work**. `git apply` is not atomic: on a fatal error it deleted files and *then* exited non-zero, and the hook read that exit as "nothing was touched", discarded the only copy of the patch, and installed no restore trap. Data loss, on every commit, in every scaffolded project — and it returned 0. |
| **#814** (PI-813) | `upgrade` refused to run on any pre-v1.0.1 scaffold, reporting the project as never scaffolded. The migration onto the `.agents/` layout was the one upgrade that could not run. Also silently stranded the merge-base sidecar, degrading every 3-way merge into a conflict. |

Merged fixes that nobody can install aren't fixed. This is the release that delivers them.

## Verification

`ruff` clean, full suite **2393 passed** at the bumped version.

## After merge

Dispatch `tag-release.yml` with tag `v1.1.2` — it validates the tag against the pyproject version, creates the tag, and dispatches `release.yml` on the tag ref to publish to PyPI (ADR-011).