### PR TITLE
fix(PI-839): post_edit_lint.sh auto-fix races multi-edit sequences: strips imports added one edit before their usage

### DIFF
--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -44,12 +44,19 @@ case "$FILE" in
 *.py)
   # Prefer 'uv run ruff' inside a uv-managed project so the hook uses
   # the same ruff the project itself uses; fall back to a system ruff.
+  #
+  # F401 (unused import) is reported but never auto-fixed here (PI-839):
+  # agents make paired edits — edit k adds an import, edit k+1 adds its
+  # usage — and this hook fires between them, when the import is
+  # momentarily "unused". Auto-removing it turns edit k+1 into F821
+  # undefined-name churn. Genuinely dead imports still fail `just lint`
+  # and pre-commit, where the file set is settled.
   if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
-    uv run ruff check --fix --quiet "$FILE" >/dev/null 2>&1 || true
+    uv run ruff check --fix --unfixable F401 --quiet "$FILE" >/dev/null 2>&1 || true
     uv run ruff format --quiet "$FILE" >/dev/null 2>&1 || true
     ERRORS=$(uv run ruff check --quiet "$FILE" 2>&1 || true)
   elif command -v ruff &>/dev/null; then
-    ruff check --fix --quiet "$FILE" >/dev/null 2>&1 || true
+    ruff check --fix --unfixable F401 --quiet "$FILE" >/dev/null 2>&1 || true
     ruff format --quiet "$FILE" >/dev/null 2>&1 || true
     ERRORS=$(ruff check --quiet "$FILE" 2>&1 || true)
   fi

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -44,12 +44,19 @@ case "$FILE" in
 *.py)
   # Prefer 'uv run ruff' inside a uv-managed project so the hook uses
   # the same ruff the project itself uses; fall back to a system ruff.
+  #
+  # F401 (unused import) is reported but never auto-fixed here (PI-839):
+  # agents make paired edits — edit k adds an import, edit k+1 adds its
+  # usage — and this hook fires between them, when the import is
+  # momentarily "unused". Auto-removing it turns edit k+1 into F821
+  # undefined-name churn. Genuinely dead imports still fail `just lint`
+  # and pre-commit, where the file set is settled.
   if { [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/uv.lock" ]; } && command -v uv &>/dev/null; then
-    uv run ruff check --fix --quiet "$FILE" >/dev/null 2>&1 || true
+    uv run ruff check --fix --unfixable F401 --quiet "$FILE" >/dev/null 2>&1 || true
     uv run ruff format --quiet "$FILE" >/dev/null 2>&1 || true
     ERRORS=$(uv run ruff check --quiet "$FILE" 2>&1 || true)
   elif command -v ruff &>/dev/null; then
-    ruff check --fix --quiet "$FILE" >/dev/null 2>&1 || true
+    ruff check --fix --unfixable F401 --quiet "$FILE" >/dev/null 2>&1 || true
     ruff format --quiet "$FILE" >/dev/null 2>&1 || true
     ERRORS=$(ruff check --quiet "$FILE" 2>&1 || true)
   fi

--- a/tests/contracts/test_post_edit_lint_autofix.py
+++ b/tests/contracts/test_post_edit_lint_autofix.py
@@ -1,0 +1,71 @@
+"""PI-839: post_edit_lint.sh must never auto-remove imports mid-edit-sequence.
+
+Agents make paired edits — edit k adds an import, edit k+1 adds its usage.
+The PostToolUse hook fires between them, when the import is momentarily
+"unused"; auto-applying ruff's F401 fix deletes it and turns edit k+1 into
+F821 undefined-name churn. The hook must leave the import in place and may
+only *report* F401. Runs the real hook script end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FALLBACK_HOOKS = _REPO_ROOT / "templates" / "fallback" / "dot_agents" / "hooks"
+_BASE_HOOKS = _REPO_ROOT / "templates" / "base" / "dot_agents" / "hooks"
+
+
+def _run_hook(file_path: str, cwd: Path) -> dict | None:
+    # post_edit_lint.sh resolves its sibling _py.sh at runtime — reproduce the
+    # scaffolded .agents/hooks/ layout rather than invoking the template in place.
+    hooks_dir = cwd / ".agents" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post_edit_lint.sh"
+    shutil.copy(_FALLBACK_HOOKS / "post_edit_lint.sh", hook)
+    shutil.copy(_BASE_HOOKS / "_py.sh", hooks_dir / "_py.sh")
+
+    payload = json.dumps({"tool_input": {"file_path": file_path}})
+    result = subprocess.run(
+        ["bash", str(hook)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+@pytest.mark.skipif(not shutil.which("ruff"), reason="Needs ruff on PATH")
+def test_unused_import_survives_the_hook(tmp_path: Path):
+    """The import added one edit before its usage must not be stripped."""
+    target = tmp_path / "mod.py"
+    target.write_text('import os\n\nprint("hi")\n')
+    _run_hook(str(target), tmp_path)
+    assert "import os" in target.read_text()
+
+
+@pytest.mark.skipif(not shutil.which("ruff"), reason="Needs ruff on PATH")
+def test_unused_import_is_still_reported(tmp_path: Path):
+    """F401 stays visible as lint context so genuinely dead imports don't rot silently."""
+    target = tmp_path / "mod.py"
+    target.write_text('import os\n\nprint("hi")\n')
+    verdict = _run_hook(str(target), tmp_path)
+    assert verdict is not None and "F401" in verdict["hookSpecificOutput"]["additionalContext"]
+
+
+@pytest.mark.skipif(not shutil.which("ruff"), reason="Needs ruff on PATH")
+def test_other_safe_fixes_still_auto_apply(tmp_path: Path):
+    """Only code-removing F401 is exempt — ordinary safe fixes keep working."""
+    target = tmp_path / "mod.py"
+    # F541: f-string without placeholders — carries a safe autofix.
+    target.write_text('x = f"hi"\nprint(x)\n')
+    _run_hook(str(target), tmp_path)
+    assert 'x = "hi"' in target.read_text()


### PR DESCRIPTION
## Problem

The PostToolUse lint hook auto-applied ruff fixes — including F401 unused-import removal — after **each** Edit/Write. Agents make paired edits (edit *k* adds an import, edit *k+1* its usage); the hook fired between them, deleted the momentarily-unused import, and the next edit produced F821 undefined-name churn. Recurred ~6 times across two working sessions in zarija.

## Fix

`--unfixable F401` on the hook's `ruff check --fix` passes (both the `uv run` and system-ruff branches). The import stays in place; F401 is still **reported** as lint context, and `just lint` / pre-commit still fail on genuinely dead imports, so nothing rots.

Fixed in the template source (`templates/fallback/dot_agents/hooks/post_edit_lint.sh`) and synced to the plugin payload via `tools/sync_plugin.py`. This repo's own `.agents/` does not carry this hook, so no local copy needed the change.

## Verification

- Live check: plain `--fix` strips `import os` from a file where it's unused; `--fix --unfixable F401` preserves it while reporting F401.
- New regression tests (`tests/contracts/test_post_edit_lint_autofix.py`) run the real hook end-to-end: import survives, F401 is reported, and an ordinary safe fix (F541) still auto-applies.
- **Proved the guard can fail**: temporarily reverting the flag fails both new tests.

Closes #839

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR