### PR TITLE
feat(PI-916): guard bq/GCS/dbt/IAM destruction in prod_guard

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "2e4d2c6abebdc4f5f822abeb70f993095225753979ff5f480f17abe1292361ce",
-    "version": "0.8.4"
+    "sha256": "8cfd3ae8e6a570131f5f8bd44caef20f94108b0f1a4055faeb380fdef30bcb6b",
+    "version": "0.8.5"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "ed9406d5a3407ed2785101876021d8cc1df8a14af3c701754720951fa3090e19",
-    "version": "0.8.3"
+    "sha256": "2e4d2c6abebdc4f5f822abeb70f993095225753979ff5f480f17abe1292361ce",
+    "version": "0.8.4"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "ad329be8000154d0d1c108fdab866c191e2b78e1723f6bda63931435892edaad",
-    "version": "0.8.2"
+    "sha256": "ed9406d5a3407ed2785101876021d8cc1df8a14af3c701754720951fa3090e19",
+    "version": "0.8.3"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -124,7 +124,31 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # merely start with the word — `deleted_at`, `delete_log` — out, and the
     # `\b` before it keeps `is_deleted FROM …` out: the word must stand alone
     # and be immediately followed by FROM, which a SELECT never does.
-    (re.compile(r"\bdelete\s+from\b", re.IGNORECASE), "SQL DELETE FROM"),
+    #
+    # A TABLE MUST FOLLOW, AND THE CLAUSE MUST END. "delete from" is ordinary
+    # English, unlike "drop table" and "truncate table", so the bare form this
+    # rule first shipped with flagged six perfectly normal commands — measured
+    # against the live deny table, not supposed:
+    #     git commit -m "chore: delete from the stale cache"
+    #     git log --grep "delete from"
+    #     grep -rn "DELETE FROM" src/
+    #     echo 'how to delete from a list in python'
+    #     # TODO: delete from the queue once drained
+    #     echo "we should delete from that table eventually"
+    # Note the second-order problem: writing a commit message ABOUT this rule
+    # tripped it.
+    #
+    # Requiring an identifier and then a WHERE, a statement terminator or a
+    # closing quote separates the statement from the sentence — prose continues
+    # with more words, SQL does not. Measured after: 0 false positives on those
+    # six, 0 missed true positives on the destructive corpus.
+    (
+        re.compile(
+            r"\bdelete\s+from\s+[A-Za-z_`\"\[][\w.`\"\[\]$-]*\s*(?:\bwhere\b|;|\"|'|$)",
+            re.IGNORECASE,
+        ),
+        "SQL DELETE FROM",
+    ),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -54,9 +54,77 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         "aws s3 bucket/recursive removal",
     ),
     (re.compile(rf"\bgcloud\b{_SEG}\bdelete\b"), "gcloud delete"),
+    # GCS recursive removal, both spellings (PI-906). The `gcloud delete` rule
+    # above LOOKS like it covers this and does not: it keys on the token
+    # `delete`, which neither `gsutil rm -r` nor the modern `gcloud storage rm
+    # -r` carries — so the highest-blast-radius GCS operation walked past a
+    # gcloud rule. (`gcloud storage buckets delete` does carry the token and is
+    # already caught above.) Shaped like the `aws s3 rm --recursive` rule: a
+    # single-object `rm` is not flagged, only the recursive form, which is what
+    # empties a bucket. `-\w*[rR]\w*` covers gsutil's `-r` and `-R`; the flag may
+    # sit before or after the URL, hence _SEG on both sides.
+    (
+        re.compile(rf"\bgsutil\b{_SEG}\brm\b{_SEG}\s(?:-\w*[rR]\w*|--recursive)\b"),
+        "gsutil recursive bucket removal",
+    ),
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bstorage\s+rm\b{_SEG}\s(?:-\w*[rR]\w*|--recursive)\b"),
+        "gcloud storage recursive bucket removal",
+    ),
+    # BigQuery dataset/table destruction (PI-906). Flag-specific rather than
+    # _SEG for `plan -destroy`'s reason: `bq query` takes SQL as an argument, so
+    # an _SEG reaching into the statement would fire on any query whose text
+    # happens to contain `rm`. Only global flags (`--project_id=…`,
+    # `--location=…`) may sit between `bq` and the verb. `--help`/`-h` is a
+    # read-only lookup of the very command being guarded — never flag it.
+    (
+        re.compile(r"\bbq\s+(?:-\S+\s+)*rm\b(?!\s+(?:--help|-h)\b)"),
+        "bq rm (BigQuery dataset/table removal)",
+    ),
     (re.compile(rf"\baz\b{_SEG}\bdelete\b"), "az delete"),
+    # dbt `--full-refresh` drops and rebuilds incremental models: data
+    # destruction wearing a build verb (PI-906). Two lookaheads because the
+    # flags appear in either order, the same idiom the `rm -r -f` rule below
+    # uses. DELIBERATE LIMIT: a production TARGET must be named explicitly, so
+    # routine `dbt run --full-refresh --target dev` stays unflagged — a guard
+    # that nags on ordinary dev work gets switched off. The cost is that a
+    # bare `--full-refresh` against a profile whose DEFAULT target is prod is
+    # not reached; naming the target is the supported way to be protected.
+    (
+        re.compile(
+            r"\bdbt\b"
+            rf"(?={_SEG}\s--full-refresh\b)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*prod)"
+        ),
+        "dbt --full-refresh against a production target",
+    ),
+    # IAM mutation on shared identities (PI-906). Granting access is not
+    # obviously "destructive" and so was never modelled, but where an identity
+    # is shared it changes other people's reach without their knowledge, and it
+    # is the least reversible thing in this table. Grants are narrowed to the
+    # roles that hand over the estate (owner/editor/any *Admin) so that routine
+    # `roles/bigquery.dataViewer` grants stay unflagged; removals are flagged
+    # unconditionally, because taking access away is destruction by another
+    # name. `get-iam-policy` is read-only and matches neither.
+    (
+        re.compile(
+            rf"\bgcloud\b{_SEG}\badd-iam-policy-binding\b"
+            rf"{_SEG}--role[=\s]\s*roles/(?:owner|editor|\S*[Aa]dmin)"
+        ),
+        "gcloud IAM grant of owner/editor/admin",
+    ),
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bremove-iam-policy-binding\b"),
+        "gcloud IAM binding removal",
+    ),
     (re.compile(r"\bdrop\s+(table|database|schema)\b", re.IGNORECASE), "SQL DROP"),
     (re.compile(r"\btruncate\s+table\b", re.IGNORECASE), "SQL TRUNCATE"),
+    # A full-table DELETE empties it as surely as a TRUNCATE, and neither rule
+    # above reaches it (PI-906). `\s+` after the verb keeps identifiers that
+    # merely start with the word — `deleted_at`, `delete_log` — out, and the
+    # `\b` before it keeps `is_deleted FROM …` out: the word must stand alone
+    # and be immediately followed by FROM, which a SELECT never does.
+    (re.compile(r"\bdelete\s+from\b", re.IGNORECASE), "SQL DELETE FROM"),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -90,11 +90,24 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # that nags on ordinary dev work gets switched off. The cost is that a
     # bare `--full-refresh` against a profile whose DEFAULT target is prod is
     # not reached; naming the target is the supported way to be protected.
+    #
+    # THE TARGET VALUE IS QUOTED AS OFTEN AS NOT, and the first cut required
+    # `prod` immediately after whitespace — so `--target "prod"` and
+    # `--target="prod"` ran the destructive refresh straight through a rule
+    # written to stop it (PR #915 review, P1). The shell strips the quotes
+    # before dbt sees them; this guard reads the RAW command string, so it has
+    # to tolerate what the shell would remove.
+    #
+    # AND THE VALUE MUST END. `\s*prod` also matched `--target prod-dev`,
+    # flagging a dev target because its name starts with the same four letters
+    # (PR #915 review). `(?![\w-])` is the boundary — a plain `\b` does NOT
+    # help here, because `-` is a non-word character and `prod\b` matches
+    # happily inside `prod-dev`.
     (
         re.compile(
             r"\bdbt\b"
             rf"(?={_SEG}\s--full-refresh\b)"
-            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*prod)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*[\"']?(?:prod|production)(?![\w-]))"
         ),
         "dbt --full-refresh against a production target",
     ),
@@ -106,10 +119,16 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # `roles/bigquery.dataViewer` grants stay unflagged; removals are flagged
     # unconditionally, because taking access away is destruction by another
     # name. `get-iam-policy` is read-only and matches neither.
+    #
+    # Same quoting problem as the dbt rule above, and the same severity (PR #915
+    # review, P1): `--role="roles/owner"` passes gcloud exactly the argument
+    # `roles/owner`, but the raw command carries a quote between `--role=` and
+    # `roles/`, so an unquoted-only pattern let the estate handover through in
+    # autonomous mode — where the verdict is a hard deny, not a prompt.
     (
         re.compile(
             rf"\bgcloud\b{_SEG}\badd-iam-policy-binding\b"
-            rf"{_SEG}--role[=\s]\s*roles/(?:owner|editor|\S*[Aa]dmin)"
+            rf"{_SEG}--role[=\s]\s*[\"']?roles/(?:owner|editor|\S*[Aa]dmin)"
         ),
         "gcloud IAM grant of owner/editor/admin",
     ),

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.4"
+__plugin_version__ = "0.8.5"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.3"
+__plugin_version__ = "0.8.4"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.2"
+__plugin_version__ = "0.8.3"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -124,7 +124,31 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # merely start with the word — `deleted_at`, `delete_log` — out, and the
     # `\b` before it keeps `is_deleted FROM …` out: the word must stand alone
     # and be immediately followed by FROM, which a SELECT never does.
-    (re.compile(r"\bdelete\s+from\b", re.IGNORECASE), "SQL DELETE FROM"),
+    #
+    # A TABLE MUST FOLLOW, AND THE CLAUSE MUST END. "delete from" is ordinary
+    # English, unlike "drop table" and "truncate table", so the bare form this
+    # rule first shipped with flagged six perfectly normal commands — measured
+    # against the live deny table, not supposed:
+    #     git commit -m "chore: delete from the stale cache"
+    #     git log --grep "delete from"
+    #     grep -rn "DELETE FROM" src/
+    #     echo 'how to delete from a list in python'
+    #     # TODO: delete from the queue once drained
+    #     echo "we should delete from that table eventually"
+    # Note the second-order problem: writing a commit message ABOUT this rule
+    # tripped it.
+    #
+    # Requiring an identifier and then a WHERE, a statement terminator or a
+    # closing quote separates the statement from the sentence — prose continues
+    # with more words, SQL does not. Measured after: 0 false positives on those
+    # six, 0 missed true positives on the destructive corpus.
+    (
+        re.compile(
+            r"\bdelete\s+from\s+[A-Za-z_`\"\[][\w.`\"\[\]$-]*\s*(?:\bwhere\b|;|\"|'|$)",
+            re.IGNORECASE,
+        ),
+        "SQL DELETE FROM",
+    ),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -54,9 +54,77 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         "aws s3 bucket/recursive removal",
     ),
     (re.compile(rf"\bgcloud\b{_SEG}\bdelete\b"), "gcloud delete"),
+    # GCS recursive removal, both spellings (PI-906). The `gcloud delete` rule
+    # above LOOKS like it covers this and does not: it keys on the token
+    # `delete`, which neither `gsutil rm -r` nor the modern `gcloud storage rm
+    # -r` carries — so the highest-blast-radius GCS operation walked past a
+    # gcloud rule. (`gcloud storage buckets delete` does carry the token and is
+    # already caught above.) Shaped like the `aws s3 rm --recursive` rule: a
+    # single-object `rm` is not flagged, only the recursive form, which is what
+    # empties a bucket. `-\w*[rR]\w*` covers gsutil's `-r` and `-R`; the flag may
+    # sit before or after the URL, hence _SEG on both sides.
+    (
+        re.compile(rf"\bgsutil\b{_SEG}\brm\b{_SEG}\s(?:-\w*[rR]\w*|--recursive)\b"),
+        "gsutil recursive bucket removal",
+    ),
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bstorage\s+rm\b{_SEG}\s(?:-\w*[rR]\w*|--recursive)\b"),
+        "gcloud storage recursive bucket removal",
+    ),
+    # BigQuery dataset/table destruction (PI-906). Flag-specific rather than
+    # _SEG for `plan -destroy`'s reason: `bq query` takes SQL as an argument, so
+    # an _SEG reaching into the statement would fire on any query whose text
+    # happens to contain `rm`. Only global flags (`--project_id=…`,
+    # `--location=…`) may sit between `bq` and the verb. `--help`/`-h` is a
+    # read-only lookup of the very command being guarded — never flag it.
+    (
+        re.compile(r"\bbq\s+(?:-\S+\s+)*rm\b(?!\s+(?:--help|-h)\b)"),
+        "bq rm (BigQuery dataset/table removal)",
+    ),
     (re.compile(rf"\baz\b{_SEG}\bdelete\b"), "az delete"),
+    # dbt `--full-refresh` drops and rebuilds incremental models: data
+    # destruction wearing a build verb (PI-906). Two lookaheads because the
+    # flags appear in either order, the same idiom the `rm -r -f` rule below
+    # uses. DELIBERATE LIMIT: a production TARGET must be named explicitly, so
+    # routine `dbt run --full-refresh --target dev` stays unflagged — a guard
+    # that nags on ordinary dev work gets switched off. The cost is that a
+    # bare `--full-refresh` against a profile whose DEFAULT target is prod is
+    # not reached; naming the target is the supported way to be protected.
+    (
+        re.compile(
+            r"\bdbt\b"
+            rf"(?={_SEG}\s--full-refresh\b)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*prod)"
+        ),
+        "dbt --full-refresh against a production target",
+    ),
+    # IAM mutation on shared identities (PI-906). Granting access is not
+    # obviously "destructive" and so was never modelled, but where an identity
+    # is shared it changes other people's reach without their knowledge, and it
+    # is the least reversible thing in this table. Grants are narrowed to the
+    # roles that hand over the estate (owner/editor/any *Admin) so that routine
+    # `roles/bigquery.dataViewer` grants stay unflagged; removals are flagged
+    # unconditionally, because taking access away is destruction by another
+    # name. `get-iam-policy` is read-only and matches neither.
+    (
+        re.compile(
+            rf"\bgcloud\b{_SEG}\badd-iam-policy-binding\b"
+            rf"{_SEG}--role[=\s]\s*roles/(?:owner|editor|\S*[Aa]dmin)"
+        ),
+        "gcloud IAM grant of owner/editor/admin",
+    ),
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bremove-iam-policy-binding\b"),
+        "gcloud IAM binding removal",
+    ),
     (re.compile(r"\bdrop\s+(table|database|schema)\b", re.IGNORECASE), "SQL DROP"),
     (re.compile(r"\btruncate\s+table\b", re.IGNORECASE), "SQL TRUNCATE"),
+    # A full-table DELETE empties it as surely as a TRUNCATE, and neither rule
+    # above reaches it (PI-906). `\s+` after the verb keeps identifiers that
+    # merely start with the word — `deleted_at`, `delete_log` — out, and the
+    # `\b` before it keeps `is_deleted FROM …` out: the word must stand alone
+    # and be immediately followed by FROM, which a SELECT never does.
+    (re.compile(r"\bdelete\s+from\b", re.IGNORECASE), "SQL DELETE FROM"),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -90,11 +90,24 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # that nags on ordinary dev work gets switched off. The cost is that a
     # bare `--full-refresh` against a profile whose DEFAULT target is prod is
     # not reached; naming the target is the supported way to be protected.
+    #
+    # THE TARGET VALUE IS QUOTED AS OFTEN AS NOT, and the first cut required
+    # `prod` immediately after whitespace — so `--target "prod"` and
+    # `--target="prod"` ran the destructive refresh straight through a rule
+    # written to stop it (PR #915 review, P1). The shell strips the quotes
+    # before dbt sees them; this guard reads the RAW command string, so it has
+    # to tolerate what the shell would remove.
+    #
+    # AND THE VALUE MUST END. `\s*prod` also matched `--target prod-dev`,
+    # flagging a dev target because its name starts with the same four letters
+    # (PR #915 review). `(?![\w-])` is the boundary — a plain `\b` does NOT
+    # help here, because `-` is a non-word character and `prod\b` matches
+    # happily inside `prod-dev`.
     (
         re.compile(
             r"\bdbt\b"
             rf"(?={_SEG}\s--full-refresh\b)"
-            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*prod)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*[\"']?(?:prod|production)(?![\w-]))"
         ),
         "dbt --full-refresh against a production target",
     ),
@@ -106,10 +119,16 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # `roles/bigquery.dataViewer` grants stay unflagged; removals are flagged
     # unconditionally, because taking access away is destruction by another
     # name. `get-iam-policy` is read-only and matches neither.
+    #
+    # Same quoting problem as the dbt rule above, and the same severity (PR #915
+    # review, P1): `--role="roles/owner"` passes gcloud exactly the argument
+    # `roles/owner`, but the raw command carries a quote between `--role=` and
+    # `roles/`, so an unquoted-only pattern let the estate handover through in
+    # autonomous mode — where the verdict is a hard deny, not a prompt.
     (
         re.compile(
             rf"\bgcloud\b{_SEG}\badd-iam-policy-binding\b"
-            rf"{_SEG}--role[=\s]\s*roles/(?:owner|editor|\S*[Aa]dmin)"
+            rf"{_SEG}--role[=\s]\s*[\"']?roles/(?:owner|editor|\S*[Aa]dmin)"
         ),
         "gcloud IAM grant of owner/editor/admin",
     ),

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -96,6 +96,18 @@ SAFE = [
     # A SELECT may legitimately carry the word `delete` in a column, a literal
     # or an identifier — only `DELETE FROM` is the destructive statement.
     "bq query \"SELECT is_deleted FROM analytics.sessions WHERE state = 'delete'\"",
+    # "delete from" IS ORDINARY ENGLISH, unlike "drop table" or "truncate
+    # table". The first cut of this rule was a bare `\bdelete\s+from\b` and it
+    # flagged all six of these — measured against the real DENY_RULES, not
+    # supposed. Every one is a command someone types weekly, and the last three
+    # concern the guard's own subject matter, so writing a commit message about
+    # this very rule tripped it.
+    'git commit -m "chore: delete from the stale cache"',
+    'git log --grep "delete from"',
+    "echo 'how to delete from a list in python'",
+    'grep -rn "DELETE FROM" src/',
+    "# TODO: delete from the queue once drained",
+    'echo "we should delete from that table eventually"',
     "bq ls my-proj:analytics",
     "bq show my-proj:analytics.sessions",
     "bq load --source_format=CSV my-proj:analytics.t gs://b/f.csv",

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -63,11 +63,21 @@ DESTRUCTIVE = [
     "dbt run --target prod --full-refresh",
     "dbt run --full-refresh -t prod",
     "dbt run --full-refresh --target=production",
+    # Shell-quoted target values (PR #915 review, P1). The shell strips these
+    # before dbt sees them; the guard reads the raw command, so it must too.
+    'dbt run --full-refresh --target "prod"',
+    "dbt run --full-refresh --target='prod'",
+    'dbt run --full-refresh --target "production"',
     # IAM mutation on a shared identity: high-privilege grants and any removal.
     "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role roles/owner",
     "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/editor",
     "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/storage.admin",
     "gcloud projects remove-iam-policy-binding mbd --member=user:a@b.c --role=roles/viewer",
+    # Quoted role values (PR #915 review, P1) — gcloud receives an identical
+    # argument, so the guard must see through the quoting the shell removes.
+    'gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role="roles/owner"',
+    "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role='roles/editor'",
+    'gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role="roles/storage.admin"',
     # A full-table DELETE empties it as surely as TRUNCATE.
     'bq query --use_legacy_sql=false "DELETE FROM analytics.sessions WHERE 1=1"',
     "psql -c 'delete from users'",
@@ -113,6 +123,9 @@ SAFE = [
     "bq load --source_format=CSV my-proj:analytics.t gs://b/f.csv",
     # Reading the guarded command's own docs is not running it.
     "bq rm --help",
+    # The rule exempts BOTH help spellings; only the long one was pinned, so a
+    # regression that dropped `-h` would have gone unnoticed (PR #915 review).
+    "bq rm -h",
     "bq help rm",
     "gsutil ls gs://prod-assets",
     "gsutil cp gs://prod-assets/a.csv .",
@@ -130,6 +143,11 @@ SAFE = [
     "dbt run --target dev",
     # Deliberate: a full refresh against a DEV target is ordinary work.
     "dbt run --full-refresh --target dev",
+    # `prod-dev` is a DEV target whose name merely starts with the guarded
+    # letters. The first cut flagged it, because a plain `\b` after `prod`
+    # matches inside `prod-dev` — `-` is a non-word character (PR #915 review).
+    "dbt run --full-refresh --target prod-dev",
+    "dbt run --full-refresh --target=prod-staging",
     "dbt test",
     "dbt build --target dev",
     "gcloud projects get-iam-policy mbd",

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -45,6 +45,32 @@ DESTRUCTIVE = [
     "helm -n prod uninstall api",
     "aws --profile prod s3 rb s3://prod-assets --force",
     "aws --region eu-west-1 ec2 terminate-instances --instance-ids i-1",
+    # ── PI-906: the cloud/data verb set the table used to miss entirely ──
+    # BigQuery removal — dataset (-r -d) is the wide blast radius, table (-t)
+    # the common one; a global flag may precede the verb.
+    "bq rm -r -f -d my-proj:analytics",
+    "bq rm -f -t my-proj:analytics.sessions",
+    "bq --project_id=my-proj rm -r -f -d analytics",
+    # GCS recursive removal, BOTH spellings. `gcloud storage rm` carries no
+    # `delete` token, so the pre-existing `gcloud delete` rule never saw it.
+    "gsutil rm -r gs://prod-assets",
+    "gsutil -m rm -r gs://prod-assets/exports",
+    "gsutil rm -R gs://prod-assets",
+    "gcloud storage rm -r gs://prod-assets",
+    "gcloud storage rm --recursive gs://prod-assets/exports",
+    # dbt --full-refresh drops and rebuilds incrementals; flags in either order.
+    "dbt run --full-refresh --target prod",
+    "dbt run --target prod --full-refresh",
+    "dbt run --full-refresh -t prod",
+    "dbt run --full-refresh --target=production",
+    # IAM mutation on a shared identity: high-privilege grants and any removal.
+    "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role roles/owner",
+    "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/editor",
+    "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/storage.admin",
+    "gcloud projects remove-iam-policy-binding mbd --member=user:a@b.c --role=roles/viewer",
+    # A full-table DELETE empties it as surely as TRUNCATE.
+    'bq query --use_legacy_sql=false "DELETE FROM analytics.sessions WHERE 1=1"',
+    "psql -c 'delete from users'",
 ]
 
 SAFE = [
@@ -63,6 +89,40 @@ SAFE = [
     "rm -rf /tmp/scratch",
     "uv run pytest",
     "psql -c 'select * from users'",
+    # ── PI-906 negative cases. These are DAILY commands: a guard that nags on
+    # them gets switched off, and a disabled guard protects nothing. Every rule
+    # added for PI-906 has its counterpart here.
+    'bq query --use_legacy_sql=false "SELECT 1"',
+    # A SELECT may legitimately carry the word `delete` in a column, a literal
+    # or an identifier — only `DELETE FROM` is the destructive statement.
+    "bq query \"SELECT is_deleted FROM analytics.sessions WHERE state = 'delete'\"",
+    "bq ls my-proj:analytics",
+    "bq show my-proj:analytics.sessions",
+    "bq load --source_format=CSV my-proj:analytics.t gs://b/f.csv",
+    # Reading the guarded command's own docs is not running it.
+    "bq rm --help",
+    "bq help rm",
+    "gsutil ls gs://prod-assets",
+    "gsutil cp gs://prod-assets/a.csv .",
+    # `-r` on a COPY is routine; only a recursive rm is flagged.
+    "gsutil -m cp -r ./dist gs://prod-assets/dist",
+    "gcloud storage ls gs://prod-assets",
+    "gcloud storage cp -r ./dist gs://prod-assets/dist",
+    # Deliberate parity with the `aws s3 rm --recursive` rule: a SINGLE-object
+    # delete is not flagged, only the recursive form that empties a bucket.
+    # Pinned because an over-match mutant that dropped the recursive
+    # requirement otherwise survived the whole suite (PI-906 mutation run).
+    "gsutil rm gs://prod-assets/one-export.csv",
+    "gcloud storage rm gs://prod-assets/one-export.csv",
+    "dbt run",
+    "dbt run --target dev",
+    # Deliberate: a full refresh against a DEV target is ordinary work.
+    "dbt run --full-refresh --target dev",
+    "dbt test",
+    "dbt build --target dev",
+    "gcloud projects get-iam-policy mbd",
+    # A low-privilege grant is not an estate handover.
+    "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/bigquery.dataViewer",
 ]
 
 
@@ -105,6 +165,43 @@ class TestVerdicts:
     @pytest.mark.parametrize("command", SAFE)
     def test_safe_commands_pass(self, tmp_path: Path, command: str):
         assert _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path) is None
+
+    @pytest.mark.parametrize(
+        ("command", "label"),
+        [
+            ("bq rm -r -f -d my-proj:analytics", "bq rm (BigQuery dataset/table removal)"),
+            ("gsutil rm -r gs://prod-assets", "gsutil recursive bucket removal"),
+            # THE RULE DEFECT (PI-906): this used to slip past a rule that looks
+            # like it covers gcloud. `\bgcloud\b…\bdelete\b` keys on the token
+            # `delete`, and the modern spelling of recursive bucket deletion
+            # does not carry it. Pinning the LABEL, not just "flagged", is what
+            # makes that regression visible — a command caught incidentally by
+            # some other rule would report a different one.
+            (
+                "gcloud storage rm -r gs://prod-assets",
+                "gcloud storage recursive bucket removal",
+            ),
+            (
+                "dbt run --full-refresh --target prod",
+                "dbt --full-refresh against a production target",
+            ),
+            (
+                "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role roles/owner",
+                "gcloud IAM grant of owner/editor/admin",
+            ),
+            (
+                "gcloud projects remove-iam-policy-binding mbd --member=user:a@b.c --role=roles/x",
+                "gcloud IAM binding removal",
+            ),
+            ('psql -c "DELETE FROM sessions WHERE 1=1"', "SQL DELETE FROM"),
+        ],
+    )
+    def test_each_new_rule_is_the_one_that_fires(self, tmp_path: Path, command: str, label: str):
+        """PI-906: each command is caught by its OWN rule, not by accident."""
+        verdict = _run_hook(_payload(command, "bypassPermissions", tmp_path), tmp_path)
+        assert verdict is not None, f"not flagged: {command}"
+        reason = verdict["hookSpecificOutput"]["permissionDecisionReason"]
+        assert f"'{label}'" in reason, reason
 
     def test_allowlist_suppresses_flag(self, tmp_path: Path):
         config = tmp_path / ".agents" / "config.yaml"


### PR DESCRIPTION


Not `Closes` — #906 is a `scale:epic` with six task groups, and this PR implements
the subset that covers the commands actually run against the live estate. What
remains open is listed at the bottom so the epic is not auto-closed over real work.

## The gap, measured before the change

`DENY_RULES` covered infrastructure (terraform/tofu, kubectl, helm, aws, az) and SQL
`DROP`/`TRUNCATE`, but nothing in the data stack. Executing the live table — not
reading it — against a representative corpus:

```
deny table: 12 rules

-- 1 bq dataset/table destruction
  PASSES-THROUGH  <-- GAP    bq rm -r -f -d my-proj:analytics
  PASSES-THROUGH  <-- GAP    bq rm -f -t my-proj:analytics.sessions
  PASSES-THROUGH  <-- GAP    bq --project_id=my-proj rm -r -f -d analytics
-- 2 gsutil recursive GCS delete
  PASSES-THROUGH  <-- GAP    gsutil rm -r gs://prod-assets
  PASSES-THROUGH  <-- GAP    gsutil -m rm -r gs://prod-assets/exports
-- 3 gcloud storage rm (modern spelling)
  PASSES-THROUGH  <-- GAP    gcloud storage rm -r gs://prod-assets
-- 4 dbt full-refresh against prod
  PASSES-THROUGH  <-- GAP    dbt run --full-refresh --target prod
-- 5 IAM privilege change on shared identities
  PASSES-THROUGH  <-- GAP    gcloud projects add-iam-policy-binding mbd … --role roles/owner
  PASSES-THROUGH  <-- GAP    gcloud projects remove-iam-policy-binding mbd … --role=roles/viewer
-- 6 SQL DELETE FROM
  PASSES-THROUGH  <-- GAP    bq query … "DELETE FROM analytics.sessions WHERE 1=1"

SUMMARY: 19 gap commands unguarded, 0 false positives on benign corpus
```

After: `19 rules`, `SUMMARY: 0 gap commands unguarded, 0 false positives`.

## One of these is a rule defect, not a missing feature

`gcloud storage rm -r gs://bucket` is the modern spelling of recursive bucket
deletion. The existing rule is `\bgcloud\b…\bdelete\b` — it keys on the token
`delete`, which that command does not carry. So the highest-blast-radius GCS
operation walked past a rule that *looks* like it covers gcloud. `gcloud storage
buckets delete` does carry the token and was already caught, which is what made the
hole easy to miss.

That is pinned by a test asserting the **label** that fires, not merely that
something fired — a command caught incidentally by another rule reports a different
label and the test goes red.

## Rules added (7)

| Rule | Scope |
|---|---|
| `bq rm` | dataset (`-r -d`) and table (`-t`) removal; `--help`/`-h` exempt |
| `gsutil rm -r` | recursive bucket removal (`-r`/`-R`/`--recursive`) |
| `gcloud storage rm -r` | the spelling the `gcloud delete` rule missed |
| `dbt --full-refresh` | only against an explicitly named production target |
| `add-iam-policy-binding` | `roles/owner`, `roles/editor`, any `*Admin` |
| `remove-iam-policy-binding` | unconditional — taking access away is destruction |
| `DELETE FROM` | a full-table DELETE empties it as surely as TRUNCATE |

Posture unchanged: `ask` interactively, `deny` under `_AUTONOMOUS_MODES`,
`safety.allow` remains the per-project escape hatch.

## False positives were treated as the primary risk

A guard that nags on ordinary work gets switched off, and a disabled guard protects
nothing. 22 daily commands are pinned in the SAFE corpus and each new rule has its
negative counterpart: `bq query`/`ls`/`show`/`load`, `bq rm --help`, `bq help rm`,
`gsutil ls`/`cp`, `gsutil -m cp -r`, `gcloud storage ls`/`cp -r`, `dbt run`,
`dbt run --target dev`, `dbt run --full-refresh --target dev`, `dbt test`,
`dbt build --target dev`, `gcloud projects get-iam-policy`, a low-privilege
`roles/bigquery.dataViewer` grant, and a SELECT whose text contains the word
`delete`.

Two deliberate design decisions, documented in the rule comments:

- **`bq` is flag-scoped, not `_SEG`-scoped**, for `plan -destroy`'s reason. `bq query`
  takes SQL as an argument, so a segment matcher reaching into the statement would
  fire on any query whose text happens to contain `rm`. Only global flags
  (`--project_id=`, `--location=`) may sit between `bq` and the verb.
- **`dbt` requires an explicitly named prod target.** A full refresh against a dev
  target is ordinary work. The cost, stated honestly rather than hidden: a bare
  `--full-refresh` against a profile whose *default* target is prod is not reached.
  Naming the target is the supported way to be protected.

Per #906's constraint, **the false-positive rate is unmeasured and is reported as
unmeasured**, not as zero. The runnable check is that the new rules fire zero times
on the benign corpus above.

## Every rule was proved able to fail

Each of the 7 rules was broken one at a time, its tests watched to go red, then
restored — the hook verified byte-identical to its pre-mutation backup afterwards.

```
=== BASELINE (unmutated) === 140 passed
### MUTANT: 1 bq rm                  -> 7 failed
### MUTANT: 2 gsutil recursive rm    -> 7 failed
### MUTANT: 3 gcloud storage rm      -> 5 failed
### MUTANT: 4 dbt --full-refresh     -> 9 failed
### MUTANT: 5 IAM grant              -> 7 failed
### MUTANT: 6 IAM removal            -> 3 failed
### MUTANT: 7 SQL DELETE FROM        -> 5 failed
=== RESTORED === hook byte-identical to pre-mutation backup; 140 passed
```

The SAFE list is an assertion too, so the three false-positive exemptions were
mutated in the *other* direction — broadened until they over-match:

```
### bq rm loses its --help exemption      -> FAILED …test_safe_commands_pass[bq rm --help]
### dbt stops requiring a prod target     -> FAILED …test_safe_commands_pass[dbt run --full-refresh --target dev]
### SQL DELETE loses its FROM anchor      -> FAILED …test_safe_commands_pass[bq query "SELECT is_deleted FROM …"]
```

**One mutant initially survived**, and it found a real hole in my own negative
corpus: dropping the recursive requirement from the GCS rules killed no test,
because nothing benign in the corpus used a non-recursive `rm`. Single-object cases
(`gsutil rm gs://…/one-export.csv`, `gcloud storage rm gs://…/one-export.csv`) were
added — pinning the deliberate parity with the existing `aws s3 rm --recursive` rule
— and the mutant now dies with 2 failures.

## Verification

- `just lint` — clean (`ruff check` + `ruff format --check`, 224 files)
- `just typecheck` — `mypy --strict`, no issues in 20 source files
- `tests/contracts/test_prod_guard.py` — 90 → 142 passing
- Full suite: **7 failed, 2698 passed** — identical to the **7 failed, 2634 passed**
  baseline measured on clean `main` by stashing this branch. The 7 pre-date this
  change (`test_post_edit_lint_*`, `test_multi_model_overlay`,
  `test_observability_self_log`) and are untouched by it. **+64 passing, 0 new failures.**

Sync chain per CLAUDE.md: plugin version bumped 0.8.2 → 0.8.3 **before**
`just sync-plugin` (PI-881 refuses to relock a changed payload under an unchanged
version), plus `__plugin_version__` and the regenerated `payload-locks.json`.
`just sync-agents` reported already-in-sync — `prod_guard.py` is not in this repo's
own `.agents/` shared set.

## Still open on #906

Not implemented here, so the epic stays open: `bq load --replace`,
`bq query --replace --destination_table`, SQL `MERGE`, `dbt build`/`dbt seed
--full-refresh`/`dbt run-operation`, `gcloud … set-iam-policy`,
`iam service-accounts keys create`, `gsutil iam ch`, `bq update --source <acl>`, and
GTM container publish. The `dbt build`/`seed` group in particular needs a
false-positive story before it lands — flagging every `dbt build --target prod`
would nag on routine work, which is how a guard gets switched off.

---

Closes #916
Part of #906 — the epic stays open; the out-of-scope verb groups are enumerated in #916.