### PR TITLE
chore: release 1.1.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.2
+version: 1.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.2"
+version = "1.1.3"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -31,7 +31,7 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
             "were DELETED. Recover them from the commit BEFORE the upgrade; do not "
             "restore from HEAD, which may already contain the deletion:\n"
             "  1. Find the deleting commit (search all history, not just the last "
-            "one): `git log --diff-filter=D --name-only -- '.claude/*'`\n"
+            "one): `git log --diff-filter=D --name-only -- .claude/`\n"
             "  2. Restore from its parent: `git checkout <sha>^ -- .claude/`\n"
             "  3. Move each recovered file to the matching `.agents/` path, then "
             "delete the leftover `.claude/` copies (`.claude/` is now a generated "

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -27,13 +27,19 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
         ),
         "action_required": (
             "If you already upgraded to 1.1.2 from a pre-v1.0.1 (`.claude/`) layout, "
-            "CHECK YOUR GIT HISTORY NOW: `git status` and `git log --diff-filter=D "
-            "--name-only -1`. Any project-authored file under `.claude/` — ADRs, the "
-            "memory/ tier — was deleted from the working tree. If the tree was clean "
-            "at upgrade time it is all recoverable (`git checkout HEAD -- .claude/`, "
-            "then move the files to the matching `.agents/` path). If it was NOT "
-            "clean, uncommitted content is gone. Upgrading straight from 1.0.x to "
-            "1.1.3 is unaffected — it never loses the files in the first place."
+            "your project-authored files under `.claude/` — ADRs, the memory/ tier — "
+            "were DELETED. Recover them from the commit BEFORE the upgrade; do not "
+            "restore from HEAD, which may already contain the deletion:\n"
+            "  1. Find the deleting commit (search all history, not just the last "
+            "one): `git log --diff-filter=D --name-only -- '.claude/*'`\n"
+            "  2. Restore from its parent: `git checkout <sha>^ -- .claude/`\n"
+            "  3. Move each recovered file to the matching `.agents/` path, then "
+            "delete the leftover `.claude/` copies (`.claude/` is now a generated "
+            "mirror).\n"
+            "If the upgrade was never committed, `git checkout -- .claude/` is enough. "
+            "If the tree was NOT clean at upgrade time, uncommitted content is gone. "
+            "Upgrading straight from 1.0.x to 1.1.3 is unaffected — it never loses the "
+            "files in the first place."
         ),
     },
     "1.1.2": {

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,27 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "1.1.3": {
+        "summary": (
+            "Fixes a data-loss bug in the 1.1.2 `.claude/` -> `.agents/` migration "
+            "(#816). That migration re-rendered the files the templates own and "
+            "DELETED everything else: project-authored ADRs and the entire memory/ "
+            "tier were removed and never recreated — silently, with the upgrade "
+            "reporting success. The migration now moves the whole `.claude/` tree "
+            "into `.agents/` before computing drift, so your own files survive and "
+            "your edits to managed files 3-way merge instead of being overwritten."
+        ),
+        "action_required": (
+            "If you already upgraded to 1.1.2 from a pre-v1.0.1 (`.claude/`) layout, "
+            "CHECK YOUR GIT HISTORY NOW: `git status` and `git log --diff-filter=D "
+            "--name-only -1`. Any project-authored file under `.claude/` — ADRs, the "
+            "memory/ tier — was deleted from the working tree. If the tree was clean "
+            "at upgrade time it is all recoverable (`git checkout HEAD -- .claude/`, "
+            "then move the files to the matching `.agents/` path). If it was NOT "
+            "clean, uncommitted content is gone. Upgrading straight from 1.0.x to "
+            "1.1.3 is unaffected — it never loses the files in the first place."
+        ),
+    },
     "1.1.2": {
         "summary": (
             "Three fixes, all of which failed silently in 1.1.x. (1) Both plugins "

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -19,7 +19,7 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
         "summary": (
             "Fixes a data-loss bug in the 1.1.2 `.claude/` -> `.agents/` migration "
             "(#816). That migration re-rendered the files the templates own and "
-            "DELETED everything else: project-authored ADRs and the entire memory/ "
+            "DELETED everything else: project-authored ADRs and the entire `memory/` "
             "tier were removed and never recreated — silently, with the upgrade "
             "reporting success. The migration now moves the whole `.claude/` tree "
             "into `.agents/` before computing drift, so your own files survive and "
@@ -27,7 +27,7 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
         ),
         "action_required": (
             "If you already upgraded to 1.1.2 from a pre-v1.0.1 (`.claude/`) layout, "
-            "your project-authored files under `.claude/` — ADRs, the memory/ tier — "
+            "your project-authored files under `.claude/` — ADRs, the `memory/` tier — "
             "were DELETED. Recover them from the commit BEFORE the upgrade; do not "
             "restore from HEAD, which may already contain the deletion:\n"
             "  1. Find the deleting commit (search all history, not just the last "

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Bump to **1.1.3**.

## Why now

Ships **#817 (PI-816)**: the 1.1.2 `.claude/` → `.agents/` migration **deleted project-authored files** — ADRs, the entire `memory/` tier — silently, while reporting success. Managed template files were re-rendered; everything else was in neither the manifest nor the render, so nothing recreated it.

**1.1.2 is the release that introduced the exposure**, so this ships immediately rather than waiting to batch anything with it.

## The migration note matters as much as the code

Anyone who already ran the 1.1.2 migration has **already lost those files**. The 1.1.3 note tells them to check their git history:

- Tree clean at upgrade time → fully recoverable (`git checkout HEAD -- .claude/`, then move to the matching `.agents/` path).
- Tree **not** clean → uncommitted content is gone.
- Upgrading 1.0.x → 1.1.3 directly is unaffected — it never loses the files in the first place.

## Verification

`ruff` clean, **2396 passed** at the bumped version.

## After merge

Dispatch `tag-release.yml` with `v1.1.3` to publish to PyPI (ADR-011).