### PR TITLE
docs(PI-840): Self-hosted runner guide: document required host binaries (jq missing = exit-127 jobs masquerading as PR failures)

### DIFF
--- a/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
+++ b/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
@@ -65,15 +65,15 @@ Assumed-present binaries:
 | `git` | checkout, every workflow step that touches the repo | `sudo apt install git` |
 | `curl` | download/API steps | `sudo apt install curl` |
 | `tar`, `gzip` | action tool downloads | usually present |
+| `gh` | `ci.yml`'s post-failure PR comment step runs `gh pr comment` on this runner whenever a PR job fails{{#if lifecycle}}; also the lifecycle workflows, if you route them here{{/if lifecycle}} | [cli.github.com](https://cli.github.com) |
 {{#if lifecycle}}| `jq` | JSON parsing in the lifecycle workflows (`validate-pr`, `board-automation`, `issue-validation`, `review-status`) — bites only if you route those here | `sudo apt install jq` |
-| `gh` | lifecycle workflows only — they default to GitHub-hosted, and the PAT-bearing ones must stay there | [cli.github.com](https://cli.github.com) |
 {{/if lifecycle}}| `shellcheck` | the shell-lint step (preinstalled on GitHub images — **absent on bare hosts**) | `sudo apt install shellcheck` |
 | `docker` | container image jobs, if enabled | [docs.docker.com/engine/install](https://docs.docker.com/engine/install/) |
 
 Preflight a new runner host with:
 
 ```bash
-for b in git curl tar gzip jq shellcheck; do
+for b in git curl tar gzip gh jq shellcheck; do
   command -v "$b" >/dev/null || echo "MISSING: $b"
 done
 ```

--- a/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
+++ b/templates/base/dot_agents/docs/guides/self-hosted-ci-runner.md.tmpl
@@ -42,8 +42,41 @@ enforces it.
    compromised job can't persist on the machine. Re-register per job via a
    small loop or the service.
 
-3. The runner needs your project's toolchain (`uv`/`bun`, `just`, docker if
-   the image jobs are enabled). The first run tells you what's missing.
+3. Install the host prerequisites below. The workflows install most of their
+   own toolchain via pinned actions, so "the first run tells you what's
+   missing" is only half-true — see the next section for the half it doesn't.
+
+## Host prerequisites (PI-840)
+
+The scaffolded workflows provision their own tools where they can (pinned
+actions install `just`, `shfmt`, the language toolchain, gitleaks, semgrep) —
+but they **assume** a few binaries are already on the host, because GitHub's
+`ubuntu-24.04` images preinstall them. A bare box (fresh WSL distro, minimal
+container) does not. The failure mode is nasty: a missing binary kills the
+step with **exit 127** mid-job — `command not found` deep inside a workflow
+step reads as a failure of whatever that step checks, not an environment
+problem (observed live: a missing `jq` on a fresh WSL box masqueraded as a
+PR-metadata failure and cost a debugging detour).
+
+Assumed-present binaries:
+
+| Binary | Used by | Debian/Ubuntu install |
+|---|---|---|
+| `git` | checkout, every workflow step that touches the repo | `sudo apt install git` |
+| `curl` | download/API steps | `sudo apt install curl` |
+| `tar`, `gzip` | action tool downloads | usually present |
+{{#if lifecycle}}| `jq` | JSON parsing in the lifecycle workflows (`validate-pr`, `board-automation`, `issue-validation`, `review-status`) — bites only if you route those here | `sudo apt install jq` |
+| `gh` | lifecycle workflows only — they default to GitHub-hosted, and the PAT-bearing ones must stay there | [cli.github.com](https://cli.github.com) |
+{{/if lifecycle}}| `shellcheck` | the shell-lint step (preinstalled on GitHub images — **absent on bare hosts**) | `sudo apt install shellcheck` |
+| `docker` | container image jobs, if enabled | [docs.docker.com/engine/install](https://docs.docker.com/engine/install/) |
+
+Preflight a new runner host with:
+
+```bash
+for b in git curl tar gzip jq shellcheck; do
+  command -v "$b" >/dev/null || echo "MISSING: $b"
+done
+```
 
 ## Switch CI over
 

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -136,3 +136,6 @@ class TestRunnerGuideHostPrereqs:
         assert "validate-pr" not in content
         assert "board-automation" not in content
         assert "lifecycle workflows" not in content
+        # gh stays unconditional: the base ci.yml's post-failure step runs
+        # `gh pr comment` on this runner (PR #853 review).
+        assert "`gh`" in content

--- a/tests/integration/test_local_ci_skill.py
+++ b/tests/integration/test_local_ci_skill.py
@@ -105,3 +105,34 @@ class TestMonitorLockoutHint:
         assert "local_ci" not in out
         # The pre-existing timeout guidance is intact.
         assert "did not settle" in out
+
+
+class TestRunnerGuideHostPrereqs:
+    """PI-840: the guide names every host binary a scaffolded workflow assumes.
+
+    A fresh runner box missing `jq` failed validate-pr/board-sync steps with
+    exit 127 — which read as a PR-metadata failure, not an environment problem.
+    """
+
+    _GUIDE = Path(".agents") / "docs" / "guides" / "self-hosted-ci-runner.md"
+
+    def test_guide_names_the_assumed_binaries(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        content = (tmp_target / self._GUIDE).read_text()
+        assert "## Host prerequisites" in content
+        for binary in ("`git`", "`curl`", "`jq`", "`shellcheck`", "`gh`", "`docker`"):
+            assert binary in content, f"guide must name {binary}"
+        # The observed failure signature, so the symptom is searchable.
+        assert "exit 127" in content
+        # A copy-pasteable preflight one-liner.
+        assert 'command -v "$b"' in content
+
+    def test_lifecycle_free_guide_omits_lifecycle_workflow_rows(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables(lifecycle_tier="none"))
+        content = (tmp_target / self._GUIDE).read_text()
+        assert "## Host prerequisites" in content
+        # The lifecycle-workflow table rows are conditional; their names would
+        # be dangling references here (test_lifecycle_none.py scans for them).
+        assert "validate-pr" not in content
+        assert "board-automation" not in content
+        assert "lifecycle workflows" not in content


### PR DESCRIPTION
## Problem

The self-hosted-runner guide documents registration and the `CI_RUNS_ON` switch but not the host binaries the scaffolded workflows assume. Observed live: a fresh WSL runner box was missing `jq`, so `validate-pr` and `board-sync` steps died with exit 127 — reading as a PR-metadata failure, not an environment problem.

## Fix

Audited the workflow templates first: the workflows self-provision most tools via pinned actions (`just`, `shfmt`, language toolchains, gitleaks, semgrep), so the missing piece is exactly the set GitHub's `ubuntu-24.04` images preinstall and a bare host lacks. New **Host prerequisites** section in `self-hosted-ci-runner.md.tmpl`:

- table of assumed binaries — `git`, `curl`, `tar`/`gzip`, `jq`, `shellcheck` (explicitly called out as preinstalled-on-GitHub-images/absent-on-bare-hosts), `gh`, `docker` — each with what uses it and an install hint
- the exit-127 failure signature spelled out so the symptom is searchable
- a copy-pasteable preflight loop (covers the issue's optional `runner_preflight.sh` ask without shipping a new script)
- the `jq`/`gh` lifecycle-workflow rows are `{{#if lifecycle}}`-conditional so they don't dangle in a lifecycle-free scaffold (the `test_lifecycle_none.py` prose scan enforces this)

## Verification

- Two new scaffold-into-tmp tests in `test_local_ci_skill.py`: the lifecycle scaffold's guide names every assumed binary + the preflight; the lifecycle-free guide keeps the section but drops the lifecycle rows. **Proved they can fail**: stashing the template change fails both.
- `test_lifecycle_none.py` prose scan green (33 passed with the module).

Closes #840

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR