### PR TITLE
chore: release 1.1.8

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: https://github.com/VytCepas/project-init
 url: https://vytcepas.github.io/project-init/
 license: Apache-2.0
-version: 1.1.7
+version: 1.1.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "project-init"
-version = "1.1.7"
+version = "1.1.8"
 description = "Scaffolder for agentic-development infrastructure inside any project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,6 +1,6 @@
 """project-init — scaffolder for agentic-development infrastructure."""
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "project-init"
-version = "1.1.7"
+version = "1.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Release 1.1.8 — ships the two fixes merged since 1.1.7.

- **fix(PI-832)** (#834): rendered `agent_guard_adapter.py` failed its own
  `ruff format --check`; a fresh multi-agent Python scaffold is now day-one
  green on `just lint`.
- **fix(PI-833)** (#835): reworded the wizard so the preset panel and the
  memory-backend prompt no longer read as two conflicting memory questions.

Version bumped across `pyproject.toml`, `src/project_init/__init__.py`,
`CITATION.cff`, and `uv.lock`. After merge, tag `v1.1.8` (via the Tag Release
workflow) triggers `release.yml` → wheel + GitHub Release + PyPI publish
(trusted publishing, ADR-011). Changelog is generated from Conventional
Commits on the tag.

https://claude.ai/code/session_01QJvV5TrhFeTTu8NTQtD1p1