### PR TITLE
chore: release 1.1.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.3
+version: 1.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.3"
+version = "1.1.4"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Bump to **1.1.4**.

Ships **#820 (PI-819)**: a required status check that no job reports leaves the branch `BLOCKED` **forever** — every actual check green, nothing errors, and every PR in the repo unmergeable. Repos scaffolded before PI-555 require the per-version matrix contexts (`Lint and test (3.12)` …) that PI-761 stopped producing on PRs, and nothing tells them why.

`check_branch_protection.sh` names the unsatisfiable checks and the remedy; `monitor_pr.sh` runs it whenever a PR is BLOCKED, instead of leaving the cause to be guessed.

## Verification

`ruff` clean, **2410 passed** at the bumped version.

## After merge

Dispatch `tag-release.yml` with `v1.1.4` to publish to PyPI (ADR-011).