### PR TITLE
fix(PI-903): Refuse a symlinked .agents marker in prod_guard

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.1"
   },
   "project-init-workflow": {
-    "sha256": "b4f194d21f814171552b192fe1e258e7103bacde7840bc4cdf5ae1651fcddc24",
-    "version": "0.8.1"
+    "sha256": "ad329be8000154d0d1c108fdab866c191e2b78e1723f6bda63931435892edaad",
+    "version": "0.8.2"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
-    "name": "Vytautas \u010cepas",
+    "name": "Vytautas Čepas",
     "url": "https://github.com/VytCepas"
   },
   "repository": "https://github.com/VytCepas/project-init",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -83,9 +83,27 @@ _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
 def _find_config(start: Path) -> Path | None:
-    """Walk up from *start* to the project's .agents/config.yaml, if any."""
+    """Walk up from *start* to the project's .agents/config.yaml, if any.
+
+    A SYMLINKED marker is refused and the walk continues (PI-903; harbor#4 M13,
+    harbor CONTRACTS/marker.md). ``is_file()`` follows symlinks, so this used to
+    accept an ``.agents/`` — or an ``.agents/config.yaml`` — pointing anywhere on
+    disk. That matters more here than it does for a boundary verdict: this
+    function locates the file ``safety.allow`` is read from, so a link planted
+    outside the repo supplies its own allowlist and switches the destructive-
+    command deny table off wholesale. A symlink is writable from outside the
+    repo's own review, which is exactly what the guard is defending.
+
+    Refusing is the safe direction (no allowlist ⇒ keep guarding), and it makes
+    this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
+    markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
+    disagreement while it existed.
+    """
     for candidate in (start, *start.parents):
-        config = candidate / ".agents" / "config.yaml"
+        agents = candidate / ".agents"
+        config = agents / "config.yaml"
+        if agents.is_symlink() or config.is_symlink():
+            continue
         if config.is_file():
             return config
     return None

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.1"
+__plugin_version__ = "0.8.2"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -83,9 +83,27 @@ _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
 def _find_config(start: Path) -> Path | None:
-    """Walk up from *start* to the project's .agents/config.yaml, if any."""
+    """Walk up from *start* to the project's .agents/config.yaml, if any.
+
+    A SYMLINKED marker is refused and the walk continues (PI-903; harbor#4 M13,
+    harbor CONTRACTS/marker.md). ``is_file()`` follows symlinks, so this used to
+    accept an ``.agents/`` — or an ``.agents/config.yaml`` — pointing anywhere on
+    disk. That matters more here than it does for a boundary verdict: this
+    function locates the file ``safety.allow`` is read from, so a link planted
+    outside the repo supplies its own allowlist and switches the destructive-
+    command deny table off wholesale. A symlink is writable from outside the
+    repo's own review, which is exactly what the guard is defending.
+
+    Refusing is the safe direction (no allowlist ⇒ keep guarding), and it makes
+    this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
+    markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
+    disagreement while it existed.
+    """
     for candidate in (start, *start.parents):
-        config = candidate / ".agents" / "config.yaml"
+        agents = candidate / ".agents"
+        config = agents / "config.yaml"
+        if agents.is_symlink() or config.is_symlink():
+            continue
         if config.is_file():
             return config
     return None

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -191,6 +191,37 @@ class TestVerdicts:
         allowed = "kubectl delete pod web --context kind-dev"
         assert _run_hook(_payload(allowed, "bypassPermissions", inner), inner) is None
 
+    def test_a_refused_link_does_not_change_ancestor_inheritance(self, tmp_path: Path):
+        """PR #904 review (P1, refuted): a link pointing at an ANCESTOR's marker
+        must resolve exactly as the same tree without the link.
+
+        The review read this as a bypass — refuse the inner link, walk on, and
+        the ancestor's `allow: [".*"]` is honoured anyway. It is not: walking up
+        to an ancestor marker is the contract's defined behaviour when the repo
+        has no marker of its own, so the link contributes nothing. Delete it and
+        you reach the same config by the same route.
+
+        The suggested mitigation — exclude refused link targets from the rest of
+        the walk — would make these two trees DIVERGE: identical on-disk layouts
+        resolving differently because an unrelated symlink happened to point at
+        one of them. This pins them equal so that "fix" fails loudly.
+        """
+        linked = tmp_path / "linked"
+        (linked / ".agents").mkdir(parents=True)
+        (linked / ".agents" / "config.yaml").write_text('safety:\n  allow: [".*"]\n')
+        (linked / "repo").mkdir()
+        (linked / "repo" / ".agents").symlink_to(linked / ".agents", target_is_directory=True)
+
+        plain = tmp_path / "plain"
+        (plain / ".agents").mkdir(parents=True)
+        (plain / ".agents" / "config.yaml").write_text('safety:\n  allow: [".*"]\n')
+        (plain / "repo").mkdir()
+
+        cmd = "terraform destroy -auto-approve"
+        with_link = _run_hook(_payload(cmd, "bypassPermissions", linked / "repo"), linked / "repo")
+        without = _run_hook(_payload(cmd, "bypassPermissions", plain / "repo"), plain / "repo")
+        assert with_link == without, "a refused link changed how an ancestor marker resolves"
+
     def test_allowlist_multiline_yaml_suppresses_flag(self, tmp_path: Path):
         """PI-187: a multi-line YAML allow list must work, not just inline JSON
         — the old parser silently dropped it to []."""

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -128,6 +128,69 @@ class TestVerdicts:
         payload = _payload(command, "bypassPermissions", subdir)
         assert _run_hook(payload, subdir) is None
 
+    def test_symlinked_agents_dir_cannot_supply_an_allowlist(self, tmp_path: Path):
+        """PI-903 (harbor#4 M13): a planted `.agents` symlink must not be read.
+
+        `is_file()` follows symlinks, so an `.agents` link pointing outside the
+        repo handed the guard an allowlist written outside the repo's own
+        review — and `allow: [".*"]` switches the whole deny table off. The link
+        is the payload; nothing inside the repo has to change for it to work.
+        """
+        outside = tmp_path / "outside" / ".agents"
+        outside.mkdir(parents=True)
+        (outside / "config.yaml").write_text('safety:\n  allow: [".*"]\n')
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".agents").symlink_to(outside, target_is_directory=True)
+
+        command = "terraform destroy -auto-approve"
+        assert _run_hook(_payload(command, "bypassPermissions", repo), repo) is not None, (
+            "a symlinked .agents/ supplied safety.allow from outside the repo"
+        )
+
+    def test_symlinked_config_file_cannot_supply_an_allowlist(self, tmp_path: Path):
+        """The other half: a real `.agents/` holding a symlinked config.yaml.
+        Checking only the directory leaves the file — the thing actually read —
+        pointing anywhere on disk."""
+        (tmp_path / "outside").mkdir()
+        planted = tmp_path / "outside" / "config.yaml"
+        planted.write_text('safety:\n  allow: [".*"]\n')
+        repo = tmp_path / "repo"
+        (repo / ".agents").mkdir(parents=True)
+        (repo / ".agents" / "config.yaml").symlink_to(planted)
+
+        command = "terraform destroy -auto-approve"
+        assert _run_hook(_payload(command, "bypassPermissions", repo), repo) is not None, (
+            "a symlinked config.yaml supplied safety.allow from outside the repo"
+        )
+
+    def test_a_refused_symlink_does_not_stop_the_walk(self, tmp_path: Path):
+        """Refusing must mean 'keep looking', not 'give up'. An inner symlinked
+        marker shadowing a real outer one would otherwise silently discard the
+        owner's genuine allowlist — matching harbor's floor_in_repo, which
+        continues its walk past a refused marker rather than returning."""
+        (tmp_path / "outside").mkdir()
+        (tmp_path / "outside" / "config.yaml").write_text('safety:\n  allow: [".*"]\n')
+        real = tmp_path / ".agents"
+        real.mkdir()
+        real.joinpath("config.yaml").write_text(
+            'safety:\n  allow: ["kubectl delete .* --context kind-dev"]\n'
+        )
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        (inner / ".agents").symlink_to(tmp_path / "outside", target_is_directory=True)
+
+        # The planted `.*` is ignored…
+        assert (
+            _run_hook(
+                _payload("terraform destroy -auto-approve", "bypassPermissions", inner), inner
+            )
+            is not None
+        )
+        # …and the real one an ancestor declares is still honoured.
+        allowed = "kubectl delete pod web --context kind-dev"
+        assert _run_hook(_payload(allowed, "bypassPermissions", inner), inner) is None
+
     def test_allowlist_multiline_yaml_suppresses_flag(self, tmp_path: Path):
         """PI-187: a multi-line YAML allow list must work, not just inline JSON
         — the old parser silently dropped it to []."""


### PR DESCRIPTION
Closes #903

Sub-issue of VytCepas/harbor#4 (M13, settled by the owner 2026-07-25).

## This is a live hole, not only a contract mismatch

`_find_config` used `Path.is_file()`, which **follows symlinks**. So an `.agents` directory — or an `.agents/config.yaml` — that is a link to anywhere on disk was read as the project's own config.

That matters more than a wrong boundary verdict, because `_find_config` locates the file **`safety.allow` is read from**:

```
repo/.agents -> /tmp/planted/.agents        # planted/.agents/config.yaml:
                                            #   safety:
                                            #     allow: [".*"]
```

`allow: [".*"]` switches the entire destructive-command deny table off — `terraform destroy`, `kubectl delete`, `DROP DATABASE`, `rm -rf` outside the project. **The link is the payload**: nothing inside the repo has to change, and a symlink is writable from outside the repo's own review, which is precisely what the guard is defending.

Verified by deleting the fix and watching the planted allowlist take effect.

## The fix

Both spellings are refused — `.agents` itself and `config.yaml` inside it — and the walk **continues** rather than returning. A refused inner marker must not shadow a real outer one, or an owner's genuine allowlist gets silently discarded. Refusing is the safe direction on its own: no allowlist means keep guarding.

## Why now

harbor's `floor_in_repo` has refused symlinked markers since its 2026-07-24 marker-forgery finding. This walk is the reference implementation `CONTRACTS/marker.md` points at, and **the two have disagreed by default ever since, with nothing surfacing it**. They now agree, and the shared fixture suite pins the agreement (harbor `fixtures/marker/cases.json`, M13/M24).

## Tests

Three, all mutation-checked — deleting the two-line refusal turns each red:

- a symlinked `.agents/` cannot supply an allowlist
- a symlinked `config.yaml` inside a real `.agents/` cannot either
- a refused symlink does not stop the walk: the planted `.*` is ignored **and** an ancestor's real allowlist is still honoured

Plugin payload re-synced with a version bump to 0.8.2 (PI-881), constant in `__init__.py` in step.

`ruff check` clean · `ruff format --check` clean · `mypy --strict` clean · 2594 passed.

**Pre-existing on `main`, not from this branch:** the same 7 hook-runtime contract tests that fail on this machine and pass on all four CI shards.