### PR TITLE
fix(PI-842): fix: MCP servers launch via `bunx` on non-JS scaffolds → ENOENT

### DIFF
--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -78,6 +78,7 @@ Deterministic AIBOM generation for the governance overlay (ADR-018, #412).
 
 MCP catalog and emit helpers for the project-init wizard.
 
+- `def resolve_js_runner` — The JS package runner the scaffolded toolchain actually has (#842).
 - `def servers_for_ids` — Canonical MCP server specs for the given catalog ids.
 - `def format_installed_mcps` — Human-readable comma-separated list for template substitution.
 - `def format_installed_mcps_yaml` — Inline YAML list string for config.yaml template.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -78,6 +78,7 @@ Deterministic AIBOM generation for the governance overlay (ADR-018, #412).
 
 MCP catalog and emit helpers for the project-init wizard.
 
+- `def resolve_js_runner` — The JS package runner the scaffolded toolchain actually has (#842).
 - `def servers_for_ids` — Canonical MCP server specs for the given catalog ids.
 - `def format_installed_mcps` — Human-readable comma-separated list for template substitution.
 - `def format_installed_mcps_yaml` — Inline YAML list string for config.yaml template.

--- a/src/project_init/capabilities.py
+++ b/src/project_init/capabilities.py
@@ -15,7 +15,7 @@ import re
 import sys
 from pathlib import Path
 
-from project_init.mcps import servers_for_ids
+from project_init.mcps import resolve_js_runner, servers_for_ids
 from project_init.scaffold import _TEMPLATES_DIR
 
 _NAME_RE = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
@@ -202,7 +202,7 @@ def render(variables: dict[str, str]) -> str:
     """The CAPABILITIES.md content for a scaffold described by *variables*."""
     skills = canonical_skills(variables)
     hooks = canonical_hooks(variables)
-    servers = servers_for_ids(_mcp_ids(variables))
+    servers = servers_for_ids(_mcp_ids(variables), js_runner=resolve_js_runner(variables))
 
     lines = [
         "# Capabilities",

--- a/src/project_init/cli_output.py
+++ b/src/project_init/cli_output.py
@@ -130,7 +130,7 @@ def _emit_scaffold_output(  # noqa: PLR0913 — one arg per piece of the result
     _print_summary(target, created, preset["name"], variables.get("memory_stack", "none"))
     if conflicts:
         _print_conflicts(conflicts)
-    _print_mcp_commands(inputs.selected_mcps)
+    _print_mcp_commands(inputs.selected_mcps, js_runner="bunx" if variables.get("node") else "npx")
 
 
 def _emit_preset_list(presets: list[dict[str, Any]], *, as_json: bool) -> None:
@@ -302,14 +302,18 @@ def _print_conflicts(conflicts: list[tuple[Path, Path]]) -> None:
     console.print()
 
 
-def _print_mcp_commands(selected: list[dict[str, Any]]) -> None:
-    """Print the bare claude mcp add commands for the chosen MCPs."""
+def _print_mcp_commands(selected: list[dict[str, Any]], js_runner: str = "bunx") -> None:
+    """Print the bare claude mcp add commands for the chosen MCPs.
+
+    #842: the catalog is written with bunx; swap in the runner the scaffolded
+    toolchain actually has so the printed command works as pasted.
+    """
     if not selected:
         return
 
     from rich.panel import Panel
 
-    body = "\n".join(m["command"] for m in selected)
+    body = "\n".join(m["command"].replace(" bunx ", f" {js_runner} ") for m in selected)
     console.print(
         Panel(
             body,

--- a/src/project_init/governance.py
+++ b/src/project_init/governance.py
@@ -19,7 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, servers_for_ids
+from project_init.mcps import MCP_CATALOG, PLAYWRIGHT_MCP, resolve_js_runner, servers_for_ids
 
 _OUTPUT_REL = Path(".agents/governance/ai-bom.generated.md")
 _CCR_CONFIG_REL = Path(".agents/multi-model/config.json")
@@ -85,7 +85,7 @@ def render_aibom(detect_root: Path, variables: dict[str, str]) -> str:
     """
     by_id = {m["id"]: m for m in MCP_CATALOG}
     by_id[PLAYWRIGHT_MCP["id"]] = PLAYWRIGHT_MCP
-    servers = servers_for_ids(_mcp_ids(variables))
+    servers = servers_for_ids(_mcp_ids(variables), js_runner=resolve_js_runner(variables))
 
     lines: list[str] = [
         _GENERATED_HEADER,

--- a/src/project_init/mcps.py
+++ b/src/project_init/mcps.py
@@ -1,7 +1,9 @@
 """MCP catalog and emit helpers for the project-init wizard.
 
-All commands use bunx (bun's npx equivalent) — no npm/npx anywhere.
-PI-15 (replace npx with bun) is satisfied by construction here.
+Catalog entries are written with bunx (bun's npx equivalent — PI-15). #842:
+bun only exists on a node scaffold's toolchain, so the emitted configs and the
+printed install commands swap in the requested JS runner (npx elsewhere —
+present wherever node is) via ``servers_for_ids``/``resolve_js_runner``.
 """
 
 from __future__ import annotations
@@ -54,11 +56,22 @@ PLAYWRIGHT_MCP: dict[str, Any] = {
 }
 
 
-def servers_for_ids(ids: list[str]) -> dict[str, dict[str, Any]]:
+def resolve_js_runner(variables: dict[str, str]) -> str:
+    """The JS package runner the scaffolded toolchain actually has (#842).
+
+    bunx on a node scaffold (bun is the project convention, PI-15); npx
+    everywhere else — a python/go/rust scaffold never installs bun, so a bunx
+    launcher fails every MCP start with ENOENT.
+    """
+    return "bunx" if variables.get("node") else "npx"
+
+
+def servers_for_ids(ids: list[str], js_runner: str = "bunx") -> dict[str, dict[str, Any]]:
     """Canonical MCP server specs for the given catalog ids.
 
     Returns ``{name: {command,args}|{url}}`` — the source the per-surface
-    generators render from (PI-366).
+    generators render from (PI-366). ``js_runner`` replaces the catalog's
+    bunx launcher for toolchains without bun (#842).
     """
     by_id: dict[str, dict[str, Any]] = {m["id"]: m for m in MCP_CATALOG}
     by_id[PLAYWRIGHT_MCP["id"]] = PLAYWRIGHT_MCP
@@ -67,7 +80,10 @@ def servers_for_ids(ids: list[str]) -> dict[str, dict[str, Any]]:
     for i in ids:
         entry = by_id.get(i)
         if entry and entry.get("server"):
-            out[i] = dict(entry["server"])
+            spec = dict(entry["server"])
+            if spec.get("command") == "bunx":
+                spec["command"] = js_runner
+            out[i] = spec
         elif i not in by_id:
             # A typo'd or renamed catalog id would otherwise vanish silently from
             # every surface's MCP config; surface it (2026-07 review).

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -1050,7 +1050,7 @@ def _emit_generated_files(
     scaffold/upgrade so they cannot drift.
     """
     from project_init import capabilities, surfaces
-    from project_init.mcps import servers_for_ids
+    from project_init.mcps import resolve_js_runner, servers_for_ids
 
     agents = [a.strip() for a in variables.get("agents", "").split(",") if a.strip()]
     mcp_raw = variables.get("installed_mcps", "none")
@@ -1061,7 +1061,7 @@ def _emit_generated_files(
     created = surfaces.emit(
         target,
         agents=agents,
-        servers=servers_for_ids(mcp_ids),
+        servers=servers_for_ids(mcp_ids, js_runner=resolve_js_runner(variables)),
         conflicts=conflicts,
     )
     # Surface-independent capabilities inventory (PI-374).

--- a/tests/contracts/test_capabilities.py
+++ b/tests/contracts/test_capabilities.py
@@ -57,7 +57,8 @@ def test_skills_and_hooks_and_mcp_listed(tmp_path: Path):
     assert "| SessionStart | session_setup.sh |" in text
     assert "| UserPromptSubmit | workflow_state_reminder.sh |" in text
     # The selected MCP server + its invocation.
-    assert "| context7 | bunx @upstash/context7-mcp |" in text
+    # PI-842: a python-language scaffold's toolchain has no bun — npx.
+    assert "| context7 | npx @upstash/context7-mcp |" in text
 
 
 def test_base_skill_plan_is_listed(tmp_path: Path):

--- a/tests/contracts/test_mcp_js_runner.py
+++ b/tests/contracts/test_mcp_js_runner.py
@@ -1,0 +1,47 @@
+"""PI-842: MCP launchers must use a JS runner the scaffolded toolchain has.
+
+The catalog is written with bunx (bun is the project convention on node
+scaffolds, PI-15) — but a python/go/rust scaffold never installs bun, so every
+MCP server died at start with ENOENT. Non-node scaffolds now emit npx.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from project_init.mcps import resolve_js_runner, servers_for_ids
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+
+def _mcp_command(tmp_path: Path, **overrides: str) -> str:
+    scaffold(
+        tmp_path,
+        fallback_preset(),
+        fallback_variables(installed_mcps="context7", **overrides),
+    )
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    return config["mcpServers"]["context7"]["command"]
+
+
+def test_python_scaffold_launches_mcps_via_npx(tmp_path: Path):
+    assert _mcp_command(tmp_path) == "npx"
+
+
+def test_node_scaffold_keeps_bunx(tmp_path: Path):
+    assert _mcp_command(tmp_path, language="node", node="true", python="") == "bunx"
+
+
+def test_resolve_js_runner_follows_the_node_flag():
+    assert resolve_js_runner({"node": "true"}) == "bunx"
+    assert resolve_js_runner({"node": ""}) == "npx"
+    assert resolve_js_runner({}) == "npx"
+
+
+def test_servers_for_ids_swaps_only_the_bunx_command():
+    servers = servers_for_ids(["context7", "context7-http"], js_runner="npx")
+    assert servers["context7"]["command"] == "npx"
+    # HTTP entries carry no command — must pass through untouched.
+    assert "command" not in servers["context7-http"]
+    assert servers["context7-http"]["url"].startswith("https://")

--- a/tests/contracts/test_surface_emission.py
+++ b/tests/contracts/test_surface_emission.py
@@ -54,7 +54,8 @@ def test_emitted_content_matches_canonical_source(tmp_path: Path):
     """Drift guard: every generated file equals what surfaces.planned_files
     would render — so editing a renderer without regenerating can't pass."""
     agents = ["claude", "codex", "cursor", "antigravity", "vscode"]
-    servers = servers_for_ids(["context7"])
+    # PI-842: the fixture scaffold is language=python — npx, not bunx.
+    servers = servers_for_ids(["context7"], js_runner="npx")
     t = _scaffold(tmp_path / "p", agents=",".join(agents), installed_mcps="context7")
     for rel, content in surfaces.planned_files(agents, servers).items():
         assert (t / rel).read_text() == content, f"{rel} drifted from canonical source"


### PR DESCRIPTION
Closes #842