### PR TITLE
feat(PI-901): Emit the detect-and-defer boundary marker (context: repo) in the descriptor

### DIFF
--- a/schemas/descriptor.schema.json
+++ b/schemas/descriptor.schema.json
@@ -5,6 +5,11 @@
   "description": "JSON schema for the cross-project memory descriptor contract (.agents/config.yaml).",
   "type": "object",
   "properties": {
+    "context": {
+      "type": "string",
+      "enum": ["repo", "ambient"],
+      "description": "Detect-and-defer boundary marker (PI-901; harbor#4 H1). 'repo' = this project governs itself and an ambient/global agent layer must stand down inside it; 'ambient' = the owner opted out and the global layer keeps acting here. Additive within contract v2 and deliberately NOT in 'required': descriptors scaffolded before this field predate it and stay valid, and `project-init upgrade` back-fills them. A reader must therefore treat an absent 'context' as unknown and fall back to the presence of .agents/ itself, never as 'ambient'."
+    },
     "project": {
       "type": "object",
       "properties": {

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1312,6 +1312,18 @@ _CONTEXT_BLOCK = (
 # it was needed (PI-880).
 _CONTEXT_ANCHOR_RE = re.compile(r"(?m)^project:")
 
+# Every spelling of a top-level `context` key that YAML accepts. A bare
+# `^context:` misses `context : ambient` and `"context": ambient` — both valid —
+# and the splice would then insert a SECOND logical `context` key. Duplicate-key-
+# tolerant readers keep whichever comes last (the inserted `repo`), silently
+# revoking the opt-out; stricter ones reject the descriptor outright (PR #902
+# review). Still anchored at column 0: `context` is top-level, and one indented
+# under another block is a different key that happens to share a name.
+# KEEP IN STEP with harbor's floor_in_repo, which reads the same key — a
+# spelling the writer preserves but the reader misses is an opt-out that
+# survives upgrade and is then ignored.
+_CONTEXT_KEY_RE = re.compile(r"""(?m)^(?:context|"context"|'context')[ \t]*:""")
+
 
 def _ensure_context_key(text: str) -> str:
     """Backfill the detect-and-defer marker into a pre-PI-901 config (harbor#4 H1).
@@ -1324,7 +1336,7 @@ def _ensure_context_key(text: str) -> str:
     reset it to ``repo`` would silently revoke a decision.
     """
     head, sep, tail = text.partition(_RECORD_MARKER)
-    if re.search(r"(?m)^context:", head):
+    if _CONTEXT_KEY_RE.search(head):
         return text
     anchor = _CONTEXT_ANCHOR_RE.search(head)
     if anchor:

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1297,6 +1297,43 @@ def _ensure_ci_block(text: str) -> str:
     return head + sep + tail
 
 
+_CONTEXT_BLOCK = (
+    "# Detect-and-defer boundary marker (PI-901; harbor#4 H1). repo = this project\n"
+    "# governs itself, so an ambient/global agent layer stands down inside it;\n"
+    "# ambient = opt out. Not `governance:` — that name is already a boolean.\n"
+    "context: repo\n"
+    "\n"
+)
+
+# The template renders `context:` immediately above `project:`, and `project:` is
+# the one top-level key present in EVERY config ever emitted (it predates the
+# descriptor contract itself). That is deliberate: the `ci:` splice anchored on a
+# key younger than the configs it had to reach and silently no-opped exactly when
+# it was needed (PI-880).
+_CONTEXT_ANCHOR_RE = re.compile(r"(?m)^project:")
+
+
+def _ensure_context_key(text: str) -> str:
+    """Backfill the detect-and-defer marker into a pre-PI-901 config (harbor#4 H1).
+
+    config.yaml is never re-rendered wholesale on upgrade, so the template line
+    alone would only ever reach *fresh* scaffolds — every already-scaffolded
+    project would stay unmarked and the layer above it could not tell that the
+    repo governs itself. Idempotent, and it never rewrites an existing value:
+    ``context: ambient`` is the owner's deliberate opt-out and an upgrade that
+    reset it to ``repo`` would silently revoke a decision.
+    """
+    head, sep, tail = text.partition(_RECORD_MARKER)
+    if re.search(r"(?m)^context:", head):
+        return text
+    anchor = _CONTEXT_ANCHOR_RE.search(head)
+    if anchor:
+        head = head[: anchor.start()] + _CONTEXT_BLOCK + head[anchor.start() :]
+    else:
+        head = _CONTEXT_BLOCK + head
+    return head + sep + tail
+
+
 def _ensure_visible_project_fields(text: str, staging: Path) -> str:
     """Surface every `project:` field a fresh scaffold renders (#259, #498, PI-880).
 
@@ -1381,6 +1418,7 @@ def apply_drift(
         text = config_path.read_text(encoding="utf-8")
         text = _VERSION_LINE_RE.sub(rf"\g<1>{variables['project_init_version']}", text, count=1)
         text = _ensure_visible_project_fields(text, staging)
+        text = _ensure_context_key(text)
         text = _ensure_ci_block(text)
         text = _sync_memory_block(text, staging)
         config_path.write_text(text, encoding="utf-8", newline="\n")  # LF on all hosts (PI-362)

--- a/templates/base/dot_agents/config.yaml.tmpl
+++ b/templates/base/dot_agents/config.yaml.tmpl
@@ -1,6 +1,21 @@
 # project-init: record of choices made at init time.
 # Safe to hand-edit; re-running `project-init` will reconcile with this file.
 
+# Detect-and-defer boundary marker (PI-901; harbor#4 H1, harbor CONTRACTS/marker.md).
+# Declares to every layer ABOVE this repo — a root orchestrator, a global agent
+# environment, any hook that would otherwise write a machine-wide log — that this
+# project governs itself.
+#   repo    — this repo wins; the ambient layer stands down inside it (what a
+#             scaffold always emits)
+#   ambient — opt out: let the global layer keep acting here
+# Deliberately NOT `governance:` — that name is already a project-init boolean
+# (the AI-governance overlay gate, ADR-018), and overloading it collides in both
+# the wizard and the schema.
+# A reader also treats the PRESENCE of .agents/ as the marker, so deleting this
+# line does not hand the repo back to the ambient layer — it only removes the
+# explicit declaration a reader can act on.
+context: repo
+
 project:
   name: "{{project_name}}"
   description: "{{project_description}}"

--- a/tests/contracts/test_descriptor_schema.py
+++ b/tests/contracts/test_descriptor_schema.py
@@ -161,6 +161,21 @@ class TestContractVersionAndBlocks:
         config = _render_full(tmp_path)
         assert config["ci"]["status_field"] == ""
 
+    def test_emits_the_detect_and_defer_context_marker(self, tmp_path: Path):
+        # PI-901 / harbor#4 H1. This is the assertion that actually protects the
+        # marker: `context` is optional in the schema (pre-PI-901 descriptors
+        # must stay valid until `upgrade` back-fills them), so schema validation
+        # alone would pass with the key dropped from the template entirely.
+        config = _render_full(tmp_path)
+        assert config["context"] == "repo"
+
+    def test_does_not_overload_the_governance_boolean(self, tmp_path: Path):
+        # harbor CONTRACTS/marker.md: `governance` is already a project-init
+        # boolean (the ADR-018 overlay gate). The marker must not reuse the name
+        # — this scaffold renders WITH governance=True, so a collision would
+        # show up here as a stray top-level key.
+        assert "governance" not in _render_full(tmp_path)
+
 
 class TestSchemaAccessor:
     """PI-786: the schemas are a consumable, versioned artifact a downstream
@@ -170,8 +185,39 @@ class TestSchemaAccessor:
         schema = load_descriptor_schema()
         props = schema["properties"]
         # The v2 contract surfaces a root orchestrator reads must be defined.
-        assert {"deploy", "observability", "hooks", "tooling", "memory", "ci"} <= set(props)
+        assert {"deploy", "observability", "hooks", "tooling", "memory", "ci", "context"} <= set(
+            props
+        )
         assert "v2" in schema["title"]
+
+    def test_schema_rejects_a_mistyped_context_value(self):
+        # PI-901: the marker is read by three separate implementations across two
+        # languages, so a near-miss value ("Repo", "project") is the realistic
+        # failure — it looks marked to a human and resolves to nothing in code.
+        # The enum is what turns that into a validation error instead of silence.
+        schema = load_descriptor_schema()
+        descriptor = {
+            "project": {"name": "x", "description": "y"},
+            "language": "python",
+            "delivery": "library",
+            "context": "Repo",
+        }
+        with pytest.raises(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(instance=descriptor, schema=schema)
+
+    def test_schema_still_accepts_a_descriptor_with_no_context(self):
+        # Every project scaffolded before PI-901 has one. Making `context`
+        # required would fail-closed on the entire installed base until the
+        # back-fill sweep finishes, so absence stays valid — and a reader is told
+        # (in the field description) to fall back to .agents/ presence, never to
+        # read absence as "ambient".
+        schema = load_descriptor_schema()
+        descriptor = {
+            "project": {"name": "x", "description": "y"},
+            "language": "python",
+            "delivery": "library",
+        }
+        jsonschema.validate(instance=descriptor, schema=schema)
 
     def test_usage_event_schema_loads(self):
         assert load_usage_event_schema()["type"] == "object"

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -128,15 +128,22 @@ def test_upgrade_backfills_every_field_a_fresh_scaffold_has(tmp_path: Path):
     head = re.sub(r"(?ms)^ci:\n.*?(?=^\w)", "", head, count=1)
     head = re.sub(r"(?ms)^hooks:\n.*?(?=^\w)", "", head, count=1)
     head = re.sub(r"(?m)^  (?:monitor_ignore_checks|review_cycles):.*\n", "", head)
+    # PI-901: the detect-and-defer marker, comment block and all — that whole
+    # region is what the splice has to re-create in a pre-901 config.
+    head = re.sub(r"(?ms)^# Detect-and-defer.*?^context: repo\n\n", "", head, count=1)
     config.write_text(head + sep + tail)
     gap_project, gap_top = _visible_shape(config)
     assert "ci" not in gap_top and "hooks" not in gap_top  # gap created
+    assert "context" not in gap_top  # gap created
     assert "monitor_ignore_checks" not in gap_project
 
     assert main(["upgrade", str(old), "--apply"]) == 0
     got_project, got_top = _visible_shape(config)
     assert got_project == want_project, got_project ^ want_project
     assert "ci" in got_top, "ci: must be backfilled even with no hooks: anchor"
+    # An unmarked repo is one the layer above never stands down in, so the
+    # back-fill is the whole reason the marker reaches the installed base.
+    assert "context" in got_top, "the detect-and-defer marker must be backfilled (PI-901)"
 
 
 def test_field_backfill_handles_a_reindented_project_block(tmp_path: Path):

--- a/tests/unit/test_context_marker_backfill.py
+++ b/tests/unit/test_context_marker_backfill.py
@@ -1,0 +1,80 @@
+"""The detect-and-defer marker reaches EXISTING scaffolds, not just fresh ones (PI-901).
+
+`.agents/config.yaml` is never re-rendered wholesale on upgrade (it holds
+hand-edited fields), so the template line alone would only ever mark *new*
+projects. `upgrade` splices `context: repo` in — idempotently, and without ever
+overwriting an owner who deliberately opted out with `context: ambient`.
+
+harbor#4 H1 / harbor CONTRACTS/marker.md: the marker is what tells a root
+orchestrator or a global agent environment to stand down inside a governed repo.
+An unmarked repo is one the layer above keeps acting in.
+"""
+
+from __future__ import annotations
+
+from project_init.scaffold import _RECORD_MARKER
+from project_init.upgrade import _ensure_context_key
+
+_PRE_901 = """\
+# project-init: record of choices made at init time.
+
+project:
+  name: "app"
+
+language: python
+
+hooks:
+  expected: [pre-commit, commit-msg, pre-push]
+"""
+
+
+def _with_record(body: str) -> str:
+    return f"{body}\n{_RECORD_MARKER}\nvariables: {{}}\n"
+
+
+def test_backfill_adds_the_marker_to_a_pre_901_config() -> None:
+    assert "\ncontext: repo\n" in _ensure_context_key(_PRE_901)
+
+
+def test_backfill_puts_context_above_project() -> None:
+    # Template order: the marker is the first key a reader meets.
+    out = _ensure_context_key(_PRE_901)
+    assert out.index("\ncontext:") < out.index("\nproject:")
+
+
+def test_backfill_is_idempotent() -> None:
+    once = _ensure_context_key(_PRE_901)
+    assert _ensure_context_key(once) == once
+
+
+def test_backfill_never_revokes_a_deliberate_opt_out() -> None:
+    # `ambient` is the owner saying "keep acting here". An upgrade that reset it
+    # to `repo` would silently revoke that decision — and the failure is
+    # invisible, because both values are valid.
+    opted_out = _ensure_context_key(_PRE_901).replace("context: repo", "context: ambient")
+    out = _ensure_context_key(opted_out)
+    assert out.count("context:") == 1
+    assert "context: ambient" in out
+
+
+def test_backfill_leaves_the_scaffold_record_intact() -> None:
+    out = _ensure_context_key(_with_record(_PRE_901))
+    assert out.count(_RECORD_MARKER) == 1
+    assert out.index("\ncontext:") < out.index(_RECORD_MARKER)
+
+
+def test_a_commented_out_marker_does_not_count_as_present() -> None:
+    # `# context: repo` in a comment is documentation, not a declaration. If the
+    # presence check matched it the splice would no-op and the repo would stay
+    # unmarked while looking marked to a human reading the file.
+    commented = "# context: repo\n" + _PRE_901
+    out = _ensure_context_key(commented)
+    assert "\ncontext: repo\n" in out
+
+
+def test_backfill_reaches_a_config_with_no_project_key() -> None:
+    # The anchor must not be the single point of failure the `ci:` one was
+    # (PI-880): with nothing to anchor on, prepend rather than silently drop.
+    out = _ensure_context_key("language: python\n")
+    assert out.startswith("# Detect-and-defer")
+    assert "\ncontext: repo\n" in out

--- a/tests/unit/test_context_marker_backfill.py
+++ b/tests/unit/test_context_marker_backfill.py
@@ -12,6 +12,9 @@ An unmarked repo is one the layer above keeps acting in.
 
 from __future__ import annotations
 
+import pytest
+import yaml
+
 from project_init.scaffold import _RECORD_MARKER
 from project_init.upgrade import _ensure_context_key
 
@@ -70,6 +73,33 @@ def test_a_commented_out_marker_does_not_count_as_present() -> None:
     commented = "# context: repo\n" + _PRE_901
     out = _ensure_context_key(commented)
     assert "\ncontext: repo\n" in out
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "context: ambient",
+        "context : ambient",
+        'context:  "ambient"',
+        '"context": ambient',
+        "'context': ambient",
+    ],
+)
+def test_no_second_context_key_for_any_valid_yaml_spelling(line: str) -> None:
+    # PR #902 review. A bare `^context:` check misses `context : ambient` and
+    # `"context": ambient` — both valid YAML — and the splice then inserts a
+    # SECOND logical `context` key. Duplicate-key-tolerant readers keep whichever
+    # comes last (the inserted `repo`), silently revoking the opt-out; stricter
+    # ones reject the descriptor outright. Either way the owner's decision is
+    # gone and nothing says so.
+    #
+    # Asserted through a real YAML parser on the VALUE a reader would get, not
+    # by re-running the production regex over the output — a test that counts
+    # matches with the very pattern under test passes for every mutation of it.
+    # (The first draft of this test did exactly that and survived reverting the
+    # fix; caught by the mutation check CLAUDE.md asks for.)
+    out = _ensure_context_key(f"{line}\n{_PRE_901}")
+    assert yaml.safe_load(out.partition(_RECORD_MARKER)[0])["context"] == "ambient", out
 
 
 def test_backfill_reaches_a_config_with_no_project_key() -> None:


### PR DESCRIPTION
Closes #901

Sub-issue of VytCepas/harbor#4 (H1). Implements the emitter half of the frozen spec in harbor `CONTRACTS/marker.md`.

## What the marker is for

One defined signal, read identically by three implementations in two languages, that tells every layer **above** a project — a root orchestrator, a global agent environment, any hook that would otherwise write a machine-wide log — that this repo governs itself and the ambient layer stands down inside it.

## What changed

| | |
|---|---|
| `templates/base/dot_agents/config.yaml.tmpl` | top-level `context: repo` |
| `schemas/descriptor.schema.json` | `context` — additive, `enum: [repo, ambient]`, **not** required |
| `src/project_init/upgrade.py` | `_ensure_context_key` splice so the marker reaches the installed base |

## Three decisions worth reviewing

**Not `governance:`.** That name is already a project-init boolean (the ADR-018 overlay gate, `variables.py`), and overloading it collides in both the wizard and the schema. A contract test now asserts no top-level `governance` key appears in a `governance=True` render, so the collision can't be reintroduced by accident.

**Not `project-init.md.tmpl`.** The contract spec named that file; it is Markdown. `.agents/config.yaml` — the file `prod_guard._find_config` actually reads — renders from `config.yaml.tmpl`, which is where every other config key already flows. Corrected here and reported upstream on harbor#4.

**Not `required`.** Every descriptor scaffolded before this predates the field, so requiring it would fail validation across the whole installed base until the back-fill sweep (harbor#4 H3) finishes. The **enum** is what earns its keep instead: for a key three implementations read, the realistic failure is a near-miss value (`Repo`, `project`) that looks marked to a human and resolves to nothing in code. The field description tells a reader to treat **absence** as unknown and fall back to `.agents/` presence — never as `ambient`.

## Why the upgrade splice is not optional

`config.yaml` is never re-rendered wholesale on upgrade, so the template line alone would only ever mark **new** projects — every existing one would stay unmarked and invisible to the layer above it. Follows the `ci:` precedent (PI-828) with one difference: the anchor is `project:`, the single top-level key present in every config ever emitted. The `ci:` splice anchored on a key *younger* than the configs it had to reach and silently no-opped exactly when it was needed (PI-880).

It never overwrites an existing value. `context: ambient` is the owner's deliberate opt-out, and an upgrade that reset it to `repo` would silently revoke a decision that has no other record.

## Tests — and the mutation check

- **contracts** — fresh-scaffold emission, schema conformance, the `governance` non-collision, enum rejects a mistyped value, absent `context` still validates
- **unit** (`test_context_marker_backfill.py`) — splice lands above `project:`, idempotent, opt-out survives, a commented-out marker does not count as present, missing anchor still lands the block
- **integration** — the marker survives a real `upgrade --apply` over a config with the whole pre-901 region stripped

Per CLAUDE.md's *"a test that cannot fail is worse than no test"*: all four assertions were mutation-checked. Removing the template line, the enum, the splice body, and its call site each turns exactly the intended test red — verified, not assumed.

`ruff check` clean · `ruff format --check` clean · `mypy --strict` clean · `2602 passed`.

**Pre-existing on `main`, not from this branch:** 7 hook-runtime contract tests fail on this machine (`test_post_edit_lint_*`, `test_multi_model_overlay`, `test_observability_self_log`). Confirmed identical on a stashed clean tree. Untouched here.

**Repo-config note, unrelated to this change:** this clone's `remote.origin.fetch` is `+refs/heads/main:refs/remotes/origin/main` (single-branch), so no feature branch ever gets a remote-tracking ref and `gh pr create` without `--head` refuses with *"you must first push the current branch"*. That is why `start_issue.sh` pushed the branch and then failed to open the PR. It will do that for every issue until either the refspec is widened or the script passes `--head`.