### PR TITLE
fix(PI-858): monitor_pr.sh CI wait can break on an ignored-only check rollup before real CI registers

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -476,7 +476,21 @@ _wait_for_head_sync
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
-  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "import json,sys; print(len(json.load(sys.stdin)))")
+  # PI-858: the "checks registered" guard must count only gate-relevant checks
+  # — the same filter _count_pending applies (no review/decision, no ignored
+  # names). An ignored check registers FIRST in practice (board-sync fires on
+  # PR-open while real CI jobs are still queueing), and a raw length here let
+  # the wait break on that ignored-only rollup: _print_failures then saw no
+  # blocking failure and --merge proceeded with real CI never having run.
+  # If only-ignored checks ever exist, the timeout below fails closed.
+  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "
+import json, sys
+ignore = set(json.loads(sys.argv[1]))
+data = json.load(sys.stdin)
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore))
+" "$IGNORE_CHECKS")
   if [ "$CHECK_COUNT" -gt 0 ] && [ "$(_count_pending "$CHECKS")" -eq 0 ]; then
     break
   fi

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -476,7 +476,21 @@ _wait_for_head_sync
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
-  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "import json,sys; print(len(json.load(sys.stdin)))")
+  # PI-858: the "checks registered" guard must count only gate-relevant checks
+  # — the same filter _count_pending applies (no review/decision, no ignored
+  # names). An ignored check registers FIRST in practice (board-sync fires on
+  # PR-open while real CI jobs are still queueing), and a raw length here let
+  # the wait break on that ignored-only rollup: _print_failures then saw no
+  # blocking failure and --merge proceeded with real CI never having run.
+  # If only-ignored checks ever exist, the timeout below fails closed.
+  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "
+import json, sys
+ignore = set(json.loads(sys.argv[1]))
+data = json.load(sys.stdin)
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore))
+" "$IGNORE_CHECKS")
   if [ "$CHECK_COUNT" -gt 0 ] && [ "$(_count_pending "$CHECKS")" -eq 0 ]; then
     break
   fi

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -476,7 +476,21 @@ _wait_for_head_sync
 CI_ELAPSED=0
 while true; do
   CHECKS=$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>/dev/null) || CHECKS="[]"
-  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "import json,sys; print(len(json.load(sys.stdin)))")
+  # PI-858: the "checks registered" guard must count only gate-relevant checks
+  # — the same filter _count_pending applies (no review/decision, no ignored
+  # names). An ignored check registers FIRST in practice (board-sync fires on
+  # PR-open while real CI jobs are still queueing), and a raw length here let
+  # the wait break on that ignored-only rollup: _print_failures then saw no
+  # blocking failure and --merge proceeded with real CI never having run.
+  # If only-ignored checks ever exist, the timeout below fails closed.
+  CHECK_COUNT=$(echo "$CHECKS" | "$PY" -c "
+import json, sys
+ignore = set(json.loads(sys.argv[1]))
+data = json.load(sys.stdin)
+print(sum(1 for c in data
+          if c.get('name') != 'review/decision'
+          and c.get('name') not in ignore))
+" "$IGNORE_CHECKS")
   if [ "$CHECK_COUNT" -gt 0 ] && [ "$(_count_pending "$CHECKS")" -eq 0 ]; then
     break
   fi

--- a/tests/integration/test_monitor_ignore_checks.py
+++ b/tests/integration/test_monitor_ignore_checks.py
@@ -28,7 +28,17 @@ _GH_STUB = """#!/bin/bash
 case "$*" in
 *"--json headRefName"*) echo "feature false" ;;
 *"--json headRefOid"*) echo "$PI_TEST_SHA" ;;
-*"pr checks"*) echo "$PI_TEST_CHECKS" ;;
+*"pr checks"*)
+  # PI-858 two-phase mode: the first poll answers PI_TEST_CHECKS, later polls
+  # answer PI_TEST_CHECKS_LATE — reproduces an ignored check registering
+  # before the real CI jobs do.
+  if [ -n "${PI_TEST_CHECKS_LATE:-}" ] && [ -f "${PI_TEST_STATE:?}" ]; then
+    echo "$PI_TEST_CHECKS_LATE"
+  else
+    [ -n "${PI_TEST_STATE:-}" ] && : >"$PI_TEST_STATE"
+    echo "$PI_TEST_CHECKS"
+  fi
+  ;;
 *"--json reviewDecision"*) echo "" ;;
 *"--json reviews"*) echo "1" ;;
 *"--json nameWithOwner"*) echo "o/r" ;;
@@ -165,3 +175,38 @@ def test_scaffold_renders_the_key_and_gh_host_reads_it(tmp_target: Path):
         check=False,
     )
     assert result.stdout.strip() == '["board-sync", "other"]'
+
+
+def test_ignored_only_rollup_keeps_waiting_and_fails_closed(tmp_target: Path, tmp_path: Path):
+    """PI-858 (zarija #132 review, P1): an ignored check registers before real CI
+    does — the wait must NOT break on that rollup and merge with CI never run;
+    with no real check ever registering it fails closed on the CI timeout."""
+    only_ignored = '[{"name":"board-sync","state":"FAILURE","bucket":"fail"}]'
+    result = _run_monitor(
+        tmp_target,
+        tmp_path,
+        checks=only_ignored,
+        config_ignore='["board-sync"]',
+        extra_env={"PI_CI_TIMEOUT": "30"},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "did not settle" in result.stdout
+    assert "Merged" not in result.stdout
+
+
+def test_real_check_registering_later_still_merges(tmp_target: Path, tmp_path: Path):
+    """Second phase of the same race: once the real check registers and passes,
+    the merge proceeds normally past the ignored failure."""
+    only_ignored = '[{"name":"board-sync","state":"FAILURE","bucket":"fail"}]'
+    result = _run_monitor(
+        tmp_target,
+        tmp_path,
+        checks=only_ignored,
+        config_ignore='["board-sync"]',
+        extra_env={
+            "PI_TEST_STATE": str(tmp_path / "first-poll-seen"),
+            "PI_TEST_CHECKS_LATE": _DEAD_CHECK,
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Merged PR #1" in result.stdout


### PR DESCRIPTION
## Problem

Follow-up to PI-837, caught by Codex review on zarija PR #132 (**P1**). The CI wait broke on `CHECK_COUNT > 0 && _count_pending == 0` where `CHECK_COUNT` was the raw rollup length but `_count_pending` excludes ignored checks. An ignored check registers **first** in practice — board-sync fires on PR-open while the real CI jobs are still queueing — so the wait broke on the ignored-only rollup, `_print_failures` reported nothing blocking, and `--merge` could proceed with real CI never having run. A premature-merge hole in a fix that shipped hours ago.

## Fix

`CHECK_COUNT` now applies the exact filter `_count_pending` uses (excludes `review/decision` and ignored names). The wait keeps polling until a real check registers; a rollup that only ever contains ignored checks fails closed on the CI timeout — consistent with the existing empty-list guard's philosophy.

## Verification

- New e2e tests: ignored-only rollup → keeps waiting, exits 1 on timeout, never merges; two-phase stub (ignored-only first poll, ignored+passing-CI later) → merges normally.
- **Proved the guard can fail**: stashing the fix fails the fail-closed test (pre-fix code merges on the ignored-only rollup).
- Full adjacent suites green (ignore-checks, reviewer-absent, review-gate, local_ci: 24 passed); shellcheck clean.

Closes #858

https://claude.ai/code/session_017fGBHYbU93F2eidac9GYaR