### PR TITLE
fix(PI-877): install.sh writes /project-init to ~/.agents/commands — Claude Code never loads it, so the advertised install produces a dead slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ uv tool install project-init   # or one-off: uvx project-init .
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
 ```
 
-This installs [`uv`](https://docs.astral.sh/uv/) if missing, clones the repo to `~/.local/share/project-init` (override with `PROJECT_INIT_HOME=...`) **pinned to the latest tagged release**, and writes a user-level slash command at `~/.agents/commands/project-init.md`.
+This installs [`uv`](https://docs.astral.sh/uv/) if missing, clones the repo to `~/.local/share/project-init` (override with `PROJECT_INIT_HOME=...`) **pinned to the latest tagged release**, and writes a user-level slash command at `~/.claude/commands/project-init.md`.
 
 Pin a specific version, or opt into the unreleased development head:
 
@@ -131,7 +131,7 @@ The execution model — not the surface name — decides what binds:
   run on your machine, so the enforcement layer is live (subject to the
   per-surface fidelity above — some drop hook matchers).
 - **Cloud-sandbox surfaces** (Claude web, Codex cloud, Jules): only
-  **repo-committed** config runs; user-level `~/.agents` is dropped, hooks run
+  **repo-committed** config runs; user-level `~/.claude` is dropped, hooks run
   inside the VM, and git goes through a push-restricted proxy — the local
   enforcement layer is replaced by the sandbox's.
 
@@ -404,7 +404,7 @@ directory yourself.
 # PyPI install:
 uv tool uninstall project-init
 # git install (installer path):
-rm -rf ~/.local/share/project-init ~/.agents/commands/project-init.md
+rm -rf ~/.local/share/project-init ~/.claude/commands/project-init.md
 ```
 
 ## Troubleshooting

--- a/docs/adr/adr-007-security-enforcement-layers.md
+++ b/docs/adr/adr-007-security-enforcement-layers.md
@@ -73,7 +73,7 @@ slipped past a clone without hooks.)
   per-surface hook configs generated for Cursor/Codex/Antigravity/VS Code are
   **best-effort and fail-open** — fidelity varies (e.g. VS Code Copilot ignores
   hook matchers), and cloud-sandbox surfaces (Claude web, Codex cloud, Jules)
-  honor only repo-committed config with no local `~/.agents`. So the in-editor
+  honor only repo-committed config with no local `~/.claude`. So the in-editor
   hooks are advisory; **git hooks + CI remain the only enforcement that binds
   every surface.** Surface fidelity + the local-vs-cloud split are documented in
   `docs/development/non-cli-surface-matrix.md` and the README's surface matrix.

--- a/docs/adr/adr-016-model-agnostic-switching.md
+++ b/docs/adr/adr-016-model-agnostic-switching.md
@@ -83,7 +83,7 @@ routing (the `background → cheap model` rule is the high-leverage cost saver).
 ### 3. Boundary & interaction model
 
 - The scaffolder calls **no LLM** at runtime (ADR-001). CCR is **machine-level**
-  (`~/.agents-code-router/config.json`, proxy on `127.0.0.1:3456`); project-init
+  (`~/.claude-code-router/config.json`, proxy on `127.0.0.1:3456`); project-init
   only scaffolds the config + installer (the graphify setup-script pattern).
 - **Config stays global** (no per-project variant — no need foreseen).
 - **Launch entrypoint stays `claude`**: setup wires `eval "$(ccr activate)"` so

--- a/docs/adr/adr-019-local-observability-overlay.md
+++ b/docs/adr/adr-019-local-observability-overlay.md
@@ -34,7 +34,7 @@ The hard constraints:
    pinned interpreter.
 4. **Two facts about the available signals:**
    - Claude Code already writes a per-session **transcript JSONL**
-     (`~/.agents/projects/<slug>/*.jsonl`) carrying model usage, tool calls, and
+     (`~/.claude/projects/<slug>/*.jsonl`) carrying model usage, tool calls, and
      timings — always present, no setup. Its schema is **not officially stable**.
    - The one thing the transcript does *not* record cleanly is **which hooks
      fired**. Claude Code's OTEL export captures more (exact active-time,

--- a/docs/development/measurement-methodology.md
+++ b/docs/development/measurement-methodology.md
@@ -86,7 +86,7 @@ Verified against Claude Code 2.1.181.
 | Tool calls / redundant reads / turns | transcript JSONL | tool-use entries |
 | Session id (→ transcript path) | `claude -p --output-format json` | `session_id` |
 
-Transcripts live at `~/.agents/projects/<project>/<session-id>.jsonl`; isolate
+Transcripts live at `~/.claude/projects/<project>/<session-id>.jsonl`; isolate
 each run by setting `CLAUDE_CONFIG_DIR` to a temp dir so runs don't pollute the
 user's history and fixed-overhead stays clean.
 

--- a/docs/development/mobile-remote-access.md
+++ b/docs/development/mobile-remote-access.md
@@ -15,7 +15,7 @@ paths keep this repo's hook-based enforcement live**. Verified against vendor do
 The decisive fact: **enforcement depends on *where the session executes*, not which
 device you hold.** A session on your machine applies your full local config — the
 scaffolded hooks (`github_command_guard.sh`, the DAG guard, `prod_guard.py`) plus
-anything in `~/.agents`. A cloud sandbox honors only **repo-committed** files:
+anything in `~/.claude`. A cloud sandbox honors only **repo-committed** files:
 committed hooks may run inside the VM, but your local user config, resources, and
 credentials don't — so per ADR-007 **git/CI is the guaranteed enforcement boundary**
 for cloud surfaces. See the local-vs-cloud caveat in

--- a/docs/development/non-cli-surface-matrix.md
+++ b/docs/development/non-cli-surface-matrix.md
@@ -78,7 +78,7 @@ and `AGENTS.md`/`CLAUDE.md`.
 
 | Surface | Already covered by current output | Gap to close (feeds #366) |
 |---|---|---|
-| Claude Code VS Code ext | hooks, skills, CLAUDE.md (same `.agents/`) | **shared project MCP**: emit a root `.mcp.json` (`mcpServers`) when MCPs are configured — `.agents/` alone does not carry shareable MCP (bare `claude mcp add` writes a private `~/.agents.json` entry) |
+| Claude Code VS Code ext | hooks, skills, CLAUDE.md (same `.agents/`) | **shared project MCP**: emit a root `.mcp.json` (`mcpServers`) when MCPs are configured — `.agents/` alone does not carry shareable MCP (bare `claude mcp add` writes a private `~/.claude.json` entry) |
 | Copilot agent mode | CLAUDE.md, `.agents/skills`, hooks (matcher-blind), AGENTS.md | `.vscode/mcp.json` (`servers` map) if MCPs are configured; document that matchers are advisory here |
 | Cursor | `.agents/skills` (skills), AGENTS.md | `.cursor/hooks.json` (`PreToolUse(Bash)`→`beforeShellExecution`, deny via `{"permission":"deny","user_message"}`; PI-385); `.cursor/mcp.json` (≈copy of `mcpServers`) |
 | Codex (CLI/IDE) | `.codex/hooks.json` ⚠️ (schema-correct & delivered; **enforcement unverified** — codex 0.138.0 didn't fire project hooks in the 2026-06-23 live test without an enable step), `.agents/skills` ✅, AGENTS.md ✅ | MCP → `.codex/config.toml` `[mcp_servers.*]` if MCPs are configured |

--- a/docs/guides/using-project-init.md
+++ b/docs/guides/using-project-init.md
@@ -10,7 +10,7 @@ project-init scaffolds a `.agents/` folder into any project so that Claude Code 
 curl -sSL https://raw.githubusercontent.com/VytCepas/project-init/main/install.sh | bash
 ```
 
-Installs `uv` if missing, clones the repo to `~/.local/share/project-init`, and writes a `/project-init` slash command into `~/.agents/commands/`.
+Installs `uv` if missing, clones the repo to `~/.local/share/project-init`, and writes a `/project-init` slash command into `~/.claude/commands/`.
 
 ---
 
@@ -273,7 +273,7 @@ git commit --allow-empty -m "test: verify hooks"
 
 | Problem | Fix |
 |---------|-----|
-| `/project-init` not found | Re-run install script; check `~/.agents/commands/project-init.md` exists |
+| `/project-init` not found | Re-run install script; check `~/.claude/commands/project-init.md` exists |
 | `uv: command not found` | Add `export PATH="$HOME/.local/bin:$PATH"` to shell profile |
 | `bunx: command not found` when adding MCPs | `curl -fsSL https://bun.sh/install \| bash` |
 | Hooks don't fire on commit | Check `python3 --version`; hooks need `python3` on PATH |

--- a/docs/research/model-agnostic-switching.md
+++ b/docs/research/model-agnostic-switching.md
@@ -267,7 +267,7 @@ Concretely:
 
 CCR is **machine-level, not project-level** (user decision: keep global, no
 per-project config): installed globally (bun-preferred/npm), config at
-`~/.agents-code-router/config.json`, runs a local proxy on `127.0.0.1:3456`.
+`~/.claude-code-router/config.json`, runs a local proxy on `127.0.0.1:3456`.
 
 **Launch default = plain `claude`.** The setup wires `eval "$(ccr activate)"`
 into the shell rc so the normal `claude` command routes through CCR — no `ccr
@@ -341,7 +341,7 @@ pattern; allowed by CLAUDE.md / ADR-001).
 
 - install CCR + Claude Code (bun-preferred, npm fallback), **pinned versions**;
 - wire `eval "$(ccr activate)"` into shell rc so plain `claude` routes;
-- seed `~/.agents-code-router/config.json` from the template (merge-safe), with
+- seed `~/.claude-code-router/config.json` from the template (merge-safe), with
   `background → cheap model` cost defaults;
 - detect OS + RAM/VRAM → recommend models that fit + suggest quant; `ollama pull`
   chosen models at chosen quant;
@@ -367,7 +367,7 @@ ccr ui                            # CCR's web editor for hand-tuning routing
 - Add **any** model (incl. unselected/custom Ollama models); `/model
   ollama,<model>` switches live.
 - **Capability guard:** `models add ollama` warns/confirms if the model is <7B.
-- Only state touched is the global `~/.agents-code-router/config.json` (jq) +
+- Only state touched is the global `~/.claude-code-router/config.json` (jq) +
   `ollama`; fully reversible.
 
 ### Update & security model (third-party supply-chain)

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 # What it does (deterministic, idempotent):
 #   1. Ensures `uv` is installed (installs via official installer if missing).
 #   2. Clones (or updates) the project-init repo to $INSTALL_DIR.
-#   3. Writes a user-level slash command at ~/.agents/commands/project-init.md
+#   3. Writes a user-level slash command at ~/.claude/commands/project-init.md
 #      so `/project-init` works in any Claude Code session on this machine.
 #   4. Prints next steps.
 
@@ -15,7 +15,14 @@ set -euo pipefail
 
 REPO_URL="${PROJECT_INIT_REPO:-https://github.com/VytCepas/project-init.git}"
 INSTALL_DIR="${PROJECT_INIT_HOME:-$HOME/.local/share/project-init}"
-COMMANDS_DIR="$HOME/.agents/commands"
+# Upstream-owned path: Claude Code reads user-level slash commands from its OWN
+# config dir (`CLAUDE_CONFIG_DIR`, else ~/.claude), NOT from a project-init one.
+# It must NOT be swept along by any .claude → .agents rename — that regression
+# shipped in PI-606/#620 and left every fresh install with a /project-init
+# command Claude Code never loaded (PI-877). Same resolution as
+# tools/benchmark/harness.py, which was bitten by this first (PI-802).
+CLAUDE_CONFIG_DIR_RESOLVED="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+COMMANDS_DIR="$CLAUDE_CONFIG_DIR_RESOLVED/commands"
 # Pin a version with PROJECT_INIT_REF=vX.Y.Z, or track the development head
 # with PROJECT_INIT_REF=main. Default: the latest GitHub Release (ADR-008).
 # For non-github.com hosts (GHES / GHE.com), point PROJECT_INIT_REPO at the full
@@ -25,113 +32,116 @@ REQUESTED_REF="${PROJECT_INIT_REF:-}"
 
 say() { printf '\033[1;36m[project-init]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[project-init]\033[0m %s\n' "$*" >&2; }
-die() { printf '\033[1;31m[project-init]\033[0m %s\n' "$*" >&2; exit 1; }
+die() {
+  printf '\033[1;31m[project-init]\033[0m %s\n' "$*" >&2
+  exit 1
+}
 
 # 1. uv
 ensure_uv() {
-    if command -v uv >/dev/null 2>&1; then
-        say "uv already installed: $(uv --version)"
-        return
-    fi
-    say "installing uv..."
-    if ! command -v curl >/dev/null 2>&1; then
-        die "curl is required to install uv"
-    fi
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    # shellcheck disable=SC1091
-    if [ -f "$HOME/.local/bin/env" ]; then . "$HOME/.local/bin/env"; fi
-    export PATH="$HOME/.local/bin:$PATH"
-    command -v uv >/dev/null 2>&1 || die "uv install failed — check shell PATH"
+  if command -v uv >/dev/null 2>&1; then
+    say "uv already installed: $(uv --version)"
+    return
+  fi
+  say "installing uv..."
+  if ! command -v curl >/dev/null 2>&1; then
+    die "curl is required to install uv"
+  fi
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # shellcheck disable=SC1091
+  if [ -f "$HOME/.local/bin/env" ]; then . "$HOME/.local/bin/env"; fi
+  export PATH="$HOME/.local/bin:$PATH"
+  command -v uv >/dev/null 2>&1 || die "uv install failed — check shell PATH"
 }
 
 # 2. ref — latest release tag unless PROJECT_INIT_REF overrides
 resolve_ref() {
-    if [ -n "$REQUESTED_REF" ]; then
-        printf '%s\n' "$REQUESTED_REF"
-        return
-    fi
-    # Derive the host + owner/repo slug from REPO_URL (any GitHub host, not just
-    # github.com), then pick the REST API base. POSIX ERE has no lazy quantifier,
-    # so strip the .git suffix separately.
-    local host slug api_base tag
-    # Strip scheme/userinfo/path/port so https://, ssh://, and git@ forms all work.
-    host=$(printf '%s\n' "$REPO_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#^[^@/]*@##; s#[/:].*$##')
-    slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*[/:]([^/]+/[^/]+)$#\1#p')
-    slug="${slug%.git}"
-    # API base: explicit override wins; github.com & *.ghe.com use api.<host>;
-    # GitHub Enterprise Server uses <host>/api/v3.
-    if [ -n "${PROJECT_INIT_API_BASE:-}" ]; then
-        api_base="$PROJECT_INIT_API_BASE"
-    else
-        case "$host" in
-            "") api_base="https://api.github.com" ;;
-            github.com | *.ghe.com) api_base="https://api.$host" ;;
-            *) api_base="https://$host/api/v3" ;;
-        esac
-    fi
-    if [ -n "$slug" ]; then
-        tag=$(curl -fsSL "$api_base/repos/$slug/releases/latest" 2>/dev/null \
-            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)
-    fi
-    if [ -n "${tag:-}" ]; then
-        printf '%s\n' "$tag"
-    else
-        warn "could not resolve the latest release (none published yet?) — falling back to the default branch"
-        warn "pin explicitly with: PROJECT_INIT_REF=vX.Y.Z"
-        # Empty ref = "track the repo's default branch". A distinct sentinel (not
-        # the literal 'main') so an explicit PROJECT_INIT_REF=main is honored as a
-        # literal branch, not hijacked into default-branch resolution — REQUESTED_REF
-        # is guaranteed non-empty, so empty can only mean this fallback (PI review).
-        printf ''
-    fi
+  if [ -n "$REQUESTED_REF" ]; then
+    printf '%s\n' "$REQUESTED_REF"
+    return
+  fi
+  # Derive the host + owner/repo slug from REPO_URL (any GitHub host, not just
+  # github.com), then pick the REST API base. POSIX ERE has no lazy quantifier,
+  # so strip the .git suffix separately.
+  local host slug api_base tag
+  # Strip scheme/userinfo/path/port so https://, ssh://, and git@ forms all work.
+  host=$(printf '%s\n' "$REPO_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#^[^@/]*@##; s#[/:].*$##')
+  slug=$(printf '%s\n' "$REPO_URL" | sed -nE 's#.*[/:]([^/]+/[^/]+)$#\1#p')
+  slug="${slug%.git}"
+  # API base: explicit override wins; github.com & *.ghe.com use api.<host>;
+  # GitHub Enterprise Server uses <host>/api/v3.
+  if [ -n "${PROJECT_INIT_API_BASE:-}" ]; then
+    api_base="$PROJECT_INIT_API_BASE"
+  else
+    case "$host" in
+    "") api_base="https://api.github.com" ;;
+    github.com | *.ghe.com) api_base="https://api.$host" ;;
+    *) api_base="https://$host/api/v3" ;;
+    esac
+  fi
+  if [ -n "$slug" ]; then
+    tag=$(curl -fsSL "$api_base/repos/$slug/releases/latest" 2>/dev/null |
+      grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)
+  fi
+  if [ -n "${tag:-}" ]; then
+    printf '%s\n' "$tag"
+  else
+    warn "could not resolve the latest release (none published yet?) — falling back to the default branch"
+    warn "pin explicitly with: PROJECT_INIT_REF=vX.Y.Z"
+    # Empty ref = "track the repo's default branch". A distinct sentinel (not
+    # the literal 'main') so an explicit PROJECT_INIT_REF=main is honored as a
+    # literal branch, not hijacked into default-branch resolution — REQUESTED_REF
+    # is guaranteed non-empty, so empty can only mean this fallback (PI review).
+    printf ''
+  fi
 }
 
 # 3. repo
 ensure_repo() {
-    REF="$(resolve_ref)"
-    ref_label="${REF:-<default branch>}"
-    if [ -d "$INSTALL_DIR/.git" ]; then
-        say "updating existing clone at $INSTALL_DIR (ref: $ref_label)"
-        # If PROJECT_INIT_REPO changed since the clone, repoint origin — else we
-        # would silently keep updating from the old remote (PI review 2026-07).
-        current_url="$(git -C "$INSTALL_DIR" remote get-url origin 2>/dev/null || true)"
-        if [ -n "$current_url" ] && [ "$current_url" != "$REPO_URL" ]; then
-            warn "origin changed ($current_url -> $REPO_URL) — updating remote"
-            git -C "$INSTALL_DIR" remote set-url origin "$REPO_URL"
-        fi
-        git -C "$INSTALL_DIR" fetch --tags --force origin
-    else
-        say "cloning $REPO_URL ($ref_label) -> $INSTALL_DIR"
-        mkdir -p "$(dirname "$INSTALL_DIR")"
-        git clone "$REPO_URL" "$INSTALL_DIR"
+  REF="$(resolve_ref)"
+  ref_label="${REF:-<default branch>}"
+  if [ -d "$INSTALL_DIR/.git" ]; then
+    say "updating existing clone at $INSTALL_DIR (ref: $ref_label)"
+    # If PROJECT_INIT_REPO changed since the clone, repoint origin — else we
+    # would silently keep updating from the old remote (PI review 2026-07).
+    current_url="$(git -C "$INSTALL_DIR" remote get-url origin 2>/dev/null || true)"
+    if [ -n "$current_url" ] && [ "$current_url" != "$REPO_URL" ]; then
+      warn "origin changed ($current_url -> $REPO_URL) — updating remote"
+      git -C "$INSTALL_DIR" remote set-url origin "$REPO_URL"
     fi
-    if [ -z "$REF" ]; then
-        # Empty ref = resolve_ref's fallback sentinel for "the repo's default
-        # branch". Resolve it for real — a fork or mirror may default to
-        # master/trunk, and a hard `checkout main` would die under `set -e`.
-        git -C "$INSTALL_DIR" remote set-head origin --auto >/dev/null 2>&1 || true
-        default_branch="$(git -C "$INSTALL_DIR" symbolic-ref --quiet --short \
-            refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
-        [ -n "$default_branch" ] || default_branch="main"
-        git -C "$INSTALL_DIR" checkout -q "$default_branch"
-        git -C "$INSTALL_DIR" pull --ff-only origin "$default_branch"
-    else
-        # An explicit PROJECT_INIT_REF — a literal branch OR tag. Check it out;
-        # a tag lands detached (immutable, no pull), while a branch pin should
-        # fast-forward to its latest tip. symbolic-ref -q HEAD succeeds only when
-        # on a branch, so it distinguishes the two without guessing.
-        git -C "$INSTALL_DIR" checkout -q "$REF"
-        if git -C "$INSTALL_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
-            git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
-        fi
+    git -C "$INSTALL_DIR" fetch --tags --force origin
+  else
+    say "cloning $REPO_URL ($ref_label) -> $INSTALL_DIR"
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    git clone "$REPO_URL" "$INSTALL_DIR"
+  fi
+  if [ -z "$REF" ]; then
+    # Empty ref = resolve_ref's fallback sentinel for "the repo's default
+    # branch". Resolve it for real — a fork or mirror may default to
+    # master/trunk, and a hard `checkout main` would die under `set -e`.
+    git -C "$INSTALL_DIR" remote set-head origin --auto >/dev/null 2>&1 || true
+    default_branch="$(git -C "$INSTALL_DIR" symbolic-ref --quiet --short \
+      refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+    [ -n "$default_branch" ] || default_branch="main"
+    git -C "$INSTALL_DIR" checkout -q "$default_branch"
+    git -C "$INSTALL_DIR" pull --ff-only origin "$default_branch"
+  else
+    # An explicit PROJECT_INIT_REF — a literal branch OR tag. Check it out;
+    # a tag lands detached (immutable, no pull), while a branch pin should
+    # fast-forward to its latest tip. symbolic-ref -q HEAD succeeds only when
+    # on a branch, so it distinguishes the two without guessing.
+    git -C "$INSTALL_DIR" checkout -q "$REF"
+    if git -C "$INSTALL_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
+      git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
     fi
-    say "installed: $(git -C "$INSTALL_DIR" describe --tags --always)"
+  fi
+  say "installed: $(git -C "$INSTALL_DIR" describe --tags --always)"
 }
 
 # 4. slash command
 ensure_slash_command() {
-    mkdir -p "$COMMANDS_DIR"
-    cat >"$COMMANDS_DIR/project-init.md" <<CMD
+  mkdir -p "$COMMANDS_DIR"
+  cat >"$COMMANDS_DIR/project-init.md" <<CMD
 ---
 description: Scaffold agentic-dev infrastructure (.agents/) into the current project
 ---
@@ -142,15 +152,15 @@ Run the project-init wizard inside the current working directory:
 
 After it finishes, read \`.agents/project-init.md\` to confirm the selected options.
 CMD
-    say "installed slash command -> $COMMANDS_DIR/project-init.md"
+  say "installed slash command -> $COMMANDS_DIR/project-init.md"
 }
 
 main() {
-    say "bootstrap starting"
-    ensure_uv
-    ensure_repo
-    ensure_slash_command
-    cat <<EOF
+  say "bootstrap starting"
+  ensure_uv
+  ensure_repo
+  ensure_slash_command
+  cat <<EOF
 
 $(printf '\033[1;32m[project-init]\033[0m done.')
 

--- a/templates/base/dot_agents/skills/README.md.tmpl
+++ b/templates/base/dot_agents/skills/README.md.tmpl
@@ -20,4 +20,4 @@ Each skill is a directory `.agents/skills/<name>/SKILL.md`. See [`INDEX.md`](IND
 {{/if no_plugin}}{{#if plugin_mode}}
 Most skills are provided by the `project-init-workflow` plugin (run `/help` to list them) — they are **not** files under this directory. The only project-local skill here is `plan/`. (Scaffold with `--no-plugin` to copy every skill in as `.agents/skills/<name>/SKILL.md`, indexed in `INDEX.md`.)
 {{/if plugin_mode}}
-User-level skills (across all projects) live in `~/.agents/skills/`.
+User-level skills (across all projects) live in `~/.claude/skills/`.

--- a/tests/contracts/test_upstream_home_paths.py
+++ b/tests/contracts/test_upstream_home_paths.py
@@ -38,7 +38,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Directories worth scanning: the product, the scaffolder, the installer, docs.
 _SCAN_DIRS = ("templates", "src", "docs", "tools", ".agents")
-_SCAN_FILES = ("install.sh",)
+
+# Root-level files are scanned by GLOB, not by an enumerated list. The first cut
+# of this guard named only install.sh and therefore missed README.md, which
+# still sent users to ~/.agents/commands and shipped an uninstall command that
+# removed the wrong file (caught by Codex in review of PI-877). An explicit list
+# re-creates that blind spot every time a root doc is added; a glob cannot.
+_SCAN_ROOT_GLOBS = ("*.md", "*.sh", "*.toml", "*.cfg", "*.ini", "*.yml", "*.yaml")
 
 _SKIP_DIR_PARTS = {".git", "__pycache__", ".venv", "node_modules", ".ruff_cache"}
 _SKIP_SUFFIXES = {".pyc", ".png", ".jpg", ".gif", ".svg", ".ico", ".woff", ".woff2"}
@@ -66,10 +72,8 @@ _ALLOWED = {
 
 def _candidate_files() -> list[Path]:
     files: list[Path] = []
-    for name in _SCAN_FILES:
-        p = REPO_ROOT / name
-        if p.is_file():
-            files.append(p)
+    for pattern in _SCAN_ROOT_GLOBS:
+        files.extend(p for p in REPO_ROOT.glob(pattern) if p.is_file())
     for d in _SCAN_DIRS:
         root = REPO_ROOT / d
         if not root.is_dir():

--- a/tests/contracts/test_upstream_home_paths.py
+++ b/tests/contracts/test_upstream_home_paths.py
@@ -1,0 +1,143 @@
+"""Guard against a `.claude` -> `.agents` rename catching external-tool paths.
+
+f375ca2 (PI-606, #620) migrated this project's own directory from `.claude/`
+to `.agents/`. The sweep was over-broad: it also rewrote machine-global home
+directories owned by *other* tools, which then pointed at paths nothing reads.
+
+Four instances shipped before this guard existed:
+
+===========  ==============================  =====================  ==========
+Path         Where                           Symptom                Fixed by
+===========  ==============================  =====================  ==========
+~/.claude    tools/benchmark/harness.py      creds not found        PI-802
+~/.claude-…  templates/multi_model           config silently unread PI-869
+~/.claude/p… templates/observability         no transcript found    PI-872
+~/.claude/c… install.sh                      dead /project-init     PI-877
+===========  ==============================  =====================  ==========
+
+PI-802 was fixed as a one-off; nobody checked whether the sweep had hit
+anything else, and three more instances sat undiscovered for a week. This test
+is the exhaustive check that should have followed it.
+
+The rule is deliberately narrow (cf. #688: docs and skills are a
+false-positive machine). It asserts two things and nothing more:
+
+1. No hyphen-suffixed `~/.agents-<tool>` home path exists anywhere. project-init
+   owns `.agents/` (project-local) and `~/.agents/` (user-level); a
+   `~/.agents-<tool>` spelling is always a renamed external path.
+2. No home-rooted `~/.agents` reference exists outside a small, explicit
+   allowlist of paths this project genuinely owns.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories worth scanning: the product, the scaffolder, the installer, docs.
+_SCAN_DIRS = ("templates", "src", "docs", "tools", ".agents")
+_SCAN_FILES = ("install.sh",)
+
+_SKIP_DIR_PARTS = {".git", "__pycache__", ".venv", "node_modules", ".ruff_cache"}
+_SKIP_SUFFIXES = {".pyc", ".png", ".jpg", ".gif", ".svg", ".ico", ".woff", ".woff2"}
+
+# Rule 1: `~/.agents-<suffix>` / `$HOME/.agents-<suffix>` — never legitimate.
+_HYPHEN_SUFFIXED = re.compile(r"(?:\$HOME|~)/\.agents-")
+
+# Rule 2: any home-rooted `.agents` reference, including the Python spelling.
+_HOME_AGENTS = re.compile(r"(?:\$HOME|~)/\.agents|Path\.home\(\)\s*/\s*[\"']\.agents[\"']")
+
+# Paths project-init genuinely owns at the user level. Keep this list SHORT and
+# justify every entry — each one is a place the guard cannot protect.
+_ALLOWED = {
+    # ADR-025 proposes a future orchestrator root layer under ~/.agents/.
+    # These are project-init-owned paths that do not exist yet, not renamed
+    # external ones. Confirmed against the ADR text, not assumed.
+    "docs/adr/adr-025-agentic-os-root-layer.md",
+    "docs/development/agentic-os-root-layer.md",
+    # harness.py's docstring names ~/.agents precisely to say creds are NOT
+    # there — the disambiguation that fixed PI-802. Removing it would lose the
+    # warning.
+    "tools/benchmark/harness.py",
+}
+
+
+def _candidate_files() -> list[Path]:
+    files: list[Path] = []
+    for name in _SCAN_FILES:
+        p = REPO_ROOT / name
+        if p.is_file():
+            files.append(p)
+    for d in _SCAN_DIRS:
+        root = REPO_ROOT / d
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file() or p.suffix in _SKIP_SUFFIXES:
+                continue
+            if _SKIP_DIR_PARTS & set(p.parts):
+                continue
+            files.append(p)
+    return files
+
+
+def _hits(pattern: re.Pattern[str], *, respect_allowlist: bool) -> list[str]:
+    found: list[str] = []
+    for path in _candidate_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if respect_allowlist and rel in _ALLOWED:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line):
+                found.append(f"{rel}:{lineno}: {line.strip()[:120]}")
+    return sorted(found)
+
+
+def test_no_hyphen_suffixed_agents_home_path():
+    """`~/.agents-<tool>` is always a renamed external path (PI-869)."""
+    # No allowlist here: there is no legitimate ~/.agents-<suffix> path at all.
+    hits = _hits(_HYPHEN_SUFFIXED, respect_allowlist=False)
+    assert not hits, (
+        "found a hyphen-suffixed ~/.agents-<tool> home path — this is an "
+        "external tool's directory renamed by a .claude -> .agents sweep "
+        "(PI-606/#620). Restore the upstream spelling:\n  " + "\n  ".join(hits)
+    )
+
+
+def test_no_unowned_agents_home_path():
+    """Home-rooted `~/.agents` outside the owned allowlist (PI-872, PI-877)."""
+    hits = _hits(_HOME_AGENTS, respect_allowlist=True)
+    assert not hits, (
+        "found a home-rooted ~/.agents path outside the owned allowlist. If an "
+        "external tool owns it, restore the upstream spelling (see PI-877); if "
+        "project-init genuinely owns it, add it to _ALLOWED with a reason:\n  " + "\n  ".join(hits)
+    )
+
+
+def test_installer_writes_to_claude_codes_command_dir():
+    """The `/project-init` command must land where Claude Code reads it (PI-877).
+
+    A fresh `curl | bash` install wrote to ~/.agents/commands/, which Claude
+    Code never loads, so the advertised slash command was dead on arrival.
+    """
+    text = (REPO_ROOT / "install.sh").read_text(encoding="utf-8")
+    assert "CLAUDE_CONFIG_DIR:-$HOME/.claude" in text, (
+        "installer must resolve Claude Code's own config dir, honoring "
+        "CLAUDE_CONFIG_DIR the way tools/benchmark/harness.py does; see PI-877"
+    )
+    assert '"$CLAUDE_CONFIG_DIR_RESOLVED/commands"' in text
+
+
+def test_allowlist_entries_still_exist():
+    """A stale allowlist silently widens the guard — fail if an entry vanishes."""
+    missing = sorted(rel for rel in _ALLOWED if not (REPO_ROOT / rel).is_file())
+    assert not missing, (
+        f"_ALLOWED names files that no longer exist: {missing}. Remove them so "
+        "the guard does not carry dead exemptions."
+    )

--- a/tests/integration/test_install_script.py
+++ b/tests/integration/test_install_script.py
@@ -48,6 +48,13 @@ def test_install_sh_writes_slash_command_with_stubs(tmp_path: Path):
     # The clone branch must have run (not the "update existing clone" path).
     assert (tmp_path / "install" / ".git").is_dir(), "install.sh must clone into INSTALL_DIR"
 
-    cmd = home / ".agents" / "commands" / "project-init.md"
+    # Claude Code's OWN config dir — NOT a project-init one. PI-606/#620 renamed
+    # both install.sh and this assertion to ~/.agents/commands, so the test kept
+    # passing while every fresh install produced a /project-init that Claude Code
+    # never loaded (PI-877). Do not "fix" a failure here by renaming the path.
+    cmd = home / ".claude" / "commands" / "project-init.md"
     assert cmd.is_file(), "install.sh must write the /project-init slash command"
     assert "project-init" in cmd.read_text()
+    assert not (home / ".agents" / "commands").exists(), (
+        "install.sh must not write commands under ~/.agents (PI-877)"
+    )

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -48,7 +48,7 @@ hence the manual, opt-in invocation.
 
 ```sh
 uv run python -m tools.benchmark.harness record-from \
-  --task feat --target bare --transcript ~/.agents/projects/<slug>/<session>.jsonl
+  --task feat --target bare --transcript ~/.claude/projects/<slug>/<session>.jsonl
 ```
 
 Useful for re-deriving records from past sessions, and the path the tests


### PR DESCRIPTION
Closes #877