### PR TITLE
fix(PI-926): prod_guard reads the context opt-out and stops walking at $HOME

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "d4bf84b174ebbf01baa40dfbb29097515b5e239b300e76a063848d7cbf370313",
-    "version": "0.8.6"
+    "sha256": "6dae1fcb1acc2846724d225bb103cee6ef1d0d6d9b08bd716194dec665e72a76",
+    "version": "0.8.7"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "8cfd3ae8e6a570131f5f8bd44caef20f94108b0f1a4055faeb380fdef30bcb6b",
-    "version": "0.8.5"
+    "sha256": "d4bf84b174ebbf01baa40dfbb29097515b5e239b300e76a063848d7cbf370313",
+    "version": "0.8.6"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "6dae1fcb1acc2846724d225bb103cee6ef1d0d6d9b08bd716194dec665e72a76",
-    "version": "0.8.7"
+    "sha256": "7885190a8a155ee6754668e21428f21f08b71ff5124f4a26bbf385b11b3386cd",
+    "version": "0.8.8"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -203,8 +203,17 @@ _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 # upgrade — a spelling the writer keeps but the reader misses is an opt-out that
 # survives in the file and is then ignored. KEEP IN STEP with harbor's
 # `floor_in_repo`, which reads the same key with the same tolerances.
+#
+# A COMMENT NEEDS WHITESPACE BEFORE IT (PR #927 review). `#` only begins a YAML
+# comment when preceded by whitespace; otherwise it is part of the plain scalar.
+# So `context: ambient#typo` is the value `ambient#typo` — NOT `ambient` — and
+# the first cut read it as an opt-out, silently discarding that repo's allowlist.
+# The direction is safe for this guard (no allowlist ⇒ keep guarding) and it is
+# still wrong: it disables a control the owner declared, on a typo, and the
+# orchestrator's real YAML parser resolves the same line differently, which is
+# precisely the three-readers divergence the shared fixtures exist to prevent.
 _CONTEXT_AMBIENT_RE = re.compile(
-    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?[^\S\n]*(?:\#.*)?$""",
+    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?(?:[^\S\n]+\#.*)?[^\S\n]*$""",
     re.MULTILINE,
 )
 

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -259,7 +259,16 @@ def _find_config(start: Path) -> Path | None:
     outside $HOME are untouched and still walk to ``/``. Resolved first, because
     the stop is an equality test and ``~/.`` names the same directory as ``~``.
     """
-    with contextlib.suppress(OSError):  # a path that cannot be resolved is used as spelled
+    # RuntimeError as well as OSError, and the difference is measurable rather
+    # than defensive (PR #927 review): `Path.resolve()` raises RuntimeError on a
+    # SYMLINK LOOP under Python 3.11 and 3.12 and stopped doing so in 3.13 —
+    # checked on all three. Both older versions are in this repo's CI matrix and
+    # this template ships to projects running whichever Python they have. An
+    # escaping exception here does not crash the session (the guard's outer
+    # handler is fail-open by design) — it makes the guard STAND DOWN, so a
+    # planted loop anywhere in the walk path switches the deny table off for
+    # that command. A path that cannot be resolved is used as spelled instead.
+    with contextlib.suppress(OSError, RuntimeError):
         start = start.resolve()
     try:
         home: Path | None = Path.home().resolve()

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -22,6 +22,7 @@ Fail-open by design: any internal error lets the command proceed.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -193,6 +194,35 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
 _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
+# harbor#4 H1 / CONTRACTS/marker.md — `context: ambient` is the owner opting a
+# repo back in to the ambient (global) agent layer. Anchored at column 0: a
+# top-level YAML key cannot be indented, and matching an indented one would let
+# a `context: ambient` nested under some unrelated block opt the whole repo out.
+# Quoted keys/values and a space before the colon ARE valid top-level YAML, and
+# project-init's own `_CONTEXT_KEY_RE` preserves exactly those spellings on
+# upgrade — a spelling the writer keeps but the reader misses is an opt-out that
+# survives in the file and is then ignored. KEEP IN STEP with harbor's
+# `floor_in_repo`, which reads the same key with the same tolerances.
+_CONTEXT_AMBIENT_RE = re.compile(
+    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?[^\S\n]*(?:\#.*)?$""",
+    re.MULTILINE,
+)
+
+
+def _declares_ambient(config: Path) -> bool:
+    """True iff *config* carries a top-level ``context: ambient`` declaration.
+
+    Unreadable is not ambient: an unreadable config supplies no allowlist
+    either, so the guard already keeps guarding, and inventing a verdict from a
+    failed read would be a guess.
+    """
+    try:
+        text = config.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_CONTEXT_AMBIENT_RE.search(text))
+
+
 def _find_config(start: Path) -> Path | None:
     """Walk up from *start* to the project's .agents/config.yaml, if any.
 
@@ -209,14 +239,41 @@ def _find_config(start: Path) -> Path | None:
     this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
     markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
     disagreement while it existed.
+
+    Two further rules from the same frozen contract:
+
+    ``context: ambient`` (harbor#4 H1, M18/M19) — the owner declaring that this
+    repo does NOT govern itself and the ambient layer keeps acting here. A repo
+    that has opted out of governed status does not get to relax the deny table
+    with its own ``safety.allow``, so the declaration returns None (no
+    allowlist) rather than continuing the walk. Deciding AT the marker is the
+    contract's rule and the reason it is not a ``continue``: the innermost
+    marker wins, so an explicit inner opt-out must not fall through and be
+    overruled by an outer repo's config. A symlink is refused because it is
+    forged; an ``ambient`` value is honoured because it is the owner speaking.
+
+    ``$HOME`` (harbor#4 M14) — the walk stops before it. A marker sitting in
+    the home directory itself otherwise supplies an allowlist to every command
+    run anywhere beneath it, and it is written by accident rather than by
+    attack: project-init run once in the wrong cwd scaffolds one there. Paths
+    outside $HOME are untouched and still walk to ``/``. Resolved first, because
+    the stop is an equality test and ``~/.`` names the same directory as ``~``.
     """
+    with contextlib.suppress(OSError):  # a path that cannot be resolved is used as spelled
+        start = start.resolve()
+    try:
+        home: Path | None = Path.home().resolve()
+    except (RuntimeError, OSError):
+        home = None  # no home to stop before; inventing one would be a guess
     for candidate in (start, *start.parents):
+        if candidate == home:
+            break
         agents = candidate / ".agents"
         config = agents / "config.yaml"
         if agents.is_symlink() or config.is_symlink():
             continue
         if config.is_file():
-            return config
+            return None if _declares_ambient(config) else config
     return None
 
 

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.6"
+__plugin_version__ = "0.8.7"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.7"
+__plugin_version__ = "0.8.8"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.5"
+__plugin_version__ = "0.8.6"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -203,8 +203,17 @@ _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 # upgrade — a spelling the writer keeps but the reader misses is an opt-out that
 # survives in the file and is then ignored. KEEP IN STEP with harbor's
 # `floor_in_repo`, which reads the same key with the same tolerances.
+#
+# A COMMENT NEEDS WHITESPACE BEFORE IT (PR #927 review). `#` only begins a YAML
+# comment when preceded by whitespace; otherwise it is part of the plain scalar.
+# So `context: ambient#typo` is the value `ambient#typo` — NOT `ambient` — and
+# the first cut read it as an opt-out, silently discarding that repo's allowlist.
+# The direction is safe for this guard (no allowlist ⇒ keep guarding) and it is
+# still wrong: it disables a control the owner declared, on a typo, and the
+# orchestrator's real YAML parser resolves the same line differently, which is
+# precisely the three-readers divergence the shared fixtures exist to prevent.
 _CONTEXT_AMBIENT_RE = re.compile(
-    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?[^\S\n]*(?:\#.*)?$""",
+    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?(?:[^\S\n]+\#.*)?[^\S\n]*$""",
     re.MULTILINE,
 )
 

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -259,7 +259,16 @@ def _find_config(start: Path) -> Path | None:
     outside $HOME are untouched and still walk to ``/``. Resolved first, because
     the stop is an equality test and ``~/.`` names the same directory as ``~``.
     """
-    with contextlib.suppress(OSError):  # a path that cannot be resolved is used as spelled
+    # RuntimeError as well as OSError, and the difference is measurable rather
+    # than defensive (PR #927 review): `Path.resolve()` raises RuntimeError on a
+    # SYMLINK LOOP under Python 3.11 and 3.12 and stopped doing so in 3.13 —
+    # checked on all three. Both older versions are in this repo's CI matrix and
+    # this template ships to projects running whichever Python they have. An
+    # escaping exception here does not crash the session (the guard's outer
+    # handler is fail-open by design) — it makes the guard STAND DOWN, so a
+    # planted loop anywhere in the walk path switches the deny table off for
+    # that command. A path that cannot be resolved is used as spelled instead.
+    with contextlib.suppress(OSError, RuntimeError):
         start = start.resolve()
     try:
         home: Path | None = Path.home().resolve()

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -22,6 +22,7 @@ Fail-open by design: any internal error lets the command proceed.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -193,6 +194,35 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
 _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
+# harbor#4 H1 / CONTRACTS/marker.md — `context: ambient` is the owner opting a
+# repo back in to the ambient (global) agent layer. Anchored at column 0: a
+# top-level YAML key cannot be indented, and matching an indented one would let
+# a `context: ambient` nested under some unrelated block opt the whole repo out.
+# Quoted keys/values and a space before the colon ARE valid top-level YAML, and
+# project-init's own `_CONTEXT_KEY_RE` preserves exactly those spellings on
+# upgrade — a spelling the writer keeps but the reader misses is an opt-out that
+# survives in the file and is then ignored. KEEP IN STEP with harbor's
+# `floor_in_repo`, which reads the same key with the same tolerances.
+_CONTEXT_AMBIENT_RE = re.compile(
+    r"""^["']?context["']?[^\S\n]*:[^\S\n]*["']?ambient["']?[^\S\n]*(?:\#.*)?$""",
+    re.MULTILINE,
+)
+
+
+def _declares_ambient(config: Path) -> bool:
+    """True iff *config* carries a top-level ``context: ambient`` declaration.
+
+    Unreadable is not ambient: an unreadable config supplies no allowlist
+    either, so the guard already keeps guarding, and inventing a verdict from a
+    failed read would be a guess.
+    """
+    try:
+        text = config.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_CONTEXT_AMBIENT_RE.search(text))
+
+
 def _find_config(start: Path) -> Path | None:
     """Walk up from *start* to the project's .agents/config.yaml, if any.
 
@@ -209,14 +239,41 @@ def _find_config(start: Path) -> Path | None:
     this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
     markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
     disagreement while it existed.
+
+    Two further rules from the same frozen contract:
+
+    ``context: ambient`` (harbor#4 H1, M18/M19) — the owner declaring that this
+    repo does NOT govern itself and the ambient layer keeps acting here. A repo
+    that has opted out of governed status does not get to relax the deny table
+    with its own ``safety.allow``, so the declaration returns None (no
+    allowlist) rather than continuing the walk. Deciding AT the marker is the
+    contract's rule and the reason it is not a ``continue``: the innermost
+    marker wins, so an explicit inner opt-out must not fall through and be
+    overruled by an outer repo's config. A symlink is refused because it is
+    forged; an ``ambient`` value is honoured because it is the owner speaking.
+
+    ``$HOME`` (harbor#4 M14) — the walk stops before it. A marker sitting in
+    the home directory itself otherwise supplies an allowlist to every command
+    run anywhere beneath it, and it is written by accident rather than by
+    attack: project-init run once in the wrong cwd scaffolds one there. Paths
+    outside $HOME are untouched and still walk to ``/``. Resolved first, because
+    the stop is an equality test and ``~/.`` names the same directory as ``~``.
     """
+    with contextlib.suppress(OSError):  # a path that cannot be resolved is used as spelled
+        start = start.resolve()
+    try:
+        home: Path | None = Path.home().resolve()
+    except (RuntimeError, OSError):
+        home = None  # no home to stop before; inventing one would be a guess
     for candidate in (start, *start.parents):
+        if candidate == home:
+            break
         agents = candidate / ".agents"
         config = agents / "config.yaml"
         if agents.is_symlink() or config.is_symlink():
             continue
         if config.is_file():
-            return config
+            return None if _declares_ambient(config) else config
     return None
 
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -460,3 +460,164 @@ class TestWiring:
         assert "cannot delete what the session cannot reach" in secrets
         agents_md = (target / "AGENTS.md").read_text()
         assert "prod_guard" in agents_md
+
+
+_DESTRUCTIVE = "terraform destroy -auto-approve"
+_PERMISSIVE = 'safety:\n  allow: [".*"]\n'
+
+
+def _flagged(cwd: Path) -> bool:
+    """True when the guard flags a destructive command run from *cwd*."""
+    return _run_hook(_payload(_DESTRUCTIVE, "bypassPermissions", cwd), cwd) is not None
+
+
+class TestContextMarkerValue:
+    """harbor#4 H1 — the `context:` value, whose reader lived only in harbor.
+
+    project-init has WRITTEN this key since PI-901 (template + upgrade splice)
+    and read it nowhere, so `context: ambient` was a field the schema defines,
+    the wizard emits and no code in this repo acts on. Every case here is a
+    fixture in harbor's shared suite (fixtures/marker/cases.json); the ids are
+    quoted so a divergence is traceable to one line of one contract.
+
+    What `ambient` means HERE: the owner declaring the repo does not govern
+    itself, so its `safety.allow` does not relax the deny table. The safe
+    direction, and the one the guard already takes when no config exists.
+    """
+
+    def test_ambient_repo_cannot_supply_an_allowlist(self, tmp_path: Path):
+        """M18: the opt-out decides, even though the marker is present."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text("context: ambient\n" + _PERMISSIVE)
+        assert _flagged(tmp_path), "an opted-out repo relaxed the deny table anyway"
+
+    def test_context_repo_still_supplies_its_allowlist(self, tmp_path: Path):
+        """M20: the value only ever ADDS an opt-out. `context: repo` is what
+        every fresh scaffold emits, and it must resolve exactly as presence
+        alone already did — the case that proves the reader discriminates
+        rather than merely rejecting everything."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text("context: repo\n" + _PERMISSIVE)
+        assert not _flagged(tmp_path), "a governed repo lost its own allowlist"
+
+    def test_absent_context_is_not_ambient(self, tmp_path: Path):
+        """M21: every config scaffolded before PI-901 lacks the key, which is
+        why `context` is optional in the schema. Absence means unknown and
+        falls back to presence; reading it as `ambient` would silently drop the
+        allowlist of the entire installed base."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text(_PERMISSIVE)
+        assert not _flagged(tmp_path)
+
+    def test_commented_out_ambient_is_documentation(self, tmp_path: Path):
+        """M22: `# context: ambient` is a note someone wrote, not a declaration."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text(
+            "# context: ambient\ncontext: repo\n" + _PERMISSIVE
+        )
+        assert not _flagged(tmp_path)
+
+    def test_nested_context_key_is_a_different_key(self, tmp_path: Path):
+        """M23: `context` is TOP-LEVEL. One indented under an unrelated block
+        shares a name and nothing else — matching it would opt a whole repo out
+        on the strength of a nested value nobody meant as a boundary."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text(
+            "context: repo\ntooling:\n  context: ambient\n" + _PERMISSIVE
+        )
+        assert not _flagged(tmp_path)
+
+    @pytest.mark.parametrize(
+        ("spelling", "case"),
+        [
+            ("context : ambient\n", "M25 space before the colon"),
+            ('"context": ambient\n', "M26 quoted key"),
+            ('context: "ambient"\n', "M27 quoted value"),
+            ("context: ambient  # opted out\n", "trailing comment"),
+        ],
+    )
+    def test_every_valid_top_level_spelling_counts(self, tmp_path: Path, spelling: str, case: str):
+        """M25-M27: the reader is deliberately the permissive one about
+        spelling, because MISSING a genuine opt-out is the unsafe direction —
+        the repo keeps a governed repo's privileges it disclaimed. `upgrade.py`
+        preserves exactly these spellings, so a spelling the writer keeps and
+        the reader misses is an opt-out that survives in the file and is then
+        ignored."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text(spelling + _PERMISSIVE)
+        assert _flagged(tmp_path), f"{case}: a valid opt-out was not read"
+
+    def test_inner_optout_is_not_overruled_by_an_outer_marker(self, tmp_path: Path):
+        """M19: the value is read AT the marker the walk finds and decides
+        there. Continuing the walk would let an outer repo's allowlist govern a
+        directory whose owner explicitly opted out."""
+        outer = tmp_path / ".agents"
+        outer.mkdir()
+        outer.joinpath("config.yaml").write_text("context: repo\n" + _PERMISSIVE)
+        inner = tmp_path / "sub"
+        (inner / ".agents").mkdir(parents=True)
+        (inner / ".agents" / "config.yaml").write_text("context: ambient\n")
+        assert _flagged(inner), "an inner opt-out fell through to the outer allowlist"
+        # …and the outer repo itself is unaffected.
+        assert not _flagged(tmp_path)
+
+
+class TestHomeStopCondition:
+    """harbor#4 M14 (owner decision 2026-08-02) — the walk stops before $HOME.
+
+    One `~/.agents/config.yaml` otherwise supplies `safety.allow` to every
+    command run anywhere beneath the home directory. The way it gets written is
+    not an attack: project-init run once in the wrong cwd scaffolds `.agents/`
+    right there, and M12's "a named FILE is required" does not help, because a
+    scaffolder writes named files.
+    """
+
+    def test_a_marker_at_home_supplies_nothing(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        (home / ".agents").mkdir(parents=True)
+        (home / ".agents" / "config.yaml").write_text(_PERMISSIVE)
+        work = home / "projects" / "thing"
+        work.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        assert _flagged(work), "a marker at $HOME switched the deny table off machine-wide"
+
+    def test_the_stop_does_not_swallow_repos_under_home(self, tmp_path: Path, monkeypatch):
+        """M28: every repo the operator owns lives UNDER $HOME. A stop that
+        swallowed them would un-govern the whole installed base while reading
+        as a security fix."""
+        home = tmp_path / "home"
+        repo = home / "projects" / "thing"
+        (repo / ".agents").mkdir(parents=True)
+        (repo / ".agents" / "config.yaml").write_text(_PERMISSIVE)
+        work = repo / "src"
+        work.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        assert not _flagged(work), "a real repo under $HOME lost its allowlist"
+
+    def test_a_repo_outside_home_still_walks_up(self, tmp_path: Path, monkeypatch):
+        """M29: the stop is a property of the path being walked, not a global
+        mode. /opt, a mounted volume and a CI checkout still walk to `/`."""
+        (tmp_path / "elsewhere" / ".agents").mkdir(parents=True)
+        (tmp_path / "elsewhere" / ".agents" / "config.yaml").write_text(_PERMISSIVE)
+        work = tmp_path / "elsewhere" / "src"
+        work.mkdir()
+        home = tmp_path / "somehome"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        assert not _flagged(work)
+
+    def test_the_boundary_is_before_home_not_at_it(self, tmp_path: Path, monkeypatch):
+        """M30: a session whose cwd IS $HOME resolves the same way, and the
+        spelling `$HOME/.` must not walk past a stop that compares paths."""
+        home = tmp_path / "home"
+        (home / ".agents").mkdir(parents=True)
+        (home / ".agents" / "config.yaml").write_text(_PERMISSIVE)
+        monkeypatch.setenv("HOME", str(home))
+        assert _flagged(home)
+        assert _flagged(Path(str(home) + "/."))

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -612,6 +612,33 @@ class TestHomeStopCondition:
         monkeypatch.setenv("HOME", str(home))
         assert not _flagged(work)
 
+    def test_a_symlink_loop_in_the_walk_path_does_not_stand_the_guard_down(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """PR #927 review. `Path.resolve()` raises RuntimeError on a symlink
+        loop under Python 3.11 and 3.12 — measured on all three, 3.13 no longer
+        does — and both are in this repo's CI matrix. An escaping exception does
+        not crash the session, because the guard's outer handler is fail-open;
+        it makes the guard STAND DOWN, so a planted loop switches the deny table
+        off for that command.
+
+        NOTE this assertion can only go red on 3.11/3.12. On 3.13+ resolve()
+        returns the unresolved path and the test passes with or without the fix
+        — which is why the fix was verified by running this file under 3.11
+        directly, not only by the local suite.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "a").symlink_to(home / "b")
+        (home / "b").symlink_to(home / "a")
+        monkeypatch.setenv("HOME", str(home))
+        # The loop goes in the PAYLOAD's cwd, not the process's: a looping path
+        # cannot be chdir'd into, so `subprocess(cwd=...)` fails before the guard
+        # ever runs. The hook reads its cwd from the payload, which is the
+        # interface that actually carries an attacker-influenced path.
+        payload = _payload(_DESTRUCTIVE, "bypassPermissions", home / "a")
+        assert _run_hook(payload, tmp_path) is not None
+
     def test_the_boundary_is_before_home_not_at_it(self, tmp_path: Path, monkeypatch):
         """M30: a session whose cwd IS $HOME resolves the same way, and the
         spelling `$HOME/.` must not walk past a stop that compares paths."""

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -539,6 +539,7 @@ class TestContextMarkerValue:
             ('"context": ambient\n', "M26 quoted key"),
             ('context: "ambient"\n', "M27 quoted value"),
             ("context: ambient  # opted out\n", "trailing comment"),
+            ("context: ambient\t# tab before the comment\n", "tab before the comment"),
         ],
     )
     def test_every_valid_top_level_spelling_counts(self, tmp_path: Path, spelling: str, case: str):
@@ -552,6 +553,24 @@ class TestContextMarkerValue:
         agents.mkdir()
         agents.joinpath("config.yaml").write_text(spelling + _PERMISSIVE)
         assert _flagged(tmp_path), f"{case}: a valid opt-out was not read"
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["context: ambient#typo\n", 'context: "ambient"#x\n', "context: ambientish\n"],
+    )
+    def test_a_hash_without_whitespace_is_part_of_the_value(self, tmp_path: Path, spelling: str):
+        """PR #927 review. `#` begins a YAML comment only when preceded by
+        whitespace; otherwise it belongs to the plain scalar. So
+        `context: ambient#typo` is the value `ambient#typo`, not `ambient`, and
+        reading it as an opt-out silently discards the repo's allowlist on a
+        typo. The direction is safe for this guard and still wrong — the
+        orchestrator's real YAML parser resolves the same line differently, and
+        three readers disagreeing about one line is what the shared fixtures
+        exist to prevent."""
+        agents = tmp_path / ".agents"
+        agents.mkdir()
+        agents.joinpath("config.yaml").write_text(spelling + _PERMISSIVE)
+        assert not _flagged(tmp_path), f"{spelling!r} was read as an opt-out"
 
     def test_inner_optout_is_not_overruled_by_an_outer_marker(self, tmp_path: Path):
         """M19: the value is read AT the marker the walk finds and decides


### PR DESCRIPTION
Closes #926

Part of the detect-and-defer boundary close-out (VytCepas/harbor#4 H1). Sibling PRs: VytCepas/harbor#96 and one in projects-orchestrator.

## The gap

This repo has **written** the boundary marker's value since PI-901 — `config.yaml.tmpl` emits `context: repo`, `upgrade.py` splices it into existing configs, `descriptor.schema.json` constrains it to an enum — and read it nowhere. A field this repo emits, another repo honours, and no code here acts on is a documented meaning that is not true. `upgrade.py:1322` even names harbor's `floor_in_repo` as the reader to keep in step with.

## What `ambient` means here

The owner declaring the repo does not govern itself. So it does not get to relax the destructive-command deny table with its own `safety.allow`: `_find_config` returns `None`, which is the state the guard already handles — no allowlist, keep guarding.

It **decides** at the marker rather than continuing the walk. The innermost marker wins, so an explicit inner opt-out must not fall through to an outer repo's allowlist. That is the difference from the PI-903 symlink refusal one line above: a symlink is a forgery and the walk goes on; an `ambient` value is the owner speaking and the walk stops.

The reader is deliberately permissive about spelling — `context : ambient`, `"context": ambient`, `context: "ambient"` — because **missing** a genuine opt-out is the unsafe direction, and `_CONTEXT_KEY_RE` in `upgrade.py` already preserves exactly those spellings. A spelling the writer keeps and the reader misses is an opt-out that survives in the file and is then ignored. It stays anchored at column 0: a nested `context:` is a different key that shares a name.

## `$HOME`

harbor#4 **M14**, settled by the owner 2026-08-02: the walk stops before the home directory. A marker sitting there otherwise supplies an allowlist to every command run anywhere beneath it, and it arrives by accident rather than by attack — this scaffolder run once in the wrong cwd writes one. M12's "a named FILE is required" does not help, because a scaffolder writes named files. Paths outside `$HOME` still walk to the root. Resolved first, because the stop is an equality test and `~/.` names the same directory as `~`.

## Verified by breaking it

Three mutants, each red on exactly the assertions that name it:

| mutant | fails |
|---|---|
| `_declares_ambient` always `False` | the five opt-out cases |
| no `$HOME` stop | both M14 cases |
| `ambient` continues the walk instead of deciding | M19 alone |

The cases that must stay green — `context: repo`, an absent key, a commented-out one, a nested one, a real repo under `$HOME`, a repo outside it — held in all three. Breaking a guard proves it discriminates, not that it discriminates correctly.

## Cross-repo check

harbor's `bin/marker-test.sh` now drives this walker over the shared fixture file (24 of its 30 cases apply to this role), so the two implementations can no longer drift silently. That is new in the sibling PR; before it, harbor's suite only ever ran its own shell resolver.

## Suite

`just test`: 2752 passed. The 6 remaining failures are the pre-existing environmental ones on this box (`post_edit_lint` ×5, observability jq escaping) — confirmed by stashing this change and watching the same 6 fail without it. `just lint`, `just typecheck`, `just sync-plugin` all clean; plugin version bumped ahead of the sync per PI-881, and `__plugin_version__` with it.
