### PR TITLE
fix(PI-849): fix: rag.md rule loads full RAG-stack description even when RAG is not wired

### DIFF
--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -159,6 +159,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 project-init variable resolution: flag→prompt→preset precedence + template context.
 
 - `class ScaffoldInputs` — The resolved wizard inputs as one named record (PI-190).
+- `def rag_gate_variables` — The rag_wired/rag_unwired template gates (#849).
 - `def resolve_delivery` — Normalize a delivery value; default 'prototype'.
 - `def resolve_deploy` — Normalize a deploy target; default 'none'.
 - `def resolve_iac` — Normalize an --iac value; default 'none'. Raises ValueError on an unknown tool.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -159,6 +159,7 @@ Per-surface agent-config generation (ADR-017, PI-366).
 project-init variable resolution: flag→prompt→preset precedence + template context.
 
 - `class ScaffoldInputs` — The resolved wizard inputs as one named record (PI-190).
+- `def rag_gate_variables` — The rag_wired/rag_unwired template gates (#849).
 - `def resolve_delivery` — Normalize a delivery value; default 'prototype'.
 - `def resolve_deploy` — Normalize a deploy target; default 'none'.
 - `def resolve_iac` — Normalize an --iac value; default 'none'. Raises ValueError on an unknown tool.

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -693,6 +693,11 @@ def _migrate_semantic_config(lines: list[str]) -> tuple[str, dict[str, str], dic
         "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "rag": "true" if "rag" in stack else "",
+        # #849: pre-record/legacy paths carry no target to probe — emit the
+        # conservative unwired gate; read_scaffold_record recomputes from the
+        # live rag_endpoint right after.
+        "rag_wired": "",
+        "rag_unwired": "true" if "rag" in stack else "",
         "memory": "" if stack == "none" else "true",
         "memory_tier": memory_tier(stack),
         # Lifecycle (#476): a pre-record config ALWAYS shipped the GitHub
@@ -789,6 +794,11 @@ def _backfill_variables(variables: dict[str, str]) -> dict[str, str]:
         "graphify": "true" if "graphify" in stack else "",
         "obsidian": "true" if "obsidian" in stack else "",
         "rag": "true" if "rag" in stack else "",
+        # #849: pre-record/legacy paths carry no target to probe — emit the
+        # conservative unwired gate; read_scaffold_record recomputes from the
+        # live rag_endpoint right after.
+        "rag_wired": "",
+        "rag_unwired": "true" if "rag" in stack else "",
         # Memory gate (#466): "" only for the vault-free `none` stack. The
         # obsidian/graphify substring checks already yield "" for none.
         "memory": "" if stack == "none" else "true",
@@ -924,6 +934,11 @@ def read_scaffold_record(target: Path) -> tuple[str, dict[str, str], dict[str, s
     floor = _python_floor_from_pyproject(target)
     if floor:
         variables["python_floor"] = floor
+    # #849: the rag.md rule gates on the live rag_endpoint value — recompute so
+    # wiring RAG (or a legacy record with no gate variables) re-renders right.
+    from project_init.variables import rag_gate_variables
+
+    variables.update(rag_gate_variables(variables.get("memory_stack", ""), target))
 
     return preset_name, variables, manifest, migrated
 

--- a/src/project_init/variables.py
+++ b/src/project_init/variables.py
@@ -114,6 +114,30 @@ class ScaffoldInputs:
 SUPPORTED_PYTHON_VERSIONS: tuple[str, ...] = ("3.11", "3.12", "3.13", "3.14")
 
 
+def rag_gate_variables(memory_stack: str, target: Path | None) -> dict[str, str]:
+    """The rag_wired/rag_unwired template gates (#849).
+
+    The full rag.md rule (~1.9KB) auto-loads every session, but until
+    `memory.rag_endpoint` is set in .agents/config.yaml the stack it describes
+    isn't wired — emit a one-line pointer instead. rag_endpoint is the durable
+    signal setup_rag.sh tells the operator to set (the index cache itself is
+    gitignored, so it can't gate re-renders on a fresh clone).
+    """
+    is_rag = memory_stack == "obsidian-graphify-rag"
+    wired = False
+    if is_rag and target:
+        cfg = target / ".agents" / "config.yaml"
+        if cfg.exists():
+            import re
+
+            m = re.search(r"(?m)^\s*rag_endpoint:([^#\n]*)", cfg.read_text(encoding="utf-8"))
+            wired = bool(m and m.group(1).strip())
+    return {
+        "rag_wired": "true" if (is_rag and wired) else "",
+        "rag_unwired": "true" if (is_rag and not wired) else "",
+    }
+
+
 def _python_floor_from_pyproject(target: Path | None) -> str | None:
     """The requires-python floor declared by an existing pyproject.toml, if any.
 
@@ -504,6 +528,7 @@ def _build_variables(
     )
 
     return {
+        **rag_gate_variables(memory_stack, target),
         "python_floor": python_floor,
         # #714: read back by gh_host.sh's review_cycles(); only rendered under
         # the {{#if lifecycle}} gate in config.yaml.tmpl.

--- a/templates/rag/dot_agents/rules/rag.md.tmpl
+++ b/templates/rag/dot_agents/rules/rag.md.tmpl
@@ -1,4 +1,4 @@
----
+{{#if rag_wired}}---
 description: RAG memory (tier 3) — a semantic recall surface, authoritative for nothing
 globs: [".agents/scripts/setup_rag.sh", ".agents/config.yaml"]
 alwaysApply: false
@@ -30,3 +30,14 @@ sqlite-vec cache in `.cocoindex_code/`.
 - **The index is a derived, gitignored cache** — never a source of truth, never
   committed, never hand-edited. Rebuild it from the corpus (`ccc index`), don't
   curate it.
+{{/if rag_wired}}{{#if rag_unwired}}---
+description: RAG memory (tier 3) — selected but not wired yet
+globs: [".agents/scripts/setup_rag.sh", ".agents/config.yaml"]
+alwaysApply: false
+---
+
+RAG (tier 3) is selected but **not set up**: run `.agents/scripts/setup_rag.sh`,
+then set `memory.rag_endpoint` in `.agents/config.yaml` and re-run
+`project-init upgrade --apply` to expand this rule into the full guidance.
+Until then use the graph + grep; details: `.agents/docs/guides/using-rag.md`.
+{{/if rag_unwired}}

--- a/templates/rag/dot_agents/scripts/setup_rag.sh
+++ b/templates/rag/dot_agents/scripts/setup_rag.sh
@@ -101,6 +101,8 @@ Expose it to agents over MCP (see .agents/rules/rag.md):
 
 Record the endpoint so a root orchestrator can discover it (#498):
   in .agents/config.yaml set  memory.rag_endpoint: "ccc mcp"   (or the index path)
+  then re-run `project-init upgrade --apply` — that expands .agents/rules/rag.md
+  from the not-wired-yet stub into the full RAG guidance (#849)
 
 The .cocoindex_code/ index is a derived cache — gitignored, never hand-edited.
 Re-run this script any time to rebuild after large code changes.

--- a/tests/contracts/test_rag_rule_gate.py
+++ b/tests/contracts/test_rag_rule_gate.py
@@ -1,0 +1,68 @@
+"""PI-849: the full rag.md rule loads only once RAG is actually wired.
+
+The tier-3 rule (~1.9KB) auto-loads every session, but until
+`memory.rag_endpoint` is set the stack it describes doesn't exist — a fresh
+tier-3 scaffold now gets a one-line pointer stub; setting the endpoint and
+re-running upgrade expands it to the full guidance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_init.scaffold import load_preset, overlay_layers, scaffold
+from project_init.variables import rag_gate_variables
+from tests.helpers import make_variables
+
+_STACK = "obsidian-graphify-rag"
+
+
+def _rag_scaffold(target: Path, **overrides: str) -> Path:
+    preset = load_preset("obsidian-only")
+    extra = overlay_layers("claude", no_plugin=False, memory_stack=_STACK)
+    preset = {**preset, "layers": [*preset["layers"], *extra]}
+    variables = make_variables(
+        memory_stack=_STACK,
+        obsidian="true",
+        graphify="true",
+        rag="true",
+        **rag_gate_variables(_STACK, target),
+        **overrides,
+    )
+    scaffold(target, preset, variables)
+    return target / ".agents" / "rules" / "rag.md"
+
+
+def test_unwired_tier3_gets_the_stub(tmp_path: Path):
+    rule = _rag_scaffold(tmp_path / "p")
+    text = rule.read_text()
+    assert "not set up" in text
+    assert "setup_rag.sh" in text
+    # The full stack description must NOT load before wiring.
+    assert "recall surface, authoritative for nothing" not in text
+    assert len(text) < 700, "the stub must stay a pointer, not a treatise"
+
+
+def test_wired_tier3_gets_the_full_rule(tmp_path: Path):
+    target = tmp_path / "p"
+    target.mkdir()
+    (target / ".agents").mkdir()
+    (target / ".agents" / "config.yaml").write_text(
+        'memory:\n  tier: 3\n  rag_endpoint: "ccc mcp"\n'
+    )
+    rule = _rag_scaffold(target)
+    text = rule.read_text()
+    assert "recall surface, authoritative for nothing" in text
+    assert "not set up" not in text.split("---", 2)[1]  # frontmatter clean
+
+
+def test_gate_variables_follow_the_endpoint(tmp_path: Path):
+    assert rag_gate_variables(_STACK, None) == {"rag_wired": "", "rag_unwired": "true"}
+    assert rag_gate_variables("obsidian-only", None) == {"rag_wired": "", "rag_unwired": ""}
+    target = tmp_path
+    (target / ".agents").mkdir()
+    cfg = target / ".agents" / "config.yaml"
+    cfg.write_text("memory:\n  rag_endpoint:        # empty = not wired yet\n")
+    assert rag_gate_variables(_STACK, target)["rag_unwired"] == "true"
+    cfg.write_text('memory:\n  rag_endpoint: "ccc mcp"\n')
+    assert rag_gate_variables(_STACK, target) == {"rag_wired": "true", "rag_unwired": ""}


### PR DESCRIPTION
Closes #849