### PR TITLE
feat(PI-906): the data-plane and access verbs the deny table missed

### DIFF
--- a/docs/adr/adr-012-prod-safety-guard.md
+++ b/docs/adr/adr-012-prod-safety-guard.md
@@ -66,3 +66,43 @@ non-interactive, so the adapter invokes prod_guard in autonomous mode →
 destructive commands **block** outright (no "ask" path on a surface that
 can't render one). Still a guardrail, not a boundary: git/CI + credential
 separation remain the guarantee (ADR-007).
+
+## Update (PI-906)
+
+The deny-table's class list above described infrastructure destruction. Two
+extensions, both because running the live table against real data-stack
+commands showed the gap rather than reasoning about it:
+
+**Data-plane destruction.** BigQuery removal and truncation, `--replace`
+overwrites, GCS recursive removal in both spellings, SQL `DELETE FROM` and
+`MERGE`, and dbt writes against a production target. A `--replace` load and a
+`dbt run` on a `table` materialisation destroy the prior contents as surely as
+a `DROP`; the verb reading like an ordinary write is the reason they were
+missed. One of these was a defect in an existing rule, not a gap:
+`gcloud storage rm -r` carries no `delete` token, so the `gcloud delete` rule
+that appears to cover GCS never saw the modern spelling of emptying a bucket.
+
+**Access mutation, which is not destruction.** IAM binding changes, policy
+replacement, service-account key creation, bucket ACL changes, and GTM
+container publish. *Granting* access is not destructive and so was never
+modelled, but where an identity is shared it changes other people's reach
+without their knowledge, and it is the least reversible thing in the table.
+Grants are narrowed to owner/editor/admin so routine reader grants stay
+unflagged; removals and wholesale policy replacement are flagged
+unconditionally.
+
+The posture is unchanged — `ask` interactively, `deny` in autonomous modes —
+and it is load-bearing here, because these verbs have legitimate routine uses.
+`dbt run --full-refresh --target dev` is ordinary work, so the dbt rules
+require a production target to be *named*: the cost is that a profile whose
+default target is prod is not reached, and naming the target is the supported
+way to be protected.
+
+Two limits stated rather than papered over. The GTM rule matches a `curl` in a
+Bash call; the same publish through a non-Bash tool or an MCP server bypasses
+it entirely, and the durable control is a GTM-side permission. And **the
+false-positive rate of the new rules is unmeasured, not zero** — `bq` and
+`dbt` traffic is too rare in this repo's corpus to establish a rate. What is
+measured is that the rules fire zero times on the known-good corpus in
+`tests/contracts/test_prod_guard.py`, which grew a negative case for every
+rule added.

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "7885190a8a155ee6754668e21428f21f08b71ff5124f4a26bbf385b11b3386cd",
-    "version": "0.8.8"
+    "sha256": "aebf8852bd34ba8d47bc9a275c5f1b84b5bf80f148aced89c514929330018b97",
+    "version": "0.8.9"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -36,6 +36,10 @@ from pathlib import Path
 # command separators; the cost is rare false positives on odd resource
 # names, which the ask/allowlist paths absorb cheaply.
 _SEG = r"[^|;&]*?"
+# `--replace` / `--replace=true` but never `--replace=false` (PI-906): the
+# false spelling is the default written out, and flagging it would nag on a
+# command that is explicitly asking NOT to overwrite.
+_REPLACE = r"--replace(?:=true)?(?![\w=-])"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
     # way (PI-488). `(?:-\S+\s+)*` tolerates global options before the verb
@@ -82,6 +86,32 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"\bbq\s+(?:-\S+\s+)*rm\b(?!\s+(?:--help|-h)\b)"),
         "bq rm (BigQuery dataset/table removal)",
     ),
+    # `bq truncate` is a bq SUBCOMMAND, not SQL, so the `truncate table` rule
+    # below never sees it — there is no `table` token in `bq truncate ds.t`
+    # (PI-906). Same shape and same help exemption as `bq rm`.
+    (
+        re.compile(r"\bbq\s+(?:-\S+\s+)*truncate\b(?!\s+(?:--help|-h)\b)"),
+        "bq truncate (BigQuery table truncation)",
+    ),
+    # `--replace` overwrites the destination: the prior contents are gone as
+    # surely as after a DROP, while the verb reads like an ordinary write
+    # (PI-906). `--replace=false` is the DEFAULT spelled out and must not be
+    # flagged, which a bare `--replace\b` would do — `\b` matches before the
+    # `=`. Hence `_REPLACE`: the bare flag or `=true`, never `=false`.
+    (
+        re.compile(rf"\bbq\s+(?:-\S+\s+)*load\b{_SEG}\s{_REPLACE}"),
+        "bq load --replace (destination overwrite)",
+    ),
+    # A destination_table WITHOUT --replace appends, which is not destruction;
+    # both must be present, and the flags appear in either order.
+    (
+        re.compile(
+            rf"\bbq\s+(?:-\S+\s+)*query\b"
+            rf"(?={_SEG}\s--destination_table[=\s])"
+            rf"(?={_SEG}\s{_REPLACE})"
+        ),
+        "bq query --replace (destination table overwrite)",
+    ),
     (re.compile(rf"\baz\b{_SEG}\bdelete\b"), "az delete"),
     # dbt `--full-refresh` drops and rebuilds incremental models: data
     # destruction wearing a build verb (PI-906). Two lookaheads because the
@@ -112,6 +142,27 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         ),
         "dbt --full-refresh against a production target",
     ),
+    # A dbt run/build/seed/snapshot against a PRODUCTION target rewrites prod
+    # relations whether or not `--full-refresh` is passed: a `table`
+    # materialisation is a drop-and-recreate every time, and `run-operation`
+    # executes an arbitrary macro (PI-906). The `--full-refresh` rule above
+    # stays first so its more specific label keeps firing for that case.
+    #
+    # JUDGMENT CALL, stated so it can be overruled: this flags the ordinary
+    # production deploy command, `dbt build --target prod`. It is `ask`, not
+    # deny, and the posture is that an agent shell reaching prod should confirm
+    # once — a deploy pipeline does not run through this hook, and a human who
+    # deploys by hand all day has `safety.allow`. Read-only verbs (test,
+    # compile, parse, docs, ls, debug, deps, show, source) are deliberately
+    # absent from the verb list.
+    (
+        re.compile(
+            r"\bdbt\b"
+            rf"(?={_SEG}\s(?:build|run|run-operation|seed|snapshot)\b)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*[\"']?(?:prod|production)(?![\w-]))"
+        ),
+        "dbt write against a production target",
+    ),
     # IAM mutation on shared identities (PI-906). Granting access is not
     # obviously "destructive" and so was never modelled, but where an identity
     # is shared it changes other people's reach without their knowledge, and it
@@ -136,6 +187,44 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(rf"\bgcloud\b{_SEG}\bremove-iam-policy-binding\b"),
         "gcloud IAM binding removal",
+    ),
+    # `set-iam-policy` REPLACES the whole policy from a file, so it revokes
+    # every binding the file omits — the widest access change in the set, and
+    # the one that looks least like one (PI-906). Flagged unconditionally: the
+    # roles are in the file, which this guard does not read.
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bset-iam-policy\b"),
+        "gcloud IAM policy replacement",
+    ),
+    # A service-account key is a long-lived credential that outlives the
+    # session, cannot be rotated by revoking a login, and is exactly what the
+    # credential-separation boundary (ADR-012) exists to keep out of an agent
+    # shell. `keys list` / `keys describe` are reads and match neither.
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\biam\s+service-accounts\s+keys\s+create\b"),
+        "gcloud service-account key creation",
+    ),
+    # Bucket-level access. `iam ch` edits bindings, `iam set` replaces the
+    # policy wholesale; `iam get` is a read and is not flagged.
+    (
+        re.compile(rf"\bgsutil\b{_SEG}\biam\s+(?:ch|set)\b"),
+        "gsutil bucket IAM mutation",
+    ),
+    # The same three verbs exist on `bq` for datasets and tables, and none of
+    # the gcloud rules above reach them — different CLI, identical effect.
+    (
+        re.compile(
+            r"\bbq\s+(?:-\S+\s+)*"
+            r"(?:set-iam-policy|add-iam-policy-binding|remove-iam-policy-binding)\b"
+        ),
+        "bq IAM policy mutation",
+    ),
+    # `bq update --source <file>` replaces a dataset's ACL (or a table's
+    # schema) from a file — the pre-IAM spelling of set-iam-policy, still
+    # supported and still a wholesale replacement.
+    (
+        re.compile(rf"\bbq\s+(?:-\S+\s+)*update\b{_SEG}\s--source[=\s]"),
+        "bq update --source (dataset ACL/schema replacement)",
     ),
     (re.compile(r"\bdrop\s+(table|database|schema)\b", re.IGNORECASE), "SQL DROP"),
     (re.compile(r"\btruncate\s+table\b", re.IGNORECASE), "SQL TRUNCATE"),
@@ -169,6 +258,26 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         ),
         "SQL DELETE FROM",
     ),
+    # MERGE rewrites and can DELETE rows in the target; only DROP/TRUNCATE and
+    # DELETE FROM were modelled (PI-906). "merge" alone is hopeless as a
+    # signal — `git merge`, `gh pr merge` and every commit message about a
+    # merge would match — so the rule keys on the SHAPE of the statement:
+    # target identifier, USING, ON, then WHEN [NOT] MATCHED.
+    #
+    # USING ... ON alone was NOT enough, measured rather than supposed: the
+    # sentence `echo "we should merge into that table using the new source on
+    # monday"` matched it. Every clause in that shape is ordinary English. The
+    # WHEN [NOT] MATCHED clause is not, and MERGE is invalid without at least
+    # one of them, so requiring it costs no true positive.
+    (
+        re.compile(
+            r"\bmerge\s+(?:into\s+)?[A-Za-z_`\"\[][\w.`\"\[\]$-]*"
+            r"\s+(?:(?:as\s+)?[A-Za-z_]\w*\s+)?using\b"
+            rf"{_SEG}\bon\b{_SEG}\bwhen\s+(?:not\s+)?matched\b",
+            re.IGNORECASE,
+        ),
+        "SQL MERGE",
+    ),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old
@@ -183,6 +292,16 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
             r"(?:\s+-{1,2}[\w-]+)+\s+(/(?!tmp\b)|~)"
         ),
         "recursive force-remove outside the project",
+    ),
+    # Publishing a GTM container version pushes tags to every live page the
+    # container is on — instant, global, and not a git-mediated change
+    # (PI-906). THE HONEST LIMIT: this matcher sees a `curl` in a Bash tool
+    # call. The same publish through a non-Bash tool, an MCP server or the GTM
+    # UI bypasses it entirely. The durable control is a GTM-side permission;
+    # this only stops the spelling an agent shell reaches for.
+    (
+        re.compile(r"tagmanager\.googleapis\.com[^\s'\"]*:publish"),
+        "GTM container version publish",
     ),
     (re.compile(r"\bgh\s+repo\s+delete\b"), "gh repo delete"),
     (re.compile(r"\bdocker\s+(volume\s+prune|system\s+prune)\b"), "docker prune"),

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.8.8"
+__plugin_version__ = "0.8.9"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -36,6 +36,10 @@ from pathlib import Path
 # command separators; the cost is rare false positives on odd resource
 # names, which the ask/allowlist paths absorb cheaply.
 _SEG = r"[^|;&]*?"
+# `--replace` / `--replace=true` but never `--replace=false` (PI-906): the
+# false spelling is the default written out, and flagging it would nag on a
+# command that is explicitly asking NOT to overwrite.
+_REPLACE = r"--replace(?:=true)?(?![\w=-])"
 DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     # OpenTofu (`tofu`) is a CLI-identical Terraform fork — guard both the same
     # way (PI-488). `(?:-\S+\s+)*` tolerates global options before the verb
@@ -82,6 +86,32 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"\bbq\s+(?:-\S+\s+)*rm\b(?!\s+(?:--help|-h)\b)"),
         "bq rm (BigQuery dataset/table removal)",
     ),
+    # `bq truncate` is a bq SUBCOMMAND, not SQL, so the `truncate table` rule
+    # below never sees it — there is no `table` token in `bq truncate ds.t`
+    # (PI-906). Same shape and same help exemption as `bq rm`.
+    (
+        re.compile(r"\bbq\s+(?:-\S+\s+)*truncate\b(?!\s+(?:--help|-h)\b)"),
+        "bq truncate (BigQuery table truncation)",
+    ),
+    # `--replace` overwrites the destination: the prior contents are gone as
+    # surely as after a DROP, while the verb reads like an ordinary write
+    # (PI-906). `--replace=false` is the DEFAULT spelled out and must not be
+    # flagged, which a bare `--replace\b` would do — `\b` matches before the
+    # `=`. Hence `_REPLACE`: the bare flag or `=true`, never `=false`.
+    (
+        re.compile(rf"\bbq\s+(?:-\S+\s+)*load\b{_SEG}\s{_REPLACE}"),
+        "bq load --replace (destination overwrite)",
+    ),
+    # A destination_table WITHOUT --replace appends, which is not destruction;
+    # both must be present, and the flags appear in either order.
+    (
+        re.compile(
+            rf"\bbq\s+(?:-\S+\s+)*query\b"
+            rf"(?={_SEG}\s--destination_table[=\s])"
+            rf"(?={_SEG}\s{_REPLACE})"
+        ),
+        "bq query --replace (destination table overwrite)",
+    ),
     (re.compile(rf"\baz\b{_SEG}\bdelete\b"), "az delete"),
     # dbt `--full-refresh` drops and rebuilds incremental models: data
     # destruction wearing a build verb (PI-906). Two lookaheads because the
@@ -112,6 +142,27 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         ),
         "dbt --full-refresh against a production target",
     ),
+    # A dbt run/build/seed/snapshot against a PRODUCTION target rewrites prod
+    # relations whether or not `--full-refresh` is passed: a `table`
+    # materialisation is a drop-and-recreate every time, and `run-operation`
+    # executes an arbitrary macro (PI-906). The `--full-refresh` rule above
+    # stays first so its more specific label keeps firing for that case.
+    #
+    # JUDGMENT CALL, stated so it can be overruled: this flags the ordinary
+    # production deploy command, `dbt build --target prod`. It is `ask`, not
+    # deny, and the posture is that an agent shell reaching prod should confirm
+    # once — a deploy pipeline does not run through this hook, and a human who
+    # deploys by hand all day has `safety.allow`. Read-only verbs (test,
+    # compile, parse, docs, ls, debug, deps, show, source) are deliberately
+    # absent from the verb list.
+    (
+        re.compile(
+            r"\bdbt\b"
+            rf"(?={_SEG}\s(?:build|run|run-operation|seed|snapshot)\b)"
+            rf"(?={_SEG}\s(?:--target[=\s]|-t\s)\s*[\"']?(?:prod|production)(?![\w-]))"
+        ),
+        "dbt write against a production target",
+    ),
     # IAM mutation on shared identities (PI-906). Granting access is not
     # obviously "destructive" and so was never modelled, but where an identity
     # is shared it changes other people's reach without their knowledge, and it
@@ -136,6 +187,44 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(rf"\bgcloud\b{_SEG}\bremove-iam-policy-binding\b"),
         "gcloud IAM binding removal",
+    ),
+    # `set-iam-policy` REPLACES the whole policy from a file, so it revokes
+    # every binding the file omits — the widest access change in the set, and
+    # the one that looks least like one (PI-906). Flagged unconditionally: the
+    # roles are in the file, which this guard does not read.
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\bset-iam-policy\b"),
+        "gcloud IAM policy replacement",
+    ),
+    # A service-account key is a long-lived credential that outlives the
+    # session, cannot be rotated by revoking a login, and is exactly what the
+    # credential-separation boundary (ADR-012) exists to keep out of an agent
+    # shell. `keys list` / `keys describe` are reads and match neither.
+    (
+        re.compile(rf"\bgcloud\b{_SEG}\biam\s+service-accounts\s+keys\s+create\b"),
+        "gcloud service-account key creation",
+    ),
+    # Bucket-level access. `iam ch` edits bindings, `iam set` replaces the
+    # policy wholesale; `iam get` is a read and is not flagged.
+    (
+        re.compile(rf"\bgsutil\b{_SEG}\biam\s+(?:ch|set)\b"),
+        "gsutil bucket IAM mutation",
+    ),
+    # The same three verbs exist on `bq` for datasets and tables, and none of
+    # the gcloud rules above reach them — different CLI, identical effect.
+    (
+        re.compile(
+            r"\bbq\s+(?:-\S+\s+)*"
+            r"(?:set-iam-policy|add-iam-policy-binding|remove-iam-policy-binding)\b"
+        ),
+        "bq IAM policy mutation",
+    ),
+    # `bq update --source <file>` replaces a dataset's ACL (or a table's
+    # schema) from a file — the pre-IAM spelling of set-iam-policy, still
+    # supported and still a wholesale replacement.
+    (
+        re.compile(rf"\bbq\s+(?:-\S+\s+)*update\b{_SEG}\s--source[=\s]"),
+        "bq update --source (dataset ACL/schema replacement)",
     ),
     (re.compile(r"\bdrop\s+(table|database|schema)\b", re.IGNORECASE), "SQL DROP"),
     (re.compile(r"\btruncate\s+table\b", re.IGNORECASE), "SQL TRUNCATE"),
@@ -169,6 +258,26 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
         ),
         "SQL DELETE FROM",
     ),
+    # MERGE rewrites and can DELETE rows in the target; only DROP/TRUNCATE and
+    # DELETE FROM were modelled (PI-906). "merge" alone is hopeless as a
+    # signal — `git merge`, `gh pr merge` and every commit message about a
+    # merge would match — so the rule keys on the SHAPE of the statement:
+    # target identifier, USING, ON, then WHEN [NOT] MATCHED.
+    #
+    # USING ... ON alone was NOT enough, measured rather than supposed: the
+    # sentence `echo "we should merge into that table using the new source on
+    # monday"` matched it. Every clause in that shape is ordinary English. The
+    # WHEN [NOT] MATCHED clause is not, and MERGE is invalid without at least
+    # one of them, so requiring it costs no true positive.
+    (
+        re.compile(
+            r"\bmerge\s+(?:into\s+)?[A-Za-z_`\"\[][\w.`\"\[\]$-]*"
+            r"\s+(?:(?:as\s+)?[A-Za-z_]\w*\s+)?using\b"
+            rf"{_SEG}\bon\b{_SEG}\bwhen\s+(?:not\s+)?matched\b",
+            re.IGNORECASE,
+        ),
+        "SQL MERGE",
+    ),
     (
         # Recursive + force can be bundled (-rf/-fr) OR split across separate
         # args in any order (rm -r -f /, rm --force --recursive /) — the old
@@ -183,6 +292,16 @@ DENY_RULES: list[tuple[re.Pattern[str], str]] = [
             r"(?:\s+-{1,2}[\w-]+)+\s+(/(?!tmp\b)|~)"
         ),
         "recursive force-remove outside the project",
+    ),
+    # Publishing a GTM container version pushes tags to every live page the
+    # container is on — instant, global, and not a git-mediated change
+    # (PI-906). THE HONEST LIMIT: this matcher sees a `curl` in a Bash tool
+    # call. The same publish through a non-Bash tool, an MCP server or the GTM
+    # UI bypasses it entirely. The durable control is a GTM-side permission;
+    # this only stops the spelling an agent shell reaches for.
+    (
+        re.compile(r"tagmanager\.googleapis\.com[^\s'\"]*:publish"),
+        "GTM container version publish",
     ),
     (re.compile(r"\bgh\s+repo\s+delete\b"), "gh repo delete"),
     (re.compile(r"\bdocker\s+(volume\s+prune|system\s+prune)\b"), "docker prune"),

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -81,6 +81,42 @@ DESTRUCTIVE = [
     # A full-table DELETE empties it as surely as TRUNCATE.
     'bq query --use_legacy_sql=false "DELETE FROM analytics.sessions WHERE 1=1"',
     "psql -c 'delete from users'",
+    # ── PI-906 part two: the verbs the first pass left on the table ──
+    # `bq truncate` is a subcommand, not SQL — the `truncate table` rule cannot
+    # see it because there is no `table` token in the command.
+    "bq truncate my-proj:analytics.sessions",
+    # `--replace` overwrites the destination; the prior contents are gone.
+    "bq load --replace my-proj:analytics.t gs://b/f.csv",
+    "bq load --source_format=CSV --replace=true my-proj:analytics.t gs://b/f.csv",
+    'bq query --replace --destination_table analytics.t "select 1"',
+    # Flag order is not fixed, and only the pair is destructive.
+    'bq query --destination_table analytics.t --replace "select 1"',
+    # MERGE rewrites and can DELETE rows in the target.
+    'psql -c "MERGE INTO users u USING staging s ON u.id = s.id WHEN MATCHED THEN DELETE"',
+    (
+        'bq query "MERGE analytics.sessions t USING staging.s s ON t.id = s.id '
+        'WHEN MATCHED THEN UPDATE SET x = 1"'
+    ),
+    # A dbt write against a PRODUCTION target, with or without --full-refresh:
+    # a `table` materialisation is a drop-and-recreate every run.
+    "dbt build --target prod",
+    "dbt run --target prod",
+    "dbt run-operation drop_old_relations --target prod",
+    "dbt seed --target production",
+    "dbt snapshot --target prod",
+    # Access mutation beyond the two binding verbs already covered.
+    "gcloud projects set-iam-policy mbd policy.json",
+    "gcloud iam service-accounts keys create key.json --iam-account=sa@p.iam.gserviceaccount.com",
+    "gsutil iam ch user:a@b.c:objectAdmin gs://prod-assets",
+    "gsutil iam set policy.json gs://prod-assets",
+    "bq set-iam-policy my-proj:analytics.sessions policy.json",
+    "bq add-iam-policy-binding --member=user:a@b.c --role=roles/bigquery.dataOwner my-proj:ds.t",
+    "bq update --source acl.json my-proj:analytics",
+    # Publishing a GTM container version goes live on every page at once.
+    (
+        "curl -X POST https://tagmanager.googleapis.com/tagmanager/v2/"
+        "accounts/1/containers/2/versions/3:publish"
+    ),
 ]
 
 SAFE = [
@@ -153,6 +189,39 @@ SAFE = [
     "gcloud projects get-iam-policy mbd",
     # A low-privilege grant is not an estate handover.
     "gcloud projects add-iam-policy-binding mbd --member=user:a@b.c --role=roles/bigquery.dataViewer",
+    # ── PI-906 part two: the negative case for every rule added above ──
+    # `--replace=false` is the DEFAULT written out. A bare `--replace\b` flags
+    # it, because `\b` matches before the `=` — so the command explicitly
+    # asking NOT to overwrite would have been the one that prompted.
+    "bq load --replace=false my-proj:analytics.t gs://b/f.csv",
+    # A destination_table WITHOUT --replace APPENDS. Only the pair destroys.
+    'bq query --destination_table analytics.t "select 1"',
+    "bq truncate --help",
+    "bq get-iam-policy my-proj:analytics.sessions",
+    "gsutil iam get gs://prod-assets",
+    "gcloud iam service-accounts list",
+    "gcloud iam service-accounts keys list --iam-account=sa@p.iam.gserviceaccount.com",
+    # dbt READ verbs against prod are how you inspect prod safely; flagging
+    # them would make the guard a nuisance on the exact command a careful
+    # person reaches for instead of a write.
+    "dbt test --target prod",
+    "dbt compile --target prod",
+    "dbt docs generate --target prod",
+    "dbt ls --target prod",
+    # "merge" is hopeless as a signal on its own — these are daily commands.
+    "git merge main",
+    "gh pr merge 42 --squash",
+    'git commit -m "chore: merge into staging"',
+    'git log --grep "merge into"',
+    # MEASURED false positive, not a supposed one: the first cut of the MERGE
+    # rule required only `USING ... ON`, and this sentence matched it. Every
+    # clause of that shape is ordinary English; `WHEN [NOT] MATCHED` is not,
+    # and no valid MERGE can omit it.
+    'echo "we should merge into that table using the new source on monday"',
+    # A GET on the same API is a read. Only `:publish` goes live.
+    "curl https://tagmanager.googleapis.com/tagmanager/v2/accounts/1/containers/2/versions/3",
+    # `--schema` is not `--source`: a column addition is not an ACL swap.
+    "bq update --schema schema.json my-proj:analytics.t",
 ]
 
 
@@ -224,6 +293,46 @@ class TestVerdicts:
                 "gcloud IAM binding removal",
             ),
             ('psql -c "DELETE FROM sessions WHERE 1=1"', "SQL DELETE FROM"),
+            # ── PI-906 part two ──
+            ("bq truncate my-proj:analytics.sessions", "bq truncate (BigQuery table truncation)"),
+            (
+                "bq load --replace my-proj:analytics.t gs://b/f.csv",
+                "bq load --replace (destination overwrite)",
+            ),
+            (
+                'bq query --replace --destination_table analytics.t "select 1"',
+                "bq query --replace (destination table overwrite)",
+            ),
+            (
+                'psql -c "MERGE INTO users u USING s ON u.id = s.id WHEN MATCHED THEN DELETE"',
+                "SQL MERGE",
+            ),
+            # NOT the --full-refresh rule: that one is more specific and sits
+            # earlier in the table, so pinning this label is what proves the
+            # new rule is doing the work for a plain prod write.
+            ("dbt build --target prod", "dbt write against a production target"),
+            ("gcloud projects set-iam-policy mbd policy.json", "gcloud IAM policy replacement"),
+            (
+                "gcloud iam service-accounts keys create k.json --iam-account=sa@p.iam.gserviceaccount.com",
+                "gcloud service-account key creation",
+            ),
+            ("gsutil iam ch user:a@b.c:objectAdmin gs://prod-assets", "gsutil bucket IAM mutation"),
+            ("bq set-iam-policy my-proj:analytics.sessions policy.json", "bq IAM policy mutation"),
+            (
+                "bq update --source acl.json my-proj:analytics",
+                "bq update --source (dataset ACL/schema replacement)",
+            ),
+            (
+                "curl -X POST https://tagmanager.googleapis.com/tagmanager/v2/"
+                "accounts/1/containers/2/versions/3:publish",
+                "GTM container version publish",
+            ),
+            # The --full-refresh rule must still own its case after the more
+            # general dbt rule joined the table below it.
+            (
+                "dbt run --full-refresh --target prod",
+                "dbt --full-refresh against a production target",
+            ),
         ],
     )
     def test_each_new_rule_is_the_one_that_fires(self, tmp_path: Path, command: str, label: str):


### PR DESCRIPTION
Closes #906

Completes the ticket's task list. **Half of it was already done** — a prior pass landed `gcloud storage rm`/`gsutil rm`, `bq rm`, `DELETE FROM`, `add-`/`remove-iam-policy-binding` and the dbt `--full-refresh` rule, but ticked no boxes and left no comment, so the ticket read as untouched. Verified rule by rule against the live table before writing anything; what follows is only what was actually missing.

## Rules added

| Class | Rules | Why it is not covered by what exists |
|---|---|---|
| BigQuery | `bq truncate`, `bq load --replace`, `bq query --replace --destination_table` | `bq truncate` is a **subcommand**, so the SQL `truncate table` rule cannot see it — there is no `table` token in `bq truncate ds.t`. A `--replace` load destroys the prior contents while reading like an ordinary write |
| SQL | `MERGE` | `MERGE` can DELETE rows in the target; only DROP/TRUNCATE/DELETE were modelled |
| dbt | `run`/`build`/`seed`/`snapshot`/`run-operation` against a named prod target | the existing rule requires `--full-refresh`. A `table` materialisation is a drop-and-recreate on **every** run, refresh flag or not |
| Access | `gcloud set-iam-policy`, `gcloud iam service-accounts keys create`, `gsutil iam ch\|set`, `bq set-iam-policy`/`add-`/`remove-iam-policy-binding`, `bq update --source` | the two binding rules are gcloud-only and do not reach the same verbs on `bq` or `gsutil`. `set-iam-policy` **replaces** the policy, so it revokes every binding the file omits |
| GTM | container version `:publish` | not a git-mediated change; goes live on every page at once |

Verb names checked against the installed CLIs rather than recalled — `bq help` lists `set-iam-policy`, `add-iam-policy-binding`, `remove-iam-policy-binding`, `truncate`, `update`; `gsutil help iam` lists `ch`, `set`, `get`.

**`bq truncate` is not in the ticket.** It surfaced while confirming the `bq` verb list and belongs to the same family as `bq rm`, so it is here.

## Two false positives the first cut shipped, both measured

- **`--replace=false` would have been flagged.** That is the default written out — the command explicitly asking *not* to overwrite would have been the one that prompted. `\b` matches before the `=`, so a bare `--replace\b` catches it. Hence `_REPLACE`: the bare flag or `=true`, never `=false`.
- **`USING … ON` was not enough for MERGE.** `echo "we should merge into that table using the new source on monday"` matched it — every clause of that shape is ordinary English. `WHEN [NOT] MATCHED` is not, and MERGE is invalid without at least one, so requiring it costs no true positive. Both are pinned as SAFE cases.

## One judgment call, stated so it can be overruled

`dbt build --target prod` — the ordinary production deploy command — now asks. The posture is that an agent shell reaching prod confirms once; a deploy pipeline does not run through a PreToolUse hook, and `safety.allow` is the escape hatch for someone who deploys by hand. Read-only dbt verbs (`test`, `compile`, `docs`, `ls`) against prod stay unflagged and are pinned as SAFE — flagging those would nag on exactly the command a careful person reaches for *instead* of a write. Say the word and I will narrow it to `--full-refresh` plus `run-operation`.

## Evidence

```
prod_guard suite            252 passed  (was 182)
full suite                  2834 passed, 7 failed
baseline on the fork point  2765 passed, 6 failed  -- the same six, plus the
                            plugin-version constant which this PR then synced
lint                        ruff check + format --check, rc=0
sync chain                  plugin 0.8.8 -> 0.8.9, sync-agents/claude/plugin, lock relocked
```

**Every rule was broken and watched go red — 18 mutants, 0 survivors**, and the file restored byte-identical afterwards (asserted, not eyeballed):

- **11 KILL mutants** — each new pattern made unmatchable in turn; every one turned its own tests red.
- **7 WIDEN mutants** — the *discriminator* removed rather than the rule: `--replace=false` allowed through, MERGE's `WHEN MATCHED` requirement dropped, dbt's prod-target lookahead dropped, `keys create` widened to any `keys` verb, `iam ch|set` widened to any `iam` verb, `--source` widened, GTM's `:publish` dropped. Each one turned a **SAFE** case red. This is the half that matters: a KILL-only run proves a rule fires, not that it discriminates.

## Limits, stated rather than papered over

- **The false-positive rate is unmeasured, and is reported as unmeasured, not as zero.** `bq`/`dbt` traffic is too rare here to establish a rate. What is measured: zero fires across the known-good corpus, which grew a negative case for every rule added.
- **The GTM rule sees a `curl` in a Bash call.** The same publish through a non-Bash tool or an MCP server bypasses it entirely. The durable control is a GTM-side permission; this stops the spelling an agent shell reaches for, and the rule comment says so.
- **dbt rules require the prod target to be *named*.** A profile whose default target is prod is not reached. Deliberate — the alternative flags `--target dev`, and a guard that nags on ordinary work gets switched off.
- Still a guardrail, not a boundary. Credential separation (ADR-012) remains the guarantee; the IAM rules are that same principle turned inward.

ADR-012 gained a PI-906 update: its class list described infrastructure destruction only, and **access mutation is a genuinely new class** — granting access is not destruction, which is why it was never modelled.
