### PR TITLE
fix(PI-838): Review gate cannot terminate on individual profile when the review agent never responds

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -662,15 +662,27 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     # feedback nobody answered.
     exit 2
   fi
+  # PI-838: the reviewer-absent path must terminate, and say what it is. With
+  # no approval policy the max-cycles→admin-merge branch above (REVIEW_REQUIRED
+  # only) never applies; this branch is the terminal state for a review agent
+  # that never responds — observed live as a quota-limited bot ignoring an
+  # explicit re-request for hours. Name the condition (CI is green; this is
+  # not a CI problem), say what cycle exhaustion does, and name --no-review —
+  # don't imply a convergence that structurally cannot happen.
   if ! _has_review_activity; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
-      echo "PR #$PR_NUMBER: no review has landed after ${REVIEW_TIMEOUT}s."
-      echo "Wait for the review agents, then re-run:"
+      echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
+      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
+      echo "Codex daily cap, may resume later). Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
+      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
       exit 2
     fi
-    echo "PR #$PR_NUMBER: no review landed within $MAX_REVIEW_CYCLES cycles — merging on green CI."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
+    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
+    echo "  follow-up review once the review agent recovers."
   fi
 fi
 

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -662,15 +662,27 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     # feedback nobody answered.
     exit 2
   fi
+  # PI-838: the reviewer-absent path must terminate, and say what it is. With
+  # no approval policy the max-cycles→admin-merge branch above (REVIEW_REQUIRED
+  # only) never applies; this branch is the terminal state for a review agent
+  # that never responds — observed live as a quota-limited bot ignoring an
+  # explicit re-request for hours. Name the condition (CI is green; this is
+  # not a CI problem), say what cycle exhaustion does, and name --no-review —
+  # don't imply a convergence that structurally cannot happen.
   if ! _has_review_activity; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
-      echo "PR #$PR_NUMBER: no review has landed after ${REVIEW_TIMEOUT}s."
-      echo "Wait for the review agents, then re-run:"
+      echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
+      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
+      echo "Codex daily cap, may resume later). Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
+      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
       exit 2
     fi
-    echo "PR #$PR_NUMBER: no review landed within $MAX_REVIEW_CYCLES cycles — merging on green CI."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
+    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
+    echo "  follow-up review once the review agent recovers."
   fi
 fi
 

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -662,15 +662,27 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     # feedback nobody answered.
     exit 2
   fi
+  # PI-838: the reviewer-absent path must terminate, and say what it is. With
+  # no approval policy the max-cycles→admin-merge branch above (REVIEW_REQUIRED
+  # only) never applies; this branch is the terminal state for a review agent
+  # that never responds — observed live as a quota-limited bot ignoring an
+  # explicit re-request for hours. Name the condition (CI is green; this is
+  # not a CI problem), say what cycle exhaustion does, and name --no-review —
+  # don't imply a convergence that structurally cannot happen.
   if ! _has_review_activity; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
-      echo "PR #$PR_NUMBER: no review has landed after ${REVIEW_TIMEOUT}s."
-      echo "Wait for the review agents, then re-run:"
+      echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
+      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
+      echo "Codex daily cap, may resume later). Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
+      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
       exit 2
     fi
-    echo "PR #$PR_NUMBER: no review landed within $MAX_REVIEW_CYCLES cycles — merging on green CI."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
+    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
+    echo "  follow-up review once the review agent recovers."
   fi
 fi
 

--- a/tests/integration/test_reviewer_absent.py
+++ b/tests/integration/test_reviewer_absent.py
@@ -1,0 +1,115 @@
+"""PI-838: the review gate must terminate — loudly — when the reviewer is absent.
+
+On the individual/standalone profile there is no approval policy, so
+`reviewDecision` stays empty and the max-cycles → admin-merge branch (which
+fires only on REVIEW_REQUIRED) never applies. When the review bot goes silent
+(observed live: a quota-limited Codex connector), the no-approval-policy path
+must still reach a terminal state within `review_cycles` — and its messages
+must name the reviewer-absent condition instead of implying a CI problem or
+suggesting a convergence that cannot happen. Runs the real script end-to-end
+against a stubbed gh that never produces a review.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_SCRIPTS = Path(".agents") / "scripts"
+
+# A reviewer that never acts: empty reviewDecision (no approval policy),
+# zero reviews of any state, no unresolved threads, CI green.
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"--json headRefName"*) echo "feature false" ;;
+*"--json headRefOid"*) echo "$PI_TEST_SHA" ;;
+*"pr checks"*) echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]' ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "0" ;;
+*"--json nameWithOwner"*) echo "o/r" ;;
+*"api graphql"*) echo "0" ;;
+*"--json state"*) echo "OPEN" ;;
+*"--json mergeStateStatus"*) echo "CLEAN" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*"pr view"*) echo "" ;;
+*) exit 0 ;;
+esac
+"""
+
+_GIT_STUB = """#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\\trefs/heads/feature\\n' "$PI_TEST_SHA"
+  exit 0
+fi
+exec {real_git} "$@"
+"""
+
+
+def _run_monitor(tmp_target: Path, tmp_path: Path, *, cycle: str):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    stub = tmp_path / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    (stub / "git").write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    (stub / "git").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env["PI_TEST_SHA"] = "a" * 40
+    return subprocess.run(
+        [
+            "bash",
+            str(tmp_target / _SCRIPTS / "monitor_pr.sh"),
+            "1",
+            "--merge",
+            "--review-cycle",
+            cycle,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_terminates_within_the_configured_cycles(tmp_target: Path, tmp_path: Path):
+    """Acceptance criterion 1: a terminal state is reached at cycle == review_cycles."""
+    result = _run_monitor(tmp_target, tmp_path, cycle="2")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Merged PR #1" in result.stdout
+
+
+def test_terminal_merge_carries_a_reviewer_absent_warning(tmp_target: Path, tmp_path: Path):
+    """The solo-dev default: merge, but say REVIEWER ABSENT loudly."""
+    result = _run_monitor(tmp_target, tmp_path, cycle="2")
+    assert "REVIEWER ABSENT" in result.stdout
+
+
+def test_intermediate_cycle_names_the_reviewer_not_ci(tmp_target: Path, tmp_path: Path):
+    """Acceptance criterion 2: the exit-2 message names the reviewer-absent
+    condition and the --no-review escape instead of implying a CI problem.
+    """
+    result = _run_monitor(tmp_target, tmp_path, cycle="0")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "--no-review" in result.stdout
+    assert "review agent has not acted" in result.stdout
+    assert "--review-cycle 1" in result.stdout
+    assert "CI failed" not in result.stdout
+
+
+def test_intermediate_cycle_says_when_the_wait_ends(tmp_target: Path, tmp_path: Path):
+    """The cycle counter must not suggest unbounded convergence — the message
+    states what happens once the cycles are exhausted.
+    """
+    result = _run_monitor(tmp_target, tmp_path, cycle="1")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "REVIEWER ABSENT" in result.stdout


### PR DESCRIPTION
## Premise check (per CLAUDE.md: verify before planning)

Ran the current template's `monitor_pr.sh` end-to-end against a stubbed `gh` (empty `reviewDecision`, zero reviews, green CI) at cycles 0/1/2: cycles 0–1 exit 2, **cycle 2 merges on green CI** — the no-approval-policy path already has a terminal state (landed with PI-714/PI-715), so the issue's 'can never terminate' claim doesn't hold for the current template (or zarija's shipped copy, which contains the same branch). Full trace posted on #838. It *is* true the max-cycles→admin-merge branch fires only on `REVIEW_REQUIRED`; the empty-decision path terminates via its own branch.

## What this PR fixes

1. **Regression coverage** (acceptance criterion 1): four end-to-end tests (`tests/integration/test_reviewer_absent.py`) run the real script against a reviewer that never acts — termination at `review_cycles` is now locked in and cannot silently regress.
2. **Messaging** (acceptance criterion 2): the intermediate exit-2 message said "Wait for the review agents, then re-run" — implying convergence a dead reviewer structurally cannot provide, and reading like a CI problem. It now: names the reviewer-absent condition ("CI is green — the review agent has not acted"), names the likely quota cause, shows the cycle counter, states what happens after the last cycle, and names `--no-review`. The terminal merge is now a loud **`WARNING: REVIEWER ABSENT`** line naming the no-approval-policy condition — the issue's solo-dev default.

No new config knob: "exit instead of merge" already exists structurally (run without `--merge`; `--no-review` to skip the gate; `review_cycles: 0` to merge on green CI immediately).

## Verification

- **Proved the guards can fail**: with the pre-fix script the three message tests fail; the termination test passes on both — by design, it pins existing behavior.
- Adjacent suites green: review gate, review cycles, monitor ignore-checks, quiet frames, template/claude sync contracts, lifecycle-none prose scan (71 passed).
- `shellcheck -S error` clean.

Closes #838

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR