### PR TITLE
fix(PI-846): fix: graphify hook-guard matcher too broad — fires on every Bash/Read/Glob incl. non-source tasks

### DIFF
--- a/templates/graphify/dot_agents/hooks/graphify_guard.sh
+++ b/templates/graphify/dot_agents/hooks/graphify_guard.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# graphify_guard.sh <search|read> — scoped replacement for the PreToolUse
+# hooks `graphify install --project` writes (PI-846).
+#
+# The installer's own matchers fire on EVERY Bash command containing a search
+# word and every Read/Glob touching ~30 extensions (including .md/.txt), ~50
+# injected tokens per call — noise on config audits and non-source work.
+# setup_graphify.sh swaps the installer's hook commands for this script, which
+# nudges only when all of these hold:
+#   * graphify-out/graph.json exists (the graph is built),
+#   * the tool call actually targets SOURCE CODE — code extensions only, and
+#     never paths under .agents/, .claude/, docs/, graphify-out/, vendored or
+#     lock/config files,
+#   * the nudge has not already fired this session (stamp keyed on the hook
+#     payload's session_id — advisory once per session, not per call).
+#
+# Fail-open by design: any parse problem exits 0 silently.
+
+set -euo pipefail
+
+MODE="${1:-read}"
+
+[ -f graphify-out/graph.json ] || exit 0
+
+INPUT=$(cat)
+
+# Resolve the interpreter through the canonical helper (PI-361).
+PYRES="$(dirname "$0")/_py.sh"
+
+GRAPHIFY_HOOK_INPUT="$INPUT" "$PYRES" - "$MODE" <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+mode = sys.argv[1]
+try:
+    payload = json.loads(os.environ.get("GRAPHIFY_HOOK_INPUT") or "{}")
+except Exception:
+    sys.exit(0)
+
+tool_input = payload.get("tool_input") or {}
+
+# Once per session: the payload carries session_id; no id → treat as unstamped.
+session = str(payload.get("session_id") or "")
+stamp = os.path.join(
+    tempfile.gettempdir(), f"graphify-guard-{session or os.getppid()}"
+)
+if os.path.exists(stamp):
+    sys.exit(0)
+
+CODE_EXTS = (
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".go", ".rs", ".java", ".rb",
+    ".c", ".h", ".cpp", ".hpp", ".cc", ".cs", ".kt", ".swift", ".php",
+    ".scala", ".lua",
+)
+EXCLUDED_PARTS = (
+    ".agents/", ".claude/", "docs/", "graphify-out/", "node_modules/",
+    ".venv/", "vendor/",
+)
+
+def is_source_target(text: str) -> bool:
+    text = text.lower().replace("\\", "/")
+    if any(part in text for part in EXCLUDED_PARTS):
+        return False
+    return any(ext in text for ext in CODE_EXTS)
+
+if mode == "search":
+    command = str(tool_input.get("command") or "")
+    search_words = ("grep", "rg ", "ripgrep", "find ", "fd ", "ack ", "ag ")
+    if not any(w in command for w in search_words):
+        sys.exit(0)
+    # A search naming no path at all is a broad sweep over the repo — nudge;
+    # one naming an excluded/non-source target is not our business.
+    if any(part in command.lower() for part in EXCLUDED_PARTS):
+        sys.exit(0)
+else:
+    target = " ".join(
+        str(tool_input.get(k) or "") for k in ("file_path", "pattern", "path")
+    )
+    if not is_source_target(target):
+        sys.exit(0)
+
+try:
+    open(stamp, "w").close()
+except Exception:
+    pass
+
+context = (
+    "graphify-out/graph.json exists — for codebase orientation, prefer "
+    "`graphify query \"<question>\"` (scoped subgraph), `graphify path`, or "
+    "`graphify explain` before sweeping raw files; grep/read directly when "
+    "modifying or debugging specific lines. Workflow: .agents/rules/graphify.md "
+    "(advisory, shown once per session)."
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": context,
+    }
+}))
+PY
+
+exit 0

--- a/templates/graphify/dot_agents/hooks/graphify_post_install.py
+++ b/templates/graphify/dot_agents/hooks/graphify_post_install.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tighten what `graphify install --project` wrote (PI-846 / PI-850).
+
+Run by setup_graphify.sh right after the installer. Two fixups, both
+fail-open (a shape the tool no longer produces is reported, never fatal):
+
+1. PI-846 — the installer wires PreToolUse hooks on `Bash` and `Read|Glob`
+   whose own matching is substring-broad (every command containing "grep",
+   every read of ~30 extensions incl. .md/.txt) and fires per call. Replace
+   those hook commands with `.agents/hooks/graphify_guard.sh`, which scopes
+   to genuine source-code activity and nudges once per session.
+
+2. PI-850 — the installer appends a full `## graphify` workflow section to
+   the root CLAUDE.md; the same guidance auto-loads from
+   `.agents/rules/graphify.md` (its single home). Trim the CLAUDE.md section
+   to a one-line pointer. The `.claude/CLAUDE.md` /graphify skill-routing
+   stub is functional wiring, not workflow duplication — left alone.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+GUARD = '"$CLAUDE_PROJECT_DIR"/.agents/hooks/graphify_guard.sh'
+
+POINTER = (
+    "## graphify\n\n"
+    "Knowledge-graph workflow (query before grep, `graphify update .` after\n"
+    "changes, never hand-edit `graphify-out/`): see `.agents/rules/graphify.md`.\n"
+)
+
+
+def tighten_settings(settings_path: Path) -> str:
+    if not settings_path.exists():
+        return "settings.json not found — skipped"
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return "settings.json unparsable — left untouched"
+    replaced = 0
+    for entry in settings.get("hooks", {}).get("PreToolUse", []):
+        matcher = entry.get("matcher", "")
+        for hook in entry.get("hooks", []):
+            command = hook.get("command", "")
+            # The installer's hooks are the ones that mention the graph file
+            # inline; ours reference the guard script instead.
+            if "graphify-out/graph.json" in command and "graphify_guard" not in command:
+                mode = "search" if matcher == "Bash" else "read"
+                hook["command"] = f"bash {GUARD} {mode}"
+                replaced += 1
+    if replaced:
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+        return f"scoped {replaced} graphify hook(s) to source-code activity"
+    return "no installer-shaped graphify hooks found — nothing to tighten"
+
+
+def trim_claude_md(claude_md: Path) -> str:
+    if not claude_md.exists():
+        return "CLAUDE.md not found — skipped"
+    text = claude_md.read_text(encoding="utf-8")
+    if "## graphify" not in text:
+        return "no ## graphify section — nothing to trim"
+    if ".agents/rules/graphify.md" in text:
+        return "CLAUDE.md already points at the rule — nothing to trim"
+    # The section runs to the next H2 or EOF.
+    new_text, n = re.subn(r"## graphify\n.*?(?=\n## |\Z)", POINTER, text, count=1, flags=re.S)
+    if n:
+        claude_md.write_text(new_text, encoding="utf-8")
+        return "trimmed CLAUDE.md ## graphify to a pointer at the rule"
+    return "## graphify section shape unrecognized — left untouched"
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    print(f"  {tighten_settings(root / '.claude' / 'settings.json')}")
+    print(f"  {trim_claude_md(root / 'CLAUDE.md')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/graphify/dot_agents/rules/graphify.md
+++ b/templates/graphify/dot_agents/rules/graphify.md
@@ -8,6 +8,11 @@ alwaysApply: false
 
 - Context lookup order: `graphify-out/graph.json` → vault notes → raw code.
   Query the graph before grepping the codebase; it is rebuilt per commit.
+- Query forms: `graphify query "<question>"` returns a scoped subgraph —
+  usually far smaller than raw grep output; `graphify path "<A>" "<B>"` for
+  relationships; `graphify explain "<concept>"` for a focused concept. Use
+  `graphify-out/wiki/index.md` (if present) for broad navigation, and read
+  `graphify-out/GRAPH_REPORT.md` only for whole-architecture review.
 - Rebuild manually after large uncommitted changes: `/graphify .` (skill)
   or `graphify update .` (CLI).
 - Export to the vault: `graphify . --obsidian` writes graph notes

--- a/templates/graphify/dot_agents/scripts/setup_graphify.sh
+++ b/templates/graphify/dot_agents/scripts/setup_graphify.sh
@@ -27,6 +27,14 @@ echo "Registering project-scoped skill + hook..."
 # committable and teammates get it on clone; default scope is user-global.
 graphify install --project
 
+echo "Tightening the installer's hook matchers + CLAUDE.md section (PI-846/PI-850)..."
+# The installer's PreToolUse hooks fire on every Bash/Read/Glob touching ~30
+# extensions, per call, and it appends a full workflow section to CLAUDE.md
+# that duplicates .agents/rules/graphify.md. Scope the hooks to real source
+# work (once per session) and trim the section to a pointer. Fail-open.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+"$SCRIPT_DIR/../hooks/_py.sh" "$SCRIPT_DIR/../hooks/graphify_post_install.py" "$(pwd)" || true
+
 echo "Installing post-commit graph rebuild hook..."
 graphify hook install
 

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -219,6 +219,12 @@ _GENERATED = {".agents/CAPABILITIES.md"}
 #     token-frugal working habits; same --no-plugin/plugin split as
 #     report_upstream_issue; INDEX/AGENTS.md/justfile edits already excluded
 _ADDED_SINCE_BASELINE = {
+    # PI-846/PI-850: graphify installer tightening — new guard hook +
+    # post-install fixer; the rule + setup script gained content.
+    ".agents/hooks/graphify_guard.sh",
+    ".agents/hooks/graphify_post_install.py",
+    ".agents/rules/graphify.md",
+    ".agents/scripts/setup_graphify.sh",
     # PI-819: diagnoses a REQUIRED status check that no job reports — the state
     # that leaves every PR permanently BLOCKED with all checks green.
     ".agents/scripts/check_branch_protection.sh",

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -204,6 +204,12 @@ _GENERATED = {".agents/CAPABILITIES.md"}
 #   • token_efficiency skill (PI-647) — new default-on skill with token-frugal
 #     working habits; INDEX/AGENTS.md/justfile rows already excluded above
 _ADDED_SINCE_BASELINE = {
+    # PI-846/PI-850: graphify installer tightening — new guard hook +
+    # post-install fixer; the rule + setup script gained content.
+    ".agents/hooks/graphify_guard.sh",
+    ".agents/hooks/graphify_post_install.py",
+    ".agents/rules/graphify.md",
+    ".agents/scripts/setup_graphify.sh",
     # PI-819: diagnoses a REQUIRED status check that no job reports — the state
     # that leaves every PR permanently BLOCKED with all checks green.
     ".agents/scripts/check_branch_protection.sh",

--- a/tests/integration/test_graphify_tightening.py
+++ b/tests/integration/test_graphify_tightening.py
@@ -1,0 +1,184 @@
+"""PI-846 / PI-850: tame what `graphify install --project` writes.
+
+The third-party installer (invoked by setup_graphify.sh) wires PreToolUse
+hooks that fire on every Bash command containing a search word and every
+Read/Glob of ~30 extensions (incl. .md/.txt), per call — and appends a full
+`## graphify` workflow section to CLAUDE.md duplicating
+`.agents/rules/graphify.md`. setup_graphify.sh now runs
+graphify_post_install.py to scope the hooks to `.agents/hooks/graphify_guard.sh`
+(source-code activity only, advisory once per session) and trim the CLAUDE.md
+section to a pointer. Fixtures below are the installer's real output,
+captured 2026-07-17 from graphifyy on PyPI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_HOOKS = _REPO / "templates" / "graphify" / "dot_agents" / "hooks"
+
+# Real `graphify install --project` output (abridged commands — the tightener
+# keys on the graph-file mention, not the full text).
+_INSTALLER_SETTINGS = {
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": (
+                            'CMD=$(...); case "$CMD" in *grep*) '
+                            "[ -f graphify-out/graph.json ] && echo '...' ;; esac"
+                        ),
+                    }
+                ],
+            },
+            {
+                "matcher": "Read|Glob",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": (
+                            "HIT=$(...exts...); [ -f graphify-out/graph.json ] "
+                            "&& echo '...MANDATORY...'"
+                        ),
+                    }
+                ],
+            },
+        ]
+    }
+}
+
+_INSTALLER_CLAUDE_MD = """## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community
+structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` ...
+- After modifying code, run `graphify update .` to keep the graph current.
+"""
+
+
+def _run_post_install(root: Path) -> str:
+    result = subprocess.run(
+        ["python3", str(_HOOKS / "graphify_post_install.py"), str(root)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _installer_output(tmp_path: Path) -> Path:
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(json.dumps(_INSTALLER_SETTINGS, indent=2))
+    (tmp_path / "CLAUDE.md").write_text(_INSTALLER_CLAUDE_MD)
+    return tmp_path
+
+
+class TestPostInstallTightening:
+    def test_hooks_are_scoped_to_the_guard(self, tmp_path: Path):
+        root = _installer_output(tmp_path)
+        out = _run_post_install(root)
+        assert "scoped 2 graphify hook(s)" in out
+        settings = json.loads((root / ".claude" / "settings.json").read_text())
+        commands = [h["command"] for e in settings["hooks"]["PreToolUse"] for h in e["hooks"]]
+        assert commands == [
+            'bash "$CLAUDE_PROJECT_DIR"/.agents/hooks/graphify_guard.sh search',
+            'bash "$CLAUDE_PROJECT_DIR"/.agents/hooks/graphify_guard.sh read',
+        ]
+
+    def test_claude_md_section_becomes_a_pointer(self, tmp_path: Path):
+        root = _installer_output(tmp_path)
+        _run_post_install(root)
+        text = (root / "CLAUDE.md").read_text()
+        assert ".agents/rules/graphify.md" in text
+        assert "god nodes" not in text
+
+    def test_idempotent_on_a_second_run(self, tmp_path: Path):
+        root = _installer_output(tmp_path)
+        _run_post_install(root)
+        first = (root / ".claude" / "settings.json").read_text()
+        out = _run_post_install(root)
+        assert "nothing to tighten" in out
+        assert "nothing to trim" in out
+        assert (root / ".claude" / "settings.json").read_text() == first
+
+    def test_unrecognized_shapes_fail_open(self, tmp_path: Path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "settings.json").write_text("{not json")
+        out = _run_post_install(tmp_path)
+        assert "left untouched" in out
+
+
+class TestGuardHook:
+    def _run_guard(self, cwd: Path, tmp: Path, mode: str, payload: dict) -> str:
+        # The guard resolves its sibling _py.sh, whose true source is
+        # templates/base — reproduce the scaffolded .agents/hooks layout.
+        import shutil
+
+        hooks_dir = cwd / ".agents" / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(_HOOKS / "graphify_guard.sh", hooks_dir / "graphify_guard.sh")
+        base_py = _REPO / "templates" / "base" / "dot_agents" / "hooks" / "_py.sh"
+        shutil.copy(base_py, hooks_dir / "_py.sh")
+        result = subprocess.run(
+            ["bash", str(hooks_dir / "graphify_guard.sh"), mode],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            env={"PATH": "/usr/bin:/bin", "TMPDIR": str(tmp)},
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout
+
+    def _graph(self, tmp_path: Path) -> Path:
+        (tmp_path / "graphify-out").mkdir()
+        (tmp_path / "graphify-out" / "graph.json").write_text("{}")
+        (tmp_path / "stamps").mkdir()
+        return tmp_path / "stamps"
+
+    def test_source_read_nudges_once_per_session(self, tmp_path: Path):
+        stamps = self._graph(tmp_path)
+        p = {"session_id": "s1", "tool_input": {"file_path": "src/app.py"}}
+        assert "additionalContext" in self._run_guard(tmp_path, stamps, "read", p)
+        p["tool_input"]["file_path"] = "src/other.py"
+        assert self._run_guard(tmp_path, stamps, "read", p) == ""
+
+    def test_new_session_nudges_again(self, tmp_path: Path):
+        stamps = self._graph(tmp_path)
+        p1 = {"session_id": "a", "tool_input": {"file_path": "src/app.py"}}
+        p2 = {"session_id": "b", "tool_input": {"file_path": "src/app.py"}}
+        assert "additionalContext" in self._run_guard(tmp_path, stamps, "read", p1)
+        assert "additionalContext" in self._run_guard(tmp_path, stamps, "read", p2)
+
+    def test_non_source_targets_stay_silent(self, tmp_path: Path):
+        stamps = self._graph(tmp_path)
+        for target in (".agents/config.yaml", ".claude/settings.json", "README.md", "docs/x.py"):
+            p = {"session_id": f"t-{target}", "tool_input": {"file_path": target}}
+            assert self._run_guard(tmp_path, stamps, "read", p) == "", target
+
+    def test_broad_source_search_nudges(self, tmp_path: Path):
+        stamps = self._graph(tmp_path)
+        p = {"session_id": "s", "tool_input": {"command": "grep -r validate src/"}}
+        assert "additionalContext" in self._run_guard(tmp_path, stamps, "search", p)
+
+    def test_non_search_bash_stays_silent(self, tmp_path: Path):
+        stamps = self._graph(tmp_path)
+        p = {"session_id": "s", "tool_input": {"command": "command -v jq"}}
+        assert self._run_guard(tmp_path, stamps, "search", p) == ""
+
+    def test_silent_without_a_graph(self, tmp_path: Path):
+        (tmp_path / "stamps").mkdir()
+        p = {"session_id": "s", "tool_input": {"file_path": "src/app.py"}}
+        assert self._run_guard(tmp_path, tmp_path / "stamps", "read", p) == ""


### PR DESCRIPTION
Closes #846