### PR TITLE
fix(PI-911): Lifecycle PR creation fails on a clone with a narrow fetch refspec

### DIFF
--- a/.agents/hooks/dag_workflow.py
+++ b/.agents/hooks/dag_workflow.py
@@ -813,7 +813,11 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
     # PR for the branch — reusing a branch name after a merge must open a new
     # PR, not report the merged one as "already exists" (matches check_pr_opened).
-    code, out = _gh(["pr", "view", "--json", "url,state"])
+    # Selector passed explicitly: with none, gh resolves the branch through its
+    # local remote-tracking ref, which a --single-branch/--depth clone never
+    # creates for anything but the default branch (see _create_pr in
+    # start_issue.sh). Naming the branch keeps the CLOSED/MERGED semantics above.
+    code, out = _gh(["pr", "view", branch, "--json", "url,state"])
     if code == 0:
         try:
             data = json.loads(out or "{}")
@@ -827,7 +831,9 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
     # Single trunk: with no explicit --base, gh targets the repo default branch.
-    args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
+    # --head explicit for the same reason as the selector above: gh's inference
+    # depends on a remote-tracking ref that a narrow fetch refspec never creates.
+    args = ["pr", "create", "--draft", "--head", branch, "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]
     code, out = _gh(args)

--- a/.agents/scripts/start_issue.sh
+++ b/.agents/scripts/start_issue.sh
@@ -246,10 +246,20 @@ fi
 PR_TITLE="${TYPE}(${ISSUE_REF}): ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
+# --head is explicit rather than inferred. Without it `gh pr create` resolves the
+# head branch through the local remote-tracking ref, so it aborts with "you must
+# first push the current branch to a remote, or use the --head flag" on any clone
+# whose fetch refspec is narrower than +refs/heads/*: a --single-branch or
+# --depth clone configures only
+# `remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main`, and no
+# tracking ref is ever created for the branch we just pushed. The push succeeded
+# and the branch exists on the remote — only gh's inference fails. We know the
+# branch name here, so there is nothing to infer.
 _create_pr() {
   gh pr create \
     --draft \
     --base "$BASE_BRANCH" \
+    --head "$BRANCH" \
     --title "$PR_TITLE" \
     --body "$PR_BODY"
 }

--- a/.claude/hooks/dag_workflow.py
+++ b/.claude/hooks/dag_workflow.py
@@ -813,7 +813,11 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
     # PR for the branch — reusing a branch name after a merge must open a new
     # PR, not report the merged one as "already exists" (matches check_pr_opened).
-    code, out = _gh(["pr", "view", "--json", "url,state"])
+    # Selector passed explicitly: with none, gh resolves the branch through its
+    # local remote-tracking ref, which a --single-branch/--depth clone never
+    # creates for anything but the default branch (see _create_pr in
+    # start_issue.sh). Naming the branch keeps the CLOSED/MERGED semantics above.
+    code, out = _gh(["pr", "view", branch, "--json", "url,state"])
     if code == 0:
         try:
             data = json.loads(out or "{}")
@@ -827,7 +831,9 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
     # Single trunk: with no explicit --base, gh targets the repo default branch.
-    args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
+    # --head explicit for the same reason as the selector above: gh's inference
+    # depends on a remote-tracking ref that a narrow fetch refspec never creates.
+    args = ["pr", "create", "--draft", "--head", branch, "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]
     code, out = _gh(args)

--- a/.claude/scripts/start_issue.sh
+++ b/.claude/scripts/start_issue.sh
@@ -246,10 +246,20 @@ fi
 PR_TITLE="${TYPE}(${ISSUE_REF}): ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
+# --head is explicit rather than inferred. Without it `gh pr create` resolves the
+# head branch through the local remote-tracking ref, so it aborts with "you must
+# first push the current branch to a remote, or use the --head flag" on any clone
+# whose fetch refspec is narrower than +refs/heads/*: a --single-branch or
+# --depth clone configures only
+# `remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main`, and no
+# tracking ref is ever created for the branch we just pushed. The push succeeded
+# and the branch exists on the remote — only gh's inference fails. We know the
+# branch name here, so there is nothing to infer.
 _create_pr() {
   gh pr create \
     --draft \
     --base "$BASE_BRANCH" \
+    --head "$BRANCH" \
     --title "$PR_TITLE" \
     --body "$PR_BODY"
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -1,7 +1,7 @@
 {
   "project-init-lifecycle": {
-    "sha256": "655fa767f69c7d1c44168810b8d5dbb87036bdfd9e4e9897a4d0adde0ba53bc5",
-    "version": "0.2.1"
+    "sha256": "44668b2d972a1bfac820138ff55944bfef27c62a49963c07d2ad0f059d4ef3f2",
+    "version": "0.2.2"
   },
   "project-init-workflow": {
     "sha256": "ad329be8000154d0d1c108fdab866c191e2b78e1723f6bda63931435892edaad",

--- a/plugins/project-init-lifecycle/.claude-plugin/plugin.json
+++ b/plugins/project-init-lifecycle/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "project-init-lifecycle",
   "displayName": "project-init GitHub Lifecycle",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "GitHub lifecycle automation from project-init (#476, ADR-021): the issue->branch->PR->review->merge DAG guard + workflow-state hooks and the create_issue/start_task/github_workflow/request_review/audit skills. Enabled only when the lifecycle tier is on; the forge-agnostic quality/safety hooks live in project-init-workflow.",
   "author": {
-    "name": "Vytautas Čepas",
+    "name": "Vytautas \u010cepas",
     "url": "https://github.com/VytCepas"
   },
   "repository": "https://github.com/VytCepas/project-init",

--- a/plugins/project-init-lifecycle/hooks/dag_workflow.py
+++ b/plugins/project-init-lifecycle/hooks/dag_workflow.py
@@ -813,7 +813,11 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
     # PR for the branch — reusing a branch name after a merge must open a new
     # PR, not report the merged one as "already exists" (matches check_pr_opened).
-    code, out = _gh(["pr", "view", "--json", "url,state"])
+    # Selector passed explicitly: with none, gh resolves the branch through its
+    # local remote-tracking ref, which a --single-branch/--depth clone never
+    # creates for anything but the default branch (see _create_pr in
+    # start_issue.sh). Naming the branch keeps the CLOSED/MERGED semantics above.
+    code, out = _gh(["pr", "view", branch, "--json", "url,state"])
     if code == 0:
         try:
             data = json.loads(out or "{}")
@@ -827,7 +831,9 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
     # Single trunk: with no explicit --base, gh targets the repo default branch.
-    args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
+    # --head explicit for the same reason as the selector above: gh's inference
+    # depends on a remote-tracking ref that a narrow fetch refspec never creates.
+    args = ["pr", "create", "--draft", "--head", branch, "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]
     code, out = _gh(args)

--- a/templates/lifecycle/dot_agents/hooks/dag_workflow.py
+++ b/templates/lifecycle/dot_agents/hooks/dag_workflow.py
@@ -813,7 +813,11 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     # `gh pr view` with no selector also resolves the most recent CLOSED/MERGED
     # PR for the branch — reusing a branch name after a merge must open a new
     # PR, not report the merged one as "already exists" (matches check_pr_opened).
-    code, out = _gh(["pr", "view", "--json", "url,state"])
+    # Selector passed explicitly: with none, gh resolves the branch through its
+    # local remote-tracking ref, which a --single-branch/--depth clone never
+    # creates for anything but the default branch (see _create_pr in
+    # start_issue.sh). Naming the branch keeps the CLOSED/MERGED semantics above.
+    code, out = _gh(["pr", "view", branch, "--json", "url,state"])
     if code == 0:
         try:
             data = json.loads(out or "{}")
@@ -827,7 +831,9 @@ def cmd_create_pr_nojira(type_: str, title: str, branch: str | None, base: str |
     pr_title = f"{type_}: {title}"
     pr_body = "No linked issue (nojira)."
     # Single trunk: with no explicit --base, gh targets the repo default branch.
-    args = ["pr", "create", "--draft", "--title", pr_title, "--body", pr_body]
+    # --head explicit for the same reason as the selector above: gh's inference
+    # depends on a remote-tracking ref that a narrow fetch refspec never creates.
+    args = ["pr", "create", "--draft", "--head", branch, "--title", pr_title, "--body", pr_body]
     if base:
         args += ["--base", base]
     code, out = _gh(args)

--- a/templates/lifecycle/dot_agents/scripts/start_issue.sh
+++ b/templates/lifecycle/dot_agents/scripts/start_issue.sh
@@ -246,10 +246,20 @@ fi
 PR_TITLE="${TYPE}(${ISSUE_REF}): ${CLEAN_TITLE}"
 PR_BODY="Closes #${ISSUE_NUMBER}"
 
+# --head is explicit rather than inferred. Without it `gh pr create` resolves the
+# head branch through the local remote-tracking ref, so it aborts with "you must
+# first push the current branch to a remote, or use the --head flag" on any clone
+# whose fetch refspec is narrower than +refs/heads/*: a --single-branch or
+# --depth clone configures only
+# `remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main`, and no
+# tracking ref is ever created for the branch we just pushed. The push succeeded
+# and the branch exists on the remote — only gh's inference fails. We know the
+# branch name here, so there is nothing to infer.
 _create_pr() {
   gh pr create \
     --draft \
     --base "$BASE_BRANCH" \
+    --head "$BRANCH" \
     --title "$PR_TITLE" \
     --body "$PR_BODY"
 }

--- a/tests/contracts/test_lifecycle_script_hardening.py
+++ b/tests/contracts/test_lifecycle_script_hardening.py
@@ -628,3 +628,91 @@ class TestMonitorPrLocalBranchCleanup:
         assert self._branch_exists(clone, "feat/T-9-x"), (
             "an enqueued-but-unmerged PR's local branch must survive"
         )
+
+
+class TestPrCreationDoesNotRelyOnGhInference:
+    """A narrow fetch refspec makes `gh pr create` abort after a successful push.
+
+    `gh` resolves the head branch through the local remote-tracking ref. A
+    `--single-branch` or `--depth` clone configures only
+    ``remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main``, so no
+    tracking ref is ever created for the branch just pushed — and gh aborts with
+    "you must first push the current branch to a remote, or use the --head flag"
+    even though the push succeeded and the branch exists on the remote.
+
+    Reproduced against a real clone: with the narrow refspec, `git rev-parse
+    @{upstream}` fails with "not stored as a remote-tracking branch" and PR
+    creation dies; widening the refspec and re-fetching fixes it. Both lifecycle
+    entry points therefore name the branch instead of letting gh infer it.
+    """
+
+    def test_start_issue_passes_head_explicitly(self, tmp_path: Path):
+        """Behavioural: run the real _create_pr with a fake gh recording argv."""
+        source = (_LIFECYCLE_SCRIPTS / "start_issue.sh").read_text()
+        m = re.search(r"^_create_pr\(\) \{\n.*?\n\}$", source, re.MULTILINE | re.DOTALL)
+        assert m, "_create_pr not found in start_issue.sh"
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        argv_log = tmp_path / "argv"
+        gh = bin_dir / "gh"
+        gh.write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$@" > {argv_log}\n'
+            'echo "https://github.com/o/r/pull/1"\n'
+        )
+        gh.chmod(0o755)
+
+        script = (
+            f"export PATH={bin_dir}:$PATH\n"
+            "set -euo pipefail\n"
+            'BASE_BRANCH=main\nBRANCH=feat/PI-1-x\nPR_TITLE="feat(PI-1): x"\nPR_BODY="Closes #1"\n'
+            f"{m.group(0)}\n_create_pr\n"
+        )
+        proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0, proc.stderr
+
+        argv = argv_log.read_text().splitlines()
+        assert "--head" in argv, f"gh pr create invoked without --head: {argv}"
+        assert argv[argv.index("--head") + 1] == "feat/PI-1-x", argv
+        # The base must still be passed — a --head fix that dropped it would
+        # silently retarget PRs at the repo default.
+        assert "--base" in argv and argv[argv.index("--base") + 1] == "main", argv
+
+    def test_create_pr_nojira_passes_head_explicitly(self, tmp_path: Path):
+        """The other entry point: dag_workflow's create-pr-nojira."""
+        import importlib.util
+
+        hook = _REPO_ROOT / "templates/lifecycle/dot_agents/hooks/dag_workflow.py"
+        spec = importlib.util.spec_from_file_location("dagw_head", hook)
+        assert spec and spec.loader
+        dag = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(dag)
+
+        calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], **kwargs: object) -> tuple[int, str]:
+            calls.append(args)
+            if args[:2] == ["pr", "view"]:
+                # No open PR yet, so creation proceeds.
+                return 1, ""
+            return 0, "https://github.com/o/r/pull/2"
+
+        dag._gh = fake_gh  # type: ignore[assignment]
+        dag._git = lambda args, **kw: (0, "")  # type: ignore[assignment]
+        dag._current_branch = lambda: "feat/nojira-x"  # type: ignore[assignment]
+        dag.cmd_push = lambda *a, **k: 0  # type: ignore[assignment]
+
+        rc = dag.cmd_create_pr_nojira("feat", "Some title", None, None)
+        assert rc == 0, calls
+
+        create = [c for c in calls if c[:2] == ["pr", "create"]]
+        assert create, f"no gh pr create call recorded: {calls}"
+        args = create[0]
+        assert "--head" in args, f"create-pr-nojira invoked gh without --head: {args}"
+        assert args[args.index("--head") + 1] == "feat/nojira-x", args
+
+        # The existing-PR probe must also name the branch, for the same reason.
+        view = [c for c in calls if c[:2] == ["pr", "view"]]
+        assert view, f"no gh pr view probe recorded: {calls}"
+        assert "feat/nojira-x" in view[0], f"pr view relies on inference: {view[0]}"


### PR DESCRIPTION
Closes #911

## The bug

`gh pr create` resolves the head branch through the local remote-tracking ref. A clone made with `--single-branch` or `--depth` configures only:

```
remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main
```

so no tracking ref is ever created for the branch just pushed. `git rev-parse @{upstream}` then fails with *"not stored as a remote-tracking branch"*, and gh aborts with:

```
aborted: you must first push the current branch to a remote, or use the --head flag
```

…even though the push succeeded and the branch exists on the remote. The lifecycle leaves the user on a fresh pushed branch with **no PR** — `start_issue.sh` promises a draft PR and doesn't deliver one.

## Diagnosed, not guessed

On the affected clone:

| Probe | Result |
|---|---|
| push without `-u`, then `git rev-parse @{upstream}` | `fatal: no upstream configured` |
| `git push -u`, then `@{upstream}` | `fatal: upstream branch … not stored as a remote-tracking branch` |
| `git config --get-all remote.origin.fetch` | `+refs/heads/main:refs/remotes/origin/main` |
| `git branch -r` | 2 refs, on a repo with 4 remote branches |
| widen refspec, `git fetch`, retry `gh pr create` with no `--head` | resolves the head; fails only with *"a pull request … already exists"* |

So **the environment was the cause.** These changes make the scripts independent of it, which matters because the scaffolder ships them to projects it does not control, and CI checkouts are routinely shallow.

## The fix

Both PR-creation entry points name the branch explicitly:

- **`start_issue.sh` `_create_pr`** gains `--head "$BRANCH"`. `--base` is unchanged, and a test asserts it survives — a `--head` fix that dropped `--base` would silently retarget PRs at the repo default.
- **`dag_workflow.py` `create-pr-nojira`** gains `--head`, and its existing-PR probe (`gh pr view`) now names the branch too: same inference, same failure mode, and passing the branch preserves the CLOSED/MERGED semantics its own comment documents.

## Tests

Added to `test_lifecycle_script_hardening.py`, each using the path's idiomatic technique:

| Test | Technique |
|---|---|
| `test_start_issue_passes_head_explicitly` | extracts the real `_create_pr` body and runs it against a fake `gh` that records argv — the harness `TestMonitorPrLocalBranchCleanup` already established in this module |
| `test_create_pr_nojira_passes_head_explicitly` | loads the hook module and stubs `_gh` to capture argument lists |

Both assert the branch is **the value after `--head`**, not merely that the flag appears somewhere.

**Red-green checked:** reverting both templates failed exactly these two tests and nothing else.

## Verification

`uv run ruff check .` clean, `ruff format --check` clean, `just typecheck` clean, `shellcheck -S error` and `shfmt -d -i 2` clean on the changed script. `test_lifecycle_script_hardening.py` 28 passed; `test_agents_template_sync.py` + `test_claude_dir_sync.py` 7 passed (byte-identity contracts hold).

Templates are the source; `.agents/` and `.claude/` refreshed via `just sync-agents` and `just sync-claude`.

Incidentally confirmed while opening this PR: with the refspec widened, `start_issue.sh` created its own draft PR unaided — the first time in three attempts.