### PR TITLE
chore: release 1.1.6

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.5
+version: 1.1.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.5"
+version = "1.1.6"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/src/project_init/migration_notes.py
+++ b/src/project_init/migration_notes.py
@@ -15,6 +15,25 @@ from project_init.scaffold import parse_version as _parse  # canonical (2026-07 
 # version -> {"summary": str, "action_required": str | None}
 # Order here is irrelevant — notes are sliced and sorted by parsed version.
 MIGRATION_NOTES: dict[str, dict[str, str | None]] = {
+    "1.1.6": {
+        "summary": (
+            "Fixes two more holes in the branch-protection diagnostic (#825). "
+            "`setup_github.sh` enforces through TWO layers — classic branch "
+            "protection AND (org profile) a `project-init-baseline` repository "
+            "ruleset — and the check read only the first, so a PR blocked solely by "
+            "a stale RULESET check was told 'all required checks are reported'. It "
+            "now unions both layers (paginated). And `setup_github.sh` itself only "
+            "CREATED a ruleset, warning if one already existed — so re-running it, "
+            "the remedy the diagnostic prints, never fixed a stale ruleset. It now "
+            "updates an existing one."
+        ),
+        "action_required": (
+            "Org-profile repos: re-run `.agents/scripts/setup_github.sh --protect` "
+            "(note the flag — without it the script touches neither branch "
+            "protection nor the ruleset). It now re-syncs a stale ruleset instead of "
+            "warning and doing nothing."
+        ),
+    },
     "1.1.5": {
         "summary": (
             "Fixes a FALSE ALARM in the 1.1.4 branch-protection diagnostic (#822). "

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Bump to **1.1.6**. Ships **#826 (PI-825)** — two holes in the branch-protection diagnostic, both of which made it lie.

- **It read only classic branch protection.** `setup_github.sh` enforces through *two* layers — classic protection **and** (org profile) a `project-init-baseline` ruleset. A PR blocked solely by a stale **ruleset** check was told *"all required checks are reported by CI"*. That's a false **reassurance** — worse than the false alarm 1.1.5 fixed, because it certifies a broken config and sends you looking anywhere but the real cause. Now unions both layers, paginated.
- **The remedy was a dead end.** `setup_github.sh` only `POST`ed a ruleset and warned if one existed — it never patched the stale one. So "re-run setup_github.sh", the fix the diagnostic printed, changed nothing. It now updates an existing ruleset, and the message names the required `--protect` flag (without it the script touches neither protection nor the ruleset).

## Verification

Both guards checked against the bugs they guard — the idempotence test fails on the shipped create-only script (*"re-running setup_github.sh cannot fix a stale ruleset, so the remedy is a dead end"*).

`ruff` clean, **2413 passed**.

## After merge

Dispatch `tag-release.yml` with `v1.1.6` to publish to PyPI (ADR-011).