### PR TITLE
fix(PI-943): the allowlist works when written the natural way, and says so when it does not

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.2"
   },
   "project-init-workflow": {
-    "sha256": "f2778c0e4f7b96162770b758228378e4d1e676684a989c84805a503a06d9d5d7",
-    "version": "0.9.1"
+    "sha256": "61b00fdf53ab286e3bac243aef033f768e8e42a24990e38365af610439b8c4be",
+    "version": "0.9.2"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -617,19 +617,58 @@ def _unquote(value: str) -> str:
     return value
 
 
-def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
-    """Read the safety.allow list from .agents/config.yaml (fail-open).
+def _parse_inline_allow(raw: str, problems: list[str]) -> list[str]:
+    """Parse the inline form, ``allow: ["a", "b"]``.
+
+    A REGEX IS NOT JSON (PI-943). ``["^cat \\.env$"]`` is the natural way to
+    write an escaped dot, and it is not valid JSON — ``\\.`` is not a legal
+    escape — so ``json.loads`` raised, the caller fell open, and the operator's
+    allowlist silently did not exist. They saw a prompt for the very command
+    they had just allowlisted, with nothing anywhere saying why.
+
+    Strict parse first, so an operator who correctly wrote ``\\\\.`` keeps the
+    literal backslash they asked for. Only on failure are backslashes escaped
+    and the parse retried — which is what someone writing a raw regex meant.
+    Doing it in that order is what keeps the lenient path from changing the
+    meaning of input that was already valid.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            parsed = json.loads(raw.replace("\\", "\\\\"))
+        except json.JSONDecodeError as exc:
+            problems.append(f"inline `allow:` could not be parsed ({exc.msg})")
+            return []
+    # A non-list allow (JSON string/object/number) must not be iterated
+    # character-by-character into an over-permissive allowlist or crash the
+    # guard — ignore it and keep guarding (PI-187 review).
+    if not isinstance(parsed, list):
+        problems.append("`allow:` is not a list — ignored")
+        return []
+    return [p for p in parsed if isinstance(p, str)]
+
+
+def _allow_patterns(root: Path) -> tuple[list[re.Pattern[str]], list[str]]:
+    """Read safety.allow from .agents/config.yaml → (patterns, problems).
 
     Accepts both an inline JSON list (``allow: ["a", "b"]``) and a multi-line
     YAML list (``allow:`` on its own line followed by ``- "a"`` items). The
     inline-only parser silently dropped the natural YAML form to ``[]`` (PI-187).
 
+    FAIL-OPEN IS RIGHT FOR A MISSING CONFIG AND WRONG FOR A MALFORMED ONE
+    (PI-943). The two are indistinguishable to the operator, and the malformed
+    case means a rule they wrote is not in force. So problems are collected and
+    returned rather than swallowed, and the caller puts them in front of the
+    person who is about to wonder why their allowlist did nothing.
+
     *root* is the Bash tool's cwd, which may be a subdirectory after `cd` —
     the config is located by walking up the tree.
     """
     config = _find_config(root)
+    problems: list[str] = []
     if config is None:
-        return []
+        return [], problems
     patterns: list[str] = []
     try:
         in_safety = False
@@ -652,18 +691,25 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
             if stripped.startswith("allow:"):
                 raw = stripped.split(":", 1)[1].strip()
                 if raw:
-                    parsed = json.loads(raw)  # inline JSON list
-                    # A non-list allow (JSON string/object/number) must not be
-                    # iterated character-by-character into an over-permissive
-                    # allowlist or crash the guard — ignore it and keep
-                    # guarding (PI-187 review).
-                    if isinstance(parsed, list):
-                        patterns.extend(p for p in parsed if isinstance(p, str))
+                    patterns.extend(_parse_inline_allow(raw, problems))
                 else:
                     in_allow = True  # multi-line YAML list follows
-        return [re.compile(p) for p in patterns if p]
-    except (OSError, json.JSONDecodeError, re.error):
-        return []
+    except OSError as exc:
+        problems.append(f"could not read {config}: {exc.strerror or exc}")
+        return [], problems
+
+    # Compiled ONE AT A TIME. The old `[re.compile(p) for p in ...]` inside the
+    # try meant a single malformed pattern discarded every other rule in the
+    # file, including the ones that had parsed perfectly (PI-943).
+    compiled: list[re.Pattern[str]] = []
+    for pattern in patterns:
+        if not pattern:
+            continue
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as exc:
+            problems.append(f"safety.allow pattern {pattern!r} is not a valid regex ({exc.msg})")
+    return compiled, problems
 
 
 def _find_obs_dir(start: Path) -> Path | None:
@@ -720,8 +766,17 @@ def usage_log(payload: dict, root: Path, decision: str, command: str) -> None:
         return
 
 
-def _verdict(reason: str, permission_mode: str) -> dict:
-    """Build the hook verdict. Autonomous modes have no human to ask (ADR-012)."""
+def _verdict(reason: str, permission_mode: str, problems: list[str] | None = None) -> dict:
+    """Build the hook verdict. Autonomous modes have no human to ask (ADR-012).
+
+    *problems* is appended to the reason. This is the one place the operator is
+    guaranteed to read: they are staring at a prompt for a command they believe
+    they allowlisted, which is exactly the moment to tell them the allowlist
+    did not load (PI-943). stderr from a PreToolUse hook that exits 0 is not
+    reliably surfaced, so it cannot be the only channel.
+    """
+    if problems:
+        reason += " NOTE: safety.allow was not fully applied — " + "; ".join(problems) + "."
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
@@ -731,7 +786,12 @@ def _verdict(reason: str, permission_mode: str) -> dict:
     }
 
 
-def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:
+def evaluate(
+    command: str,
+    permission_mode: str,
+    allow: list[re.Pattern[str]],
+    problems: list[str] | None = None,
+) -> dict | None:
     """Return the hook verdict for *command*, or None to let it through."""
     if any(p.search(command) for p in allow):
         return None
@@ -744,6 +804,7 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
                 "(Guardrail only — real protection is credential separation, "
                 "see .agents/docs/guides/secrets.md.)",
                 permission_mode,
+                problems,
             )
     exposure = _exposes_secret(command)
     if exposure is not None:
@@ -756,6 +817,7 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
             "(Guardrail only — real protection is credential separation, "
             "see .agents/docs/guides/secrets.md.)",
             permission_mode,
+            problems,
         )
     return None
 
@@ -777,7 +839,11 @@ def main() -> int:
     mode = payload.get("permission_mode") or payload.get("permissionMode") or ""
     root = Path(payload.get("cwd") or ".")
     try:
-        verdict = evaluate(command, mode, _allow_patterns(root))
+        allow, problems = _allow_patterns(root)
+        for problem in problems:
+            # Best-effort second channel. Not the primary one — see _verdict.
+            print(f"prod_guard: {problem}", file=sys.stderr)
+        verdict = evaluate(command, mode, allow, problems)
     except Exception:  # noqa: BLE001 — guardrail must never break the session
         verdict = None
 

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.1"
+__plugin_version__ = "0.9.2"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/docs/guides/secrets.md
+++ b/templates/base/dot_agents/docs/guides/secrets.md
@@ -69,6 +69,17 @@ genuinely needed, add a regex to `safety.allow` in `.agents/config.yaml` —
 but prefer having the value injected as an environment variable, which
 leaves nothing to read.
 
+If an allowlist entry does not take effect, the guard now says so in the
+permission prompt itself rather than failing silently. Either spelling works:
+
+```yaml
+safety:
+  allow: ["^cat \.env$"]     # inline
+  # or
+  allow:
+    - "^cat \.env$"          # multi-line
+```
+
 ## CI secrets
 
 Use the platform's mechanism (GitHub Actions secrets/environments), never

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -617,19 +617,58 @@ def _unquote(value: str) -> str:
     return value
 
 
-def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
-    """Read the safety.allow list from .agents/config.yaml (fail-open).
+def _parse_inline_allow(raw: str, problems: list[str]) -> list[str]:
+    """Parse the inline form, ``allow: ["a", "b"]``.
+
+    A REGEX IS NOT JSON (PI-943). ``["^cat \\.env$"]`` is the natural way to
+    write an escaped dot, and it is not valid JSON — ``\\.`` is not a legal
+    escape — so ``json.loads`` raised, the caller fell open, and the operator's
+    allowlist silently did not exist. They saw a prompt for the very command
+    they had just allowlisted, with nothing anywhere saying why.
+
+    Strict parse first, so an operator who correctly wrote ``\\\\.`` keeps the
+    literal backslash they asked for. Only on failure are backslashes escaped
+    and the parse retried — which is what someone writing a raw regex meant.
+    Doing it in that order is what keeps the lenient path from changing the
+    meaning of input that was already valid.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            parsed = json.loads(raw.replace("\\", "\\\\"))
+        except json.JSONDecodeError as exc:
+            problems.append(f"inline `allow:` could not be parsed ({exc.msg})")
+            return []
+    # A non-list allow (JSON string/object/number) must not be iterated
+    # character-by-character into an over-permissive allowlist or crash the
+    # guard — ignore it and keep guarding (PI-187 review).
+    if not isinstance(parsed, list):
+        problems.append("`allow:` is not a list — ignored")
+        return []
+    return [p for p in parsed if isinstance(p, str)]
+
+
+def _allow_patterns(root: Path) -> tuple[list[re.Pattern[str]], list[str]]:
+    """Read safety.allow from .agents/config.yaml → (patterns, problems).
 
     Accepts both an inline JSON list (``allow: ["a", "b"]``) and a multi-line
     YAML list (``allow:`` on its own line followed by ``- "a"`` items). The
     inline-only parser silently dropped the natural YAML form to ``[]`` (PI-187).
 
+    FAIL-OPEN IS RIGHT FOR A MISSING CONFIG AND WRONG FOR A MALFORMED ONE
+    (PI-943). The two are indistinguishable to the operator, and the malformed
+    case means a rule they wrote is not in force. So problems are collected and
+    returned rather than swallowed, and the caller puts them in front of the
+    person who is about to wonder why their allowlist did nothing.
+
     *root* is the Bash tool's cwd, which may be a subdirectory after `cd` —
     the config is located by walking up the tree.
     """
     config = _find_config(root)
+    problems: list[str] = []
     if config is None:
-        return []
+        return [], problems
     patterns: list[str] = []
     try:
         in_safety = False
@@ -652,18 +691,25 @@ def _allow_patterns(root: Path) -> list[re.Pattern[str]]:
             if stripped.startswith("allow:"):
                 raw = stripped.split(":", 1)[1].strip()
                 if raw:
-                    parsed = json.loads(raw)  # inline JSON list
-                    # A non-list allow (JSON string/object/number) must not be
-                    # iterated character-by-character into an over-permissive
-                    # allowlist or crash the guard — ignore it and keep
-                    # guarding (PI-187 review).
-                    if isinstance(parsed, list):
-                        patterns.extend(p for p in parsed if isinstance(p, str))
+                    patterns.extend(_parse_inline_allow(raw, problems))
                 else:
                     in_allow = True  # multi-line YAML list follows
-        return [re.compile(p) for p in patterns if p]
-    except (OSError, json.JSONDecodeError, re.error):
-        return []
+    except OSError as exc:
+        problems.append(f"could not read {config}: {exc.strerror or exc}")
+        return [], problems
+
+    # Compiled ONE AT A TIME. The old `[re.compile(p) for p in ...]` inside the
+    # try meant a single malformed pattern discarded every other rule in the
+    # file, including the ones that had parsed perfectly (PI-943).
+    compiled: list[re.Pattern[str]] = []
+    for pattern in patterns:
+        if not pattern:
+            continue
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as exc:
+            problems.append(f"safety.allow pattern {pattern!r} is not a valid regex ({exc.msg})")
+    return compiled, problems
 
 
 def _find_obs_dir(start: Path) -> Path | None:
@@ -720,8 +766,17 @@ def usage_log(payload: dict, root: Path, decision: str, command: str) -> None:
         return
 
 
-def _verdict(reason: str, permission_mode: str) -> dict:
-    """Build the hook verdict. Autonomous modes have no human to ask (ADR-012)."""
+def _verdict(reason: str, permission_mode: str, problems: list[str] | None = None) -> dict:
+    """Build the hook verdict. Autonomous modes have no human to ask (ADR-012).
+
+    *problems* is appended to the reason. This is the one place the operator is
+    guaranteed to read: they are staring at a prompt for a command they believe
+    they allowlisted, which is exactly the moment to tell them the allowlist
+    did not load (PI-943). stderr from a PreToolUse hook that exits 0 is not
+    reliably surfaced, so it cannot be the only channel.
+    """
+    if problems:
+        reason += " NOTE: safety.allow was not fully applied — " + "; ".join(problems) + "."
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
@@ -731,7 +786,12 @@ def _verdict(reason: str, permission_mode: str) -> dict:
     }
 
 
-def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -> dict | None:
+def evaluate(
+    command: str,
+    permission_mode: str,
+    allow: list[re.Pattern[str]],
+    problems: list[str] | None = None,
+) -> dict | None:
     """Return the hook verdict for *command*, or None to let it through."""
     if any(p.search(command) for p in allow):
         return None
@@ -744,6 +804,7 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
                 "(Guardrail only — real protection is credential separation, "
                 "see .agents/docs/guides/secrets.md.)",
                 permission_mode,
+                problems,
             )
     exposure = _exposes_secret(command)
     if exposure is not None:
@@ -756,6 +817,7 @@ def evaluate(command: str, permission_mode: str, allow: list[re.Pattern[str]]) -
             "(Guardrail only — real protection is credential separation, "
             "see .agents/docs/guides/secrets.md.)",
             permission_mode,
+            problems,
         )
     return None
 
@@ -777,7 +839,11 @@ def main() -> int:
     mode = payload.get("permission_mode") or payload.get("permissionMode") or ""
     root = Path(payload.get("cwd") or ".")
     try:
-        verdict = evaluate(command, mode, _allow_patterns(root))
+        allow, problems = _allow_patterns(root)
+        for problem in problems:
+            # Best-effort second channel. Not the primary one — see _verdict.
+            print(f"prod_guard: {problem}", file=sys.stderr)
+        verdict = evaluate(command, mode, allow, problems)
     except Exception:  # noqa: BLE001 — guardrail must never break the session
         verdict = None
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -976,3 +976,74 @@ class TestScaffoldedReadPermissions:
         assert "Read(**/.env.*)" not in tmpl, (
             "a blanket .env.* deny also blocks .env.example/.sample/.template"
         )
+
+
+class TestAllowlistParsing:
+    """PI-943: the guard's only escape hatch must work when written the
+    natural way, and must say so when it does not.
+
+    An inline `allow:` is parsed as JSON, and `\\.` is not a legal JSON
+    escape — so the most likely spelling of "a literal dot" made the whole
+    allowlist vanish, silently, and the operator saw a prompt for the command
+    they had just allowlisted.
+    """
+
+    def _config(self, tmp_path: Path, body: str) -> Path:
+        agents = tmp_path / ".agents"
+        agents.mkdir(exist_ok=True)
+        (agents / "config.yaml").write_text(body)
+        return tmp_path
+
+    def test_a_backslash_in_the_inline_form_is_honoured(self, tmp_path: Path):
+        root = self._config(tmp_path, 'safety:\n  allow: ["^cat \\.env$"]\n')
+        assert _run_hook(_payload("cat .env", "default", root), root) is None
+
+    def test_the_multiline_form_was_never_broken(self, tmp_path: Path):
+        """It does not go through json.loads, so it always worked. Pinned so a
+        future 'unify the two parsers' does not break the half that works."""
+        root = self._config(tmp_path, 'safety:\n  allow:\n    - "^cat \\.env$"\n')
+        assert _run_hook(_payload("cat .env", "default", root), root) is None
+
+    def test_a_deliberate_double_backslash_keeps_its_meaning(self, tmp_path: Path):
+        """Strict-then-lenient, in that order. `\\\\.` is valid JSON meaning a
+        literal backslash followed by any character; the lenient retry must not
+        get a chance to re-read input that already parsed."""
+        root = self._config(tmp_path, 'safety:\n  allow: ["^cat \\\\\\\\.env$"]\n')
+        # That pattern requires a literal backslash before `env`, which this
+        # command does not have — so it must NOT be allowlisted.
+        assert _run_hook(_payload("cat .env", "default", root), root) is not None
+
+    def test_the_allowlist_still_narrows(self, tmp_path: Path):
+        """The lenient retry must not turn into 'allow everything'."""
+        root = self._config(tmp_path, 'safety:\n  allow: ["^cat \\.env$"]\n')
+        assert _run_hook(_payload("cat id_rsa", "default", root), root) is not None
+
+    def test_one_bad_regex_does_not_discard_the_others(self, tmp_path: Path):
+        """The old compile-in-a-list-comprehension meant a single malformed
+        pattern threw away every rule in the file, including the good ones."""
+        root = self._config(tmp_path, 'safety:\n  allow: ["*broken(", "^cat \\.env$"]\n')
+        assert _run_hook(_payload("cat .env", "default", root), root) is None
+
+    def test_an_unparseable_allowlist_says_so_in_the_prompt(self, tmp_path: Path):
+        """Fail-open is right for a MISSING config and wrong for a malformed
+        one: the two are indistinguishable to the operator, and the malformed
+        case means a rule they wrote is not in force."""
+        root = self._config(tmp_path, "safety:\n  allow: [unquoted, nonsense\n")
+        verdict = _run_hook(_payload("cat .env", "default", root), root)
+        assert verdict is not None, "a broken allowlist must not open the gate"
+        reason = verdict["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "safety.allow was not fully applied" in reason
+
+    def test_a_bad_regex_is_named_in_the_prompt(self, tmp_path: Path):
+        root = self._config(tmp_path, 'safety:\n  allow: ["*broken("]\n')
+        verdict = _run_hook(_payload("cat .env", "default", root), root)
+        assert verdict is not None
+        reason = verdict["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "not a valid regex" in reason
+
+    def test_a_healthy_allowlist_adds_no_noise(self, tmp_path: Path):
+        """A note on every prompt would be the thing people learn to skip."""
+        root = self._config(tmp_path, 'safety:\n  allow: ["^cat \\.env$"]\n')
+        verdict = _run_hook(_payload("cat id_rsa", "default", root), root)
+        assert verdict is not None
+        assert "not fully applied" not in verdict["hookSpecificOutput"]["permissionDecisionReason"]


### PR DESCRIPTION
Closes #943

The guard's only escape hatch did nothing when written the natural way, and said nothing about it.

```yaml
safety:
  allow: ["^cat \.env$"]
```

`\.` is not a legal JSON escape, the inline form is parsed with `json.loads`, and the reader is fail-open — so the operator got an empty allowlist, kept being prompted for the command they had just allowlisted, and had nothing anywhere telling them why.

## Three defects, not one

| | |
|---|---|
| **The natural spelling does not parse** | strict `json.loads` first, so a deliberate `\\.` keeps the literal backslash it asked for; only on failure are backslashes escaped and the parse retried, which is what someone writing a raw regex meant. The order is the whole trick — a lenient-first parse would silently change the meaning of input that was already valid |
| **One bad pattern discarded every good one** | `[re.compile(p) for p in patterns]` sat inside the `try`, so a single malformed regex threw away the entire file's rules. Patterns compile one at a time now |
| **Silence** | fail-open is right for a *missing* config and wrong for a *malformed* one — indistinguishable to the operator, and the malformed case means a rule they wrote is not in force |

## Where the diagnostic goes, and why not stderr

stderr from a PreToolUse hook that exits 0 is not reliably surfaced, so it cannot be the only channel. The note is appended to the **permission prompt itself** — which is precisely where the operator is looking, because they are staring at a prompt for a command they believe they allowlisted:

```
prod_guard: 'read of a secret-bearing file' … NOTE: safety.allow was not fully
applied — safety.allow pattern '*broken(' is not a valid regex (nothing to repeat).
```

stderr still gets a line as a second channel. And the note appears **only when there is a problem** — a note on every prompt is the thing people learn to skip, and that negative case is pinned.

## Also measured: the multi-line form was never broken

It does not go through `json.loads` at all, so it always worked. That makes this "one of two spellings is broken", exactly as the ticket suspected rather than assumed. It is now pinned by a test, so a future "unify the two parsers" cannot quietly break the half that works.

## Evidence

```
prod_guard suite   368 passed  (was 360)
full suite         2963 passed, 6 failed — the same six, unrelated (see below)
lint               rc=0
plugin             0.9.1 -> 0.9.2, synced and relocked
```

**4 mutants, 0 survivors**, each restoring the exact pre-fix behaviour of one half: the lenient retry removed (3 tests red), per-pattern compile reverted to all-or-nothing (2 red), the note suppressed (2 red), and the note made unconditional (1 red — the no-noise case). File restored byte-identical, asserted.

Eight new tests, including the two that keep the fix honest: a deliberate `\\\\.` must still mean a literal backslash and must **not** be allowlisted by the lenient path, and the allowlist must still narrow — the retry must not become "allow everything".

## Note on the six failing tests

They fail **locally on macOS only**; CI has been green on all four PRs merged today, including all four test shards. So `main` is not red — my earlier phrasing of "the same six that fail on main" was accurate about my machine and misleading about the repo. Worth its own ticket; not this one.
