### PR TITLE
chore: declare this repo's own detect-and-defer boundary

### DIFF
--- a/.agents/config.yaml
+++ b/.agents/config.yaml
@@ -1,3 +1,4 @@
+context: repo
 # Project configuration read by lifecycle scripts and hooks
 # (create_issue.sh, start_issue.sh, setup_github.sh, workflow_state_reminder.sh).
 project:

--- a/.claude/config.yaml
+++ b/.claude/config.yaml
@@ -1,3 +1,4 @@
+context: repo
 # Project configuration read by lifecycle scripts and hooks
 # (create_issue.sh, start_issue.sh, setup_github.sh, workflow_state_reminder.sh).
 project:


### PR DESCRIPTION
No-issue PR. harbor#4 **H3** — the installed-base back-fill. Sibling: VytCepas/harbor#96 (the tool), VytCepas/project-init#927 (the reader).

project-init emits `context: repo` into every project it scaffolds and did not carry the key itself. The scaffolder was the one governed repo on this machine whose boundary was **inferred rather than declared**.

**It changes no verdict.** Absence falls back to marker presence — harbor's M21 rule, and the reason `context` is deliberately optional in `descriptor.schema.json` — so this repo already resolved to repo-context via `.agents/config.yaml`. What changes is that the intent is written down: the day someone wants a repo ambient there is a field to change rather than a marker to delete, and `projects-orchestrator` now reports the value instead of a blank.

`.claude/config.yaml` moves with it (`just sync-claude`), because that mirror is byte-hashed by `tests/contracts/test_claude_dir_sync.py` and a splice into `.agents/` alone turns it red.

Written by harbor's `bin/marker-backfill.sh`, whose target set is the **fleet** rather than a directory scan — `~/dbt-core` carries a tracked `.agents/` tree belonging to the employer's org and is out of the fleet only because it has no `config.yaml`, so the permissive predicate M12 settled against would have committed into someone else's repository.

## Evidence

`test_claude_dir_sync.py` + `test_descriptor_schema.py` green; `just lint` clean. The full suite on this branch shows 7 failures, 6 of them the pre-existing environmental ones and the 7th being the multi_model ollama test that **#928 fixes** — this branch is off `main`, which still carries that bug.
