### PR TITLE
fix(PI-822): a PR-only required check is not a phantom

### DIFF
--- a/.agents/scripts/check_branch_protection.sh
+++ b/.agents/scripts/check_branch_protection.sh
@@ -12,8 +12,7 @@
 # phantom contexts and the fix.
 #
 # Usage: check_branch_protection.sh [PR_NUMBER]
-#   With a PR number: compares required contexts against the checks that PR reported.
-#   Without one:      compares them against the check names on the default branch.
+#   Defaults to the PR for the current branch. A PR is required: see below.
 # Exit 0 = protection is satisfiable; 1 = phantom contexts found; 0 also when the
 # state cannot be determined (no gh, not authed, no protection) — a diagnostic must
 # never itself block a workflow.
@@ -44,25 +43,34 @@ if [ -z "$REQUIRED" ]; then
   exit 0
 fi
 
-# Checks that actually reported. Two kinds satisfy a required context and BOTH must
-# be collected, or the diagnostic invents phantoms that are not there — a false
-# alarm here is worse than none, because it sends someone rewriting protection that
-# was fine:
-#   - Actions check-runs      -> .name       (e.g. "CI gate")
-#   - classic commit statuses -> .context    (e.g. Vercel, Codecov)
-# The fallback is applied PER ENTRY (`.[] | (.name // .context)`), not across the
-# whole stream: `.[]?.name // .[]?.context` only falls back when the left side
-# yields nothing at all, so a rollup holding both kinds would silently drop every
-# status and report it as unsatisfiable (PI-819 review).
-if [ -n "$PR_NUMBER" ]; then
-  REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
-    --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
-else
-  REPORTED=$(
-    gh api "repos/$REPO/commits/$BRANCH/check-runs" --jq '.check_runs[]?.name' 2>/dev/null || true
-    gh api "repos/$REPO/commits/$BRANCH/status" --jq '.statuses[]?.context' 2>/dev/null || true
-  )
+# Checks that actually reported, taken from the PR's rollup — the exact set GitHub
+# matches the required contexts against.
+#
+# It MUST be a PR. A required context can legitimately be PR-only (validate-pr's
+# "Check PR title, branch, and linked issue" never runs on a push to the default
+# branch), so the branch's check-runs cannot tell a phantom from a PR-only check —
+# they look identical: absent. An earlier version fell back to the branch and
+# duly accused a perfectly satisfiable check of being unsatisfiable (PI-822).
+#
+# A false alarm here is worse than no diagnostic at all: it sends someone rewriting
+# branch protection that was fine. So when there is no PR to look at, say so and
+# stop, rather than guess.
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null || true) # PR for this branch
 fi
+if [ -z "$PR_NUMBER" ]; then
+  {
+    echo "check_branch_protection: no pull request to check against."
+    echo "  Pass a PR number: check_branch_protection.sh <PR>"
+    echo "  A required check can be PR-only, so the default branch's check-runs"
+    echo "  cannot distinguish a phantom from a check that simply never runs on a"
+    echo "  push — and guessing would raise a false alarm."
+  } >&2
+  exit 0
+fi
+
+REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+  --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
 
 PHANTOM=$(comm -23 <(printf '%s\n' "$REQUIRED" | sort -u) <(printf '%s\n' "$REPORTED" | sort -u))
 

--- a/.claude/scripts/check_branch_protection.sh
+++ b/.claude/scripts/check_branch_protection.sh
@@ -12,8 +12,7 @@
 # phantom contexts and the fix.
 #
 # Usage: check_branch_protection.sh [PR_NUMBER]
-#   With a PR number: compares required contexts against the checks that PR reported.
-#   Without one:      compares them against the check names on the default branch.
+#   Defaults to the PR for the current branch. A PR is required: see below.
 # Exit 0 = protection is satisfiable; 1 = phantom contexts found; 0 also when the
 # state cannot be determined (no gh, not authed, no protection) — a diagnostic must
 # never itself block a workflow.
@@ -44,25 +43,34 @@ if [ -z "$REQUIRED" ]; then
   exit 0
 fi
 
-# Checks that actually reported. Two kinds satisfy a required context and BOTH must
-# be collected, or the diagnostic invents phantoms that are not there — a false
-# alarm here is worse than none, because it sends someone rewriting protection that
-# was fine:
-#   - Actions check-runs      -> .name       (e.g. "CI gate")
-#   - classic commit statuses -> .context    (e.g. Vercel, Codecov)
-# The fallback is applied PER ENTRY (`.[] | (.name // .context)`), not across the
-# whole stream: `.[]?.name // .[]?.context` only falls back when the left side
-# yields nothing at all, so a rollup holding both kinds would silently drop every
-# status and report it as unsatisfiable (PI-819 review).
-if [ -n "$PR_NUMBER" ]; then
-  REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
-    --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
-else
-  REPORTED=$(
-    gh api "repos/$REPO/commits/$BRANCH/check-runs" --jq '.check_runs[]?.name' 2>/dev/null || true
-    gh api "repos/$REPO/commits/$BRANCH/status" --jq '.statuses[]?.context' 2>/dev/null || true
-  )
+# Checks that actually reported, taken from the PR's rollup — the exact set GitHub
+# matches the required contexts against.
+#
+# It MUST be a PR. A required context can legitimately be PR-only (validate-pr's
+# "Check PR title, branch, and linked issue" never runs on a push to the default
+# branch), so the branch's check-runs cannot tell a phantom from a PR-only check —
+# they look identical: absent. An earlier version fell back to the branch and
+# duly accused a perfectly satisfiable check of being unsatisfiable (PI-822).
+#
+# A false alarm here is worse than no diagnostic at all: it sends someone rewriting
+# branch protection that was fine. So when there is no PR to look at, say so and
+# stop, rather than guess.
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null || true) # PR for this branch
 fi
+if [ -z "$PR_NUMBER" ]; then
+  {
+    echo "check_branch_protection: no pull request to check against."
+    echo "  Pass a PR number: check_branch_protection.sh <PR>"
+    echo "  A required check can be PR-only, so the default branch's check-runs"
+    echo "  cannot distinguish a phantom from a check that simply never runs on a"
+    echo "  push — and guessing would raise a false alarm."
+  } >&2
+  exit 0
+fi
+
+REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+  --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
 
 PHANTOM=$(comm -23 <(printf '%s\n' "$REQUIRED" | sort -u) <(printf '%s\n' "$REPORTED" | sort -u))
 

--- a/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
+++ b/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
@@ -12,8 +12,7 @@
 # phantom contexts and the fix.
 #
 # Usage: check_branch_protection.sh [PR_NUMBER]
-#   With a PR number: compares required contexts against the checks that PR reported.
-#   Without one:      compares them against the check names on the default branch.
+#   Defaults to the PR for the current branch. A PR is required: see below.
 # Exit 0 = protection is satisfiable; 1 = phantom contexts found; 0 also when the
 # state cannot be determined (no gh, not authed, no protection) — a diagnostic must
 # never itself block a workflow.
@@ -44,25 +43,34 @@ if [ -z "$REQUIRED" ]; then
   exit 0
 fi
 
-# Checks that actually reported. Two kinds satisfy a required context and BOTH must
-# be collected, or the diagnostic invents phantoms that are not there — a false
-# alarm here is worse than none, because it sends someone rewriting protection that
-# was fine:
-#   - Actions check-runs      -> .name       (e.g. "CI gate")
-#   - classic commit statuses -> .context    (e.g. Vercel, Codecov)
-# The fallback is applied PER ENTRY (`.[] | (.name // .context)`), not across the
-# whole stream: `.[]?.name // .[]?.context` only falls back when the left side
-# yields nothing at all, so a rollup holding both kinds would silently drop every
-# status and report it as unsatisfiable (PI-819 review).
-if [ -n "$PR_NUMBER" ]; then
-  REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
-    --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
-else
-  REPORTED=$(
-    gh api "repos/$REPO/commits/$BRANCH/check-runs" --jq '.check_runs[]?.name' 2>/dev/null || true
-    gh api "repos/$REPO/commits/$BRANCH/status" --jq '.statuses[]?.context' 2>/dev/null || true
-  )
+# Checks that actually reported, taken from the PR's rollup — the exact set GitHub
+# matches the required contexts against.
+#
+# It MUST be a PR. A required context can legitimately be PR-only (validate-pr's
+# "Check PR title, branch, and linked issue" never runs on a push to the default
+# branch), so the branch's check-runs cannot tell a phantom from a PR-only check —
+# they look identical: absent. An earlier version fell back to the branch and
+# duly accused a perfectly satisfiable check of being unsatisfiable (PI-822).
+#
+# A false alarm here is worse than no diagnostic at all: it sends someone rewriting
+# branch protection that was fine. So when there is no PR to look at, say so and
+# stop, rather than guess.
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null || true) # PR for this branch
 fi
+if [ -z "$PR_NUMBER" ]; then
+  {
+    echo "check_branch_protection: no pull request to check against."
+    echo "  Pass a PR number: check_branch_protection.sh <PR>"
+    echo "  A required check can be PR-only, so the default branch's check-runs"
+    echo "  cannot distinguish a phantom from a check that simply never runs on a"
+    echo "  push — and guessing would raise a false alarm."
+  } >&2
+  exit 0
+fi
+
+REPORTED=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+  --jq '.statusCheckRollup[]? | (.name // .context) | select(. != null)' 2>/dev/null || true)
 
 PHANTOM=$(comm -23 <(printf '%s\n' "$REQUIRED" | sort -u) <(printf '%s\n' "$REPORTED" | sort -u))
 

--- a/tests/integration/test_branch_protection_diagnostic.py
+++ b/tests/integration/test_branch_protection_diagnostic.py
@@ -36,6 +36,7 @@ for ((i=0; i<$#; i++)); do
 done
 _emit() { printf '%s' "$1" | jq -r "$_filter"; }
 case "$*" in
+  *"--json number"*)        echo "${STUB_PR_NUMBER:-}" ;;
   *nameWithOwner*)          echo "o/r" ;;
   *defaultBranchRef*)       echo "main" ;;
   *required_status_checks*) _emit "$REQUIRED_JSON" ;;
@@ -147,3 +148,45 @@ def test_never_blocks_when_gh_is_unavailable(tmp_path: Path):
         check=False,
     )
     assert result.returncode == 0, f"the diagnostic blocked the workflow:\n{result.stderr}"
+
+
+def test_a_pr_only_required_check_is_never_called_a_phantom(tmp_path: Path):
+    """The killer false positive (PI-822), found by running the SHIPPED script.
+
+    `Check PR title, branch, and linked issue` runs on pull_request only — it never
+    reports on a push to the default branch. The first version fell back to the
+    branch's check-runs when given no PR, so it accused that perfectly satisfiable
+    check of being unsatisfiable and told the user to rewrite branch protection that
+    was fine. A false alarm is worse than no diagnostic.
+
+    With no PR resolvable the script must now decline to guess: exit 0, say why.
+    """
+    _require_jq()
+    script = _script(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(_GH_STUB)
+    gh.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "STUB_PR_NUMBER": "",  # no PR for this branch
+        "REQUIRED_JSON": json.dumps(
+            {"contexts": ["CI gate", "Check PR title, branch, and linked issue"]}
+        ),
+        # The branch's check-runs hold only the push-triggered job — the PR-only
+        # check is absent, which is normal and must NOT read as a phantom.
+        "CHECKRUNS_JSON": json.dumps({"check_runs": [{"name": "CI gate"}]}),
+        "STATUSES_JSON": json.dumps({"statuses": []}),
+        "ROLLUP_JSON": json.dumps({"statusCheckRollup": []}),
+    }
+    result = subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, env=env, check=False
+    )
+    assert result.returncode == 0, (
+        f"a PR-only required check was falsely called a phantom:\n{result.stderr}"
+    )
+    assert "Check PR title" not in result.stdout + result.stderr.replace(
+        "cannot distinguish a phantom", ""
+    ), "the script accused a PR-only check instead of declining to guess"


### PR DESCRIPTION
Closes #822

Shipped in **1.1.4** and found by running the *released* script against a real repo — not by any test.

With no PR number, `check_branch_protection.sh` fell back to the default branch's check-runs and accused `Check PR title, branch, and linked issue` — a **perfectly satisfiable** check — of being unsatisfiable, telling the user to rewrite branch protection that was fine:

```console
$ check_branch_protection.sh          # 1.1.4
❌ branch protection requires checks that NOTHING reports:
      - Check PR title, branch, and linked issue

$ check_branch_protection.sh 96       # …the very same repo, with a PR
check_branch_protection: all required checks on main are reported by CI.
```

The script's own comment says *a false alarm is worse than no diagnostic, because it sends someone rewriting branch protection that was fine*. This was exactly that, in the shipped script.

## The mode is unsound at its root

Not a missing endpoint — a missing **distinction**. A required context can legitimately be PR-only (`validate-pr` runs on `pull_request`; it never reports on a push). On the default branch, a PR-only check and a genuine phantom look **identical: absent**. Branch check-runs cannot tell them apart, so no amount of extra endpoints fixes it.

That also means the `/status` + `check-runs` union I added in the #820 review was solving the wrong problem — it made the unsound mode *more thorough* rather than removing it. Dropped.

## Fix

Only a PR's `statusCheckRollup` is authoritative — it is the exact set GitHub matches the required contexts against. So:

- default to the PR for the current branch;
- with no PR, **decline to guess**: explain why and exit 0, instead of accusing.

## Verification

The new test **fails against the shipped 1.1.4 script** (*"a PR-only required check was falsely called a phantom"*) and passes here.

Against the live repo:

```console
$ check_branch_protection.sh      # no PR
check_branch_protection: no pull request to check against. […] guessing would
raise a false alarm.                                                  exit=0

$ check_branch_protection.sh 96
check_branch_protection: all required checks on main are reported by CI.  exit=0
```

**2411 passed.** shellcheck + shfmt clean.

## Note

Found only by running the shipped artifact against a live repo. The tests stubbed a world where every required check reports *somewhere* — so they were green on a script that raised false alarms in reality. Same lesson as the rest of this chain: **a green suite says nothing about the contract with the system outside it.**