### PR TITLE
fix(PI-872): observability overlay reads transcripts from ~/.agents/projects, but Claude Code writes ~/.claude/projects (PI-606 rename regression)

### DIFF
--- a/templates/observability/dot_agents/docs/guides/using-observability.md
+++ b/templates/observability/dot_agents/docs/guides/using-observability.md
@@ -39,7 +39,7 @@ silently produces an empty report.
 Two data sources, both local:
 
 1. **The transcript JSONL** Claude Code already writes
-   (`~/.agents/projects/<slug>/*.jsonl`) — always present, no setup.
+   (`~/.claude/projects/<slug>/*.jsonl`) — always present, no setup.
 2. **The hook self-log** (`.agents/observability/usage.jsonl`) — written by the
    project's own hooks, but **only while this overlay is installed** (the
    `.agents/observability/` directory is the activation marker). It is the one

--- a/templates/observability/dot_agents/observability/usage_report.py
+++ b/templates/observability/dot_agents/observability/usage_report.py
@@ -49,7 +49,7 @@ def project_slug(project_dir: str) -> str:
     Claude replaces every character that is not alphanumeric or ``-`` with
     ``-`` (so ``/``, ``.``, and ``_`` all become ``-``), which for an absolute
     path yields a leading ``-``. Empirically verified against
-    ``~/.agents/projects/`` (e.g. ``/home/u/projects/project_init`` →
+    ``~/.claude/projects/`` (e.g. ``/home/u/projects/project_init`` →
     ``-home-u-projects-project-init``).
     """
     return "".join(c if (c.isalnum() or c == "-") else "-" for c in project_dir)
@@ -64,7 +64,11 @@ def _price_for(model: str) -> tuple[float, float]:
 
 
 def _projects_root() -> Path:
-    return Path.home() / ".agents" / "projects"
+    # Upstream-owned path: ``~/.claude`` is Claude Code's OWN transcript
+    # directory, not a project-init one. It must NOT be swept along by any
+    # .claude → .agents rename (that regression shipped in PI-606/#620 and left
+    # this overlay unable to find any transcript at all — see PI-872).
+    return Path.home() / ".claude" / "projects"
 
 
 def discover_transcript(
@@ -74,7 +78,7 @@ def discover_transcript(
 
     Order: explicit ``--transcript`` → ``--session-id`` under the derived slug
     → newest ``*.jsonl`` under the derived slug → newest ``*.jsonl`` anywhere
-    under ``~/.agents/projects`` whose entries' ``cwd`` matches the project dir.
+    under ``~/.claude/projects`` whose entries' ``cwd`` matches the project dir.
     """
     if transcript:
         p = Path(transcript).expanduser()

--- a/tests/contracts/test_observability_overlay.py
+++ b/tests/contracts/test_observability_overlay.py
@@ -100,6 +100,38 @@ class TestObservabilityOn:
         assert "OTEL" in gtext or "OpenTelemetry" in gtext
         assert "documentation only" in gtext.lower()
 
+    def test_usage_report_reads_claude_codes_own_transcript_dir(self, tmp_path: Path):
+        """Transcripts must be read from where Claude Code writes them (PI-872).
+
+        ``~/.claude/projects`` is Claude Code's OWN directory. The ``.claude`` ->
+        ``.agents`` sweep in PI-606 (#620) renamed it to ``~/.agents/projects``,
+        which does not exist, so ``discover_transcript`` could never locate a
+        transcript and the whole overlay raised FileNotFoundError.
+
+        Note ``~/.agents/`` *is* legitimate elsewhere (user-level skills), and
+        ``project_dir / ".agents" / "observability"`` is the correct
+        project-local hook log — so this asserts on the machine-global
+        transcript root specifically, not on ``.agents`` appearing at all.
+        """
+        target = _scaffold(tmp_path / "p", observability=True)
+        report = target / ".agents" / "observability" / "usage_report.py"
+        text = report.read_text(encoding="utf-8")
+
+        assert 'Path.home() / ".claude" / "projects"' in text, (
+            "transcript root must be Claude Code's own dir; see PI-872"
+        )
+        assert 'Path.home() / ".agents"' not in text, (
+            "Claude Code's transcript dir is upstream-owned and must not be "
+            "swept by a .claude -> .agents rename (PI-606/#620, PI-872)"
+        )
+        # The project-local hook log is a different path and must survive.
+        assert 'project_dir / ".agents" / "observability"' in text
+
+        guide = (target / ".agents" / "docs" / "guides" / "using-observability.md").read_text(
+            encoding="utf-8"
+        )
+        assert "~/.agents/projects" not in guide, "guide must not name the renamed path"
+
     def test_usage_report_satisfies_scaffolded_ruff_gates(self, tmp_path: Path):
         """The generated analyzer is committed into Python projects, so it must
         satisfy the scaffold's own PERF/S/BLE ruff gates on day one."""


### PR DESCRIPTION
Closes #872