### PR TITLE
fix(PI-939): a bump PR that can report, and a review status that unsticks itself

### DIFF
--- a/.agents/scripts/monitor_pr.sh
+++ b/.agents/scripts/monitor_pr.sh
@@ -210,6 +210,64 @@ sys.exit(len(bad))
 " "$IGNORE_CHECKS"
 }
 
+# PI-939: read the derived review/decision commit status, or "" if absent.
+_review_decision_state() {
+  gh pr checks "$PR_NUMBER" --json name,bucket 2>/dev/null | "$PY" -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for c in data:
+    if c.get('name') == 'review/decision':
+        print(c.get('bucket') or '')
+        break
+" 2>/dev/null || true
+}
+
+# PI-939: re-trigger review-status.yml with a plain PR comment.
+#
+# review/decision is computed by a workflow, and the two events that SHOULD
+# refresh it both fail to. Resolving a review thread emits no Actions event at
+# all (`pull_request_review_thread` is a webhook event only, #719). And where
+# the repository's Actions policy requires approval for bot actors, the
+# `pull_request_review` run a bot reviewer triggers is queued at
+# `action_required` — which cannot be cleared from the API either:
+#
+#   POST /actions/runs/{id}/approve
+#   403  This run is not from a fork pull request or queued by the Actions bot
+#
+# So the status stays stale on a PR whose review gate has actually passed, and
+# the merge below reports BLOCKED with no visible cause. `issue_comment` IS a
+# trigger on that workflow and IS attributed to the commenter rather than a
+# bot, so a comment settles it. That was a manual step; it is not any more.
+_nudge_review_decision() {
+  local state elapsed=0
+  state=$(_review_decision_state)
+  if [ "$state" = "pass" ]; then
+    return 0
+  fi
+  echo "review/decision is '${state:-absent}' though the review gate passed — commenting to re-trigger review-status.yml (PI-939)."
+  if ! gh pr comment "$PR_NUMBER" \
+    --body "Review threads addressed and resolved. Re-triggering \`review/decision\`: resolving a thread emits no workflow event, so this comment is the documented nudge." \
+    >/dev/null 2>&1; then
+    echo "  could not post the comment — review/decision left as-is."
+    return 0
+  fi
+  while [ "$elapsed" -lt 120 ]; do
+    sleep 15
+    elapsed=$((elapsed + 15))
+    state=$(_review_decision_state)
+    if [ "$state" = "pass" ]; then
+      echo "  review/decision: pass after ${elapsed}s."
+      return 0
+    fi
+  done
+  # Not an error: the status may legitimately be failing, and the merge step
+  # below reports that with its own diagnostics. Say what was tried.
+  echo "  review/decision still '${state:-absent}' after ${elapsed}s — the merge may report BLOCKED."
+}
+
 # Print review feedback — inline comments first, falls back to full PR comments view.
 _print_review_comments() {
   local inline
@@ -721,6 +779,14 @@ fi
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER passed: $PR_URL"
+
+# The review gate above has passed. If the derived status has not caught up,
+# nudge it before attempting the merge — not after, when the failure mode is an
+# opaque BLOCKED. Skipped when the operator turned the review gate off, because
+# there is then no gate whose result the status is lagging behind.
+if [ "$MODE" = "--merge" ] && [ "$MAX_REVIEW_CYCLES" -ne 0 ] && [ "$REVIEW_DECISION" != "SKIPPED" ]; then
+  _nudge_review_decision
+fi
 
 if [ "$MODE" = "--merge" ]; then
   MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -210,6 +210,64 @@ sys.exit(len(bad))
 " "$IGNORE_CHECKS"
 }
 
+# PI-939: read the derived review/decision commit status, or "" if absent.
+_review_decision_state() {
+  gh pr checks "$PR_NUMBER" --json name,bucket 2>/dev/null | "$PY" -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for c in data:
+    if c.get('name') == 'review/decision':
+        print(c.get('bucket') or '')
+        break
+" 2>/dev/null || true
+}
+
+# PI-939: re-trigger review-status.yml with a plain PR comment.
+#
+# review/decision is computed by a workflow, and the two events that SHOULD
+# refresh it both fail to. Resolving a review thread emits no Actions event at
+# all (`pull_request_review_thread` is a webhook event only, #719). And where
+# the repository's Actions policy requires approval for bot actors, the
+# `pull_request_review` run a bot reviewer triggers is queued at
+# `action_required` — which cannot be cleared from the API either:
+#
+#   POST /actions/runs/{id}/approve
+#   403  This run is not from a fork pull request or queued by the Actions bot
+#
+# So the status stays stale on a PR whose review gate has actually passed, and
+# the merge below reports BLOCKED with no visible cause. `issue_comment` IS a
+# trigger on that workflow and IS attributed to the commenter rather than a
+# bot, so a comment settles it. That was a manual step; it is not any more.
+_nudge_review_decision() {
+  local state elapsed=0
+  state=$(_review_decision_state)
+  if [ "$state" = "pass" ]; then
+    return 0
+  fi
+  echo "review/decision is '${state:-absent}' though the review gate passed — commenting to re-trigger review-status.yml (PI-939)."
+  if ! gh pr comment "$PR_NUMBER" \
+    --body "Review threads addressed and resolved. Re-triggering \`review/decision\`: resolving a thread emits no workflow event, so this comment is the documented nudge." \
+    >/dev/null 2>&1; then
+    echo "  could not post the comment — review/decision left as-is."
+    return 0
+  fi
+  while [ "$elapsed" -lt 120 ]; do
+    sleep 15
+    elapsed=$((elapsed + 15))
+    state=$(_review_decision_state)
+    if [ "$state" = "pass" ]; then
+      echo "  review/decision: pass after ${elapsed}s."
+      return 0
+    fi
+  done
+  # Not an error: the status may legitimately be failing, and the merge step
+  # below reports that with its own diagnostics. Say what was tried.
+  echo "  review/decision still '${state:-absent}' after ${elapsed}s — the merge may report BLOCKED."
+}
+
 # Print review feedback — inline comments first, falls back to full PR comments view.
 _print_review_comments() {
   local inline
@@ -721,6 +779,14 @@ fi
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER passed: $PR_URL"
+
+# The review gate above has passed. If the derived status has not caught up,
+# nudge it before attempting the merge — not after, when the failure mode is an
+# opaque BLOCKED. Skipped when the operator turned the review gate off, because
+# there is then no gate whose result the status is lagging behind.
+if [ "$MODE" = "--merge" ] && [ "$MAX_REVIEW_CYCLES" -ne 0 ] && [ "$REVIEW_DECISION" != "SKIPPED" ]; then
+  _nudge_review_decision
+fi
 
 if [ "$MODE" = "--merge" ]; then
   MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")

--- a/.github/workflows/third-party-updates.yml
+++ b/.github/workflows/third-party-updates.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # PI-939: needed to approve the PR's own pending workflow runs below. Harmless
+  # when the approve call is refused — the step is best-effort by construction.
+  actions: write
 
 jobs:
   check-and-propose:
@@ -29,10 +32,43 @@ jobs:
         run: |
           uv run python tools/check_third_party_updates.py check --json | tee updates.json
 
+      # PI-939: a PR opened with GITHUB_TOKEN is authored by github-actions[bot],
+      # and this repo's Actions policy queues bot-actor runs as `action_required`.
+      # The result is the worst shape a gate can have: the PR's head SHA carries
+      # ZERO check runs — not red, not green, never reported — so branch
+      # protection is unsatisfiable by construction and the PR sits at BLOCKED
+      # until a human clicks "Approve and run". Two bump PRs accumulated that way
+      # before anyone noticed, because nothing about the state looks like failure.
+      #
+      # BUMP_PR_TOKEN (a PAT or GitHub App installation token) is the real fix:
+      # a PR opened under a non-Actions identity triggers workflows normally.
+      # It is optional on purpose — a missing secret must not turn the weekly
+      # check into a hard failure, and the fallback still opens a usable PR.
       - name: Security-scan candidates and open PRs (no auto-merge)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BUMP_PR_TOKEN || github.token }}
+          BUMP_PR_TOKEN_PRESENT: ${{ secrets.BUMP_PR_TOKEN != '' }}
         run: |
+          if [ "$BUMP_PR_TOKEN_PRESENT" != "true" ]; then
+            echo "::warning::BUMP_PR_TOKEN is not set — opening the PR as" \
+              "github-actions[bot]. Its checks will queue at action_required" \
+              "and need a manual 'Approve and run' (PI-939)."
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           bash tools/propose_third_party_bumps.sh updates.json
+
+      # Best-effort recovery for the fallback path. Approving the bot's own
+      # queued runs is allowed for the runs the Actions bot queued; it is NOT
+      # allowed for every event (the `pull_request_review` run refuses with
+      # "This run is not from a fork pull request or queued by the Actions
+      # bot"), so this can only ever be a partial remedy and never a gate.
+      # Failures are swallowed deliberately: a PR that opened successfully must
+      # not be reported as a failed weekly check because a recovery step could
+      # not run.
+      - name: Approve any runs left waiting on the PRs just opened
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash tools/approve_pending_bump_runs.sh

--- a/docs/development/repo-reference.md
+++ b/docs/development/repo-reference.md
@@ -26,6 +26,41 @@ Use this table when adding new capabilities to this repo or its templates:
 
 After creating a skill, add an entry to `.agents/skills/INDEX.md` so it is discoverable without reading every file.
 
+## The weekly third-party bump, and the one secret it wants
+
+`third-party-updates.yml` opens a PR proposing a version bump for the pinned
+third-party tools (ADR-016 §5). It never auto-merges.
+
+**Set a repository secret `BUMP_PR_TOKEN`** — a PAT or a GitHub App
+installation token with `contents: write` and `pull-requests: write`. Without
+it the workflow still opens the PR, but under the `github-actions[bot]`
+identity, and this repository's Actions approval policy queues bot-actor runs
+at `action_required` instead of running them. The PR's head SHA then carries
+**zero check runs** — not red, not green, never reported — so branch
+protection is unsatisfiable and the PR sits at `BLOCKED` until someone clicks
+"Approve and run" in the Actions tab. Two PRs accumulated that way before
+anyone noticed, because nothing about the state looks like failure (#939).
+
+The fallback is deliberately not a hard failure: a missing secret must not
+turn the weekly check into a red build. It emits a `::warning::`, and a
+best-effort recovery step (`tools/approve_pending_bump_runs.sh`) approves what
+it can. **It cannot approve everything** — the endpoint refuses runs it did not
+queue, including the `pull_request_review` run that gates `review/decision`:
+
+```
+POST /actions/runs/{id}/approve
+403  This run is not from a fork pull request or queued by the Actions bot
+```
+
+For that one the remedy is a plain PR comment, which re-triggers
+`review-status.yml`; `monitor_pr.sh` now posts it automatically when the
+review gate has passed and the status has not caught up.
+
+The approval policy itself is a repository setting (Settings → Actions →
+General) and is **not readable or writable over the REST API for a public
+repo** — `/actions/permissions/access` answers 422. Narrowing it there is the
+only fix that removes the problem rather than working around it.
+
 ## What this repo does NOT include
 
 - No LLM calls from the scaffolder itself

--- a/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
+++ b/templates/lifecycle/dot_agents/scripts/monitor_pr.sh
@@ -210,6 +210,64 @@ sys.exit(len(bad))
 " "$IGNORE_CHECKS"
 }
 
+# PI-939: read the derived review/decision commit status, or "" if absent.
+_review_decision_state() {
+  gh pr checks "$PR_NUMBER" --json name,bucket 2>/dev/null | "$PY" -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for c in data:
+    if c.get('name') == 'review/decision':
+        print(c.get('bucket') or '')
+        break
+" 2>/dev/null || true
+}
+
+# PI-939: re-trigger review-status.yml with a plain PR comment.
+#
+# review/decision is computed by a workflow, and the two events that SHOULD
+# refresh it both fail to. Resolving a review thread emits no Actions event at
+# all (`pull_request_review_thread` is a webhook event only, #719). And where
+# the repository's Actions policy requires approval for bot actors, the
+# `pull_request_review` run a bot reviewer triggers is queued at
+# `action_required` — which cannot be cleared from the API either:
+#
+#   POST /actions/runs/{id}/approve
+#   403  This run is not from a fork pull request or queued by the Actions bot
+#
+# So the status stays stale on a PR whose review gate has actually passed, and
+# the merge below reports BLOCKED with no visible cause. `issue_comment` IS a
+# trigger on that workflow and IS attributed to the commenter rather than a
+# bot, so a comment settles it. That was a manual step; it is not any more.
+_nudge_review_decision() {
+  local state elapsed=0
+  state=$(_review_decision_state)
+  if [ "$state" = "pass" ]; then
+    return 0
+  fi
+  echo "review/decision is '${state:-absent}' though the review gate passed — commenting to re-trigger review-status.yml (PI-939)."
+  if ! gh pr comment "$PR_NUMBER" \
+    --body "Review threads addressed and resolved. Re-triggering \`review/decision\`: resolving a thread emits no workflow event, so this comment is the documented nudge." \
+    >/dev/null 2>&1; then
+    echo "  could not post the comment — review/decision left as-is."
+    return 0
+  fi
+  while [ "$elapsed" -lt 120 ]; do
+    sleep 15
+    elapsed=$((elapsed + 15))
+    state=$(_review_decision_state)
+    if [ "$state" = "pass" ]; then
+      echo "  review/decision: pass after ${elapsed}s."
+      return 0
+    fi
+  done
+  # Not an error: the status may legitimately be failing, and the merge step
+  # below reports that with its own diagnostics. Say what was tried.
+  echo "  review/decision still '${state:-absent}' after ${elapsed}s — the merge may report BLOCKED."
+}
+
 # Print review feedback — inline comments first, falls back to full PR comments view.
 _print_review_comments() {
   local inline
@@ -721,6 +779,14 @@ fi
 
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 echo "PR #$PR_NUMBER passed: $PR_URL"
+
+# The review gate above has passed. If the derived status has not caught up,
+# nudge it before attempting the merge — not after, when the failure mode is an
+# opaque BLOCKED. Skipped when the operator turned the review gate off, because
+# there is then no gate whose result the status is lagging behind.
+if [ "$MODE" = "--merge" ] && [ "$MAX_REVIEW_CYCLES" -ne 0 ] && [ "$REVIEW_DECISION" != "SKIPPED" ]; then
+  _nudge_review_decision
+fi
 
 if [ "$MODE" = "--merge" ]; then
   MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")

--- a/tests/contracts/test_third_party_update_pr.py
+++ b/tests/contracts/test_third_party_update_pr.py
@@ -1,0 +1,75 @@
+"""PI-939: the weekly bump PR must be able to go green on its own.
+
+A PR opened with `GITHUB_TOKEN` is authored by `github-actions[bot]`, and under
+this repository's Actions approval policy a bot-actor run is queued at
+`action_required` rather than run. The PR's head SHA then carries ZERO check
+runs — not red, not green, never reported — so branch protection is
+unsatisfiable by construction. Two bump PRs accumulated that way before anyone
+noticed, because nothing about the state looks like failure.
+
+These are text assertions on a workflow file, which is the weakest kind of
+test: they cannot prove the PR goes green, only that the mechanism that would
+make it go green is still wired. The acceptance test in #939 needs a real
+scheduled run and is named there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "third-party-updates.yml"
+)
+
+
+def _body() -> str:
+    return _WORKFLOW.read_text()
+
+
+def test_the_pr_is_opened_under_a_non_actions_identity_when_one_exists():
+    assert "secrets.BUMP_PR_TOKEN || github.token" in _body(), (
+        "the bump PR must prefer a non-GITHUB_TOKEN identity; a PR authored by "
+        "github-actions[bot] gets no check runs at all"
+    )
+
+
+def test_a_missing_secret_warns_instead_of_failing():
+    """The secret is optional on purpose: a missing one must not turn the
+    weekly check into a hard failure, and the fallback still opens a usable PR
+    — but it must say so, or the resulting stuck PR has no explanation."""
+    body = _body()
+    assert "BUMP_PR_TOKEN_PRESENT" in body
+    assert "::warning::" in body
+    assert "action_required" in body, "the warning must name the state it produces"
+
+
+def test_the_recovery_step_exists_and_cannot_fail_the_run():
+    body = _body()
+    assert "tools/approve_pending_bump_runs.sh" in body
+    assert "continue-on-error: true" in body, (
+        "a recovery step must never fail the weekly check whose real job succeeded"
+    )
+    assert "actions: write" in body, "approving a run needs the actions scope"
+
+
+def test_the_recovery_script_is_honest_about_what_it_cannot_approve():
+    """Measured against a live run on 2026-08-21: the approve endpoint returns
+    403 "This run is not from a fork pull request or queued by the Actions bot"
+    for the `pull_request_review` run, which is exactly the one gating
+    review/decision. A remedy that silently covers half the problem is worse
+    than one that names its half."""
+    script = (
+        Path(__file__).resolve().parents[2] / "tools" / "approve_pending_bump_runs.sh"
+    ).read_text()
+    assert "queued by the Actions bot" in script
+    assert "review/decision" in script
+    assert "exit 0" in script
+
+
+def test_the_recovery_script_only_touches_bot_authored_prs():
+    """It approves runs, and approving a run is running code — it must never
+    reach a PR a human or a third party opened."""
+    script = (
+        Path(__file__).resolve().parents[2] / "tools" / "approve_pending_bump_runs.sh"
+    ).read_text()
+    assert 'select(.author.login == "app/github-actions")' in script

--- a/tests/contracts/test_third_party_update_pr.py
+++ b/tests/contracts/test_third_party_update_pr.py
@@ -72,4 +72,9 @@ def test_the_recovery_script_only_touches_bot_authored_prs():
     script = (
         Path(__file__).resolve().parents[2] / "tools" / "approve_pending_bump_runs.sh"
     ).read_text()
-    assert 'select(.author.login == "app/github-actions")' in script
+    assert 'BOT_AUTHOR="app/github-actions"' in script
+    # The in-LOOP check is the one that matters: applying the filter only
+    # during discovery let an explicitly named PR bypass it entirely
+    # (PR #944 review, P1).
+    assert 'if [ "$author" != "$BOT_AUTHOR" ]; then' in script
+    assert "refusing to approve its runs" in script

--- a/tests/integration/test_approve_pending_bump_runs.py
+++ b/tests/integration/test_approve_pending_bump_runs.py
@@ -1,0 +1,136 @@
+"""PI-939: the bump-PR run approver, and the boundary it must not cross.
+
+Approving a workflow run RUNS THE CODE in that run. The script therefore only
+ever touches PRs authored by `app/github-actions` — and the first cut applied
+that filter only when *discovering* PRs, so an explicitly named PR bypassed it
+entirely (PR #944 review, P1).
+
+The second behaviour under test is timing: workflow-run creation is
+asynchronous, and the script runs seconds after the PR is opened. "No runs
+yet" and "no runs ever" look identical at second zero and mean opposite
+things, so it polls before concluding (PR #944 review, P2).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "tools" / "approve_pending_bump_runs.sh"
+
+# PI_TEST_AUTHOR drives the author check. PI_TEST_RUNS_AFTER is how many
+# discovery rounds pass before the action_required run "appears", which is what
+# makes the polling observable.
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"--json author"*) echo "$PI_TEST_AUTHOR" ;;
+*"--json headRefOid"*) echo "deadbeef" ;;
+*"--json number,author"*) echo "" ;;
+*"/approve"*)
+  echo "$* " >> "$PI_TEST_APPROVED"
+  echo '{}'
+  ;;
+*"total_count"*)
+  # Reads a flag the run_ids branch sets, NOT the round counter: the script
+  # queries run_ids first, so a counter shared between the two branches would
+  # be read one round ahead and the stub would answer inconsistently about the
+  # same moment in time.
+  if [ "$(cat "$PI_TEST_APPEARED" 2>/dev/null || echo 0)" = "1" ]; then
+    echo "${PI_TEST_TOTAL:-1}"
+  else
+    echo 0
+  fi
+  ;;
+*"actions/runs"*)
+  n=$(cat "$PI_TEST_ROUNDS" 2>/dev/null || echo 0)
+  echo $((n + 1)) > "$PI_TEST_ROUNDS"
+  if [ "$n" -ge "${PI_TEST_RUNS_AFTER:-0}" ]; then
+    echo 1 > "$PI_TEST_APPEARED"
+    [ -n "${PI_TEST_PENDING:-}" ] && echo 12345
+  else
+    echo 0 > "$PI_TEST_APPEARED"
+  fi
+  ;;
+*) exit 0 ;;
+esac
+"""
+
+
+@pytest.fixture
+def run_script(tmp_path: Path):
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    approved = tmp_path / "approved"
+    rounds = tmp_path / "rounds"
+    appeared = tmp_path / "appeared"
+
+    def _run(*args: str, author: str, pending: bool = True, runs_after: int = 0, total: int = 1):
+        env = os.environ.copy()
+        env["PATH"] = f"{stub}:{env['PATH']}"
+        env["PI_TEST_AUTHOR"] = author
+        env["PI_TEST_APPROVED"] = str(approved)
+        env["PI_TEST_ROUNDS"] = str(rounds)
+        env["PI_TEST_APPEARED"] = str(appeared)
+        env["PI_TEST_RUNS_AFTER"] = str(runs_after)
+        env["PI_TEST_TOTAL"] = str(total)
+        if pending:
+            env["PI_TEST_PENDING"] = "1"
+        env["APPROVE_WAIT_SECONDS"] = "6"
+        env["APPROVE_POLL_SECONDS"] = "1"
+        result = subprocess.run(
+            ["bash", str(_SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        return result, approved
+
+    return _run
+
+
+def test_a_human_authored_pr_is_refused_even_when_named_explicitly(run_script):
+    """The filter is a boundary, not a discovery convenience."""
+    result, approved = run_script("123", author="SomePerson")
+    assert result.returncode == 0
+    assert "refusing to approve its runs" in result.stdout
+    assert not approved.exists(), "approved a run on a PR the bot did not author"
+
+
+def test_a_bot_authored_pr_is_approved(run_script):
+    result, approved = run_script("123", author="app/github-actions")
+    assert result.returncode == 0
+    assert "approved run 12345" in result.stdout
+    assert approved.exists()
+
+
+def test_it_waits_for_runs_that_have_not_appeared_yet(run_script):
+    """Querying once can find nothing about a PR that is about to be stuck."""
+    result, approved = run_script("123", author="app/github-actions", runs_after=2)
+    assert result.returncode == 0
+    assert "approved run 12345" in result.stdout, result.stdout
+    assert approved.exists()
+
+
+def test_runs_that_report_normally_are_left_alone(run_script):
+    """With a real token the runs just run. Nothing to approve is the happy
+    path, and it must not be reported in the same words as the stuck one."""
+    result, _ = run_script("123", author="app/github-actions", pending=False)
+    assert result.returncode == 0
+    assert "reporting normally" in result.stdout
+    assert "stuck state" not in result.stdout
+
+
+def test_no_runs_at_all_is_reported_as_the_stuck_state(run_script):
+    """The failure this whole script exists for must not print as 'nothing to
+    do' — that wording is what let two PRs accumulate unnoticed."""
+    result, _ = run_script("123", author="app/github-actions", pending=False, total=0)
+    assert result.returncode == 0
+    assert "stuck state" in result.stdout
+    assert "Approve and run" in result.stdout

--- a/tests/integration/test_review_decision_nudge.py
+++ b/tests/integration/test_review_decision_nudge.py
@@ -1,0 +1,118 @@
+"""PI-939: monitor_pr.sh re-triggers a stale `review/decision` itself.
+
+`review/decision` is a commit status computed by a workflow, and the two events
+that should refresh it both fail to:
+
+- resolving a review thread emits no Actions event at all
+  (`pull_request_review_thread` is a webhook event only, #719);
+- where the repository's Actions policy requires approval for bot actors, the
+  `pull_request_review` run a bot reviewer triggers is queued at
+  `action_required` — and the approve endpoint refuses that event with
+  "This run is not from a fork pull request or queued by the Actions bot",
+  measured against a live run on 2026-08-21.
+
+So the status stays stale on a PR whose review gate has actually passed, and
+the merge reports BLOCKED with no visible cause. `issue_comment` IS a trigger
+on that workflow, so a plain comment settles it — a step the operator was
+performing by hand on every PR.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from project_init.scaffold import scaffold
+from tests.helpers import fallback_preset, fallback_variables
+
+_SCRIPTS = Path(".agents") / "scripts"
+
+# `review/decision` reports pending until a comment is posted; posting one
+# creates PI_TEST_COMMENTED, after which it reports pass. That is the real
+# causal chain — the comment is what re-runs the workflow.
+_GH_STUB = """#!/bin/bash
+case "$*" in
+*"--json headRefName"*) echo "feature false" ;;
+*"--json headRefOid"*) echo "$PI_TEST_SHA" ;;
+*"pr comment"*)
+  : >"$PI_TEST_COMMENTED"
+  echo "https://example.invalid/pr/1#issuecomment-1"
+  ;;
+*"pr checks"*)
+  if [ -n "${PI_TEST_DECISION_ALREADY_PASS:-}" ] || [ -f "$PI_TEST_COMMENTED" ]; then
+    echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"},'\\
+'{"name":"review/decision","state":"SUCCESS","bucket":"pass"}]'
+  else
+    echo '[{"name":"ci","state":"SUCCESS","bucket":"pass"},'\\
+'{"name":"review/decision","state":"PENDING","bucket":"pending"}]'
+  fi
+  ;;
+*"--json reviewDecision"*) echo "" ;;
+*"--json reviews"*) echo "1" ;;
+*"--json nameWithOwner"*) echo "o/r" ;;
+*"api graphql"*) echo "0" ;;
+*"--json state"*) echo "OPEN" ;;
+*"--json mergeStateStatus"*) echo "CLEAN" ;;
+*"--json url"*) echo "https://example.invalid/pr/1" ;;
+*"pr view"*) echo "" ;;
+*) exit 0 ;;
+esac
+"""
+
+_GIT_STUB = """#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\\trefs/heads/feature\\n' "$PI_TEST_SHA"
+  exit 0
+fi
+exec {real_git} "$@"
+"""
+
+
+def _run_monitor(tmp_target: Path, tmp_path: Path, *, already_pass: bool = False):
+    scaffold(tmp_target, fallback_preset(), fallback_variables())
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    (stub / "git").write_text(_GIT_STUB.format(real_git=shutil.which("git")))
+    (stub / "git").chmod(0o755)
+    (stub / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "sleep").chmod(0o755)
+    commented = tmp_path / "commented"
+    env = os.environ.copy()
+    env["PATH"] = f"{stub}:{env['PATH']}"
+    env["PI_TEST_SHA"] = "a" * 40
+    env["PI_TEST_COMMENTED"] = str(commented)
+    if already_pass:
+        env["PI_TEST_DECISION_ALREADY_PASS"] = "1"
+    result = subprocess.run(
+        ["bash", str(tmp_target / _SCRIPTS / "monitor_pr.sh"), "1", "--merge"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_target,
+        env=env,
+        timeout=90,
+        check=False,
+    )
+    return result, commented
+
+
+def test_a_stale_review_decision_is_nudged_and_settles(tmp_target: Path, tmp_path: Path):
+    result, commented = _run_monitor(tmp_target, tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert commented.exists(), "no comment was posted, so nothing re-triggered the workflow"
+    assert "re-trigger review-status.yml" in result.stdout
+    assert "review/decision: pass" in result.stdout
+    assert "Merged" in result.stdout
+
+
+def test_a_passing_review_decision_is_left_alone(tmp_target: Path, tmp_path: Path):
+    """Commenting on every PR regardless would be noise on the majority case,
+    and noise is what trains a reader to skim past the comment that mattered."""
+    result, commented = _run_monitor(tmp_target, tmp_path, already_pass=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not commented.exists(), "commented on a PR whose review/decision was already green"
+    assert "re-trigger review-status.yml" not in result.stdout
+    assert "Merged" in result.stdout

--- a/tools/approve_pending_bump_runs.sh
+++ b/tools/approve_pending_bump_runs.sh
@@ -26,6 +26,10 @@
 #
 # Usage: approve_pending_bump_runs.sh [pr-number ...]
 #        With no arguments, every open PR authored by github-actions[bot].
+#        An explicitly named PR is author-checked too — the filter is a
+#        boundary, not a discovery convenience.
+#
+# Env: APPROVE_WAIT_SECONDS (default 90), APPROVE_POLL_SECONDS (default 10).
 
 set -uo pipefail
 
@@ -34,12 +38,20 @@ command -v gh >/dev/null 2>&1 || {
   exit 0
 }
 
+# How long to wait for a PR's workflow runs to appear. PR event delivery and
+# workflow-run creation are asynchronous, and this script runs seconds after
+# the PR is opened — querying once can legitimately find nothing and then
+# report "no runs waiting" about a PR that is about to be stuck (PR #944
+# review, P2).
+WAIT_SECONDS="${APPROVE_WAIT_SECONDS:-90}"
+POLL_SECONDS="${APPROVE_POLL_SECONDS:-10}"
+
+# `app/github-actions` is how gh spells the bot author.
+BOT_AUTHOR="app/github-actions"
+
 prs=()
 [ $# -gt 0 ] && prs=("$@")
 if [ ${#prs[@]} -eq 0 ]; then
-  # `app/github-actions` is how gh spells the bot author. Restrict to it: this
-  # script approves runs, and approving a run is running code, so it must never
-  # reach a PR a human or a third party opened.
   # A while-read loop, not `mapfile`: this repo gates on macOS bash 3.2, which
   # has no mapfile, and a script that only ever runs on the Linux runner still
   # gets read by people on the machine that cannot run it.
@@ -47,7 +59,7 @@ if [ ${#prs[@]} -eq 0 ]; then
     [ -n "$n" ] && prs+=("$n")
   done < <(
     gh pr list --state open --json number,author \
-      --jq '.[] | select(.author.login == "app/github-actions") | .number' 2>/dev/null
+      --jq ".[] | select(.author.login == \"$BOT_AUTHOR\") | .number" 2>/dev/null
   )
 fi
 
@@ -61,20 +73,57 @@ refused=0
 
 for pr in "${prs[@]}"; do
   [ -n "$pr" ] || continue
+
+  # THE AUTHOR CHECK BELONGS HERE, not only in the discovery above. An explicit
+  # `approve_pending_bump_runs.sh 123` bypassed the filter entirely and could
+  # approve — that is, RUN — code on a PR a human or a third party opened,
+  # defeating the exact boundary this script's header claims to respect
+  # (PR #944 review, P1). Re-validating every PR costs one API call.
+  author=$(gh pr view "$pr" --json author --jq '.author.login' 2>/dev/null) || continue
+  if [ "$author" != "$BOT_AUTHOR" ]; then
+    echo "PR #${pr}: author is '${author:-unknown}', not ${BOT_AUTHOR} — refusing to approve its runs."
+    continue
+  fi
   head_sha=$(gh pr view "$pr" --json headRefOid --jq '.headRefOid' 2>/dev/null) || continue
   [ -n "$head_sha" ] || continue
 
   # Runs are matched on the head SHA, not the branch: a branch-name match would
   # also pick up runs from an earlier push that are no longer what the PR is
   # blocked on.
-  run_ids=$(
-    gh api "repos/{owner}/{repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
-      --jq '.workflow_runs[] | select(.status == "action_required" or .conclusion == "action_required") | .id' \
-      2>/dev/null
-  )
+  #
+  # Polled, because "no runs yet" and "no runs ever" look identical at second
+  # zero and mean opposite things. Two cheap queries per round rather than one
+  # plus a JSON parse: `gh --jq` is already the idiom here and this repo keeps
+  # `jq` itself off the dependency list.
+  waited=0
+  run_ids=""
+  total_runs=0
+  while :; do
+    run_ids=$(
+      gh api "repos/{owner}/{repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
+        --jq '.workflow_runs[] | select(.status == "action_required" or .conclusion == "action_required") | .id' \
+        2>/dev/null
+    )
+    total_runs=$(
+      gh api "repos/{owner}/{repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
+        --jq '.total_count' 2>/dev/null
+    )
+    # Something to approve, or runs reporting normally: either way the question
+    # is answered and there is nothing left to wait for.
+    [ -n "$run_ids" ] && break
+    [ "${total_runs:-0}" -gt 0 ] 2>/dev/null && break
+    [ "$waited" -ge "$WAIT_SECONDS" ] && break
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+  done
 
   if [ -z "$run_ids" ]; then
-    echo "PR #${pr}: no runs waiting for approval."
+    if [ "${total_runs:-0}" -gt 0 ] 2>/dev/null; then
+      echo "PR #${pr}: ${total_runs} run(s) reporting normally — nothing to approve."
+    else
+      echo "PR #${pr}: NO workflow runs appeared within ${waited}s — that is the stuck state," \
+        "not a healthy one. Check the Actions tab for 'Approve and run'."
+    fi
     continue
   fi
 

--- a/tools/approve_pending_bump_runs.sh
+++ b/tools/approve_pending_bump_runs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# PI-939: approve workflow runs left at `action_required` on this repo's open
+# bot-authored bump PRs, and say plainly what could not be approved.
+#
+# WHY THIS EXISTS. A PR opened with GITHUB_TOKEN is authored by
+# github-actions[bot]. Under this repo's Actions approval policy a bot-actor
+# run is queued as `action_required` rather than run, so the PR's head SHA
+# carries no check runs at all. Branch protection then blocks the PR on
+# contexts that will never report — a state that reads as "waiting" and is
+# actually "stuck forever". The durable fix is opening the PR under a
+# non-Actions identity (BUMP_PR_TOKEN); this is the recovery for when that
+# secret is absent.
+#
+# WHAT IT CANNOT DO, stated so the caller does not over-trust it:
+#   - The approve endpoint refuses runs it did not queue: "This run is not from
+#     a fork pull request or queued by the Actions bot". The `Review status`
+#     run triggered by a bot's review is exactly that case, so `review/decision`
+#     is NOT recoverable here. A plain PR comment re-triggers that workflow;
+#     monitor_pr.sh does it.
+#   - GITHUB_TOKEN may be refused outright depending on repository settings.
+#     That is reported, not retried, and never fails the caller.
+#
+# Exit code is always 0. This is a best-effort remedy attached to a workflow
+# whose real job already succeeded; turning "could not un-stick a PR" into a
+# failed weekly check would replace a quiet problem with a noisy one.
+#
+# Usage: approve_pending_bump_runs.sh [pr-number ...]
+#        With no arguments, every open PR authored by github-actions[bot].
+
+set -uo pipefail
+
+command -v gh >/dev/null 2>&1 || {
+  echo "approve_pending_bump_runs: gh not found — nothing to do." >&2
+  exit 0
+}
+
+prs=()
+[ $# -gt 0 ] && prs=("$@")
+if [ ${#prs[@]} -eq 0 ]; then
+  # `app/github-actions` is how gh spells the bot author. Restrict to it: this
+  # script approves runs, and approving a run is running code, so it must never
+  # reach a PR a human or a third party opened.
+  # A while-read loop, not `mapfile`: this repo gates on macOS bash 3.2, which
+  # has no mapfile, and a script that only ever runs on the Linux runner still
+  # gets read by people on the machine that cannot run it.
+  while IFS= read -r n; do
+    [ -n "$n" ] && prs+=("$n")
+  done < <(
+    gh pr list --state open --json number,author \
+      --jq '.[] | select(.author.login == "app/github-actions") | .number' 2>/dev/null
+  )
+fi
+
+if [ ${#prs[@]} -eq 0 ]; then
+  echo "approve_pending_bump_runs: no open bot-authored PRs."
+  exit 0
+fi
+
+approved=0
+refused=0
+
+for pr in "${prs[@]}"; do
+  [ -n "$pr" ] || continue
+  head_sha=$(gh pr view "$pr" --json headRefOid --jq '.headRefOid' 2>/dev/null) || continue
+  [ -n "$head_sha" ] || continue
+
+  # Runs are matched on the head SHA, not the branch: a branch-name match would
+  # also pick up runs from an earlier push that are no longer what the PR is
+  # blocked on.
+  run_ids=$(
+    gh api "repos/{owner}/{repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
+      --jq '.workflow_runs[] | select(.status == "action_required" or .conclusion == "action_required") | .id' \
+      2>/dev/null
+  )
+
+  if [ -z "$run_ids" ]; then
+    echo "PR #${pr}: no runs waiting for approval."
+    continue
+  fi
+
+  for run_id in $run_ids; do
+    if err=$(gh api --method POST "repos/{owner}/{repo}/actions/runs/${run_id}/approve" 2>&1); then
+      echo "PR #${pr}: approved run ${run_id}."
+      approved=$((approved + 1))
+    else
+      echo "PR #${pr}: could NOT approve run ${run_id} — ${err%%$'\n'*}"
+      refused=$((refused + 1))
+    fi
+  done
+
+  if [ "$refused" -gt 0 ]; then
+    echo "PR #${pr}: some runs still need a human 'Approve and run' in the Actions tab."
+  fi
+done
+
+echo "approve_pending_bump_runs: ${approved} approved, ${refused} refused."
+exit 0


### PR DESCRIPTION
Closes #939

## The root cause is narrower than the ticket, and it changes the fix

Re-measured rather than taken from the ticket. Every run currently sitting at `action_required` in this repo:

```
2026-08-21  Review status  actor=Copilot   branch=feat/PI-893-...
2026-08-21  Review status  actor=Copilot   branch=feat/PI-893-...
2026-08-20  Review status  actor=Copilot   branch=fix/PI-932-...
2026-08-11  Review status  actor=Copilot   branch=fix/PI-936-...
```

Not `github-actions[bot]` — **`Copilot`**. The approval policy fires on *bot actors generally*, so it hits two things: the bump PRs the ticket is about, **and** the `pull_request_review` run that computes `review/decision` on every ordinary PR. That second one is why `review/decision` had to be nudged by hand on all three PRs merged today. The ticket recorded it as a "second-order trap"; it is the same defect, and it is the half that costs something on every PR rather than weekly.

Two of the ticket's claims re-derived, both still true:

```
GET  /actions/permissions/access                422  "only applies to internal and private repositories"
POST /actions/runs/32452514858/approve          403  "not from a fork pull request or queued by the Actions bot"
```

## What ships

**The bump PR** — opened under `secrets.BUMP_PR_TOKEN` when it exists, `github.token` when it does not. The secret is optional on purpose: a missing one must not turn the weekly check into a red build. The fallback emits a `::warning::` naming `action_required`, so the resulting stuck PR carries its own explanation instead of accumulating silently.

**A best-effort recovery** — `tools/approve_pending_bump_runs.sh` approves what it can and **says what it cannot**. The 403 above means the `pull_request_review` run is not recoverable this way, and a remedy that silently covers half the problem is worse than one that names its half. It exits 0 unconditionally: turning "could not un-stick a PR" into a failed weekly check replaces a quiet problem with a noisy one. It only ever touches PRs authored by `app/github-actions`, because approving a run is running code.

**`monitor_pr.sh` nudges `review/decision` itself.** This is the part with daily value. The status is computed by a workflow, and both events that should refresh it fail to — resolving a thread emits no Actions event at all (`pull_request_review_thread` is webhook-only, #719), and the bot's review run queues at `action_required` with no API route to clear it. `issue_comment` *is* a trigger on that workflow and *is* attributed to the commenter, so a plain comment settles it. That was a manual step on every PR; it is not any more.

## What this does NOT fix, plainly

**The approval policy itself.** It is a repository setting (Settings → Actions → General), it is not readable or writable over REST for a public repo (the 422 above), and narrowing it is the only change that removes the problem rather than working around it. Everything here is a workaround, and the docs say so.

**The acceptance test cannot run in this PR.** #939's own criterion is "let one scheduled bump PR open and assert its head SHA carries check runs without a human touching anything". That needs a real upstream release and the operator to add `BUMP_PR_TOKEN` first. So the workflow half is verified as *wired*, not as *working* — the tests for it are text assertions on a YAML file, which is the weakest kind of test, and their docstring says exactly that.

**Two operator actions are required** and neither is in my reach: add the `BUMP_PR_TOKEN` secret, and consider narrowing the approval policy. Both documented in `docs/development/repo-reference.md`.

## Evidence

```
new nudge tests        2 passed
workflow contract      5 passed
full suite             2949 passed, 6 failed — the same six that fail on main
lint                   ruff check + format --check, rc=0; shellcheck --severity=warning clean
approve script         runs clean against this repo (no bot PRs → exit 0)
run discovery          verified against a real head SHA carrying an action_required run
```

The nudge was broken and watched go red — **4 mutants, 0 survivors**: the call removed, the comment call neutered, the already-green short-circuit forced off, the status read blanked. Both the template and the synced `.agents/` copy restored byte-identical afterwards, asserted.

The nudge is deliberately **not** unconditional: a PR whose `review/decision` is already green gets no comment, and that negative case is pinned. Commenting on every PR would be noise, and noise trains a reader to skim past the comment that mattered.

## One thing found on the way, worth a follow-up

`test_invokes_gitleaks_and_propagates_findings_exit` fails whenever **this repo's own lint is red** — the scaffolded pre-commit hook runs `just lint` as gate 1 and exits before ever invoking gitleaks, so the assertion that fails is `"--staged" in log.read_text()` with a `FileNotFoundError`. It reports a gitleaks problem that is not one. It cost me a wrong diagnosis earlier today, twice. Not fixed here — it is a test-diagnostic defect, not a gate defect, and it belongs in its own change.
