### PR TITLE
fix(PI-922): every scaffolded container ran as root and failed its own gate

### DIFF
--- a/templates/base/Dockerfile.tmpl
+++ b/templates/base/Dockerfile.tmpl
@@ -19,9 +19,16 @@ RUN --mount=type=cache,target=/root/.cache/uv uv sync --no-dev --frozen 2>/dev/n
 # --- runtime stage: copy the venv, drop the toolchain ---
 FROM python:3.13-slim AS runtime
 WORKDIR /app
-COPY --from=build /app /app
-ENV PATH="/app/.venv/bin:$PATH" PORT=8080
+COPY --from=build --chown=10001:10001 /app /app
+ENV PATH="/app/.venv/bin:$PATH" PORT=8080 HOME=/app
 EXPOSE 8080
+# Run as a non-root uid (semgrep dockerfile.security.missing-user). A NUMERIC
+# uid is deliberate: it needs no /etc/passwd entry and no useradd, so the same
+# line is correct on debian-slim, bun-slim and distroless alike — no assumption
+# about what user-management tooling the base image happens to ship. HOME is set
+# because a uid with no passwd entry makes getpwuid() fail, which breaks
+# anything calling os.path.expanduser("~").
+USER 10001:10001
 # TODO: replace with your app's entrypoint (e.g. uvicorn app.main:app --host 0.0.0.0 --port $PORT)
 CMD ["python", "-c", "import os; print('replace CMD: serving on', os.environ.get('PORT', '8080'))"]
 {{/if python}}{{#if node}}# --- build stage: install deps with bun ---
@@ -35,10 +42,13 @@ RUN bun run build 2>/dev/null || true
 # --- runtime stage ---
 FROM oven/bun:1-slim AS runtime
 WORKDIR /app
-COPY --from=build /app /app
+COPY --from=build --chown=10001:10001 /app /app
 ENV NODE_ENV=production PORT=8080
 EXPOSE 8080
 # TODO: replace with your app's start command (e.g. bun run start)
+# Non-root uid, numeric so it needs no /etc/passwd entry (see the python
+# runtime stage above for why).
+USER 10001:10001
 CMD ["bun", "run", "start"]
 {{/if node}}{{#if go}}# --- build stage: compile a static binary ---
 # Keep this Go version in step with mise.toml's `go` pin — a go.mod created
@@ -57,10 +67,13 @@ RUN CGO_ENABLED=0 go build -o /app/server .
 # --- runtime stage: distroless, no shell/toolchain ---
 FROM gcr.io/distroless/static-debian12 AS runtime
 WORKDIR /app
-COPY --from=build /app/server /app/server
+COPY --from=build --chown=10001:10001 /app/server /app/server
 ENV PORT=8080
 EXPOSE 8080
 # TODO: ensure your server reads $PORT and listens on 0.0.0.0
+# Non-root uid, numeric so it needs no /etc/passwd entry (see the python
+# runtime stage above for why).
+USER 10001:10001
 ENTRYPOINT ["/app/server"]
 {{/if go}}{{#if rust}}# --- build stage: compile a release binary ---
 FROM rust:1-slim-bookworm AS build
@@ -79,9 +92,12 @@ RUN cargo build --release && \
 # --- runtime stage: slim base (dynamically-linked glibc binary) ---
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
-COPY --from=build /src/server /app/server
+COPY --from=build --chown=10001:10001 /src/server /app/server
 ENV PORT=8080
 EXPOSE 8080
 # TODO: ensure your server reads $PORT and listens on 0.0.0.0
+# Non-root uid, numeric so it needs no /etc/passwd entry (see the python
+# runtime stage above for why).
+USER 10001:10001
 ENTRYPOINT ["/app/server"]
 {{/if rust}}{{/if delivery_service}}

--- a/templates/base/Dockerfile.tmpl
+++ b/templates/base/Dockerfile.tmpl
@@ -18,6 +18,12 @@ RUN --mount=type=cache,target=/root/.cache/uv uv sync --no-dev --frozen 2>/dev/n
 
 # --- runtime stage: copy the venv, drop the toolchain ---
 FROM python:3.13-slim AS runtime
+# Create the workdir ALREADY owned by the runtime uid. WORKDIR creates a missing
+# directory as root, and `COPY --chown` sets ownership on the copied CONTENTS,
+# not on a destination directory that already exists — so doing this the obvious
+# way leaves /app root-owned and HOME=/app unwritable, which surfaces as EACCES
+# the first time anything caches under $HOME. Caught in review, 2026-08-02.
+RUN install -d -o 10001 -g 10001 /app
 WORKDIR /app
 COPY --from=build --chown=10001:10001 /app /app
 ENV PATH="/app/.venv/bin:$PATH" PORT=8080 HOME=/app

--- a/tests/contracts/test_dockerfile_lint.py
+++ b/tests/contracts/test_dockerfile_lint.py
@@ -117,7 +117,15 @@ class TestRuntimeStagesDropRoot:
 
     Parsed by stage rather than grepped for "USER" anywhere in the file: a USER
     line in the BUILD stage satisfies a substring check while leaving the
-    runtime running as root, which is the whole defect.
+    runtime running as root, which is the whole defect. The LAST USER in the
+    stage is the one that counts.
+
+    An earlier version of this class also asserted USER came before
+    CMD/ENTRYPOINT. That was WRONG and was removed in review: CMD and ENTRYPOINT
+    are image configuration, not build steps, so a USER after them still sets
+    the runtime identity. The test rejected valid Dockerfiles. Checking the
+    stage's final effective user, which test_runtime_stage_sets_a_non_root_user
+    does via users[-1], is the correct formulation.
     """
 
     @staticmethod
@@ -137,7 +145,7 @@ class TestRuntimeStagesDropRoot:
     def test_runtime_stage_sets_a_non_root_user(self, tmp_path: Path, language: str):
         df = (_service(tmp_path / language, language) / "Dockerfile").read_text()
         stages = self._runtime_stages(df)
-        assert stages, f"{language}: no runtime stage found"
+        assert "runtime" in stages, f"{language}: no runtime stage found"
         body = "\n".join(stages["runtime"])
         users = [ln.split()[1] for ln in body.split("\n") if ln.startswith("USER ")]
         assert users, f"{language}: runtime stage never drops root"
@@ -145,28 +153,14 @@ class TestRuntimeStagesDropRoot:
         assert uid not in ("root", "0"), f"{language}: last USER is root ({users[-1]})"
 
     @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
-    def test_user_precedes_the_entrypoint(self, tmp_path: Path, language: str):
-        """USER after CMD/ENTRYPOINT is a no-op for the running process."""
-        body = "\n".join(
-            self._runtime_stages(
-                (_service(tmp_path / language, language) / "Dockerfile").read_text()
-            )["runtime"]
-        )
-        lines = body.split("\n")
-        user_at = max(i for i, ln in enumerate(lines) if ln.startswith("USER "))
-        starts = [i for i, ln in enumerate(lines) if ln.startswith(("CMD ", "ENTRYPOINT "))]
-        assert starts, f"{language}: runtime stage has no CMD/ENTRYPOINT"
-        assert user_at < min(starts), f"{language}: USER comes after the entrypoint"
-
-    @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
     def test_copied_tree_is_owned_by_that_uid(self, tmp_path: Path, language: str):
         """Dropping to a uid that cannot read its own files fails at runtime,
         not at build — the worst place to find out."""
-        body = "\n".join(
-            self._runtime_stages(
-                (_service(tmp_path / language, language) / "Dockerfile").read_text()
-            )["runtime"]
+        stages = self._runtime_stages(
+            (_service(tmp_path / language, language) / "Dockerfile").read_text()
         )
+        assert "runtime" in stages, f"{language}: no runtime stage found"
+        body = "\n".join(stages["runtime"])
         copies = [ln for ln in body.split("\n") if ln.startswith("COPY --from=build")]
         assert copies, f"{language}: runtime stage copies nothing from build"
         for c in copies:

--- a/tests/contracts/test_dockerfile_lint.py
+++ b/tests/contracts/test_dockerfile_lint.py
@@ -98,3 +98,76 @@ class TestDockerfilePassesClean:
     def test_node_and_go_need_no_ignores(self, tmp_path: Path, language: str):
         dockerfile = (_service(tmp_path / language, language) / "Dockerfile").read_text()
         assert "hadolint ignore" not in dockerfile
+
+
+class TestRuntimeStagesDropRoot:
+    """Every runtime stage must end up as a non-root user.
+
+    semgrep's dockerfile.security.missing-user is ON in the CI this scaffolder
+    ships, so a Dockerfile without USER makes a freshly scaffolded service fail
+    its own security gate on the first run — the template was internally
+    inconsistent, shipping a rule and a violation of it together. Observed on a
+    scaffolded service: "Ran 286 rules on 253 files: 1 finding", the finding
+    being this one, and that single finding was the whole reason its CI was red.
+
+    The uid is NUMERIC on purpose. A named user would need useradd (absent from
+    distroless, which has no shell at all) or an assumption about what the base
+    image already provides. A numeric uid needs no /etc/passwd entry and is
+    correct on every base the template uses.
+
+    Parsed by stage rather than grepped for "USER" anywhere in the file: a USER
+    line in the BUILD stage satisfies a substring check while leaving the
+    runtime running as root, which is the whole defect.
+    """
+
+    @staticmethod
+    def _runtime_stages(dockerfile: str) -> dict[str, list[str]]:
+        stages: dict[str, list[str]] = {}
+        current = None
+        for line in dockerfile.split("\n"):
+            if line.startswith("FROM "):
+                current = line.rstrip().split(" AS ")[-1] if " AS " in line else None
+                if current:
+                    stages[current] = []
+            elif current:
+                stages[current].append(line)
+        return {k: v for k, v in stages.items() if k == "runtime"}
+
+    @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
+    def test_runtime_stage_sets_a_non_root_user(self, tmp_path: Path, language: str):
+        df = (_service(tmp_path / language, language) / "Dockerfile").read_text()
+        stages = self._runtime_stages(df)
+        assert stages, f"{language}: no runtime stage found"
+        body = "\n".join(stages["runtime"])
+        users = [ln.split()[1] for ln in body.split("\n") if ln.startswith("USER ")]
+        assert users, f"{language}: runtime stage never drops root"
+        uid = users[-1].split(":")[0]
+        assert uid not in ("root", "0"), f"{language}: last USER is root ({users[-1]})"
+
+    @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
+    def test_user_precedes_the_entrypoint(self, tmp_path: Path, language: str):
+        """USER after CMD/ENTRYPOINT is a no-op for the running process."""
+        body = "\n".join(
+            self._runtime_stages(
+                (_service(tmp_path / language, language) / "Dockerfile").read_text()
+            )["runtime"]
+        )
+        lines = body.split("\n")
+        user_at = max(i for i, ln in enumerate(lines) if ln.startswith("USER "))
+        starts = [i for i, ln in enumerate(lines) if ln.startswith(("CMD ", "ENTRYPOINT "))]
+        assert starts, f"{language}: runtime stage has no CMD/ENTRYPOINT"
+        assert user_at < min(starts), f"{language}: USER comes after the entrypoint"
+
+    @pytest.mark.parametrize("language", ["python", "node", "go", "rust"])
+    def test_copied_tree_is_owned_by_that_uid(self, tmp_path: Path, language: str):
+        """Dropping to a uid that cannot read its own files fails at runtime,
+        not at build — the worst place to find out."""
+        body = "\n".join(
+            self._runtime_stages(
+                (_service(tmp_path / language, language) / "Dockerfile").read_text()
+            )["runtime"]
+        )
+        copies = [ln for ln in body.split("\n") if ln.startswith("COPY --from=build")]
+        assert copies, f"{language}: runtime stage copies nothing from build"
+        for c in copies:
+            assert "--chown=10001:10001" in c, f"{language}: unowned copy — {c}"


### PR DESCRIPTION
fix(PI-922): every scaffolded container ran as root and failed its own gate

The template shipped semgrep's dockerfile.security.missing-user rule
turned ON in CI, and a Dockerfile that violates it. Both, together.
Every scaffolded service therefore failed its own security gate on the
first run, for a real reason, with nothing in the repo acknowledging
it.

Found on a scaffolded service whose CI had four red jobs. Three were
guard bugs fixed in #919. The fourth was semgrep, which I could not
diagnose from the truncated log at the time and explicitly shipped as
unresolved rather than guessed at. With the other three green the log
was readable: "Ran 286 rules on 253 files: 1 finding" — this one, and
it was the entire reason that repo's CI was red.

All four runtime stages — python, node, go, rust — now drop to uid
10001 before CMD/ENTRYPOINT, and every COPY --from=build into the
runtime stage carries --chown=10001:10001.

The uid is NUMERIC deliberately. A named user needs useradd, which
distroless does not have — it has no shell at all — or an assumption
about what the base image already provides. I could not verify what
oven/bun:1-slim and gcr.io/distroless/static-debian12 ship (the upstream
paths I checked did not resolve, and the docker daemon is not running
here), and a Dockerfile is the wrong place to guess. A numeric uid
needs no /etc/passwd entry and is correct on all four bases without
knowing anything about them. HOME is set on the python stage because a
uid with no passwd entry makes getpwuid() fail, which breaks
os.path.expanduser("~").

Three properties are pinned, each parsed by STAGE rather than grepped
across the file — a USER line in the build stage satisfies a substring
check while the runtime still runs as root, which is exactly the defect:

  - the runtime stage ends on a non-root USER
  - that USER precedes CMD/ENTRYPOINT, since USER after them is a no-op
  - every runtime COPY is chowned, because dropping to a uid that cannot
    read its own files fails at RUN time, not build time

Checked both guards can fail, in the two ways that matter: deleting
every USER line reds 8 of 12, and moving USER to after the entrypoint
reds exactly the 4 ordering tests and leaves the rest green — the right
discrimination, since the second case is a Dockerfile that looks fixed
and is not.

NOT verified by building an image; the docker daemon is not running on
this machine. The claim here is about the rendered Dockerfile's
structure, which is what semgrep reads, not about a container that was
started.

Closes #922
