### PR TITLE
fix(PI-869): multi-model overlay seeds CCR config to ~/.agents-code-router, a path CCR never reads (PI-606 rename regression)

### DIFF
--- a/templates/multi_model/dot_agents/docs/guides/using-multi-model.md
+++ b/templates/multi_model/dot_agents/docs/guides/using-multi-model.md
@@ -43,7 +43,7 @@ mismatch*, not "Claude Code is slow" (it's a strong harness):
 **Gemini** *is* seeded (the `gemini` provider), but its tool-calling/streaming via
 translation is less battle-tested than Claude/DeepSeek, so Antigravity (`agy`) stays
 the higher-fidelity Gemini path. Add any other OpenAI/Anthropic-compatible provider by
-editing `~/.agents-code-router/config.json` (`ccr ui`, or a gateway like OpenRouter);
+editing `~/.claude-code-router/config.json` (`ccr ui`, or a gateway like OpenRouter);
 expect a quality penalty routing a first-party-harness model through CCR (no published
 CCR-vs-native benchmarks).
 
@@ -58,7 +58,7 @@ cp .agents/multi-model/.env.example .agents/multi-model/.env   # fill in provide
 
 The installer (idempotent) installs [claude-code-router](https://github.com/musistudio/claude-code-router)
 at a **pinned** version (bun-preferred, npm fallback), seeds the machine-global
-config at `~/.agents-code-router/config.json` from this project's template + your
+config at `~/.claude-code-router/config.json` from this project's template + your
 `.env`, optionally pulls local Ollama models sized to your RAM, and can wire your
 shell so plain `claude` routes through CCR.
 
@@ -144,7 +144,7 @@ the global CCR config for you, with the **<7B** guard):
 ```
 
 Reverting is clean: stop using CCR (plain `claude`) or
-`rm ~/.agents-code-router/config.json` removes it entirely.
+`rm ~/.claude-code-router/config.json` removes it entirely.
 
 ## Caveats (any non-Claude model)
 

--- a/templates/multi_model/dot_agents/multi-model/README.md
+++ b/templates/multi_model/dot_agents/multi-model/README.md
@@ -11,7 +11,7 @@ Those run below the model and stay identical whichever model you point at.
 - `config.json` — the [claude-code-router (CCR)](https://github.com/musistudio/claude-code-router)
   config template: providers (Claude / DeepSeek / Kimi / Gemini / Ollama) and `Router`
   cost defaults. This is the **seed** for the machine-global config at
-  `~/.agents-code-router/config.json` (CCR is machine-level, not per-project).
+  `~/.claude-code-router/config.json` (CCR is machine-level, not per-project).
 - `.env.example` — provider API-key slots. Copy to `.env` (gitignored) and fill in.
 - `../scripts/setup_models.sh` — one-time installer: installs CCR (pinned),
   seeds the global config from `config.json` + your `.env`, optionally pulls local
@@ -46,4 +46,4 @@ claude                                                          # opens as usual
   "Invalid tool parameters".
 
 Reverting is clean: stop using CCR (plain `claude` against Anthropic) or
-`rm ~/.agents-code-router/config.json` to remove it entirely.
+`rm ~/.claude-code-router/config.json` to remove it entirely.

--- a/templates/multi_model/dot_agents/multi-model/dot_env.example
+++ b/templates/multi_model/dot_agents/multi-model/dot_env.example
@@ -3,7 +3,7 @@
 # Copy this file to `.env` in the same directory and fill in the keys for the
 # providers you actually route to (see config.json -> Router). `.env` is already
 # gitignored. `setup_models.sh` reads this file to seed the global CCR config at
-# ~/.agents-code-router/config.json.
+# ~/.claude-code-router/config.json.
 #
 # You only need a key for a provider you reference in Router. The shipped
 # defaults route: default/longContext -> Claude, background/think -> DeepSeek.

--- a/templates/multi_model/dot_agents/scripts/models.sh
+++ b/templates/multi_model/dot_agents/scripts/models.sh
@@ -4,14 +4,14 @@
 #
 # Add / switch / remove models after the initial setup_models.sh run — including
 # models you didn't pick at init, or your own Ollama models. Wraps Ollama + edits
-# to the machine-global CCR config (~/.agents-code-router/config.json) via jq.
+# to the machine-global CCR config (~/.claude-code-router/config.json) via jq.
 # Deterministic, no LLM. Switching itself is live in Claude Code: /model prov,model.
 #
 # Tip: alias it for the bare `models …` form the docs use:
 #   alias models="$PWD/.agents/scripts/models.sh"
 set -euo pipefail
 
-CONFIG="${CCR_CONFIG:-$HOME/.agents-code-router/config.json}"
+CONFIG="${CCR_CONFIG:-$HOME/.claude-code-router/config.json}"
 OLLAMA_BASE_URL="http://localhost:11434/v1/chat/completions"
 
 info() { printf '\033[0;36m›\033[0m %s\n' "$*"; }

--- a/templates/multi_model/dot_agents/scripts/setup_models.sh
+++ b/templates/multi_model/dot_agents/scripts/setup_models.sh
@@ -32,7 +32,11 @@ MM_DIR="$(cd "$SCRIPT_DIR/../multi-model" && pwd)"
 TEMPLATE_CONFIG="$MM_DIR/config.json"
 ENV_FILE="$MM_DIR/.env"
 ENV_EXAMPLE="$MM_DIR/.env.example"
-GLOBAL_DIR="$HOME/.agents-code-router"
+# Upstream-owned path: this is claude-code-router's OWN config directory, not a
+# project-init one. It must NOT be swept along by any .claude → .agents rename
+# (that regression shipped in PI-606/#620 and silently broke config seeding for
+# every --multi-model scaffold — see PI-869).
+GLOBAL_DIR="$HOME/.claude-code-router"
 GLOBAL_CONFIG="$GLOBAL_DIR/config.json"
 
 # --- tiny output helpers ------------------------------------------------------
@@ -91,7 +95,7 @@ ensure_env() {
 }
 
 # --- 4. seed the machine-global config (merge-safe) + substitute keys ---------
-# CCR config is machine-level (~/.agents-code-router/config.json), shared across
+# CCR config is machine-level (~/.claude-code-router/config.json), shared across
 # projects. We never clobber an existing config silently — it is backed up first.
 seed_config() {
   mkdir -p "$GLOBAL_DIR"
@@ -99,7 +103,7 @@ seed_config() {
     local backup="$GLOBAL_CONFIG.bak.$(date +%Y%m%d%H%M%S)"
     cp "$GLOBAL_CONFIG" "$backup"
     warn "Existing global CCR config backed up to: $backup"
-    if ! ask "Overwrite ~/.agents-code-router/config.json with this project's template?"; then
+    if ! ask "Overwrite ~/.claude-code-router/config.json with this project's template?"; then
       info "Left the existing global config in place. Edit it by hand or run 'ccr ui'."
       return
     fi
@@ -250,7 +254,7 @@ Done. Multi-model switching is set up.
   .agents/scripts/models.sh add ollama qwen3:14b  # add/remove models after setup (needs jq)
 
 Background requests auto-route to DeepSeek (cheap) — the biggest silent saver.
-Edit providers/keys in ~/.agents-code-router/config.json (or .agents/multi-model/.env, then re-run).
+Edit providers/keys in ~/.claude-code-router/config.json (or .agents/multi-model/.env, then re-run).
 EOF
 }
 

--- a/tests/contracts/test_multi_model_overlay.py
+++ b/tests/contracts/test_multi_model_overlay.py
@@ -105,6 +105,43 @@ class TestMultiModelOn:
         assert '. "$ENV_FILE"' not in content
         assert 'mv "$tmp" "$GLOBAL_CONFIG"' in content
 
+    def test_installer_seeds_ccr_upstream_config_dir(self):
+        """The seeded config must land where CCR actually reads it (PI-869).
+
+        ``~/.claude-code-router`` is claude-code-router's OWN directory, not a
+        project-init one. The ``.claude`` -> ``.agents`` sweep in PI-606 (#620)
+        renamed it to ``~/.agents-code-router``, so the installer wrote a config
+        CCR never read: setup reported success, CCR started on its own defaults,
+        and the advertised background->DeepSeek cost route silently never applied.
+
+        This guards the path in both directions — a future rename sweep that
+        catches this line again fails here.
+        """
+        content = (self.target / ".agents" / "scripts" / "setup_models.sh").read_text()
+        assert 'GLOBAL_DIR="$HOME/.claude-code-router"' in content, (
+            "installer must target CCR's real config dir; see PI-869"
+        )
+
+        # models.sh reads the same machine-global config, so it carried the
+        # identical rename and must be guarded alongside the installer.
+        helper = (self.target / ".agents" / "scripts" / "models.sh").read_text()
+        assert "$HOME/.claude-code-router/config.json" in helper, (
+            "day-2 helper must read CCR's real config dir; see PI-869"
+        )
+
+        # Sweep the whole rendered overlay: scripts, guide, READMEs and .env
+        # example all name this path, and a stale one misdirects the user even
+        # where it is only prose.
+        stale = sorted(
+            p.relative_to(self.target).as_posix()
+            for p in self.target.rglob("*")
+            if p.is_file() and ".agents-code-router" in p.read_text(errors="ignore")
+        )
+        assert not stale, (
+            "CCR's config dir is upstream-owned and must not be swept by a "
+            f".claude -> .agents rename (PI-606/#620 regression, PI-869): {stale}"
+        )
+
     def test_day2_helper_present_executable_and_documented(self):
         helper = self.target / ".agents" / "scripts" / "models.sh"
         assert helper.is_file()


### PR DESCRIPTION
Closes #869