### PR TITLE
fix: bump project-init-workflow plugin to 0.8.1 so caches pick up the PI-839/PI-837 payload changes

### DIFF
--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.1.8"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.0"
+__plugin_version__ = "0.8.1"
 __repo_url__ = "https://github.com/VytCepas/project-init"


### PR DESCRIPTION
PRs #841 (`post_edit_lint.sh --unfixable F401`) and #851 (`local_ci` skill guidance) changed the `project-init-workflow` plugin payload without bumping its version. Claude Code caches plugin payloads by version, so `claude plugin update` reports *already at the latest version (0.8.0)* and keeps serving the pre-fix hook — observed live while upgrading zarija: marketplace clone at today's head, cached 0.8.0 payload still stripping F401 imports.

Bumped 0.8.0 → 0.8.1 in both lockstep spots (`plugins/project-init-workflow/.claude-plugin/plugin.json` + `__plugin_version__`); the packaging contract test that pins them together passes.

Follow-up worth considering (not in this PR): a contract test that fails when `plugins/` content changes in a commit that doesn't bump the owning plugin's version — this failure mode is silent by construction.

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR