### PR TITLE
feat(PI-909): Warn when upgrade would render a stale install's templates

### DIFF
--- a/.agents/docs/CODE_MAP.md
+++ b/.agents/docs/CODE_MAP.md
@@ -108,6 +108,8 @@ Curated per-version upgrade notes surfaced by `project-init upgrade` (#244).
 
 Core scaffolding logic — pure functions, no user interaction.
 
+- `def templates_dir` — The directory this process renders templates from.
+- `def stale_install` — A project-init checkout at/above *cwd* whose templates differ from ours.
 - `class TemplateRenderError` — Raised in strict mode when unrendered placeholders survive scaffolding.
 - `def list_presets` — Return all available presets as parsed dicts, sorted by name.
 - `def parse_version` — Parse a leading ``X.Y.Z`` (optional ``v`` prefix) into a tuple, or None.

--- a/.claude/docs/CODE_MAP.md
+++ b/.claude/docs/CODE_MAP.md
@@ -108,6 +108,8 @@ Curated per-version upgrade notes surfaced by `project-init upgrade` (#244).
 
 Core scaffolding logic — pure functions, no user interaction.
 
+- `def templates_dir` — The directory this process renders templates from.
+- `def stale_install` — A project-init checkout at/above *cwd* whose templates differ from ours.
 - `class TemplateRenderError` — Raised in strict mode when unrendered placeholders survive scaffolding.
 - `def list_presets` — Return all available presets as parsed dicts, sorted by name.
 - `def parse_version` — Parse a leading ``X.Y.Z`` (optional ``v`` prefix) into a tuple, or None.

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -23,6 +23,81 @@ if not _TEMPLATES_DIR.exists():
     # Dev mode: templates live at repo root, not inside the package.
     _TEMPLATES_DIR = _PACKAGE_DIR.parent.parent / "templates"
 
+
+def templates_dir() -> Path:
+    """The directory this process renders templates from.
+
+    Public because staleness is only diagnosable by comparing it to a source
+    checkout — see :func:`stale_install`.
+    """
+    return _TEMPLATES_DIR
+
+
+def _templates_digest(root: Path) -> str:
+    """Content digest of a templates tree: path + bytes of every file.
+
+    ~15ms for the 288-file tree, so it is cheap enough to run before an upgrade.
+    Content rather than mtimes: a fresh `uv pip install` rewrites mtimes without
+    changing a byte, and warning on that would be a false positive.
+    """
+    h = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        # Byte-compiled droppings are not part of the product, and one tree
+        # having them would otherwise read as drift.
+        if path.suffix == ".pyc" or "__pycache__" in path.parts:
+            continue
+        h.update(str(path.relative_to(root)).encode())
+        h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _is_project_init_checkout(root: Path) -> bool:
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file() or not (root / "templates").is_dir():
+        return False
+    try:
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    name = data.get("project", {}).get("name")
+    return isinstance(name, str) and name == "project-init"
+
+
+def stale_install(cwd: Path | None = None) -> Path | None:
+    """A project-init checkout at/above *cwd* whose templates differ from ours.
+
+    Returns the checkout root when this process would render templates that are
+    NOT the ones in the checkout the user is standing in, and their contents
+    actually differ. ``None`` otherwise.
+
+    Why this exists: ``templates/`` is the product, and a non-editable install
+    copies it *into* the package. Reinstall the package and the copy freezes;
+    keep committing to the checkout and the two diverge. ``project-init upgrade``
+    then renders the frozen copy while the user reasonably believes it is
+    applying the checkout they are looking at — it reports success having
+    re-applied stale files. That is how a fixed prod_guard was re-shipped with
+    its vulnerability intact (downstream of PI-903), because the installed
+    package still carried the pre-fix template.
+
+    Deliberately advisory, not fatal: someone with a legitimate PyPI install who
+    happens to ``cd`` into a clone is doing nothing wrong, and a guard that
+    blocks ordinary work gets switched off.
+    """
+    start = (cwd or Path.cwd()).resolve()
+    ours = _TEMPLATES_DIR.resolve()
+    for root in (start, *start.parents):
+        if not _is_project_init_checkout(root):
+            continue
+        theirs = (root / "templates").resolve()
+        if theirs == ours:
+            return None  # editable/dev install — already the checkout's own
+        if _templates_digest(theirs) != _templates_digest(ours):
+            return root
+        return None
+    return None
+
+
 _DOT_PREFIX = "dot_"
 _VAR_RE = re.compile(r"\{\{(\w+)\}\}")
 # Matches an INNERMOST conditional block — the tempered dot forbids another

--- a/src/project_init/subcommands.py
+++ b/src/project_init/subcommands.py
@@ -15,6 +15,29 @@ from pathlib import Path
 from project_init import __version__
 
 
+def _warn_if_stale_install() -> None:
+    """Warn when the running package's templates are not the checkout's.
+
+    `templates/` is the product, so a non-editable install carries a frozen copy
+    of it. Once the checkout moves on, `upgrade` renders the frozen copy and
+    reports success — silently re-applying stale files. Kept advisory: a PyPI
+    install used from inside a clone is legitimate.
+    """
+    from project_init.scaffold import stale_install, templates_dir
+
+    root = stale_install()
+    if root is None:
+        return
+    sys.stderr.write(
+        f"warning: this project-init renders templates from {templates_dir()}, "
+        f"but you are inside the checkout at {root}, whose templates/ differ.\n"
+        "         `templates/` is the product, so the upgrade would apply the "
+        "INSTALLED copy — not what you are looking at — and report success.\n"
+        "         Fix: `uv pip install -e .` in that checkout, or run it as "
+        "`uv run project-init`.\n"
+    )
+
+
 def _upgrade_main(argv: list[str]) -> int:
     """Parse and run the `project-init upgrade` subcommand (PI-142)."""
     from project_init.upgrade import (
@@ -104,6 +127,11 @@ def _upgrade_main(argv: list[str]) -> int:
             "note: -i/--interactive only takes effect with --apply; this is a "
             "read-only drift report. Re-run with --apply -i to choose per file.\n"
         )
+
+    # Stale-install warning: an upgrade that renders a frozen copy of the
+    # templates while the user is looking at a newer checkout reports success
+    # having re-applied old files. Advisory by design — see scaffold.stale_install.
+    _warn_if_stale_install()
 
     # Clean-tree guard (#242): refuse --apply on a dirty git work tree so the
     # upgrade lands as one revertible diff. A CLI-layer precondition — kept out

--- a/tests/unit/test_stale_install.py
+++ b/tests/unit/test_stale_install.py
@@ -1,0 +1,162 @@
+"""A non-editable install renders a frozen copy of `templates/` (PI-903 follow-up).
+
+`templates/` is the product, and a non-editable `uv pip install` copies it *into*
+the package. Reinstall once, keep committing to the checkout, and the two
+diverge — after which `project-init upgrade` renders the frozen copy while the
+user reasonably believes it is applying the checkout in front of them, and
+reports success.
+
+That is not hypothetical. Downstream of PI-903 (the symlinked-marker prod_guard
+fix), an upgrade run from a stale install re-applied the *pre-fix* prod_guard
+template and reported success — reintroducing the vulnerability the upgrade was
+performed to obtain.
+
+These tests drive `stale_install` against real on-disk fixtures rather than
+asserting on the warning's prose: the point is the detection, and it must not
+fire when there is nothing wrong.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from project_init.scaffold import stale_install, templates_dir
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fake_checkout(root: Path, *, templates_from: Path, name: str = "project-init") -> Path:
+    """A minimal project-init source checkout: pyproject + templates/."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "0.0.0"\n', encoding="utf-8"
+    )
+    shutil.copytree(templates_from, root / "templates")
+    return root
+
+
+class TestStaleInstallDetection:
+    def test_no_warning_from_an_unrelated_directory(self, tmp_path: Path):
+        """The overwhelmingly common case: not inside any checkout at all."""
+        assert stale_install(tmp_path) is None
+
+    def test_no_warning_when_standing_in_this_checkout(self):
+        """Running the suite from this repo must never warn.
+
+        Note the suite renders from the session-scoped frozen snapshot of
+        ``templates/`` (conftest ``_frozen_templates``), not the live tree — so
+        this is the different-path-same-content case, which is precisely the one
+        that must stay silent. An editable install is the same case with the
+        paths equal.
+        """
+        assert stale_install(_REPO_ROOT) is None
+        # Also from a subdirectory — the walk goes up.
+        assert stale_install(_REPO_ROOT / "src" / "project_init") is None
+
+    def test_no_warning_when_a_separate_copy_is_byte_identical(self, tmp_path: Path):
+        """Different path, same content — nothing is stale.
+
+        A fresh install rewrites mtimes without changing a byte. Warning here
+        would be a false positive, and a guard that cries wolf gets ignored.
+        """
+        checkout = _fake_checkout(tmp_path / "clone", templates_from=templates_dir())
+        assert stale_install(checkout) is None
+
+    def test_warns_when_the_checkout_has_moved_on(self, tmp_path: Path):
+        """The real failure: checkout carries a fix the rendered templates lack."""
+        checkout = _fake_checkout(tmp_path / "clone", templates_from=templates_dir())
+        # Simulate a commit landing in the checkout after the install froze.
+        target = checkout / "templates" / "base" / "dot_agents" / "hooks" / "prod_guard.py"
+        assert target.is_file(), "fixture expectation: prod_guard template exists"
+        target.write_text(
+            target.read_text(encoding="utf-8") + "\n# a fix the installed copy lacks\n",
+            encoding="utf-8",
+        )
+        assert stale_install(checkout) == checkout
+
+    def test_warns_on_a_deleted_template_too(self, tmp_path: Path):
+        """Drift is not only added bytes — a removed file must count."""
+        checkout = _fake_checkout(tmp_path / "clone", templates_from=templates_dir())
+        victim = next((checkout / "templates").rglob("*.tmpl"))
+        victim.unlink()
+        assert stale_install(checkout) == checkout
+
+    def test_ignores_a_directory_that_merely_looks_like_a_checkout(self, tmp_path: Path):
+        """Some other project with a templates/ dir is not a project-init checkout."""
+        other = _fake_checkout(
+            tmp_path / "other", templates_from=templates_dir(), name="something-else"
+        )
+        (other / "templates" / "STRAY.txt").write_text("drift", encoding="utf-8")
+        assert stale_install(other) is None
+
+    def test_a_pyproject_without_templates_is_not_a_checkout(self, tmp_path: Path):
+        root = tmp_path / "bare"
+        root.mkdir()
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "project-init"\nversion = "0.0.0"\n', encoding="utf-8"
+        )
+        assert stale_install(root) is None
+
+    def test_a_malformed_pyproject_does_not_raise(self, tmp_path: Path):
+        """A broken TOML somewhere above cwd must not crash an upgrade."""
+        root = tmp_path / "broken"
+        (root / "templates").mkdir(parents=True)
+        (root / "pyproject.toml").write_text("[project\nname = ", encoding="utf-8")
+        assert stale_install(root) is None
+
+    def test_nearest_checkout_wins(self, tmp_path: Path):
+        """An inner checkout shadows an outer one; the walk stops at the first."""
+        outer = _fake_checkout(tmp_path / "outer", templates_from=templates_dir())
+        (outer / "templates" / "OUTER.txt").write_text("drift", encoding="utf-8")
+        inner = _fake_checkout(outer / "nested" / "inner", templates_from=templates_dir())
+        # inner is byte-identical to what we render, so the answer is None even
+        # though the outer one has drifted.
+        assert stale_install(inner) is None
+
+
+class TestUpgradeEmitsTheWarning:
+    def test_upgrade_warns_via_stderr(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        """Wiring check: the detection reaches the user on `upgrade`."""
+        from project_init import subcommands
+
+        checkout = _fake_checkout(tmp_path / "clone", templates_from=templates_dir())
+        (checkout / "templates" / "DRIFT.txt").write_text("x", encoding="utf-8")
+
+        monkey_root = checkout
+
+        def _fake_stale(cwd: Path | None = None) -> Path | None:
+            return monkey_root
+
+        original = subcommands.__dict__.get("_warn_if_stale_install")
+        assert original is not None
+        # Exercise the real writer, with only the detector stubbed — so the
+        # message and the stream it goes to are the ones users see.
+        import project_init.scaffold as scaffold_mod
+
+        saved = scaffold_mod.stale_install
+        scaffold_mod.stale_install = _fake_stale  # type: ignore[assignment]
+        try:
+            subcommands._warn_if_stale_install()
+        finally:
+            scaffold_mod.stale_install = saved  # type: ignore[assignment]
+
+        err = capsys.readouterr().err
+        assert "warning:" in err
+        assert str(checkout) in err
+        assert "uv pip install -e ." in err
+
+    def test_silent_when_nothing_is_stale(self, capsys: pytest.CaptureFixture[str]):
+        import project_init.scaffold as scaffold_mod
+        from project_init import subcommands
+
+        saved = scaffold_mod.stale_install
+        scaffold_mod.stale_install = lambda cwd=None: None  # type: ignore[assignment]
+        try:
+            subcommands._warn_if_stale_install()
+        finally:
+            scaffold_mod.stale_install = saved  # type: ignore[assignment]
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
Closes #909

## The bug

`templates/` is the product, and a non-editable install copies it *into* the package. Reinstall once, keep committing to the checkout, and the two diverge — after which `project-init upgrade` renders the frozen copy while the user reasonably believes it is applying the checkout in front of them, and **reports success**.

Not hypothetical. Downstream of PI-903 (the symlinked-marker `prod_guard` fix), an upgrade run from a stale install re-applied the **pre-fix** `prod_guard` template and reported success — reintroducing the very vulnerability the upgrade was performed to obtain. Nothing in the output hinted at it, because from the scaffolder's point of view nothing was wrong.

## The fix

`scaffold.stale_install()` walks up from cwd for a project-init checkout (`pyproject` `[project] name == "project-init"` plus a `templates/` dir) and reports it when that `templates/` differs from the tree this process renders from. `templates_dir()` is exposed alongside it, since staleness is only diagnosable by comparing the two. `_upgrade_main()` warns on stderr, next to the existing `-i`/`--apply` note.

```
warning: this project-init renders templates from /Users/…/project-init/templates,
         but you are inside the checkout at /tmp/…/fake, whose templates/ differ.
         `templates/` is the product, so the upgrade would apply the INSTALLED
         copy — not what you are looking at — and report success.
         Fix: `uv pip install -e .` in that checkout, or run it as `uv run project-init`.
```

Three deliberate choices:

- **Compares content, not mtimes.** A fresh `uv pip install` rewrites mtimes without changing a byte; warning on that would be a false positive, and a guard that cries wolf gets ignored. ~15ms for the 288-file tree, so it is cheap enough to run before every upgrade.
- **Ignores `__pycache__`/`*.pyc`** — not part of the product, and one tree having them would otherwise read as drift.
- **Advisory, never fatal.** A legitimate PyPI install used from inside a clone is doing nothing wrong, and per AGENTS.md a guard that blocks ordinary work gets switched off.

## Tests

`tests/unit/test_stale_install.py`, weighted toward the **negative** cases because a false positive is the failure mode that would get this removed:

| Case | Expected |
|---|---|
| unrelated directory | silent |
| this checkout (incl. from a subdirectory) | silent |
| byte-identical copy at a different path | silent |
| same-shaped checkout of a *different* project | silent |
| `pyproject` with no `templates/` | silent |
| malformed TOML above cwd | silent, no raise |
| nearest checkout wins over a drifted outer one | silent |
| checkout has an added template byte | warns |
| checkout has a *deleted* template | warns |

Plus two wiring tests that the warning reaches stderr and stays silent otherwise.

**Red-green checked:** neutering `stale_install` to `return None` failed exactly the two positive tests and left the seven negative ones green.

**Verified end-to-end through the real CLI**, not only in-process: run from a fixture checkout whose templates differ, `project-init upgrade` prints the warning ahead of its target validation; run from an unrelated directory and from this checkout, it prints nothing.

## Verification

`uv run ruff check .` clean, `ruff format --check` clean, `just typecheck` (mypy --strict) clean, `uv run pytest tests/unit/test_stale_install.py` 11 passed.

Full suite: 2624 passed, 7 failed — all 7 fail identically on clean `main` at `ac85947` with these changes stashed. Pre-existing and unrelated.

`CODE_MAP.md` regenerated (`just code-map`, `just sync-claude`) for the two new public functions.