### PR TITLE
fix: brace a variable before a non-ASCII ellipsis, and bump the CCR pin

### DIFF
--- a/templates/multi_model/dot_agents/scripts/models.sh
+++ b/templates/multi_model/dot_agents/scripts/models.sh
@@ -106,7 +106,13 @@ cmd_add() {
         '.Providers += [{"name":"ollama","api_base_url":$url,"api_key":"ollama","models":[]}]'
     fi
     if have ollama; then
-      info "Pulling $model…"
+      # BRACES, because the next character is a non-ASCII ellipsis. Bash decides
+      # where a bare `$name` ends with isalnum(), which is LOCALE-DEPENDENT: under
+      # a non-UTF-8 locale the three bytes of `…` (E2 80 A6) read as alphanumeric
+      # and get folded into the identifier, so this line died with
+      # `model\xe2: unbound variable` under `set -u`. Found 2026-08-02 by the
+      # overlay's own contract test, which then crashed decoding the error.
+      info "Pulling ${model}…"
       ollama pull "$model"
     else warn "ollama not installed — registering anyway."; fi
   else
@@ -130,7 +136,7 @@ cmd_rm() {
   _jq_write --arg p "$provider" --arg m "$model" \
     '(.Providers[] | select(.name==$p) | .models) |= ((. // []) - [$m])'
   if [ "$provider" = "ollama" ] && have ollama; then
-    info "Removing local model $model…"
+    info "Removing local model ${model}…"
     ollama rm "$model" 2>/dev/null || warn "ollama rm $model failed (not pulled?)."
   fi
   ok "Unregistered $model from $provider."

--- a/templates/multi_model/dot_agents/scripts/setup_models.sh
+++ b/templates/multi_model/dot_agents/scripts/setup_models.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # hold every scaffolded project behind a bump PR on a fast-moving tool. It is
 # installed at upstream latest and is absent from the manifest by design.
 CCR_PKG="@musistudio/claude-code-router"
-CCR_VERSION="3.0.16"
+CCR_VERSION="3.0.18"
 CLAUDE_PKG="@anthropic-ai/claude-code"
 
 # --- paths --------------------------------------------------------------------
@@ -200,7 +200,7 @@ setup_ollama() {
     info "Nothing entered — skipping."
     return
   }
-  info "Pulling $choice…"
+  info "Pulling ${choice}…"
   ollama pull "$choice" && ok "Pulled $choice. Switch to it with: /model ollama,$choice"
 }
 

--- a/tools/pinned_third_party.toml
+++ b/tools/pinned_third_party.toml
@@ -10,7 +10,7 @@
 [tools.ccr]
 package = "@musistudio/claude-code-router"
 ecosystem = "npm"
-pinned = "3.0.16"
+pinned = "3.0.18"
 # The shell variable carrying this version in each used_in file (kept in lockstep
 # with `pinned` by `check_third_party_updates.py apply`).
 version_var = "CCR_VERSION"


### PR DESCRIPTION
No-issue PR. Found complete and green in the working tree during the harbor#4 H1 work; committed so it is reviewable rather than sitting uncommitted.

## The quoting bug

`info "Pulling $model…"` died with `model\xe2: unbound variable` under `set -u`.

Bash decides where a bare `$name` ends using `isalnum()`, which is **locale-dependent**: under a non-UTF-8 locale the three bytes of `…` (`E2 80 A6`) read as alphanumeric and get folded into the identifier. The overlay's own contract test surfaced it and then crashed decoding the error, which is why it presented as a test-harness problem rather than a script one.

Braced at all three sites — `models.sh` twice, `setup_models.sh` once.

**Worth generalising:** any `$var` immediately followed by a non-ASCII character in a shell string is locale-dependent, and the failure appears only on machines whose locale is not UTF-8. It never reproduces for the author.

## The pin

CCR `3.0.16` → `3.0.18`, with `CCR_VERSION` in `setup_models.sh` moved in lockstep — the shape `check_third_party_updates.py apply` emits, and what the pin's own contract test checks.

## Evidence

- 53 targeted tests (`-k "multi_model or third_party or ccr"`) pass
- `shellcheck -S error -x` clean on both scripts
- the full suite was green with these changes in the tree (2752 passed; the 6 failures are the pre-existing environmental ones on this box)
