### PR TITLE
fix(PI-880): bug: `upgrade` does not splice new config.yaml blocks (`ci:`, `monitor_ignore_checks`) into existing scaffolds

### DIFF
--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1143,8 +1143,10 @@ def _mirror_mode(src: Path, dest: Path) -> None:
 # a pre-field project actually advances past v0 on `upgrade --apply` (#498,
 # ADR-025) — an orchestrator reads the visible YAML, not the hidden record.
 # One indented `key: …` line inside the `project:` block; multi-line values do
-# not occur there. Used to diff the user's project fields against a fresh render.
-_PROJECT_FIELD_RE = re.compile(r"^  ([A-Za-z_]\w*):")
+# not occur there. The indent is captured, not fixed at two spaces, so a config a
+# formatter reindented is still recognised — else every field reads as missing
+# and gets a duplicate default that can shadow the user's value (PI-880 review).
+_PROJECT_FIELD_RE = re.compile(r"^(\s+)([A-Za-z_]\w*):")
 
 
 def _project_field_lines(head: str) -> dict[str, str]:
@@ -1161,7 +1163,7 @@ def _project_field_lines(head: str) -> dict[str, str]:
     for line in block.group(1).splitlines():
         m = _PROJECT_FIELD_RE.match(line)
         if m:
-            fields[m.group(1)] = line
+            fields[m.group(2)] = line
     return fields
 
 
@@ -1297,9 +1299,15 @@ def _ensure_visible_project_fields(text: str, staging: Path) -> str:
     staged_config = staging / _CONFIG_REL
     if staged_config.is_file():
         staged_head = staged_config.read_text(encoding="utf-8").partition(_RECORD_MARKER)[0]
-        have = set(_project_field_lines(head))
+        have = _project_field_lines(head)
+        # Match the config's own project-block indent (a formatter may not use two
+        # spaces) so injected lines never mix indentation and break the YAML.
+        sample = next(iter(have.values()), "  x")
+        indent = sample[: len(sample) - len(sample.lstrip())]
         missing = [
-            line for key, line in _project_field_lines(staged_head).items() if key not in have
+            indent + line.lstrip()
+            for key, line in _project_field_lines(staged_head).items()
+            if key not in have
         ]
         if missing:
             block = "\n".join(missing)

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1142,16 +1142,27 @@ def _mirror_mode(src: Path, dest: Path) -> None:
 # project_init_version line, in declaration order. The contract version leads so
 # a pre-field project actually advances past v0 on `upgrade --apply` (#498,
 # ADR-025) — an orchestrator reads the visible YAML, not the hidden record.
-_PROJECT_VISIBLE_FIELDS = (
-    (
-        "project_init_contract_version",
-        "descriptor-contract schema a root orchestrator reads (#498, ADR-025); absent ⇒ v0",
-    ),
-    ("project_init_plugin_version", "plugin payload version (ADR-010)"),
-    ("profile", "individual | standalone | org — distribution profile (ADR-013)"),
-    ("enforcement", "advisory | hard — see ADR-013 / #251"),
-    ("project_init_host", "upstream GitHub host — #255/#259"),
-)
+# One indented `key: …` line inside the `project:` block; multi-line values do
+# not occur there. Used to diff the user's project fields against a fresh render.
+_PROJECT_FIELD_RE = re.compile(r"^  ([A-Za-z_]\w*):")
+
+
+def _project_field_lines(head: str) -> dict[str, str]:
+    """Map each top-level `project:` field key to its full source line, in order.
+
+    *head* is a config's human section (above the scaffold-record marker); only
+    the `project:` block is scanned, so top-level keys like `language:` — and the
+    record's own JSON below — are ignored.
+    """
+    block = re.search(r"(?ms)^project:\n(.*?)(?=^\S)", head)
+    if not block:
+        return {}
+    fields: dict[str, str] = {}
+    for line in block.group(1).splitlines():
+        m = _PROJECT_FIELD_RE.match(line)
+        if m:
+            fields[m.group(1)] = line
+    return fields
 
 
 _UPDATES_BLOCK = (
@@ -1237,7 +1248,12 @@ _CI_BLOCK = (
     "\n"
 )
 
-_HOOKS_KEY_RE = re.compile(r"(?m)^hooks:")
+# The template renders `ci:` just above `hooks:`; both are unconditional in a
+# fresh scaffold. A config old enough to lack `ci:` also predates `hooks:`, so
+# anchoring on `hooks:` alone silently no-ops exactly when the splice is needed
+# (PI-880). Fall back to `updates:` (guaranteed present by the field pass that
+# runs first) so the block still lands, keeping template order (ci before both).
+_CI_ANCHOR_RE = re.compile(r"(?m)^(?:hooks|updates):")
 
 
 def _ensure_ci_block(text: str) -> str:
@@ -1251,30 +1267,43 @@ def _ensure_ci_block(text: str) -> str:
     projects could never declare a non-forge CI endpoint.
     """
     head, sep, tail = text.partition(_RECORD_MARKER)
-    if re.search(r"(?m)^ci:", head) or not _HOOKS_KEY_RE.search(head):
+    if re.search(r"(?m)^ci:", head):
         return text
-    head = _HOOKS_KEY_RE.sub(lambda m: _CI_BLOCK + m.group(0), head, count=1)
+    anchor = _CI_ANCHOR_RE.search(head)
+    if anchor:
+        head = head[: anchor.start()] + _CI_BLOCK + head[anchor.start() :]
+    else:
+        head = head.rstrip("\n") + "\n\n" + _CI_BLOCK
     return head + sep + tail
 
 
-def _ensure_visible_project_fields(text: str, variables: dict[str, str]) -> str:
-    """Surface recorded `project:` fields in the hand-editable config (#259, #498).
+def _ensure_visible_project_fields(text: str, staging: Path) -> str:
+    """Surface every `project:` field a fresh scaffold renders (#259, #498, PI-880).
 
-    Idempotent. Operates on the human section only (above the scaffold-record
-    marker) so injected lines survive ``write_scaffold_record``'s strip-and-
-    re-append. Missing ``project:`` fields are inserted together, in declaration
-    order, in a single substitution after the ``project_init_version`` line; the
-    ``updates`` consent placeholder is appended if the config predates it.
+    The source of truth is the staging render of *this project's own* variables,
+    not a hand-kept field list — so a field added upstream since the scaffold was
+    created (e.g. ``review_cycles``, ``monitor_ignore_checks``) reaches an
+    existing project too, and the upgraded config carries the same project fields
+    a fresh one would. Idempotent, and it only ever ADDS: a field the user
+    already has (possibly hand-edited) is left untouched.
+
+    Operates on the human section only (above the scaffold-record marker) so
+    injected lines survive ``write_scaffold_record``'s strip-and-re-append.
+    Missing fields are inserted together, in template order, after the
+    ``project_init_version`` line; the ``updates`` consent placeholder is
+    appended if the config predates it.
     """
     head, sep, tail = text.partition(_RECORD_MARKER)
-    missing = [
-        f"  {key}: {variables.get(key, '')}  # {comment}"
-        for key, comment in _PROJECT_VISIBLE_FIELDS
-        if not re.search(rf"(?m)^\s+{re.escape(key)}:", head)
-    ]
-    if missing:
-        block = "\n".join(missing)
-        head = _VERSION_LINE_RE.sub(lambda m: f"{m.group(0)}\n{block}", head, count=1)
+    staged_config = staging / _CONFIG_REL
+    if staged_config.is_file():
+        staged_head = staged_config.read_text(encoding="utf-8").partition(_RECORD_MARKER)[0]
+        have = set(_project_field_lines(head))
+        missing = [
+            line for key, line in _project_field_lines(staged_head).items() if key not in have
+        ]
+        if missing:
+            block = "\n".join(missing)
+            head = _VERSION_LINE_RE.sub(lambda m: f"{m.group(0)}\n{block}", head, count=1)
     if "declined_additions:" not in head:
         head = head.rstrip("\n") + _UPDATES_BLOCK
     return head + sep + tail
@@ -1325,7 +1354,7 @@ def apply_drift(
     if config_path.exists():
         text = config_path.read_text(encoding="utf-8")
         text = _VERSION_LINE_RE.sub(rf"\g<1>{variables['project_init_version']}", text, count=1)
-        text = _ensure_visible_project_fields(text, variables)
+        text = _ensure_visible_project_fields(text, staging)
         text = _ensure_ci_block(text)
         text = _sync_memory_block(text, staging)
         config_path.write_text(text, encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -96,6 +96,49 @@ def _tree_snapshot(target: Path) -> dict[str, bytes]:
     }
 
 
+def _visible_shape(config: Path) -> tuple[set[str], set[str]]:
+    """(project-field keys, top-level keys) of a config's human section."""
+    from project_init.upgrade import _project_field_lines
+
+    head = config.read_text().partition(_RECORD_MARKER)[0]
+    return set(_project_field_lines(head)), set(re.findall(r"(?m)^([a-z][\w]*):", head))
+
+
+def test_upgrade_backfills_every_field_a_fresh_scaffold_has(tmp_path: Path):
+    """PI-880: an existing config must gain EVERY field a fresh scaffold renders.
+
+    config.yaml is drift-excluded, so additive fields only reach an existing
+    project through the upgrade's targeted splice. That splice used to miss the
+    `ci:` block (its `hooks:` anchor is absent in a config old enough to need it)
+    and every newer `project:` field (`monitor_ignore_checks`, `review_cycles`,
+    …) — so an upgraded child diverged from a fresh one. Assert the field sets
+    now match.
+    """
+    fresh = tmp_path / "fresh"
+    _scaffold(fresh)
+    want_project, want_top = _visible_shape(fresh / _CONFIG_REL)
+    assert "monitor_ignore_checks" in want_project and "ci" in want_top  # fixture sanity
+
+    old = tmp_path / "old"
+    _scaffold(old)
+    config = old / _CONFIG_REL
+    head, sep, tail = config.read_text().partition(_RECORD_MARKER)
+    # Reproduce the real pre-#828 shape: no `ci:` AND no `hooks:` key (both were
+    # added together, so the config that needs ci: has no hooks: to anchor on).
+    head = re.sub(r"(?ms)^ci:\n.*?(?=^\w)", "", head, count=1)
+    head = re.sub(r"(?ms)^hooks:\n.*?(?=^\w)", "", head, count=1)
+    head = re.sub(r"(?m)^  (?:monitor_ignore_checks|review_cycles):.*\n", "", head)
+    config.write_text(head + sep + tail)
+    gap_project, gap_top = _visible_shape(config)
+    assert "ci" not in gap_top and "hooks" not in gap_top  # gap created
+    assert "monitor_ignore_checks" not in gap_project
+
+    assert main(["upgrade", str(old), "--apply"]) == 0
+    got_project, got_top = _visible_shape(config)
+    assert got_project == want_project, got_project ^ want_project
+    assert "ci" in got_top, "ci: must be backfilled even with no hooks: anchor"
+
+
 class TestDirtyTreeGuard:
     """#242: --apply is gated on a clean git work tree, with an undo hint."""
 

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -139,6 +139,34 @@ def test_upgrade_backfills_every_field_a_fresh_scaffold_has(tmp_path: Path):
     assert "ci" in got_top, "ci: must be backfilled even with no hooks: anchor"
 
 
+def test_field_backfill_handles_a_reindented_project_block(tmp_path: Path):
+    """PI-880 review: a project block a formatter reindented (not two spaces) must
+    not read every field as missing and gain duplicate, value-shadowing defaults.
+    Existing fields are detected regardless of indent, and a genuinely-missing one
+    is inserted at the block's own indent (never mixing widths)."""
+    from project_init.upgrade import _ensure_visible_project_fields
+
+    staging = tmp_path / "staging"
+    (staging / _CONFIG_REL).parent.mkdir(parents=True)
+    (staging / _CONFIG_REL).write_text(
+        'project:\n  name: "x"\n  project_init_version: 1.0.0\n'
+        "  review_cycles: 2\n  monitor_ignore_checks: []\n\nmcps: []\n"
+    )
+    # A four-space project block that already carries a hand-set
+    # monitor_ignore_checks and is missing review_cycles.
+    user = (
+        'project:\n    name: "x"\n    project_init_version: 1.0.0\n'
+        '    monitor_ignore_checks: ["board-sync"]\n\nmcps: []\n'
+    )
+    out = _ensure_visible_project_fields(user, staging)
+    assert out.count("monitor_ignore_checks:") == 1, "must not duplicate an existing field"
+    assert '["board-sync"]' in out, "the user's hand-set value must survive"
+    assert re.search(r"(?m)^    review_cycles:", out), (
+        "missing field inserted at the block's indent"
+    )
+    assert "\n  review_cycles:" not in out, "no two-space line mixed into a four-space block"
+
+
 class TestDirtyTreeGuard:
     """#242: --apply is gated on a clean git work tree, with an undo hint."""
 

--- a/tests/unit/test_ci_block_backfill.py
+++ b/tests/unit/test_ci_block_backfill.py
@@ -60,6 +60,17 @@ def test_backfill_leaves_the_scaffold_record_intact() -> None:
     assert out.index("\nci:") < out.index(_RECORD_MARKER)
 
 
-def test_backfill_no_ops_on_a_config_without_hooks() -> None:
-    # Nothing to anchor against — leave the file alone rather than guess.
-    assert _ensure_ci_block("project:\n  name: app\n") == "project:\n  name: app\n"
+def test_backfill_reaches_a_config_without_a_hooks_key() -> None:
+    # PI-880: a config old enough to lack `ci:` also predates `hooks:`, so the
+    # splice must not depend on `hooks:` being there. With no `hooks:`/`updates:`
+    # anchor it appends the block rather than silently dropping it.
+    out = _ensure_ci_block("project:\n  name: app\n")
+    assert "status_url:" in out
+
+
+def test_backfill_anchors_above_updates_when_hooks_is_absent() -> None:
+    # The realistic pre-`hooks:` shape (PI-880): the field pass guarantees an
+    # `updates:` key, so `ci:` lands just above it — template order preserved.
+    pre = 'project:\n  name: "app"\n\ntooling:\n  lint_command: "x"\n\nupdates:\n  declined_additions: {}\n'
+    out = _ensure_ci_block(pre)
+    assert out.index("\nci:") < out.index("\nupdates:")


### PR DESCRIPTION
Closes #880