### PR TITLE
fix(PI-936): --no-review skips the review wait, not branch protection

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -524,8 +524,28 @@ fi
 
 # --no-review: explicit bypass — skip review gate entirely after CI passes.
 # Use only for solo-dev PRs where no reviewer will ever respond.
+#
+# It skips WAITING for a reviewer. It does not bypass branch protection, and until
+# 2026-08-11 it did: this branch went straight to _admin_merge, so on any host whose
+# profile refuses admin-merge the flag could never merge anything. A green, unblocked PR
+# needs the same plain squash the --merge path performs at the bottom of this script, and
+# routing it through the override made the one flag documented for solo repos the one
+# flag guaranteed to fail there.
 if [ "$NO_REVIEW" -eq 1 ] && [ "$MODE" = "--merge" ]; then
   echo "PR #$PR_NUMBER: CI passed. --no-review specified — skipping review gate."
+  MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
+  if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
+    if _merge_with_retry; then
+      echo "Merged PR #$PR_NUMBER"
+      _cleanup_local_branch
+      exit 0
+    fi
+    echo "ERROR: merge failed for PR #$PR_NUMBER" >&2
+    exit 1
+  fi
+  # Anything else is a server-side rule the review gate cannot satisfy, which is what
+  # --admin is for — and what _admin_merge refuses where hard enforcement must bind.
+  echo "PR #$PR_NUMBER is $MERGE_STATE — a plain merge will not take it."
   _admin_merge
   exit 0
 fi

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -524,8 +524,28 @@ fi
 
 # --no-review: explicit bypass — skip review gate entirely after CI passes.
 # Use only for solo-dev PRs where no reviewer will ever respond.
+#
+# It skips WAITING for a reviewer. It does not bypass branch protection, and until
+# 2026-08-11 it did: this branch went straight to _admin_merge, so on any host whose
+# profile refuses admin-merge the flag could never merge anything. A green, unblocked PR
+# needs the same plain squash the --merge path performs at the bottom of this script, and
+# routing it through the override made the one flag documented for solo repos the one
+# flag guaranteed to fail there.
 if [ "$NO_REVIEW" -eq 1 ] && [ "$MODE" = "--merge" ]; then
   echo "PR #$PR_NUMBER: CI passed. --no-review specified — skipping review gate."
+  MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
+  if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
+    if _merge_with_retry; then
+      echo "Merged PR #$PR_NUMBER"
+      _cleanup_local_branch
+      exit 0
+    fi
+    echo "ERROR: merge failed for PR #$PR_NUMBER" >&2
+    exit 1
+  fi
+  # Anything else is a server-side rule the review gate cannot satisfy, which is what
+  # --admin is for — and what _admin_merge refuses where hard enforcement must bind.
+  echo "PR #$PR_NUMBER is $MERGE_STATE — a plain merge will not take it."
   _admin_merge
   exit 0
 fi

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -524,8 +524,28 @@ fi
 
 # --no-review: explicit bypass — skip review gate entirely after CI passes.
 # Use only for solo-dev PRs where no reviewer will ever respond.
+#
+# It skips WAITING for a reviewer. It does not bypass branch protection, and until
+# 2026-08-11 it did: this branch went straight to _admin_merge, so on any host whose
+# profile refuses admin-merge the flag could never merge anything. A green, unblocked PR
+# needs the same plain squash the --merge path performs at the bottom of this script, and
+# routing it through the override made the one flag documented for solo repos the one
+# flag guaranteed to fail there.
 if [ "$NO_REVIEW" -eq 1 ] && [ "$MODE" = "--merge" ]; then
   echo "PR #$PR_NUMBER: CI passed. --no-review specified — skipping review gate."
+  MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
+  if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
+    if _merge_with_retry; then
+      echo "Merged PR #$PR_NUMBER"
+      _cleanup_local_branch
+      exit 0
+    fi
+    echo "ERROR: merge failed for PR #$PR_NUMBER" >&2
+    exit 1
+  fi
+  # Anything else is a server-side rule the review gate cannot satisfy, which is what
+  # --admin is for — and what _admin_merge refuses where hard enforcement must bind.
+  echo "PR #$PR_NUMBER is $MERGE_STATE — a plain merge will not take it."
   _admin_merge
   exit 0
 fi

--- a/tests/integration/test_no_review_merge.py
+++ b/tests/integration/test_no_review_merge.py
@@ -1,0 +1,115 @@
+"""`--no-review` must merge a green PR on a profile that refuses admin-merge.
+
+The flag is documented for solo repositories where no reviewer will ever respond, and
+until 2026-08-11 its branch went straight to `_admin_merge`. On the `org` profile
+admin-merge is refused outright — hard enforcement has to bind — so the one flag written
+for repositories with no reviewer was the one flag guaranteed to fail on them. Observed
+live across four consecutive PRs, every one of which was green, `CLEAN`, and had to be
+merged by hand with `gh pr merge --squash`.
+
+The two tests here are the halves of one claim: a `CLEAN` PR merges, and a `BLOCKED` one
+still does not. Without the second, the fix would be indistinguishable from deleting the
+protection check, which is the opposite of what `--no-review` means.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_SCRIPTS = Path(".agents") / "scripts"
+
+# CI green, no reviewer, and `mergeStateStatus` supplied per test. `pr merge` succeeds
+# only WITHOUT `--admin`: that is the whole point — the stub reproduces a host where the
+# override is unavailable, so a fix that reaches for it cannot pass by accident.
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"pr merge"*"--admin"*) echo "refused: admin override unavailable" >&2; exit 1 ;;
+*"pr merge"*) echo "merged" ;;
+*"--json headRefName"*) echo "feature false" ;;
+*"--json headRefOid"*) echo "$PI_TEST_SHA" ;;
+*"pr checks"*) echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"}]' ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "0" ;;
+*"--json nameWithOwner"*) echo "o/r" ;;
+*"api graphql"*) echo "0" ;;
+*"--json state"*) echo "$PI_TEST_PR_STATE" ;;
+*"--json mergeStateStatus"*) echo "$PI_TEST_MERGE_STATE" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*"pr view"*) echo "" ;;
+*) exit 0 ;;
+esac
+"""
+
+_GIT_STUB = """#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\\trefs/heads/feature\\n' "$PI_TEST_SHA"
+  exit 0
+fi
+exec {real_git} "$@"
+"""
+
+
+def _run_monitor(tmp_target: Path, tmp_path: Path, *, merge_state: str, pr_state: str = "OPEN"):
+    """Run the real script under the `org` profile, which is the one that refuses."""
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    config = tmp_target / ".agents" / "config.yaml"
+    config.write_text(f"{config.read_text()}\nprofile: org\n", encoding="utf-8")
+    stub = tmp_path / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    (stub / "git").write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    (stub / "git").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env["PI_TEST_SHA"] = "a" * 40
+    env["PI_TEST_MERGE_STATE"] = merge_state
+    env["PI_TEST_PR_STATE"] = pr_state
+    return subprocess.run(
+        ["bash", str(tmp_target / _SCRIPTS / "monitor_pr.sh"), "1", "--merge", "--no-review"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_a_clean_pr_merges_without_the_admin_override(tmp_target: Path, tmp_path: Path):
+    """The reproduction. Before the fix this exited 1 with "admin-merge is refused"."""
+    result = _run_monitor(tmp_target, tmp_path, merge_state="CLEAN")
+    assert "Merged PR #1" in result.stdout, result.stdout + result.stderr
+
+
+def test_a_clean_merge_exits_zero(tmp_target: Path, tmp_path: Path):
+    """`just pr-merge` reads the exit code, so a merge that prints success and exits
+    non-zero still reads to the caller as a failed merge."""
+    result = _run_monitor(tmp_target, tmp_path, merge_state="CLEAN")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_a_blocked_pr_is_still_refused(tmp_target: Path, tmp_path: Path):
+    """The discrimination half, and the reason this is a fix rather than a deletion.
+
+    `--no-review` skips WAITING for a reviewer; it does not bypass branch protection. A
+    change that simply dropped the override check would pass the two tests above and fail
+    this one.
+    """
+    result = _run_monitor(tmp_target, tmp_path, merge_state="BLOCKED")
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_a_blocked_pr_says_which_state_stopped_it(tmp_target: Path, tmp_path: Path):
+    """The old message named the override that was refused and never the state that led
+    there, which is what made this take four PRs to diagnose."""
+    result = _run_monitor(tmp_target, tmp_path, merge_state="BLOCKED")
+    assert "BLOCKED" in result.stdout


### PR DESCRIPTION
Closes #936

`--no-review` is documented for solo repositories where no reviewer will ever respond,
and its branch went straight to `_admin_merge`. On a profile that refuses admin-merge
outright — where hard enforcement has to bind — that made the one flag written for
repositories with no reviewer the one flag guaranteed to fail on them.

Observed live across four consecutive PRs, every one green and `CLEAN`, each merged by
hand with `gh pr merge --squash`:

```
PR #98: CI passed. --no-review specified — skipping review gate.
ERROR: admin-merge is refused under the org profile (#251) — hard
  enforcement must bind. Use auto-merge or the merge queue under the
  required checks, or resolve the blocking review/checks.
```

The advice in that message is unreachable on a repo with no required checks and no
reviewer who can ever approve — there is no queue to use and no review to resolve.

## The fix

The plain squash path already existed. The `--merge` block at the bottom of the script
reads `mergeStateStatus` and calls `_merge_with_retry`; the `--no-review` branch now does
the same, and falls back to `_admin_merge` only when the state is something a plain merge
cannot take. That is what `--admin` is for, and `_admin_merge` still refuses it where it
must.

The two behaviours were conflated, and they are different things: **`--no-review` skips
*waiting for a reviewer*. It does not bypass branch protection.**

## Evidence

Reproduced before fixing. Three of the four new tests fail against the unfixed script
with the live symptom (`ERROR: admin merge failed`) and pass after:

| Test | Unfixed | Fixed |
|---|---|---|
| a CLEAN PR merges without the admin override | fail | pass |
| a clean merge exits zero | fail | pass |
| a BLOCKED PR is still refused | **pass** | pass |
| a BLOCKED PR says which state stopped it | fail | pass |

The third is the discrimination half and it is the reason this is a fix rather than a
deletion — a change that merely dropped the override check would pass the other three and
fail that one. The `gh` stub makes `pr merge --admin` exit 1 while a plain `pr merge`
succeeds, so a fix that reaches for the override cannot pass by accident.

`tests/integration -k 'monitor or review or merge or protection'`: 117 passed.

## Scope

Fixed in `templates/lifecycle/` first per CLAUDE.md, then `just sync-agents` +
`just sync-claude`; all three copies stay byte-identical, `sync_agents_from_templates.py`
reports no drift, and `sync_plugin.py --check` reports the payload in sync — so no plugin
version bump is owed.

## Unrelated, and pre-existing

`tests/contracts` has **6 failures on clean `main`**, unchanged by this branch — measured
by stashing:

- `test_observability_self_log.py::TestHelperGating::test_governance_fields_and_escaping`
- `test_post_edit_lint_autofix.py` (3)
- `test_post_edit_lint_typecheck.py` (2)

Not touched here. Worth its own issue.
