### PR TITLE
chore: release 1.1.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.4
+version: 1.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.4"
+version = "1.1.5"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,26 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "1.1.5": {
+        "summary": (
+            "Fixes a FALSE ALARM in the 1.1.4 branch-protection diagnostic (#822). "
+            "Run without a PR number, `check_branch_protection.sh` compared the "
+            "required contexts against the default branch's check-runs and reported "
+            "a PR-only check (`Check PR title, branch, and linked issue`) as "
+            "unsatisfiable — telling you to rewrite branch protection that was "
+            "perfectly fine. A required context can legitimately be PR-only, and on "
+            "the default branch a PR-only check and a real phantom look identical: "
+            "absent. It now uses the PR's own check rollup — the exact set GitHub "
+            "matches against — and declines to guess when there is no PR."
+        ),
+        "action_required": (
+            "If 1.1.4's diagnostic told you a required check was unsatisfiable, "
+            "re-check with a PR number before changing anything: "
+            "`.agents/scripts/check_branch_protection.sh <PR>`. If it now reports "
+            "all checks satisfied, your branch protection was always correct and "
+            "needs no change."
+        ),
+    },
     "1.1.4": {
         "summary": (
             "Diagnoses the silent forever-block (#819). Branch protection is written "

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -18,10 +18,10 @@ MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
     "1.1.5": {
         "summary": (
             "Fixes a FALSE ALARM in the 1.1.4 branch-protection diagnostic (#822). "
-            "Run without a PR number, `check_branch_protection.sh` compared the "
-            "required contexts against the default branch's check-runs and reported "
-            "a PR-only check (`Check PR title, branch, and linked issue`) as "
-            "unsatisfiable — telling you to rewrite branch protection that was "
+            "Run without a PR number, `.agents/scripts/check_branch_protection.sh` "
+            "compared required contexts against the default branch's check-runs and "
+            "reported a PR-only check (`Check PR title, branch, and linked issue`) "
+            "as unsatisfiable — telling you to rewrite branch protection that was "
             "perfectly fine. A required context can legitimately be PR-only, and on "
             "the default branch a PR-only check and a real phantom look identical: "
             "absent. It now uses the PR's own check rollup — the exact set GitHub "

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Bump to **1.1.5**.

Ships **#823 (PI-822)**: 1.1.4's branch-protection diagnostic raised a **false alarm**. Run without a PR number it compared required contexts against the default branch's check-runs and reported a PR-only check (`Check PR title, branch, and linked issue`) as unsatisfiable — telling users to rewrite branch protection that was **perfectly fine**.

A required context can legitimately be PR-only, and on the default branch a PR-only check and a real phantom look identical: **absent**. The diagnostic now uses the PR's own check rollup — the exact set GitHub matches against — and declines to guess when there is no PR.

**1.1.4 is the release that introduced this**, so it ships immediately rather than waiting to batch.

The 1.1.5 migration note tells anyone who acted on the 1.1.4 warning to re-check with a PR number *before* changing anything: if it now reports all checks satisfied, their protection was always correct.

## Verification

`ruff` clean, **2411 passed** at the bumped version.

## After merge

Dispatch `tag-release.yml` with `v1.1.5` to publish to PyPI (ADR-011).