### PR TITLE
fix(PI-907): Make the scaffolded shfmt install host-safe and arch-aware

### DIFF
--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -176,17 +176,54 @@ jobs:
           just-version: "1.57.0"
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
+      #
+      # Host-safe and OS/arch aware, because `runs-on` here is
+      # `vars.CI_RUNS_ON || ubuntu-24.04` and `just ci-local-on` sets that
+      # variable to `self-hosted`. Two consequences the original step got wrong:
+      #
+      #   1. A self-hosted runner shares $HOME with its operator. A step that
+      #      writes into ~/.local/bin modifies a real machine, not a throwaway
+      #      VM — so if a usable shfmt is already on PATH, leave it alone.
+      #   2. The asset must match the runner. Hardcoding linux_amd64 installed a
+      #      Linux x86 binary onto a macOS/ARM runner, which then failed the
+      #      lint step with "cannot execute binary file" *after* overwriting the
+      #      operator's working shfmt. A nightly cron repeated it unattended.
       - name: Install shfmt
         run: |
+          set -eu
+          if command -v shfmt >/dev/null 2>&1 && shfmt --version >/dev/null 2>&1; then
+            echo "shfmt $(shfmt --version) already present — leaving the host's copy alone"
+            exit 0
+          fi
+
+          version="3.8.0"
+          case "$(uname -s)" in
+            Linux)  os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS for shfmt install: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64)  arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "unsupported arch for shfmt install: $(uname -m)" >&2; exit 1 ;;
+          esac
+          asset="shfmt_v${version}_${os}_${arch}"
+
           mkdir -p "$HOME/.local/bin"
           tmp="$(mktemp -d)"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          base="https://github.com/mvdan/sh/releases/download/v${version}"
+          curl -sSfL "$base/$asset" -o "$tmp/$asset"
           # Verify the binary against the release's published checksums before
-          # trusting it — no unverified curl|install of an executable.
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
-          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
-          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
-          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          # trusting it — no unverified curl|install of an executable. macOS
+          # ships shasum rather than sha256sum.
+          curl -sSfL "$base/sha256sums.txt" -o "$tmp/sha256sums.txt"
+          if command -v sha256sum >/dev/null 2>&1; then
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | sha256sum -c - )
+          else
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | shasum -a 256 -c - )
+          fi
+          chmod +x "$tmp/$asset"
+          mv "$tmp/$asset" "$HOME/.local/bin/shfmt"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync dev dependencies
@@ -268,17 +305,54 @@ jobs:
           just-version: "1.57.0"
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
+      #
+      # Host-safe and OS/arch aware, because `runs-on` here is
+      # `vars.CI_RUNS_ON || ubuntu-24.04` and `just ci-local-on` sets that
+      # variable to `self-hosted`. Two consequences the original step got wrong:
+      #
+      #   1. A self-hosted runner shares $HOME with its operator. A step that
+      #      writes into ~/.local/bin modifies a real machine, not a throwaway
+      #      VM — so if a usable shfmt is already on PATH, leave it alone.
+      #   2. The asset must match the runner. Hardcoding linux_amd64 installed a
+      #      Linux x86 binary onto a macOS/ARM runner, which then failed the
+      #      lint step with "cannot execute binary file" *after* overwriting the
+      #      operator's working shfmt. A nightly cron repeated it unattended.
       - name: Install shfmt
         run: |
+          set -eu
+          if command -v shfmt >/dev/null 2>&1 && shfmt --version >/dev/null 2>&1; then
+            echo "shfmt $(shfmt --version) already present — leaving the host's copy alone"
+            exit 0
+          fi
+
+          version="3.8.0"
+          case "$(uname -s)" in
+            Linux)  os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS for shfmt install: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64)  arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "unsupported arch for shfmt install: $(uname -m)" >&2; exit 1 ;;
+          esac
+          asset="shfmt_v${version}_${os}_${arch}"
+
           mkdir -p "$HOME/.local/bin"
           tmp="$(mktemp -d)"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          base="https://github.com/mvdan/sh/releases/download/v${version}"
+          curl -sSfL "$base/$asset" -o "$tmp/$asset"
           # Verify the binary against the release's published checksums before
-          # trusting it — no unverified curl|install of an executable.
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
-          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
-          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
-          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          # trusting it — no unverified curl|install of an executable. macOS
+          # ships shasum rather than sha256sum.
+          curl -sSfL "$base/sha256sums.txt" -o "$tmp/sha256sums.txt"
+          if command -v sha256sum >/dev/null 2>&1; then
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | sha256sum -c - )
+          else
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | shasum -a 256 -c - )
+          fi
+          chmod +x "$tmp/$asset"
+          mv "$tmp/$asset" "$HOME/.local/bin/shfmt"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       # Fresh scaffolds have no lockfile — or even a package.json (`bun
@@ -339,17 +413,54 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
+      #
+      # Host-safe and OS/arch aware, because `runs-on` here is
+      # `vars.CI_RUNS_ON || ubuntu-24.04` and `just ci-local-on` sets that
+      # variable to `self-hosted`. Two consequences the original step got wrong:
+      #
+      #   1. A self-hosted runner shares $HOME with its operator. A step that
+      #      writes into ~/.local/bin modifies a real machine, not a throwaway
+      #      VM — so if a usable shfmt is already on PATH, leave it alone.
+      #   2. The asset must match the runner. Hardcoding linux_amd64 installed a
+      #      Linux x86 binary onto a macOS/ARM runner, which then failed the
+      #      lint step with "cannot execute binary file" *after* overwriting the
+      #      operator's working shfmt. A nightly cron repeated it unattended.
       - name: Install shfmt
         run: |
+          set -eu
+          if command -v shfmt >/dev/null 2>&1 && shfmt --version >/dev/null 2>&1; then
+            echo "shfmt $(shfmt --version) already present — leaving the host's copy alone"
+            exit 0
+          fi
+
+          version="3.8.0"
+          case "$(uname -s)" in
+            Linux)  os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS for shfmt install: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64)  arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "unsupported arch for shfmt install: $(uname -m)" >&2; exit 1 ;;
+          esac
+          asset="shfmt_v${version}_${os}_${arch}"
+
           mkdir -p "$HOME/.local/bin"
           tmp="$(mktemp -d)"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          base="https://github.com/mvdan/sh/releases/download/v${version}"
+          curl -sSfL "$base/$asset" -o "$tmp/$asset"
           # Verify the binary against the release's published checksums before
-          # trusting it — no unverified curl|install of an executable.
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
-          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
-          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
-          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          # trusting it — no unverified curl|install of an executable. macOS
+          # ships shasum rather than sha256sum.
+          curl -sSfL "$base/sha256sums.txt" -o "$tmp/sha256sums.txt"
+          if command -v sha256sum >/dev/null 2>&1; then
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | sha256sum -c - )
+          else
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | shasum -a 256 -c - )
+          fi
+          chmod +x "$tmp/$asset"
+          mv "$tmp/$asset" "$HOME/.local/bin/shfmt"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       # golangci-lint-action above doesn't run justfile recipes, so the .agents/
@@ -401,17 +512,54 @@ jobs:
           components: clippy, rustfmt, llvm-tools-preview
 
       # ShellCheck ships preinstalled on ubuntu-24.04 runners; shfmt does not.
+      #
+      # Host-safe and OS/arch aware, because `runs-on` here is
+      # `vars.CI_RUNS_ON || ubuntu-24.04` and `just ci-local-on` sets that
+      # variable to `self-hosted`. Two consequences the original step got wrong:
+      #
+      #   1. A self-hosted runner shares $HOME with its operator. A step that
+      #      writes into ~/.local/bin modifies a real machine, not a throwaway
+      #      VM — so if a usable shfmt is already on PATH, leave it alone.
+      #   2. The asset must match the runner. Hardcoding linux_amd64 installed a
+      #      Linux x86 binary onto a macOS/ARM runner, which then failed the
+      #      lint step with "cannot execute binary file" *after* overwriting the
+      #      operator's working shfmt. A nightly cron repeated it unattended.
       - name: Install shfmt
         run: |
+          set -eu
+          if command -v shfmt >/dev/null 2>&1 && shfmt --version >/dev/null 2>&1; then
+            echo "shfmt $(shfmt --version) already present — leaving the host's copy alone"
+            exit 0
+          fi
+
+          version="3.8.0"
+          case "$(uname -s)" in
+            Linux)  os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS for shfmt install: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64)  arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "unsupported arch for shfmt install: $(uname -m)" >&2; exit 1 ;;
+          esac
+          asset="shfmt_v${version}_${os}_${arch}"
+
           mkdir -p "$HOME/.local/bin"
           tmp="$(mktemp -d)"
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o "$tmp/shfmt_v3.8.0_linux_amd64"
+          base="https://github.com/mvdan/sh/releases/download/v${version}"
+          curl -sSfL "$base/$asset" -o "$tmp/$asset"
           # Verify the binary against the release's published checksums before
-          # trusting it — no unverified curl|install of an executable.
-          curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/sha256sums.txt -o "$tmp/sha256sums.txt"
-          ( cd "$tmp" && grep 'shfmt_v3.8.0_linux_amd64$' sha256sums.txt | sha256sum -c - )
-          chmod +x "$tmp/shfmt_v3.8.0_linux_amd64"
-          mv "$tmp/shfmt_v3.8.0_linux_amd64" "$HOME/.local/bin/shfmt"
+          # trusting it — no unverified curl|install of an executable. macOS
+          # ships shasum rather than sha256sum.
+          curl -sSfL "$base/sha256sums.txt" -o "$tmp/sha256sums.txt"
+          if command -v sha256sum >/dev/null 2>&1; then
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | sha256sum -c - )
+          else
+            ( cd "$tmp" && grep " $asset\$" sha256sums.txt | shasum -a 256 -c - )
+          fi
+          chmod +x "$tmp/$asset"
+          mv "$tmp/$asset" "$HOME/.local/bin/shfmt"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install just

--- a/tests/contracts/test_ci_runs_on.py
+++ b/tests/contracts/test_ci_runs_on.py
@@ -10,11 +10,12 @@ never use the variable, so tokens never materialize on a user's machine.
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 from project_init.scaffold import scaffold
 from tests.helpers import fallback_preset, fallback_variables
-from tests.workflow import load_workflow
+from tests.workflow import _strip_shell_comments, load_workflow
 
 _EXPR = "${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}"
 
@@ -161,3 +162,91 @@ class TestCiRunsOnEscapeHatch:
         assert "public-fork" in guide
         # The don't-flip-without-a-runner warning.
         assert "queue forever" in guide
+
+
+class TestShfmtInstallIsHostSafe:
+    """PI-666 follow-up: the shfmt step ran as if the runner were always
+    GitHub-hosted ubuntu.
+
+    It curled `shfmt_v3.8.0_linux_amd64` and `mv`'d it over
+    `$HOME/.local/bin/shfmt`. On the macOS/ARM self-hosted runner that
+    `just ci-local-on` routes to, that installed a Linux x86 binary: the lint
+    step died with "cannot execute binary file", and because a self-hosted
+    runner shares $HOME with its operator it had already overwritten the
+    developer's working shfmt. A nightly cron then repeated it unattended.
+
+    Same class as `test_semgrep_uses_uvx_not_pip` above: correct on a hosted
+    runner, destructive on the runner this feature exists to enable.
+    """
+
+    @staticmethod
+    def _install_script(target: Path) -> str:
+        """The rendered `run:` body of the Install shfmt step, structurally."""
+        from tests.workflow import job, load_workflow, steps
+
+        found = [
+            s["run"]
+            for s in steps(job(load_workflow(target), "lint-and-test"))
+            if s.get("name") == "Install shfmt" and "run" in s
+        ]
+        assert found, "lint-and-test has no Install shfmt step with a run: body"
+        return found[0]
+
+    def test_asset_is_derived_from_the_runner_not_hardcoded(self, tmp_target: Path):
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        script = _strip_shell_comments(self._install_script(tmp_target))
+        # The hardcoded asset name must not survive in executable shell.
+        assert "shfmt_v3.8.0_linux_amd64" not in script, (
+            "shfmt asset is hardcoded to linux_amd64; wrong on any self-hosted "
+            f"macOS/ARM runner:\n{script}"
+        )
+        assert "uname -s" in script and "uname -m" in script, (
+            f"asset must be derived from the runner's OS/arch:\n{script}"
+        )
+        # macOS has no sha256sum — an unconditional call would abort under set -e
+        # before the checksum is ever verified.
+        assert "shasum" in script, f"no sha256sum fallback for macOS:\n{script}"
+
+    def test_it_leaves_an_existing_shfmt_untouched(self, tmp_path: Path, tmp_target: Path):
+        """Behavioural: run the rendered script with a shfmt already on PATH.
+
+        Asserting the guard's *text* would pass on a comment describing it. This
+        executes the real step against a fake HOME and proves nothing is written.
+        """
+        scaffold(tmp_target, fallback_preset(), fallback_variables())
+        script = self._install_script(tmp_target)
+
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        bindir = tmp_path / "hostbin"
+        bindir.mkdir()
+        host_shfmt = bindir / "shfmt"
+        host_shfmt.write_text("#!/bin/sh\necho 3.13.1\n")
+        host_shfmt.chmod(0o755)
+        sentinel = host_shfmt.read_bytes()
+
+        env = {
+            "HOME": str(home),
+            "PATH": f"{bindir}:/usr/bin:/bin:/usr/sbin:/sbin",
+            # The step appends to $GITHUB_PATH; give it a real file so the
+            # redirect cannot fail the script for an unrelated reason.
+            "GITHUB_PATH": str(tmp_path / "github_path"),
+        }
+        (tmp_path / "github_path").touch()
+
+        result = subprocess.run(
+            ["sh", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, f"step failed: {result.stderr}"
+        # The host's copy is byte-identical: not overwritten, not replaced.
+        assert host_shfmt.read_bytes() == sentinel, "the host's shfmt was modified"
+        # And nothing was installed into the operator's ~/.local/bin.
+        assert not (home / ".local" / "bin" / "shfmt").exists(), (
+            "step wrote into $HOME despite a usable shfmt already being on PATH"
+        )


### PR DESCRIPTION
Closes #907

## The bug

The `Install shfmt` step assumed the runner was always GitHub-hosted ubuntu: it curled `shfmt_v3.8.0_linux_amd64` and `mv`'d it over `$HOME/.local/bin/shfmt`. Four byte-identical copies, one per language, so every scaffold shipped it.

But `runs-on` in the same file is `${{ vars.CI_RUNS_ON || 'ubuntu-24.04' }}`, and the justfile ships `just ci-local-on` to set that variable to `self-hosted` (PI-666). On a macOS/ARM self-hosted runner the step installed a Linux x86 binary. The lint step then failed with:

```
/Users/…/.local/bin/shfmt: cannot execute binary file
```

…**after** overwriting the operator's working shfmt 3.13.1 — because a self-hosted runner shares `$HOME` with the human who owns the machine. The nightly cron then repeated it unattended, so the damage recurred with no push involved.

Same class as the existing `test_semgrep_uses_uvx_not_pip`: correct on a hosted runner, destructive on the runner this feature exists to enable.

## The fix

Two changes, in order of importance:

1. **Early exit when a usable shfmt is already on PATH.** This is what makes the step host-safe — a runner sharing `$HOME` must not install over its operator's tools at all.
2. **Derive the asset from `uname -s`/`uname -m`**, with a `shasum -a 256` fallback where `sha256sum` is absent (macOS), so the checksum is still verified instead of aborting the step under `set -e`.

## Tests

Added to `tests/contracts/test_ci_runs_on.py`, which already owns this failure class.

| Test | Kind |
|---|---|
| `test_asset_is_derived_from_the_runner_not_hardcoded` | structural, over comment-stripped shell so a comment naming the old asset can't pass it |
| `test_it_leaves_an_existing_shfmt_untouched` | **behavioural** — extracts the rendered `run:` body from the parsed workflow and executes it against a fake `HOME` with a stub shfmt on PATH, then asserts the stub is byte-identical and nothing was written to `$HOME` |

**Red-green checked.** Reverted the template and both tests failed — the behavioural one by actually writing into the fake `HOME`, reproducing the reported bug. Restored and confirmed the template is byte-identical to the fixed version.

## Verification

`uv run ruff check .` clean, `ruff format --check` clean, `just typecheck` clean, `uv run pytest tests/contracts/test_ci_runs_on.py` 10 passed.

Full suite: 2624 passed, 7 failed — all 7 fail identically on clean `main` at `ac85947` with these changes stashed (`test_multi_model_overlay`, `test_observability_self_log`, `test_post_edit_lint_autofix`, `test_post_edit_lint_typecheck`). Pre-existing, unrelated, not touched here.

## Not fixed here

This repo's own `.github/workflows/ci.yml` and `nightly.yml` carry the same step, but both pin `runs-on: ubuntu-24.04` with no `CI_RUNS_ON`, so the bug is unreachable there. Worth adopting if this repo ever routes its own CI to a self-hosted runner.

## Incidental

`start_issue.sh` could not open the draft PR — `gh pr create` aborted with *"you must first push the current branch to a remote, or use the --head flag"* even though the branch was pushed and `gh api repos/…/branches/<branch>` resolved it. Adding `--head "$BRANCH"` to the script's `_create_pr` would fix it; the PR was opened that way by hand.