### PR TITLE
fix(PI-837): monitor_pr.sh deadlocks on a known-dead check (billing-locked GitHub-hosted job); check runs cross-contaminate sibling branches sharing a head commit

### DIFF
--- a/.agents/scripts/gh_host.sh
+++ b/.agents/scripts/gh_host.sh
@@ -80,6 +80,20 @@ review_cycles() {
   printf '%s\n' "${n:-2}"
 }
 
+# Check names monitor_pr.sh treats as informational — reported, never blocking
+# (#837). Echoes the raw single-line JSON array from config.yaml (e.g.
+# ["board-sync"]), or nothing when the key is absent/empty. Use for checks that
+# are known-dead — a billing-locked GitHub-hosted job dies permanently as a
+# zero-step startup failure while self-hosted CI stays green — so one dead
+# check cannot deadlock every PR's merge path. Anchored on this file's
+# location for the same reason gh_profile is.
+monitor_ignore_checks() {
+  local cfg raw=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && raw=$(sed -nE 's/^[[:space:]]*monitor_ignore_checks:[[:space:]]*(\[[^]]*\]).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "$raw"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -29,6 +29,21 @@
 #   Two fix cycles are required before admin-merge is allowed. This ensures
 #   review feedback (including Copilot comments) is read and addressed at
 #   least once before force-merging.
+#
+# Ignored (informational) checks — PI-837:
+#   `monitor_ignore_checks` in .agents/config.yaml (single-line JSON array of
+#   check names; per-run override: PI_MONITOR_IGNORE_CHECKS, comma-separated)
+#   names checks that are reported but never block the merge. Use it for a
+#   known-dead check: during a GitHub Actions billing lockout, GitHub-hosted
+#   jobs die permanently as zero-step startup failures while self-hosted CI
+#   stays green — without this list one dead check deadlocks every PR.
+#
+#   Gotcha: check runs attach to COMMITS, not PRs. A sibling branch created at
+#   the same head commit shares its check rollup — a failure produced by the
+#   other branch's PR events shows up here too (observed: zarija #130/#131).
+#   Remedy when it happens: give the PR a unique head, e.g.
+#     git commit --allow-empty -m "chore: refresh PR head" && push
+#   which clears the stale failure from this PR's rollup.
 
 set -euo pipefail
 
@@ -129,9 +144,32 @@ if [ "$MODE" != "--merge" ]; then
   fi
 fi
 
+# PI-837: checks treated as informational — reported, never blocking.
+# Precedence: PI_MONITOR_IGNORE_CHECKS env (comma-separated) > config.yaml
+# `monitor_ignore_checks` (single-line JSON array) > none. Normalized to a
+# JSON array once, here; a malformed config value fails loudly rather than
+# silently ignoring nothing.
+IGNORE_CHECKS=$("$PY" -c "
+import json, os, sys
+env = os.environ.get('PI_MONITOR_IGNORE_CHECKS', '')
+if env.strip():
+    names = [n.strip() for n in env.split(',') if n.strip()]
+else:
+    raw = sys.argv[1].strip() or '[]'
+    try:
+        names = json.loads(raw)
+        assert isinstance(names, list) and all(isinstance(n, str) for n in names)
+    except Exception:
+        print(f'monitor_ignore_checks in .agents/config.yaml must be a single-line'
+              f' JSON array of check names; got: {raw}', file=sys.stderr)
+        sys.exit(2)
+print(json.dumps(names))
+" "$(monitor_ignore_checks)")
+
 _count_pending() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
 # Exclude review/decision; it is a derived commit status that only appears
 # after a review event. We detect review state directly via reviewDecision.
@@ -139,26 +177,37 @@ data = json.load(sys.stdin)
 # cancel), not a hand-rolled state allowlist: just-queued Actions report
 # state=QUEUED (and WAITING/REQUESTED for env-gated jobs), all bucket=pending.
 # An allowlist that omitted those let the CI-wait break before CI ran (#428).
-print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('bucket') == 'pending'))
-"
+# Ignored checks are excluded too: a check the operator declared informational
+# must not hang the CI wait any more than it may block the merge (PI-837).
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore
+          and c.get('bucket') == 'pending'))
+" "$IGNORE_CHECKS"
 }
 
 _print_failures() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
-bad = [
-    c for c in data
-    if c.get('name') != 'review/decision'
-    and (
+bad, informational = [], []
+for c in data:
+    if c.get('name') == 'review/decision':
+        continue
+    failing = (
         c.get('bucket') in ('fail', 'cancel')
         or c.get('state') in ('FAILURE', 'CANCELLED', 'TIMED_OUT', 'ERROR')
     )
-]
+    if not failing:
+        continue
+    (informational if c.get('name') in ignore else bad).append(c)
+for c in informational:
+    print(f\"  {c['name']}: {c.get('state') or c.get('bucket')} — informational (monitor_ignore_checks), not blocking\")
 for c in bad:
     print(f\"  {c['name']}: {c.get('state') or c.get('bucket')}\")
 sys.exit(len(bad))
-"
+" "$IGNORE_CHECKS"
 }
 
 # Print review feedback — inline comments first, falls back to full PR comments view.

--- a/.claude/scripts/gh_host.sh
+++ b/.claude/scripts/gh_host.sh
@@ -80,6 +80,20 @@ review_cycles() {
   printf '%s\n' "${n:-2}"
 }
 
+# Check names monitor_pr.sh treats as informational — reported, never blocking
+# (#837). Echoes the raw single-line JSON array from config.yaml (e.g.
+# ["board-sync"]), or nothing when the key is absent/empty. Use for checks that
+# are known-dead — a billing-locked GitHub-hosted job dies permanently as a
+# zero-step startup failure while self-hosted CI stays green — so one dead
+# check cannot deadlock every PR's merge path. Anchored on this file's
+# location for the same reason gh_profile is.
+monitor_ignore_checks() {
+  local cfg raw=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && raw=$(sed -nE 's/^[[:space:]]*monitor_ignore_checks:[[:space:]]*(\[[^]]*\]).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "$raw"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -29,6 +29,21 @@
 #   Two fix cycles are required before admin-merge is allowed. This ensures
 #   review feedback (including Copilot comments) is read and addressed at
 #   least once before force-merging.
+#
+# Ignored (informational) checks — PI-837:
+#   `monitor_ignore_checks` in .agents/config.yaml (single-line JSON array of
+#   check names; per-run override: PI_MONITOR_IGNORE_CHECKS, comma-separated)
+#   names checks that are reported but never block the merge. Use it for a
+#   known-dead check: during a GitHub Actions billing lockout, GitHub-hosted
+#   jobs die permanently as zero-step startup failures while self-hosted CI
+#   stays green — without this list one dead check deadlocks every PR.
+#
+#   Gotcha: check runs attach to COMMITS, not PRs. A sibling branch created at
+#   the same head commit shares its check rollup — a failure produced by the
+#   other branch's PR events shows up here too (observed: zarija #130/#131).
+#   Remedy when it happens: give the PR a unique head, e.g.
+#     git commit --allow-empty -m "chore: refresh PR head" && push
+#   which clears the stale failure from this PR's rollup.
 
 set -euo pipefail
 
@@ -129,9 +144,32 @@ if [ "$MODE" != "--merge" ]; then
   fi
 fi
 
+# PI-837: checks treated as informational — reported, never blocking.
+# Precedence: PI_MONITOR_IGNORE_CHECKS env (comma-separated) > config.yaml
+# `monitor_ignore_checks` (single-line JSON array) > none. Normalized to a
+# JSON array once, here; a malformed config value fails loudly rather than
+# silently ignoring nothing.
+IGNORE_CHECKS=$("$PY" -c "
+import json, os, sys
+env = os.environ.get('PI_MONITOR_IGNORE_CHECKS', '')
+if env.strip():
+    names = [n.strip() for n in env.split(',') if n.strip()]
+else:
+    raw = sys.argv[1].strip() or '[]'
+    try:
+        names = json.loads(raw)
+        assert isinstance(names, list) and all(isinstance(n, str) for n in names)
+    except Exception:
+        print(f'monitor_ignore_checks in .agents/config.yaml must be a single-line'
+              f' JSON array of check names; got: {raw}', file=sys.stderr)
+        sys.exit(2)
+print(json.dumps(names))
+" "$(monitor_ignore_checks)")
+
 _count_pending() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
 # Exclude review/decision; it is a derived commit status that only appears
 # after a review event. We detect review state directly via reviewDecision.
@@ -139,26 +177,37 @@ data = json.load(sys.stdin)
 # cancel), not a hand-rolled state allowlist: just-queued Actions report
 # state=QUEUED (and WAITING/REQUESTED for env-gated jobs), all bucket=pending.
 # An allowlist that omitted those let the CI-wait break before CI ran (#428).
-print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('bucket') == 'pending'))
-"
+# Ignored checks are excluded too: a check the operator declared informational
+# must not hang the CI wait any more than it may block the merge (PI-837).
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore
+          and c.get('bucket') == 'pending'))
+" "$IGNORE_CHECKS"
 }
 
 _print_failures() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
-bad = [
-    c for c in data
-    if c.get('name') != 'review/decision'
-    and (
+bad, informational = [], []
+for c in data:
+    if c.get('name') == 'review/decision':
+        continue
+    failing = (
         c.get('bucket') in ('fail', 'cancel')
         or c.get('state') in ('FAILURE', 'CANCELLED', 'TIMED_OUT', 'ERROR')
     )
-]
+    if not failing:
+        continue
+    (informational if c.get('name') in ignore else bad).append(c)
+for c in informational:
+    print(f\"  {c['name']}: {c.get('state') or c.get('bucket')} — informational (monitor_ignore_checks), not blocking\")
 for c in bad:
     print(f\"  {c['name']}: {c.get('state') or c.get('bucket')}\")
 sys.exit(len(bad))
-"
+" "$IGNORE_CHECKS"
 }
 
 # Print review feedback — inline comments first, falls back to full PR comments view.

--- a/plugins/project-init-workflow/skills/local_ci/SKILL.md
+++ b/plugins/project-init-workflow/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/amp/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/amp/dot_agents/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/antigravity/dot_agents/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/base/dot_agents/config.yaml.tmpl
+++ b/templates/base/dot_agents/config.yaml.tmpl
@@ -14,6 +14,7 @@ project:
   project_key: ""          # e.g. "PI" → branches use feat/PI-42-slug, PR titles use feat(PI-42):
   github_project_number: 1 # numeric GitHub Project V2 board number{{#if lifecycle}} — single source of truth read by board-automation.yml, create_issue.sh, and setup_github.sh (#556){{/if lifecycle}}
 {{#if lifecycle}}  review_cycles: {{review_cycles}}       # review-fix passes monitor_pr.sh runs before it stops asking (#714); 0 = no review control, merge on green CI. Override per-run with PI_REVIEW_CYCLES.
+  monitor_ignore_checks: []  # single-line JSON array of check names monitor_pr.sh treats as informational — reported, never blocking (#837), e.g. ["board-sync"] when a GitHub-hosted job is billing-locked while real CI runs self-hosted. Override per-run with PI_MONITOR_IGNORE_CHECKS (comma-separated).
 {{/if lifecycle}}
 
 language: {{language}}            # python | node | go | none

--- a/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
+++ b/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
@@ -77,7 +77,36 @@ parallelism.
   your machine. They cost seconds and fit the free tier once `ci.yml` moves
   off. Do not point them at `CI_RUNS_ON`.
 - The `scorecard` job stays GitHub-hosted (an OSSF requirement).
+{{#if lifecycle}}
+## Known-dead checks during the lockout (PI-837)
 
+The GitHub-hosted workflows above keep **failing permanently** while the
+billing lockout lasts — each run dies as a zero-step `startup_failure`.
+Those failures register as checks on your PRs, and `monitor_pr.sh --merge`
+blocks on any failing check, so one dead check would deadlock every PR even
+though real CI is green on your runner. Name such checks in
+`.agents/config.yaml`:
+
+```yaml
+  monitor_ignore_checks: ["board-sync"]   # reported, never blocking
+```
+
+(or per-run: `PI_MONITOR_IGNORE_CHECKS=board-sync monitor_pr.sh …`). The
+check is still printed — marked informational — and the merge proceeds.
+Remove the entry once billing recovers; the gate reverts to blocking.
+
+**Gotcha — check runs attach to commits, not PRs.** A branch created while
+pointing at the same commit as another PR's head shares that commit's check
+rollup: a failure produced by the sibling's PR events appears on *your* PR
+too, and can re-block it after you already worked around the failure. Remedy:
+give the PR a unique head commit —
+
+```bash
+git commit --allow-empty -m "chore: refresh PR head" && .agents/scripts/push_branch.sh
+```
+
+which clears the stale failure from this PR's rollup.
+{{/if lifecycle}}
 ## Alternatives
 
 Make the repo public (Actions is free), raise the spending limit, or wait for

--- a/templates/base/dot_agents/scripts/gh_host.sh
+++ b/templates/base/dot_agents/scripts/gh_host.sh
@@ -80,6 +80,20 @@ review_cycles() {
   printf '%s\n' "${n:-2}"
 }
 
+# Check names monitor_pr.sh treats as informational — reported, never blocking
+# (#837). Echoes the raw single-line JSON array from config.yaml (e.g.
+# ["board-sync"]), or nothing when the key is absent/empty. Use for checks that
+# are known-dead — a billing-locked GitHub-hosted job dies permanently as a
+# zero-step startup failure while self-hosted CI stays green — so one dead
+# check cannot deadlock every PR's merge path. Anchored on this file's
+# location for the same reason gh_profile is.
+monitor_ignore_checks() {
+  local cfg raw=""
+  cfg="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config.yaml"
+  [ -f "$cfg" ] && raw=$(sed -nE 's/^[[:space:]]*monitor_ignore_checks:[[:space:]]*(\[[^]]*\]).*/\1/p' "$cfg" | head -1)
+  printf '%s\n' "$raw"
+}
+
 # Base branch for feature PRs. Single trunk: the scaffolder pins the rendered
 # workflows (ci.yml, validate-pr.yml) to 'main', so this MUST return 'main' too —
 # resolving the live default branch instead would let start_issue.sh target a

--- a/templates/codex/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/codex/dot_agents/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/fallback/dot_agents/skills/local_ci/SKILL.md
+++ b/templates/fallback/dot_agents/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/junie/dot_junie/skills/local_ci/SKILL.md
+++ b/templates/junie/dot_junie/skills/local_ci/SKILL.md
@@ -56,6 +56,17 @@ intact. Revert any time with `just ci-local-off`.
 **Do not set the variable before the runner is online** — jobs queue forever,
 which is quieter and worse than the billing error.
 
+**Known-dead checks still block merges (PI-837).** The secret/PAT-bearing
+workflows stay GitHub-hosted (see safety rails) and keep failing as zero-step
+`startup_failure` runs while the lockout lasts — and the lifecycle PR merge
+monitor (where installed) blocks on any failing check. Name them in `.agents/config.yaml`, e.g.
+`monitor_ignore_checks: ["board-sync"]` (per-run:
+`PI_MONITOR_IGNORE_CHECKS=board-sync`): they are then reported as
+informational instead of blocking. Remove the entry once billing recovers.
+Note check runs attach to *commits*, not PRs — a stale failure inherited from
+a sibling branch at the same head clears with an empty head-refresh commit
+(details: `.agents/docs/guides/self-hosted-ci-runner.md`).
+
 ## 4. Honest alternatives
 
 - Make the repo **public** — Actions becomes free.

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -29,6 +29,21 @@
 #   Two fix cycles are required before admin-merge is allowed. This ensures
 #   review feedback (including Copilot comments) is read and addressed at
 #   least once before force-merging.
+#
+# Ignored (informational) checks — PI-837:
+#   `monitor_ignore_checks` in .agents/config.yaml (single-line JSON array of
+#   check names; per-run override: PI_MONITOR_IGNORE_CHECKS, comma-separated)
+#   names checks that are reported but never block the merge. Use it for a
+#   known-dead check: during a GitHub Actions billing lockout, GitHub-hosted
+#   jobs die permanently as zero-step startup failures while self-hosted CI
+#   stays green — without this list one dead check deadlocks every PR.
+#
+#   Gotcha: check runs attach to COMMITS, not PRs. A sibling branch created at
+#   the same head commit shares its check rollup — a failure produced by the
+#   other branch's PR events shows up here too (observed: zarija #130/#131).
+#   Remedy when it happens: give the PR a unique head, e.g.
+#     git commit --allow-empty -m "chore: refresh PR head" && push
+#   which clears the stale failure from this PR's rollup.
 
 set -euo pipefail
 
@@ -129,9 +144,32 @@ if [ "$MODE" != "--merge" ]; then
   fi
 fi
 
+# PI-837: checks treated as informational — reported, never blocking.
+# Precedence: PI_MONITOR_IGNORE_CHECKS env (comma-separated) > config.yaml
+# `monitor_ignore_checks` (single-line JSON array) > none. Normalized to a
+# JSON array once, here; a malformed config value fails loudly rather than
+# silently ignoring nothing.
+IGNORE_CHECKS=$("$PY" -c "
+import json, os, sys
+env = os.environ.get('PI_MONITOR_IGNORE_CHECKS', '')
+if env.strip():
+    names = [n.strip() for n in env.split(',') if n.strip()]
+else:
+    raw = sys.argv[1].strip() or '[]'
+    try:
+        names = json.loads(raw)
+        assert isinstance(names, list) and all(isinstance(n, str) for n in names)
+    except Exception:
+        print(f'monitor_ignore_checks in .agents/config.yaml must be a single-line'
+              f' JSON array of check names; got: {raw}', file=sys.stderr)
+        sys.exit(2)
+print(json.dumps(names))
+" "$(monitor_ignore_checks)")
+
 _count_pending() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
 # Exclude review/decision; it is a derived commit status that only appears
 # after a review event. We detect review state directly via reviewDecision.
@@ -139,26 +177,37 @@ data = json.load(sys.stdin)
 # cancel), not a hand-rolled state allowlist: just-queued Actions report
 # state=QUEUED (and WAITING/REQUESTED for env-gated jobs), all bucket=pending.
 # An allowlist that omitted those let the CI-wait break before CI ran (#428).
-print(sum(1 for c in data if c.get('name') != 'review/decision' and c.get('bucket') == 'pending'))
-"
+# Ignored checks are excluded too: a check the operator declared informational
+# must not hang the CI wait any more than it may block the merge (PI-837).
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore
+          and c.get('bucket') == 'pending'))
+" "$IGNORE_CHECKS"
 }
 
 _print_failures() {
   echo "$1" | "$PY" -c "
 import json, sys
+ignore = set(json.loads(sys.argv[1]))
 data = json.load(sys.stdin)
-bad = [
-    c for c in data
-    if c.get('name') != 'review/decision'
-    and (
+bad, informational = [], []
+for c in data:
+    if c.get('name') == 'review/decision':
+        continue
+    failing = (
         c.get('bucket') in ('fail', 'cancel')
         or c.get('state') in ('FAILURE', 'CANCELLED', 'TIMED_OUT', 'ERROR')
     )
-]
+    if not failing:
+        continue
+    (informational if c.get('name') in ignore else bad).append(c)
+for c in informational:
+    print(f\"  {c['name']}: {c.get('state') or c.get('bucket')} — informational (monitor_ignore_checks), not blocking\")
 for c in bad:
     print(f\"  {c['name']}: {c.get('state') or c.get('bucket')}\")
 sys.exit(len(bad))
-"
+" "$IGNORE_CHECKS"
 }
 
 # Print review feedback — inline comments first, falls back to full PR comments view.

--- a/tests/integration/test_monitor_ignore_checks.py
+++ b/tests/integration/test_monitor_ignore_checks.py
@@ -1,0 +1,167 @@
+"""PI-837: a known-dead check must not deadlock monitor_pr.sh --merge.
+
+During a GitHub Actions billing lockout, GitHub-hosted jobs (deliberately kept
+off the self-hosted runner because they carry a PAT) die permanently as
+zero-step startup failures. monitor_pr.sh hard-failed on ANY failed check, so
+one dead check blocked every PR's merge path while real CI was green.
+
+`monitor_ignore_checks` in .agents/config.yaml (env override:
+PI_MONITOR_IGNORE_CHECKS) names checks treated as informational — reported,
+never blocking, and never hanging the CI wait. Runs the real script end-to-end
+against a stubbed gh.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_SCRIPTS = Path(".agents") / "scripts"
+
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"--json headRefName"*) echo "feature false" ;;
+*"--json headRefOid"*) echo "$PI_TEST_SHA" ;;
+*"pr checks"*) echo "$PI_TEST_CHECKS" ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "1" ;;
+*"--json nameWithOwner"*) echo "o/r" ;;
+*"api graphql"*) echo "0" ;;
+*"--json state"*) echo "OPEN" ;;
+*"--json mergeStateStatus"*) echo "CLEAN" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*"pr view"*) echo "" ;;
+*) exit 0 ;;
+esac
+"""
+
+_GIT_STUB = """#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\\trefs/heads/feature\\n' "$PI_TEST_SHA"
+  exit 0
+fi
+exec {real_git} "$@"
+"""
+
+_DEAD_CHECK = (
+    '[{"name":"ci","state":"SUCCESS","bucket":"pass"},'
+    '{"name":"board-sync","state":"FAILURE","bucket":"fail"}]'
+)
+
+
+def _set_ignore_list(target: Path, value: str) -> None:
+    cfg = target / ".agents" / "config.yaml"
+    text = cfg.read_text()
+    assert "monitor_ignore_checks:" in text, "scaffold must render the key"
+    cfg.write_text(
+        re.sub(
+            r"^([ \t]*)monitor_ignore_checks:.*$",
+            rf"\1monitor_ignore_checks: {value}",
+            text,
+            flags=re.M,
+        )
+    )
+
+
+def _run_monitor(
+    tmp_target: Path,
+    tmp_path: Path,
+    *,
+    checks: str,
+    config_ignore: str | None = None,
+    extra_env: dict[str, str] | None = None,
+):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    if config_ignore is not None:
+        _set_ignore_list(tmp_target, config_ignore)
+    stub = tmp_path / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    (stub / "git").write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    (stub / "git").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env["PI_TEST_SHA"] = "a" * 40
+    env["PI_TEST_CHECKS"] = checks
+    env.pop("PI_MONITOR_IGNORE_CHECKS", None)
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["bash", str(tmp_target / _SCRIPTS / "monitor_pr.sh"), "1", "--merge"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_failing_ignored_check_does_not_block_merge(tmp_target: Path, tmp_path: Path):
+    result = _run_monitor(tmp_target, tmp_path, checks=_DEAD_CHECK, config_ignore='["board-sync"]')
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Merged PR #1" in result.stdout
+    assert "informational" in result.stdout
+
+
+def test_failing_unlisted_check_still_blocks(tmp_target: Path, tmp_path: Path):
+    """The guard must still be able to fail — an unlisted failure blocks."""
+    result = _run_monitor(tmp_target, tmp_path, checks=_DEAD_CHECK)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "CI failed" in result.stdout
+    assert "Merged" not in result.stdout
+
+
+def test_env_override_ignores_without_config(tmp_target: Path, tmp_path: Path):
+    result = _run_monitor(
+        tmp_target,
+        tmp_path,
+        checks=_DEAD_CHECK,
+        extra_env={"PI_MONITOR_IGNORE_CHECKS": "board-sync"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Merged PR #1" in result.stdout
+
+
+def test_pending_ignored_check_does_not_hang_the_ci_wait(tmp_target: Path, tmp_path: Path):
+    pending = (
+        '[{"name":"ci","state":"SUCCESS","bucket":"pass"},'
+        '{"name":"board-sync","state":"QUEUED","bucket":"pending"}]'
+    )
+    result = _run_monitor(
+        tmp_target,
+        tmp_path,
+        checks=pending,
+        config_ignore='["board-sync"]',
+        extra_env={"PI_CI_TIMEOUT": "30"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Merged PR #1" in result.stdout
+
+
+def test_malformed_config_value_fails_loudly(tmp_target: Path, tmp_path: Path):
+    result = _run_monitor(tmp_target, tmp_path, checks=_DEAD_CHECK, config_ignore="[board-sync]")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "monitor_ignore_checks" in result.stderr
+
+
+def test_scaffold_renders_the_key_and_gh_host_reads_it(tmp_target: Path):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    _set_ignore_list(tmp_target, '["board-sync", "other"]')
+    result = subprocess.run(
+        ["bash", "-c", ". .agents/scripts/gh_host.sh; monitor_ignore_checks"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        timeout=30,
+        check=False,
+    )
+    assert result.stdout.strip() == '["board-sync", "other"]'


### PR DESCRIPTION
## Problem

`monitor_pr.sh` hard-fails on **any** failed check. During a GitHub Actions billing lockout, GitHub-hosted jobs die permanently as zero-step startup failures — and the scaffold deliberately keeps PAT-bearing jobs (e.g. board-automation's `board-sync`) GitHub-hosted. On a repo running CI through the `CI_RUNS_ON` self-hosted switch, every PR's merge path deadlocked: real CI green, dead check blocking `--merge` forever (observed live: zarija #130/#131). PI-671 covers the checks-never-register half; this is the check-registers-and-fails half.

## Fix

- **`monitor_ignore_checks` in `.agents/config.yaml`** (rendered by the scaffold as `[]`, lifecycle-only): single-line JSON array of check names treated as informational — reported with an explicit "informational (monitor_ignore_checks), not blocking" marker, never blocking the merge, and excluded from the CI pending-wait so a stuck ignored check can't hang the loop either. Per-run override: `PI_MONITOR_IGNORE_CHECKS` (comma-separated), same precedence pattern as `PI_REVIEW_CYCLES`. A malformed config value fails loudly (exit 2) instead of silently ignoring nothing.
- **`gh_host.sh`** gains the `monitor_ignore_checks()` reader (anchored on the script's own location, like `gh_profile`/`review_cycles`).
- **Docs for the commit-attachment gotcha**: check runs attach to commits, not PRs — a sibling branch created at the same head commit cross-contaminates the rollup; remedy is an empty head-refresh commit. Documented in the script header, `self-hosted-ci-runner.md` guide, and the `local_ci` skill (which also now names the ignore-list escape hatch).

Template sources fixed first; `.agents/`+`.claude/` synced via `just sync-agents`/`sync-claude`, plugin payloads via `tools/sync_plugin.py`.

## Verification

- 6 new end-to-end tests (`tests/integration/test_monitor_ignore_checks.py`) run the real script against a stubbed `gh`: ignored failing check merges + prints informational; **unlisted failing check still blocks (exit 1)**; env override works; pending ignored check doesn't hang the CI wait; malformed config exits 2 with a naming message; scaffold renders the key and `gh_host.sh` reads it back.
- **Proved the guard can fail**: swapping in the pre-fix `monitor_pr.sh`, 4 of the 6 tests fail; restored, all pass.
- Full suite: 2431 passed, 6 skipped (one pre-existing env-dependent ollama test deselected locally — it assumes ollama is absent and otherwise does a real model pull; unrelated to this change).
- `shellcheck -S error` clean on both edited scripts.

Closes #837

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR