### PR TITLE
fix(PI-833): stop the wizard reading as two conflicting memory questions

### DIFF
--- a/src/project_init/console.py
+++ b/src/project_init/console.py
@@ -96,7 +96,9 @@ def render_presets(
     table = Table(box=box.SIMPLE_HEAD, pad_edge=False, show_edge=False, expand=True)
     table.add_column("#", style="key", width=2, justify="right")
     table.add_column("Preset", style="heading", no_wrap=True)
-    table.add_column("Memory", style="accent", no_wrap=True)
+    # "(default)" signals the stack is a starting point the later memory prompt
+    # refines — not a decision locked in at preset choice (#833).
+    table.add_column("Memory (default)", style="accent", no_wrap=True)
     table.add_column("What you get", style="muted", ratio=1)
     for i, preset in enumerate(presets, 1):
         rec = "  [recommend]✔ recommended[/recommend]" if i == default_idx else ""

--- a/src/project_init/wizard_prompts.py
+++ b/src/project_init/wizard_prompts.py
@@ -122,12 +122,14 @@ def _choose_preset_interactive(presets: list[dict[str, Any]]) -> dict[str, Any]:
     # starting point, so the choice is informed rather than blind.
     console.print(
         Panel(
-            "A [bold]preset[/bold] is your starting bundle — it sets the default "
-            "overlays (memory, lifecycle, toolchain).\n\n"
-            "[cyan]Helps:[/cyan] pick the closest fit, then the prompts below let "
-            "you still decline or add individual pieces.\n"
+            "A [bold]preset[/bold] is your starting bundle — it sets sensible "
+            "defaults for the overlays (lifecycle, memory, toolchain) that the "
+            "prompts below then let you confirm or change one at a time.\n\n"
+            "[cyan]Helps:[/cyan] pick the closest fit; nothing here is locked in "
+            "— each overlay gets its own prompt, so you can still decline or add "
+            "individual pieces.\n"
             '[dim]Default: the recommended obsidian-only preset. "core" is the '
-            "leanest (no memory backend).[/dim]",
+            "leanest.[/dim]",
             title="Preset",
             border_style="cyan",
         )
@@ -345,6 +347,8 @@ def _choose_memory_interactive(default: str = "obsidian-only") -> str:
 
     default_idx = _MEMORY_STACKS.index(default) + 1 if default in _MEMORY_STACKS else 3
     body = (
+        "[dim]Confirm or change the memory backend your preset set up front — "
+        "the default below is that preset's stack, not a fresh choice.[/dim]\n\n"
         "A [bold]memory backend[/bold] gives your agents a place to persist "
         "decisions, conventions, and session notes [bold]across conversations[/bold] "
         "— so context survives beyond a single chat. Everything stays on disk. "


### PR DESCRIPTION
Closes #833

## Problem

The interactive wizard bookended the flow with two memory decisions:

- The **preset** panel headlined memory ("sets the default overlays
  (memory, …)", "core is the leanest (no memory backend)") and the presets
  table gave memory its own dedicated column — so the opening preset choice
  read as a memory choice.
- `_choose_memory_interactive` then asked about memory again ~8 prompts
  later, with no cue that it was refining the earlier choice rather than a
  fresh, conflicting one.

## Fix — reword only

Chosen over reordering/skipping to keep the overlay-prompt cluster
(multi-model / governance / observability / memory / lifecycle) intact and
preserve the always-informed choice (ADR-023). No behavior change — the
preset's stack is still the memory prompt's default.

- **Preset panel:** memory no longer headlines; overlays listed as
  lifecycle/memory/toolchain, with an explicit note that each overlay gets
  its own confirm/change prompt below. Dropped "(no memory backend)" as
  core's differentiator.
- **Presets table:** column renamed `Memory (default)` — the stack reads as a
  starting point the later prompt refines, not a locked-in decision.
- **Memory prompt:** leads with a cue that it confirms/changes the preset's
  stack (the shown default), not a fresh choice.

Existing wizard/console tests (`test_wizard_explanations`, `test_console`)
pass; none pinned the reworded copy.

https://claude.ai/code/session_01QJvV5TrhFeTTu8NTQtD1p1