### PR TITLE
fix(PI-816): upgrade deleted the project's own files during the .agents migration

### DIFF
--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -139,6 +139,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 
 `project-init upgrade` — re-render from recorded config with a drift report.
 
+- `def is_legacy_layout` — True when *target*'s record still lives at the pre-PI-606 ``.claude/`` path.
 - `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -139,6 +139,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 
 `project-init upgrade` — re-render from recorded config with a drift report.
 
+- `def is_legacy_layout` — True when *target*'s record still lives at the pre-PI-606 ``.claude/`` path.
 - `def scaffold_record_path` — Locate *target*'s scaffold record, tolerating the pre-PI-606 location.
 - `class UpgradeError` — Raised when the project cannot be upgraded (missing/invalid config).
 - `class DriftReport` — Outcome of comparing a fresh render against the scaffolded project.

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -86,10 +86,10 @@ def _is_sibling(rel: Path) -> bool:
 def is_legacy_layout(target: Path) -> bool:
     """True when *target*'s record still lives at the pre-PI-606 ``.claude/`` path.
 
-    Must be read BEFORE anything is relocated, and it is the gate on
-    :func:`_carry_unmanaged_legacy_content`: in a *current* project ``.claude/`` is
-    a generated mirror of ``.agents/``, so carrying it across would collide with
-    every canonical file it already duplicates.
+    Must be read BEFORE anything is migrated, and it is the gate on
+    :func:`_migrate_legacy_tree`: in a *current* project ``.claude/`` is a generated
+    mirror of ``.agents/``, so migrating it across would collide with every
+    canonical file it already duplicates.
     """
     return (target / _LEGACY_CONFIG_REL).is_file() and not (target / _CONFIG_REL).is_file()
 
@@ -145,7 +145,7 @@ def scaffold_record_path(target: Path) -> Path:
 
     This resolver only *reads*. The record is excluded from the managed drift set,
     so a re-render never recreates it at the new path — `--apply` migrates it with
-    an explicit move (`_relocate_legacy_state`). When neither path exists, the
+    an explicit move (`_migrate_legacy_tree`). When neither path exists, the
     canonical one is returned so the error names the location a current project
     should have.
     """
@@ -1816,9 +1816,9 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     """
     import sys
 
-    # Read BEFORE anything relocates — the relocation is what makes it stop being
-    # true, and _carry_unmanaged_legacy_content must not run on a current project
-    # (there .claude/ is a generated mirror of .agents/, not user content).
+    # Read BEFORE anything moves — the migration is what makes it stop being true,
+    # and _migrate_legacy_tree must not run on a current project (there .claude/ is
+    # a generated mirror of .agents/, not user content).
     legacy_layout = is_legacy_layout(target)
     try:
         preset_name, variables, manifest, migrated = read_scaffold_record(target)
@@ -1851,18 +1851,6 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     # project fields on --apply (2026-07 review).
     variables["project_init_plugin_version"] = __plugin_version__
 
-    # Migrate the legacy tree BEFORE rendering and computing drift (PI-813/PI-816).
-    # Order is the whole fix. Migrate afterwards and every legacy file looks like a
-    # brand-new render: the drift engine has nothing at the canonical path to compare
-    # against, so it writes the fresh template over the user's copy. That is how the
-    # memory tier was lost — `memory/MEMORY.md` IS a template output, so "carry only
-    # the unmanaged files" still clobbered it. Move everything first and the project
-    # simply looks normal: managed files 3-way merge against their base, and
-    # unmanaged files (ADRs, memory the templates don't own) are in neither the
-    # manifest nor the render, so nothing touches them.
-    if apply and legacy_layout:
-        _migrate_legacy_tree(target)
-
     staging_root = Path(tempfile.mkdtemp(prefix="project-init-upgrade-"))
     staging = staging_root / "render"
     try:
@@ -1894,12 +1882,23 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
         # Run apply even with zero file drift: the config version line and the
         # scaffold record must still refresh to the current tool version.
         if apply:
-            # Migrate a legacy project's record + merge-base sidecar into .agents/
-            # before apply_drift writes through them (PI-813). Deliberately inside
-            # the apply branch and after the addition gate: a gated run applies
-            # nothing, so it must not move the user's files either. Once consent is
-            # given the run reaches here and migrates. read_base() above already
-            # resolves the legacy sidecar, so the merge base is correct either way.
+            if legacy_layout:
+                # Migrate here — past the consent gate, before apply_drift (PI-813,
+                # PI-816). Both edges are load-bearing and pull in opposite directions:
+                #   - AFTER the gate, because a gated run returns 2 having applied
+                #     nothing, and a run that applies nothing must not move the user's
+                #     files either.
+                #   - BEFORE apply_drift, or every legacy file looks like a brand-new
+                #     render and the fresh template is written over the user's copy —
+                #     which is how the memory tier was lost (memory/MEMORY.md IS a
+                #     template output, so "carry only unmanaged files" still clobbered it).
+                # Hence the recompute below rather than migrating up at the render:
+                # drift was measured against the pre-migration tree, where the managed
+                # files did not exist yet. Re-measuring against the migrated tree turns
+                # them from "new" (overwrite) into "changed/merged" (3-way merge against
+                # the recorded base), which is what preserves user edits.
+                _migrate_legacy_tree(target)
+                report = compute_drift(target, staging, rendered, manifest, read_base(target))
             suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
             report.new = [rel for rel in report.new if rel not in suppressed]
             # Per-file interactive walk (#245): drop the files the user skips so

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -83,38 +83,55 @@ def _is_sibling(rel: Path) -> bool:
     return bool(_SIBLING_RE.search(rel.name))
 
 
-def _relocate_legacy_state(target: Path) -> list[str]:
-    """Move a pre-PI-606 project's scaffold state into ``.agents/`` (PI-813).
+def is_legacy_layout(target: Path) -> bool:
+    """True when *target*'s record still lives at the pre-PI-606 ``.claude/`` path.
 
-    Both files are excluded from the managed drift set — the record because it is
-    the hand-editable file the scaffolder owns, the sidecar because it is internal
-    — so a re-render never recreates either at the new path. Without an explicit
-    move a legacy project would upgrade every file *except* the two that describe
-    it, and come back legacy on the next run.
-
-    The sidecar matters as much as the record: ``read_base`` treats a missing
-    sidecar as "no base recorded", so leaving it in ``.claude/`` degrades every
-    3-way merge into a conflict without a word of warning.
-
-    Returns the relative paths moved (empty when there is nothing to migrate).
+    Must be read BEFORE anything is relocated, and it is the gate on
+    :func:`_carry_unmanaged_legacy_content`: in a *current* project ``.claude/`` is
+    a generated mirror of ``.agents/``, so carrying it across would collide with
+    every canonical file it already duplicates.
     """
-    moved: list[str] = []
-    for legacy_rel, canonical_rel in (
-        (_LEGACY_CONFIG_REL, _CONFIG_REL),
-        (_LEGACY_BASE_REL, _BASE_REL),
-    ):
-        legacy, canonical = target / legacy_rel, target / canonical_rel
-        if canonical.exists() or not legacy.exists():
-            continue
+    return (target / _LEGACY_CONFIG_REL).is_file() and not (target / _CONFIG_REL).is_file()
+
+
+def _migrate_legacy_tree(target: Path) -> None:
+    """Move a pre-PI-606 project's whole ``.claude/`` tree into ``.agents/`` (PI-813, PI-816).
+
+    Everything moves — the scaffold record, the merge-base sidecar, and the files the
+    scaffolder does not own (the team's ADRs, the memory tier). Splitting these apart
+    was the bug: "migrate the record, re-render the rest" deleted every unmanaged file,
+    and "carry only the unmanaged files" still clobbered `memory/MEMORY.md`, because
+    that IS a template output and the fresh render won.
+
+    Moving the tree first sidesteps both. The project then looks like an ordinary
+    ``.agents/`` project to the render and the drift engine: managed files 3-way merge
+    against their recorded base, and unmanaged files appear in neither the manifest nor
+    the render, so nothing touches them.
+
+    Never clobbers: an occupied destination gets a ``.new`` sibling, the same rule the
+    drift engine applies. Call only when :func:`is_legacy_layout` held, and only on an
+    apply — a dry or gated run applies nothing and must not move the user's files.
+    """
+    legacy_root = target / ".claude"
+    if not legacy_root.is_dir():
+        return
+    from rich.console import Console
+
+    console = Console()
+    moved = 0
+    for src in sorted(p for p in legacy_root.rglob("*") if p.is_file()):
+        dest = target / ".agents" / src.relative_to(legacy_root)
         try:
-            canonical.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(legacy), str(canonical))
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if dest.exists():
+                dest = _new_sibling(dest, src.read_bytes())
+            shutil.move(str(src), str(dest))
         except OSError as exc:
-            # Abort loudly rather than half-migrate and traceback mid-upgrade.
-            msg = f"cannot migrate {legacy_rel} to {canonical_rel}: {exc}"
+            msg = f"cannot migrate {src.relative_to(target)} to {dest}: {exc}"
             raise UpgradeError(msg) from exc
-        moved.append(f"{legacy_rel} → {canonical_rel}")
-    return moved
+        moved += 1
+    if moved:
+        console.print(f"[green]migrated[/green] {moved} file(s) .claude/ → .agents/")
 
 
 def scaffold_record_path(target: Path) -> Path:
@@ -1799,6 +1816,10 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     """
     import sys
 
+    # Read BEFORE anything relocates — the relocation is what makes it stop being
+    # true, and _carry_unmanaged_legacy_content must not run on a current project
+    # (there .claude/ is a generated mirror of .agents/, not user content).
+    legacy_layout = is_legacy_layout(target)
     try:
         preset_name, variables, manifest, migrated = read_scaffold_record(target)
     except UpgradeError as e:
@@ -1829,6 +1850,18 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
     # ("0.1.0"), which would stamp a stale plugin version into the visible
     # project fields on --apply (2026-07 review).
     variables["project_init_plugin_version"] = __plugin_version__
+
+    # Migrate the legacy tree BEFORE rendering and computing drift (PI-813/PI-816).
+    # Order is the whole fix. Migrate afterwards and every legacy file looks like a
+    # brand-new render: the drift engine has nothing at the canonical path to compare
+    # against, so it writes the fresh template over the user's copy. That is how the
+    # memory tier was lost — `memory/MEMORY.md` IS a template output, so "carry only
+    # the unmanaged files" still clobbered it. Move everything first and the project
+    # simply looks normal: managed files 3-way merge against their base, and
+    # unmanaged files (ADRs, memory the templates don't own) are in neither the
+    # manifest nor the render, so nothing touches them.
+    if apply and legacy_layout:
+        _migrate_legacy_tree(target)
 
     staging_root = Path(tempfile.mkdtemp(prefix="project-init-upgrade-"))
     staging = staging_root / "render"
@@ -1867,10 +1900,6 @@ def run_upgrade(  # noqa: PLR0913 — CLI entry point; options map 1:1 to flags
             # nothing, so it must not move the user's files either. Once consent is
             # given the run reaches here and migrates. read_base() above already
             # resolves the legacy sidecar, so the merge base is correct either way.
-            for moved in _relocate_legacy_state(target):
-                from rich.console import Console
-
-                Console().print(f"[green]migrated[/green] {moved}")
             suppressed = {p for gid in gate["declined_now"] for p in groups[gid]["paths"]}
             report.new = [rel for rel in report.new if rel not in suppressed]
             # Per-file interactive walk (#245): drop the files the user skips so

--- a/tests/integration/test_upgrade_edges.py
+++ b/tests/integration/test_upgrade_edges.py
@@ -197,6 +197,11 @@ class TestLegacyUnmanagedContentIsCarried:
         # The scaffold already writes a .claude/ mirror, so drop it before the move.
         shutil.rmtree(target / ".claude", ignore_errors=True)
         (target / ".agents").rename(target / ".claude")
+        # A real v1.0.0 record lists `.claude/` paths in its manifest — which is why
+        # every file reads as a genuinely-new addition and the consent gate fires.
+        # Without this the fixture is a current scaffold wearing a legacy hat.
+        cfg = target / ".claude" / "config.yaml"
+        cfg.write_text(cfg.read_text().replace(".agents/", ".claude/"))
         # …plus files the scaffolder does not own and never renders.
         adr = target / ".claude" / "docs" / "adr" / "adr-003-our-own.md"
         adr.parent.mkdir(parents=True, exist_ok=True)
@@ -232,3 +237,24 @@ class TestLegacyUnmanagedContentIsCarried:
         )
         after = sorted(p.relative_to(target).as_posix() for p in (target / ".agents").rglob("*"))
         assert before == after or set(before) <= set(after)
+
+    def test_a_gated_run_moves_nothing(self, tmp_path: Path):
+        """A run that stops at the addition-consent gate must not mutate the tree.
+
+        The migration has to happen BEFORE apply_drift (or the fresh render clobbers
+        the user's files) and AFTER the consent gate (or a run that applies nothing
+        still moves the user's files). Getting only the first edge right silently
+        half-migrated a project that then exited 2 having applied nothing (PI-816
+        review — Codex and Copilot both caught it).
+        """
+        target = self._legacy_with_own_content(tmp_path)
+        before = sorted(p.relative_to(target).as_posix() for p in (target / ".claude").rglob("*"))
+
+        # No --accept-new: a legacy project's whole tree is a new addition group, so
+        # this stops at the gate and applies nothing.
+        rc = run_upgrade(target, apply=True)
+
+        assert rc == 2, "expected the addition-consent gate to stop this run"
+        after = sorted(p.relative_to(target).as_posix() for p in (target / ".claude").rglob("*"))
+        assert after == before, "a gated run moved the user's files out of .claude/"
+        assert not (target / ".agents").exists(), "a gated run migrated the tree anyway"

--- a/tests/integration/test_upgrade_edges.py
+++ b/tests/integration/test_upgrade_edges.py
@@ -4,6 +4,7 @@ file/dir type collisions, and CRLF preservation through the 3-way merge.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -177,3 +178,57 @@ class TestLegacyClaudeRecordLocation:
 
         run_upgrade(target, apply=True)
         assert canonical_base.is_file(), "upgrade --apply must migrate the merge-base sidecar"
+
+
+class TestLegacyUnmanagedContentIsCarried:
+    """The migration must not delete the project's OWN files (PI-816).
+
+    `.claude/` -> `.agents/` re-renders the *managed* files and rebuilds `.claude/`
+    as a projection. A project-authored file is in neither set — not in the manifest,
+    so the drift engine never reports it; not a template output, so nothing recreates
+    it. It was silently deleted. Real loss, on a real upgrade: two project ADRs and
+    the entire memory/ tier.
+    """
+
+    def _legacy_with_own_content(self, tmp_path: Path) -> Path:
+        target = tmp_path / "proj"
+        _scaffold(target)
+        # Recreate a true v1.0.0 layout: everything under .claude/, no .agents/.
+        # The scaffold already writes a .claude/ mirror, so drop it before the move.
+        shutil.rmtree(target / ".claude", ignore_errors=True)
+        (target / ".agents").rename(target / ".claude")
+        # …plus files the scaffolder does not own and never renders.
+        adr = target / ".claude" / "docs" / "adr" / "adr-003-our-own.md"
+        adr.parent.mkdir(parents=True, exist_ok=True)
+        adr.write_text("# ADR-003: a decision WE wrote\n")
+        mem = target / ".claude" / "memory" / "MEMORY.md"
+        mem.parent.mkdir(parents=True, exist_ok=True)
+        mem.write_text("our project memory\n")
+        return target
+
+    def test_project_authored_files_survive_the_migration(self, tmp_path: Path):
+        target = self._legacy_with_own_content(tmp_path)
+
+        run_upgrade(target, apply=True, accept_new=["all"])
+
+        adr = target / ".agents" / "docs" / "adr" / "adr-003-our-own.md"
+        mem = target / ".agents" / "memory" / "MEMORY.md"
+        assert adr.is_file(), "the upgrade deleted a project-authored ADR"
+        assert mem.is_file(), "the upgrade deleted the project's memory tier"
+        assert adr.read_text() == "# ADR-003: a decision WE wrote\n", "content mangled"
+        assert mem.read_text() == "our project memory\n", "content mangled"
+
+    def test_a_current_project_is_untouched(self, tmp_path: Path):
+        """The carry must NOT fire on a normal project, where .claude/ is a
+        generated mirror — carrying it would collide with every canonical file."""
+        target = tmp_path / "proj"
+        _scaffold(target)
+        before = sorted(p.relative_to(target).as_posix() for p in (target / ".agents").rglob("*"))
+
+        run_upgrade(target, apply=True, accept_new=["all"])
+
+        assert not list((target / ".agents").rglob("*.new")), (
+            "carry fired on a current project and collided with the .claude/ mirror"
+        )
+        after = sorted(p.relative_to(target).as_posix() for p in (target / ".agents").rglob("*"))
+        assert before == after or set(before) <= set(after)


### PR DESCRIPTION
Closes #816

The `.claude/` → `.agents/` migration re-rendered the **managed** files and rebuilt `.claude/` as a projection. A project-authored file was in neither set — not in the manifest, so the drift engine never reported it; not a template output, so nothing recreated it. It was **deleted, silently**, and the run reported success.

## Real loss, on a real upgrade

`projects-orchestrator`, v1.0.0 → v1.1.2 — both project ADRs and the **entire `memory/` tier** (`MEMORY.md`, `SCHEMA.md`, `project_context`, `project_roadmap`, `user_role`, `feedback_conventions`). Recoverable only because that tree happened to be clean. An upgrade with uncommitted memory edits loses them outright.

Worse: the migrated record rewrites `memory_path: .agents/memory` — so it points at a directory whose contents it just deleted.

## The fix is about ORDER, and my first attempt got it wrong

I first tried "carry the unmanaged files across". **It still lost `memory/MEMORY.md`** — because that *is* a template output. The carry skipped it as managed, and `apply_drift` then wrote the fresh render over the user's copy. Any rule that partitions the tree into managed/unmanaged *before* the drift computation has this hole, and the test caught it.

So: **migrate the whole `.claude/` tree into `.agents/` before rendering and computing drift.** The project then looks like an ordinary `.agents/` project —

- managed files 3-way merge against their recorded base, so user edits are preserved rather than overwritten;
- unmanaged files appear in neither the manifest nor the render, so nothing touches them.

The record and merge-base sidecar come along as ordinary files, so `_relocate_legacy_state` disappears entirely: **one move, not three special cases.**

## Safety

- **Never clobbers** — an occupied destination gets a `.new` sibling, the same rule the drift engine already applies.
- **Gated on `is_legacy_layout()`**, sampled *before* anything moves. This matters: in a current project `.claude/` is a *generated mirror* of `.agents/`, so migrating it would collide with every canonical file. There's an explicit test that a current project is untouched and grows no `.new` siblings.
- Apply-only. A dry or gated run applies nothing, so it must not move the user's files either.

## Verification

Per CLAUDE.md, checked against the bug it guards: both new tests **fail on `main`** — *"the upgrade deleted a project-authored ADR"* — and pass here.

End-to-end on a true legacy layout (`.agents/` absent entirely): the project ADR, `MEMORY.md` and `project_roadmap.md` all survive with content intact.

Full suite: **2395 passed**. `ruff` + `mypy --strict` clean.

## Note

This is the third data-loss defect in this chain (after #811's pre-commit hook and #813's stranded merge-base sidecar). The common root: **the tooling treats "not a managed template file" as "not important" — when that is precisely the user's own work.**