### PR TITLE
fix(PI-825): check ruleset-required status checks too, not just classic protection

### DIFF
--- a/.agents/scripts/check_branch_protection.sh
+++ b/.agents/scripts/check_branch_protection.sh
@@ -34,10 +34,24 @@ fi
 
 BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo main)
 
-# Required contexts. A repo with no protection (or a token without admin scope)
-# returns an error — that is not a failure, there is simply nothing to check.
-REQUIRED=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
+# Required contexts, from BOTH enforcement layers. setup_github.sh writes classic
+# branch protection AND (org profile) a `project-init-baseline` repository ruleset,
+# each carrying its own required_status_checks. Reading only the classic layer means
+# a PR blocked solely by a stale RULESET check is told "all required checks are
+# reported" — a false REASSURANCE, which is worse than the false alarm this script
+# exists to avoid: it sends the operator looking anywhere but the real cause
+# (PI-825).
+#
+# /rules/branches/<branch> is the authoritative view — the rules actually in force
+# for that branch, whatever ruleset they came from. A repo with no protection (or a
+# token without admin scope) errors on either call; that is not a failure, there is
+# simply nothing to check.
+CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
+RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+  --jq '.[]? | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
+REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
 if [ -z "$REQUIRED" ]; then
   echo "check_branch_protection: no required status checks on $BRANCH — nothing to verify." >&2
   exit 0

--- a/.agents/scripts/check_branch_protection.sh
+++ b/.agents/scripts/check_branch_protection.sh
@@ -48,7 +48,10 @@ BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/n
 # simply nothing to check.
 CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
-RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+# --paginate: /rules/branches is paginated, and a required_status_checks rule on a
+# later page would be silently omitted — producing the same false "all healthy" this
+# whole check exists to prevent.
+RULESET=$(gh api --paginate "repos/$REPO/rules/branches/$BRANCH" \
   --jq '.[]? | select(.type == "required_status_checks")
         | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
 REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
@@ -105,7 +108,9 @@ fi
   echo "   up (e.g. PI-761 made the Python matrix run per-PR on the floor version"
   echo "   only, so 'Lint and test (3.12)' and friends stopped being reported)."
   echo ""
-  echo "   Fix: re-run  .agents/scripts/setup_github.sh"
+  # --protect is REQUIRED: without it setup_github.sh never touches protection
+  # or the ruleset, so the "remedy" would silently do nothing at all.
+  echo "   Fix: re-run  .agents/scripts/setup_github.sh --protect"
   echo "   It requires the single 'CI gate' job, which needs: the whole matrix and"
   echo "   the secret scan — so it stays correct across any future matrix change."
 } >&2

--- a/.agents/scripts/setup_github.sh
+++ b/.agents/scripts/setup_github.sh
@@ -153,10 +153,23 @@ JSON
   "bypass_actors": []
 }
 RULESET_JSON
-    if gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
+    # Update-or-create, not create-only. A POST that fails because the ruleset
+    # already exists left a STALE ruleset in place forever: its required checks kept
+    # blocking every PR, and re-running this script — the remedy every diagnostic
+    # points at — changed nothing (PI-825). Idempotence is the whole point of a
+    # setup script you are told to re-run.
+    RULESET_ID=$(gh api "repos/$OWNER/$NAME/rulesets" \
+      --jq '.[]? | select(.name == "project-init-baseline") | .id' 2>/dev/null | head -1)
+    if [ -n "$RULESET_ID" ]; then
+      if gh api "repos/$OWNER/$NAME/rulesets/$RULESET_ID" -X PUT --input "$RULESET" >/dev/null 2>&1; then
+        echo "Repository ruleset 'project-init-baseline' updated (id $RULESET_ID) — required checks re-synced"
+      else
+        echo "WARNING: could not update the existing repository ruleset (plan/permission insufficient)." >&2
+      fi
+    elif gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
       echo "Repository ruleset 'project-init-baseline' applied (binds everyone — empty bypass)"
     else
-      echo "WARNING: could not create the repository ruleset (it may already exist, or the plan/permission is insufficient)." >&2
+      echo "WARNING: could not create the repository ruleset (plan/permission insufficient)." >&2
     fi
   else
     echo "Rulesets API unavailable on this host/plan — relying on branch protection only." >&2

--- a/.claude/scripts/check_branch_protection.sh
+++ b/.claude/scripts/check_branch_protection.sh
@@ -34,10 +34,24 @@ fi
 
 BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo main)
 
-# Required contexts. A repo with no protection (or a token without admin scope)
-# returns an error — that is not a failure, there is simply nothing to check.
-REQUIRED=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
+# Required contexts, from BOTH enforcement layers. setup_github.sh writes classic
+# branch protection AND (org profile) a `project-init-baseline` repository ruleset,
+# each carrying its own required_status_checks. Reading only the classic layer means
+# a PR blocked solely by a stale RULESET check is told "all required checks are
+# reported" — a false REASSURANCE, which is worse than the false alarm this script
+# exists to avoid: it sends the operator looking anywhere but the real cause
+# (PI-825).
+#
+# /rules/branches/<branch> is the authoritative view — the rules actually in force
+# for that branch, whatever ruleset they came from. A repo with no protection (or a
+# token without admin scope) errors on either call; that is not a failure, there is
+# simply nothing to check.
+CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
+RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+  --jq '.[]? | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
+REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
 if [ -z "$REQUIRED" ]; then
   echo "check_branch_protection: no required status checks on $BRANCH — nothing to verify." >&2
   exit 0

--- a/.claude/scripts/check_branch_protection.sh
+++ b/.claude/scripts/check_branch_protection.sh
@@ -48,7 +48,10 @@ BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/n
 # simply nothing to check.
 CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
-RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+# --paginate: /rules/branches is paginated, and a required_status_checks rule on a
+# later page would be silently omitted — producing the same false "all healthy" this
+# whole check exists to prevent.
+RULESET=$(gh api --paginate "repos/$REPO/rules/branches/$BRANCH" \
   --jq '.[]? | select(.type == "required_status_checks")
         | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
 REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
@@ -105,7 +108,9 @@ fi
   echo "   up (e.g. PI-761 made the Python matrix run per-PR on the floor version"
   echo "   only, so 'Lint and test (3.12)' and friends stopped being reported)."
   echo ""
-  echo "   Fix: re-run  .agents/scripts/setup_github.sh"
+  # --protect is REQUIRED: without it setup_github.sh never touches protection
+  # or the ruleset, so the "remedy" would silently do nothing at all.
+  echo "   Fix: re-run  .agents/scripts/setup_github.sh --protect"
   echo "   It requires the single 'CI gate' job, which needs: the whole matrix and"
   echo "   the secret scan — so it stays correct across any future matrix change."
 } >&2

--- a/.claude/scripts/setup_github.sh
+++ b/.claude/scripts/setup_github.sh
@@ -153,10 +153,23 @@ JSON
   "bypass_actors": []
 }
 RULESET_JSON
-    if gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
+    # Update-or-create, not create-only. A POST that fails because the ruleset
+    # already exists left a STALE ruleset in place forever: its required checks kept
+    # blocking every PR, and re-running this script — the remedy every diagnostic
+    # points at — changed nothing (PI-825). Idempotence is the whole point of a
+    # setup script you are told to re-run.
+    RULESET_ID=$(gh api "repos/$OWNER/$NAME/rulesets" \
+      --jq '.[]? | select(.name == "project-init-baseline") | .id' 2>/dev/null | head -1)
+    if [ -n "$RULESET_ID" ]; then
+      if gh api "repos/$OWNER/$NAME/rulesets/$RULESET_ID" -X PUT --input "$RULESET" >/dev/null 2>&1; then
+        echo "Repository ruleset 'project-init-baseline' updated (id $RULESET_ID) — required checks re-synced"
+      else
+        echo "WARNING: could not update the existing repository ruleset (plan/permission insufficient)." >&2
+      fi
+    elif gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
       echo "Repository ruleset 'project-init-baseline' applied (binds everyone — empty bypass)"
     else
-      echo "WARNING: could not create the repository ruleset (it may already exist, or the plan/permission is insufficient)." >&2
+      echo "WARNING: could not create the repository ruleset (plan/permission insufficient)." >&2
     fi
   else
     echo "Rulesets API unavailable on this host/plan — relying on branch protection only." >&2

--- a/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
+++ b/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
@@ -34,10 +34,24 @@ fi
 
 BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo main)
 
-# Required contexts. A repo with no protection (or a token without admin scope)
-# returns an error — that is not a failure, there is simply nothing to check.
-REQUIRED=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
+# Required contexts, from BOTH enforcement layers. setup_github.sh writes classic
+# branch protection AND (org profile) a `project-init-baseline` repository ruleset,
+# each carrying its own required_status_checks. Reading only the classic layer means
+# a PR blocked solely by a stale RULESET check is told "all required checks are
+# reported" — a false REASSURANCE, which is worse than the false alarm this script
+# exists to avoid: it sends the operator looking anywhere but the real cause
+# (PI-825).
+#
+# /rules/branches/<branch> is the authoritative view — the rules actually in force
+# for that branch, whatever ruleset they came from. A repo with no protection (or a
+# token without admin scope) errors on either call; that is not a failure, there is
+# simply nothing to check.
+CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
+RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+  --jq '.[]? | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
+REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
 if [ -z "$REQUIRED" ]; then
   echo "check_branch_protection: no required status checks on $BRANCH — nothing to verify." >&2
   exit 0

--- a/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
+++ b/templates/lifecycle/dot_agents/scripts/check_branch_protection.sh
@@ -48,7 +48,10 @@ BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/n
 # simply nothing to check.
 CLASSIC=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks" \
   --jq '.contexts[]?' 2>/dev/null || true)
-RULESET=$(gh api "repos/$REPO/rules/branches/$BRANCH" \
+# --paginate: /rules/branches is paginated, and a required_status_checks rule on a
+# later page would be silently omitted — producing the same false "all healthy" this
+# whole check exists to prevent.
+RULESET=$(gh api --paginate "repos/$REPO/rules/branches/$BRANCH" \
   --jq '.[]? | select(.type == "required_status_checks")
         | .parameters.required_status_checks[]?.context' 2>/dev/null || true)
 REQUIRED=$(printf '%s\n%s\n' "$CLASSIC" "$RULESET" | sed '/^$/d' | sort -u)
@@ -105,7 +108,9 @@ fi
   echo "   up (e.g. PI-761 made the Python matrix run per-PR on the floor version"
   echo "   only, so 'Lint and test (3.12)' and friends stopped being reported)."
   echo ""
-  echo "   Fix: re-run  .agents/scripts/setup_github.sh"
+  # --protect is REQUIRED: without it setup_github.sh never touches protection
+  # or the ruleset, so the "remedy" would silently do nothing at all.
+  echo "   Fix: re-run  .agents/scripts/setup_github.sh --protect"
   echo "   It requires the single 'CI gate' job, which needs: the whole matrix and"
   echo "   the secret scan — so it stays correct across any future matrix change."
 } >&2

--- a/templates/lifecycle/dot_agents/scripts/setup_github.sh
+++ b/templates/lifecycle/dot_agents/scripts/setup_github.sh
@@ -153,10 +153,23 @@ JSON
   "bypass_actors": []
 }
 RULESET_JSON
-    if gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
+    # Update-or-create, not create-only. A POST that fails because the ruleset
+    # already exists left a STALE ruleset in place forever: its required checks kept
+    # blocking every PR, and re-running this script — the remedy every diagnostic
+    # points at — changed nothing (PI-825). Idempotence is the whole point of a
+    # setup script you are told to re-run.
+    RULESET_ID=$(gh api "repos/$OWNER/$NAME/rulesets" \
+      --jq '.[]? | select(.name == "project-init-baseline") | .id' 2>/dev/null | head -1)
+    if [ -n "$RULESET_ID" ]; then
+      if gh api "repos/$OWNER/$NAME/rulesets/$RULESET_ID" -X PUT --input "$RULESET" >/dev/null 2>&1; then
+        echo "Repository ruleset 'project-init-baseline' updated (id $RULESET_ID) — required checks re-synced"
+      else
+        echo "WARNING: could not update the existing repository ruleset (plan/permission insufficient)." >&2
+      fi
+    elif gh api "repos/$OWNER/$NAME/rulesets" -X POST --input "$RULESET" >/dev/null 2>&1; then
       echo "Repository ruleset 'project-init-baseline' applied (binds everyone — empty bypass)"
     else
-      echo "WARNING: could not create the repository ruleset (it may already exist, or the plan/permission is insufficient)." >&2
+      echo "WARNING: could not create the repository ruleset (plan/permission insufficient)." >&2
     fi
   else
     echo "Rulesets API unavailable on this host/plan — relying on branch protection only." >&2

--- a/tests/integration/test_branch_protection_diagnostic.py
+++ b/tests/integration/test_branch_protection_diagnostic.py
@@ -39,6 +39,7 @@ case "$*" in
   *"--json number"*)        echo "${STUB_PR_NUMBER:-}" ;;
   *nameWithOwner*)          echo "o/r" ;;
   *defaultBranchRef*)       echo "main" ;;
+  *rules/branches*)         _emit "${RULESET_JSON:-[]}" ;;
   *required_status_checks*) _emit "$REQUIRED_JSON" ;;
   *statusCheckRollup*)      _emit "$ROLLUP_JSON" ;;
   *check-runs*)             _emit "$CHECKRUNS_JSON" ;;
@@ -62,7 +63,14 @@ def _script(tmp_path: Path) -> Path:
     return target / ".agents" / "scripts" / "check_branch_protection.sh"
 
 
-def _run(script: Path, tmp_path: Path, *, required: list[str], rollup: list[dict]):
+def _run(
+    script: Path,
+    tmp_path: Path,
+    *,
+    required: list[str],
+    rollup: list[dict],
+    ruleset: list[dict] | None = None,
+):
     _require_jq()
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
@@ -73,6 +81,7 @@ def _run(script: Path, tmp_path: Path, *, required: list[str], rollup: list[dict
         **os.environ,
         "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
         "REQUIRED_JSON": json.dumps({"contexts": required}),
+        "RULESET_JSON": json.dumps(ruleset or []),
         "ROLLUP_JSON": json.dumps({"statusCheckRollup": rollup}),
         "CHECKRUNS_JSON": json.dumps({"check_runs": [e for e in rollup if "name" in e]}),
         "STATUSES_JSON": json.dumps({"statuses": [e for e in rollup if "context" in e]}),
@@ -190,3 +199,33 @@ def test_a_pr_only_required_check_is_never_called_a_phantom(tmp_path: Path):
     assert "Check PR title" not in result.stdout + result.stderr.replace(
         "cannot distinguish a phantom", ""
     ), "the script accused a PR-only check instead of declining to guess"
+
+
+def test_a_phantom_that_lives_only_in_a_ruleset_is_still_found(tmp_path: Path):
+    """setup_github.sh enforces via TWO layers: classic branch protection and (org
+    profile) a `project-init-baseline` repository ruleset, each with its own
+    required_status_checks. Reading only the classic layer told a PR blocked solely
+    by a stale RULESET check that everything was fine — a false REASSURANCE, worse
+    than the false alarm this script exists to prevent, because it sends the
+    operator looking anywhere but the real cause (PI-825)."""
+    result = _run(
+        _script(tmp_path),
+        tmp_path,
+        required=["CI gate"],  # classic layer is clean…
+        ruleset=[
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": "CI gate"},
+                        {"context": "Lint and test (3.12)"},  # …the stale one is HERE
+                    ]
+                },
+            }
+        ],
+        rollup=[{"name": "CI gate"}],
+    )
+    assert result.returncode == 1, "a ruleset-only phantom was missed — reported healthy"
+    assert "Lint and test (3.12)" in result.stderr, (
+        f"the ruleset-required check was not named:\n{result.stderr}"
+    )

--- a/tests/integration/test_setup_github_ruleset_idempotent.py
+++ b/tests/integration/test_setup_github_ruleset_idempotent.py
@@ -1,0 +1,72 @@
+"""PI-825: `setup_github.sh` must UPDATE an existing ruleset, not only create one.
+
+The script POSTed a new `project-init-baseline` ruleset and, if one already existed,
+merely warned. So a stale ruleset kept blocking every PR forever, and re-running the
+script — the remedy every diagnostic points at, including this project's own — did
+nothing at all. Idempotence is the entire point of a setup script you are told to
+re-run.
+
+Driven with a stubbed `gh` that records the HTTP verbs it is asked to perform, so
+this asserts the script's actual behaviour rather than its source text (AGENTS.md).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import make_variables, memory_preset
+
+# Records every `gh api` call to $CALLS, and reports an EXISTING baseline ruleset.
+_GH_STUB = """#!/usr/bin/env bash
+echo "$*" >> "$CALLS"
+case "$*" in
+  *"rulesets --jq"*|*"rulesets"*--jq*) echo "42" ;;          # a baseline ruleset exists
+  *"repo view"*)                       echo "o/r" ;;
+  *) : ;;
+esac
+exit 0
+"""
+
+
+def _setup_script(tmp_path: Path) -> Path:
+    target = tmp_path / "proj"
+    scaffold(target, memory_preset("obsidian-only"), make_variables(), strict=True)
+    # The ruleset is the ORG profile's hard-enforcement layer; gh_profile() reads
+    # `profile:` out of config.yaml, so an individual-profile scaffold never reaches
+    # the ruleset code at all.
+    cfg = target / ".agents" / "config.yaml"
+    cfg.write_text(cfg.read_text().replace("profile: individual", "profile: org"))
+    return target / ".agents" / "scripts" / "setup_github.sh"
+
+
+def test_an_existing_ruleset_is_updated_not_just_warned_about(tmp_path: Path):
+    script = _setup_script(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(_GH_STUB)
+    gh.chmod(0o755)
+    calls = tmp_path / "calls.txt"
+    calls.write_text("")
+
+    subprocess.run(
+        ["bash", str(script), "--protect"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "CALLS": str(calls),
+        },
+    )
+
+    log = calls.read_text()
+    assert "rulesets/42" in log and "-X PUT" in log, (
+        "an existing ruleset was never updated — re-running setup_github.sh cannot "
+        f"fix a stale ruleset, so the remedy is a dead end:\n{log}"
+    )


### PR DESCRIPTION
Closes #825

Found by Codex on the downstream bump PR, and it's the sharpest failure yet in this script.

`setup_github.sh` enforces through **two** layers — classic branch protection **and** (org profile) a `project-init-baseline` repository ruleset, each with its own `required_status_checks`. The diagnostic read only the classic layer, so a PR blocked **solely** by a stale ruleset check was told:

```
check_branch_protection: all required checks on main are reported by CI.
```

…while sitting `BLOCKED`.

## This is the worse failure of the two

**PI-822 was a false alarm** — it accused a healthy config, and at least pointed at branch protection. **This is a false reassurance**: it certifies a broken one, and sends the operator looking anywhere *but* the real cause — the exact dead end the script was written to prevent.

A diagnostic whose "all healthy" means nothing is worse than no diagnostic at all.

## Fix

Union both layers. `GET /repos/{repo}/rules/branches/{branch}` is authoritative — the rules actually in force for that branch, whatever ruleset they came from.

## Verification

The new test **fails against the shipped 1.1.5 script** — *"a ruleset-only phantom was missed — reported healthy"* — and passes here.

**2412 passed.** shellcheck + shfmt clean.

## Note

Third bug in this one small script (#819 → #822 → #825), each found the same way: **by running it against a real repo, never by a test.** The tests modelled one enforcement layer because that was the one I knew about — the code was self-consistent, the suite was green, and the contract with GitHub was wrong. Same root cause as every other bug in this chain.