### PR TITLE
fix: rewrap reviewer-absent echo lines on sentence boundaries

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -673,16 +673,15 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
       echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
-      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
-      echo "Codex daily cap, may resume later). Re-run to give it another window:"
+      echo "CI is green — the review agent has not acted."
+      echo "A quota-limited bot (e.g. a Codex daily cap) may resume later. Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
-      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
-      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds with a REVIEWER ABSENT warning."
+      echo "--no-review skips the review gate entirely."
       exit 2
     fi
-    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
-    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
-    echo "  follow-up review once the review agent recovers."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles and this branch has no approval policy."
+    echo "  Merging on green CI. Consider a follow-up review once the review agent recovers."
   fi
 fi
 

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -673,16 +673,15 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
       echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
-      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
-      echo "Codex daily cap, may resume later). Re-run to give it another window:"
+      echo "CI is green — the review agent has not acted."
+      echo "A quota-limited bot (e.g. a Codex daily cap) may resume later. Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
-      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
-      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds with a REVIEWER ABSENT warning."
+      echo "--no-review skips the review gate entirely."
       exit 2
     fi
-    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
-    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
-    echo "  follow-up review once the review agent recovers."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles and this branch has no approval policy."
+    echo "  Merging on green CI. Consider a follow-up review once the review agent recovers."
   fi
 fi
 

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -673,16 +673,15 @@ if [ -z "$REVIEW_DECISION" ] && [ "$MODE" = "--merge" ]; then
     if [ "$REVIEW_CYCLE" -lt "$MAX_REVIEW_CYCLES" ]; then
       NEXT=$((REVIEW_CYCLE + 1))
       echo "PR #$PR_NUMBER: no review of any state has landed after ${REVIEW_TIMEOUT}s (cycle $REVIEW_CYCLE/$MAX_REVIEW_CYCLES)."
-      echo "CI is green — the review agent has not acted (a quota-limited bot, e.g. a"
-      echo "Codex daily cap, may resume later). Re-run to give it another window:"
+      echo "CI is green — the review agent has not acted."
+      echo "A quota-limited bot (e.g. a Codex daily cap) may resume later. Re-run to give it another window:"
       echo "  .agents/scripts/monitor_pr.sh $PR_NUMBER --merge --review-cycle $NEXT"
-      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds"
-      echo "with a REVIEWER ABSENT warning. --no-review skips the review gate entirely."
+      echo "After cycle $MAX_REVIEW_CYCLES with no review and no approval policy, the merge proceeds with a REVIEWER ABSENT warning."
+      echo "--no-review skips the review gate entirely."
       exit 2
     fi
-    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles"
-    echo "  and this branch has no approval policy. Merging on green CI. Consider a"
-    echo "  follow-up review once the review agent recovers."
+    echo "WARNING: REVIEWER ABSENT — no review of any state landed within $MAX_REVIEW_CYCLES cycles and this branch has no approval policy."
+    echo "  Merging on green CI. Consider a follow-up review once the review agent recovers."
   fi
 fi
 


### PR DESCRIPTION
Follow-up to PI-838, from the PR #853 Copilot review: the reviewer-absent echo lines broke mid-phrase ("e.g. a" / "merge proceeds"), reading awkwardly in terminal output. Rewrapped on sentence boundaries — same information, same phrases the PI-838 regression tests assert on (`test_reviewer_absent.py` green). `.agents/`+`.claude/` mirrors synced.

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR