### PR TITLE
fix(PI-913): Address the review findings on #910 and #912

### DIFF
--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -60,8 +60,16 @@ def _is_project_init_checkout(root: Path) -> bool:
             data = tomllib.load(fh)
     except (OSError, tomllib.TOMLDecodeError):
         return False
-    name = data.get("project", {}).get("name")
-    return isinstance(name, str) and name == "project-init"
+    # Every level is type-checked before it is walked. `project` being a valid
+    # TOML *non-table* (`project = "invalid"`) is syntactically fine, so the
+    # decode above succeeds and a chained .get() then raises AttributeError —
+    # which, because this runs before upgrade validates its target, aborted every
+    # `upgrade` invoked from such a directory with a traceback. An advisory check
+    # that can harden into a crash is worse than no check (PR #910 review, P2).
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+    return project.get("name") == "project-init"
 
 
 def stale_install(cwd: Path | None = None) -> Path | None:

--- a/src/project_init/subcommands.py
+++ b/src/project_init/subcommands.py
@@ -22,10 +22,22 @@ def _warn_if_stale_install() -> None:
     of it. Once the checkout moves on, `upgrade` renders the frozen copy and
     reports success — silently re-applying stale files. Kept advisory: a PyPI
     install used from inside a clone is legitimate.
+
+    An advisory diagnostic must never be able to fail the command it precedes.
+    The #910 review found one way it could — a non-table `project` value raising
+    AttributeError — but that was an instance, not the class: this runs before
+    `upgrade` validates its target, and the detection walks parent directories,
+    parses arbitrary TOML and reads several hundred files, so an unreadable file
+    or a deleted cwd is equally capable of aborting an unrelated upgrade with a
+    traceback. Type checks fix the known instance; the blanket guard here fixes
+    the class. Failing to diagnose staleness costs a warning, never the run.
     """
     from project_init.scaffold import stale_install, templates_dir
 
-    root = stale_install()
+    try:
+        root = stale_install()
+    except Exception:  # noqa: BLE001 — advisory only; see the docstring
+        return
     if root is None:
         return
     sys.stderr.write(

--- a/tests/contracts/test_lifecycle_script_hardening.py
+++ b/tests/contracts/test_lifecycle_script_hardening.py
@@ -716,3 +716,93 @@ class TestPrCreationDoesNotRelyOnGhInference:
         view = [c for c in calls if c[:2] == ["pr", "view"]]
         assert view, f"no gh pr view probe recorded: {calls}"
         assert "feat/nojira-x" in view[0], f"pr view relies on inference: {view[0]}"
+
+
+class TestPrCreationFixReachesGeneratedProjects:
+    """PR #912 review (P1): the tests above read templates/ directly.
+
+    They stay green if lifecycle overlay selection or rendering ever stops
+    shipping these files to generated projects — the fix would be present in the
+    source and absent from every scaffold, with nothing failing. CLAUDE.md
+    requires template changes to be exercised through a temporary generated
+    scaffold, so assert against the rendered output as well.
+    """
+
+    @staticmethod
+    def _scaffolded(tmp_path: Path) -> Path:
+        from project_init.scaffold import scaffold
+        from tests.helpers import fallback_preset, fallback_variables
+
+        target = tmp_path / "generated"
+        scaffold(target, fallback_preset(), fallback_variables())
+        return target
+
+    def test_generated_start_issue_passes_head(self, tmp_path: Path):
+        target = self._scaffolded(tmp_path)
+        script = target / ".agents" / "scripts" / "start_issue.sh"
+        assert script.is_file(), "lifecycle scaffold did not emit start_issue.sh"
+
+        m = re.search(
+            r"^_create_pr\(\) \{\n.*?\n\}$",
+            script.read_text(encoding="utf-8"),
+            re.MULTILINE | re.DOTALL,
+        )
+        assert m, "_create_pr missing from the GENERATED start_issue.sh"
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        argv_log = tmp_path / "argv"
+        gh = bin_dir / "gh"
+        gh.write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$@" > {argv_log}\n'
+            'echo "https://github.com/o/r/pull/1"\n'
+        )
+        gh.chmod(0o755)
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"export PATH={bin_dir}:$PATH\nset -euo pipefail\n"
+                'BASE_BRANCH=main\nBRANCH=feat/PI-1-x\nPR_TITLE="t"\nPR_BODY="b"\n'
+                f"{m.group(0)}\n_create_pr\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        argv = argv_log.read_text().splitlines()
+        assert "--head" in argv, f"generated script omits --head: {argv}"
+        assert argv[argv.index("--head") + 1] == "feat/PI-1-x", argv
+
+    def test_generated_dag_workflow_passes_head(self, tmp_path: Path):
+        import importlib.util
+
+        target = self._scaffolded(tmp_path)
+        hook = target / ".agents" / "hooks" / "dag_workflow.py"
+        assert hook.is_file(), "lifecycle scaffold did not emit dag_workflow.py"
+
+        spec = importlib.util.spec_from_file_location("dagw_generated", hook)
+        assert spec and spec.loader
+        dag = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(dag)
+
+        calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], **kwargs: object) -> tuple[int, str]:
+            calls.append(args)
+            if args[:2] == ["pr", "view"]:
+                return 1, ""
+            return 0, "https://github.com/o/r/pull/2"
+
+        dag._gh = fake_gh  # type: ignore[assignment]
+        dag._git = lambda args, **kw: (0, "")  # type: ignore[assignment]
+        dag._current_branch = lambda: "feat/nojira-x"  # type: ignore[assignment]
+        dag.cmd_push = lambda *a, **k: 0  # type: ignore[assignment]
+
+        assert dag.cmd_create_pr_nojira("feat", "Some title", None, None) == 0, calls
+        create = [c for c in calls if c[:2] == ["pr", "create"]]
+        assert create, f"no gh pr create recorded: {calls}"
+        assert "--head" in create[0], f"generated hook omits --head: {create[0]}"
+        assert create[0][create[0].index("--head") + 1] == "feat/nojira-x", create[0]

--- a/tests/unit/test_stale_install.py
+++ b/tests/unit/test_stale_install.py
@@ -174,6 +174,30 @@ class TestUpgradeEmitsTheWarning:
         assert str(checkout) in err
         assert "uv pip install -e ." in err
 
+    def test_a_raising_detector_cannot_break_upgrade(self, capsys: pytest.CaptureFixture[str]):
+        """The class behind the #910 P2, not just that instance.
+
+        This runs before `upgrade` validates its target, and the detection walks
+        parent directories, parses arbitrary TOML and reads several hundred
+        files. An unreadable file or a deleted cwd must cost a warning, never the
+        run — so the caller swallows anything the detector raises.
+        """
+        import project_init.scaffold as scaffold_mod
+        from project_init import subcommands
+
+        def boom(cwd: Path | None = None) -> Path | None:
+            raise OSError("simulated: templates file vanished mid-walk")
+
+        saved = scaffold_mod.stale_install
+        scaffold_mod.stale_install = boom  # type: ignore[assignment]
+        try:
+            subcommands._warn_if_stale_install()  # must not raise
+        finally:
+            scaffold_mod.stale_install = saved  # type: ignore[assignment]
+
+        # Silent: a failed diagnostic is not worth alarming the user about.
+        assert capsys.readouterr().err == ""
+
     def test_silent_when_nothing_is_stale(self, capsys: pytest.CaptureFixture[str]):
         import project_init.scaffold as scaffold_mod
         from project_init import subcommands

--- a/tests/unit/test_stale_install.py
+++ b/tests/unit/test_stale_install.py
@@ -107,6 +107,32 @@ class TestStaleInstallDetection:
         (root / "pyproject.toml").write_text("[project\nname = ", encoding="utf-8")
         assert stale_install(root) is None
 
+    @pytest.mark.parametrize(
+        "pyproject",
+        [
+            pytest.param('project = "invalid"\n', id="project-is-a-string"),
+            pytest.param("project = 42\n", id="project-is-an-int"),
+            pytest.param("project = []\n", id="project-is-an-array"),
+            pytest.param("[project]\nname = 42\n", id="name-is-not-a-string"),
+            pytest.param('[tool.poetry]\nname = "x"\n', id="no-project-table"),
+        ],
+    )
+    def test_a_valid_toml_with_an_unexpected_project_value_is_not_a_checkout(
+        self, tmp_path: Path, pyproject: str
+    ):
+        """PR #910 review (P2): syntactically valid TOML, wrong shape.
+
+        `project = "invalid"` decodes fine, so the TOMLDecodeError guard does not
+        catch it and a chained .get() raised AttributeError. Because the check
+        runs before `upgrade` validates its target, that traceback aborted EVERY
+        upgrade invoked from such a directory — an advisory warning hardened into
+        a crash. Reproduced before fixing.
+        """
+        root = tmp_path / "oddly-shaped"
+        (root / "templates").mkdir(parents=True)
+        (root / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+        assert stale_install(root) is None
+
     def test_nearest_checkout_wins(self, tmp_path: Path):
         """An inner checkout shadows an outer one; the walk stops at the first."""
         outer = _fake_checkout(tmp_path / "outer", templates_from=templates_dir())


### PR DESCRIPTION
Closes #913

Both #910 and #912 carried a Codex review comment that landed **after** the review window and was merged over (I used `--no-review`). Both findings were correct. This PR addresses them.

## P2 (#910) — a non-table `project` value crashed every upgrade

`data.get("project", {}).get("name")` assumed `project` was a table. But `project = "invalid"` is syntactically valid TOML, so the `TOMLDecodeError` guard never fired and the chained `.get()` raised `AttributeError`.

Because `_warn_if_stale_install()` runs *before* `upgrade` validates its target, that traceback aborted **every** `project-init upgrade` invoked from such a directory — including upgrades targeting an unrelated path. An advisory check that hardens into a crash is worse than no check.

Reproduced before fixing:

```
$ stale_install(Path("/tmp/nontable"))
RAISED: AttributeError 'str' object has no attribute 'get'

$ project-init upgrade /tmp/target      # from that directory
  File ".../scaffold.py", line 63, in _is_project_init_checkout
    name = data.get("project", {}).get("name")
AttributeError: 'str' object has no attribute 'get'
```

Now every level is type-checked before it is walked, and after the fix the same invocation reaches its normal *"not scaffolded by project-init"* error. Parametrized regression covers `project` as string / int / array, `name` not a string, and a pyproject with no `[project]` table at all.

## P1 (#912) — the tests read `templates/` directly

They would stay green if lifecycle overlay selection or rendering ever stopped shipping these files to generated projects: fix present in source, absent from every scaffold, nothing failing.

`TestPrCreationFixReachesGeneratedProjects` now scaffolds into `tmp_path` and asserts against the **rendered** `.agents/scripts/start_issue.sh` and `.agents/hooks/dag_workflow.py`, reusing the same fake-`gh`-records-argv and stubbed-`_gh` techniques. The template-source tests are kept — they localise a regression to the source, while these prove it reaches users.

## A correction about my own red-green check

The first red-green attempt on those two tests was **invalid and I nearly reported it as proof**. `git stash push <paths>` stashed nothing, because by then the template changes were committed content on the branch rather than local edits — so the tests "passed while reverted" and demonstrated nothing.

Redone by actually removing `--head` from both templates: all four tests failed, then restored and re-verified green. Worth recording for the next person: the session-scoped `_frozen_templates` fixture snapshots `templates/` at session start, so a revert has to happen *before* pytest is invoked, not during — a mid-session edit is invisible to `scaffold()`.

## Verification

`ruff check` clean, `ruff format --check` clean, `just typecheck` clean. `test_lifecycle_script_hardening.py` + `test_stale_install.py`: 46 passed.

Full suite: 2633 passed, 7 failed — the same seven pre-existing macOS-local failures present on clean `main`.

No templates changed here, so no `sync-plugin`/`sync-agents` bump is needed; `test_plugin_marketplace`, `test_agents_template_sync` and `test_claude_dir_sync` all pass (29).