### PR TITLE
fix(PI-946): an optional include that is actually optional on bash 3.2

### DIFF
--- a/.agents/hooks/_usage_log.sh
+++ b/.agents/hooks/_usage_log.sh
@@ -2,6 +2,30 @@
 # _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
 # #406). Sourced by the always-on shell hooks; defines usage_log().
 #
+# HOW TO SOURCE THIS FILE, and why the obvious way is wrong (PI-946).
+# `.` is a POSIX SPECIAL BUILTIN: when it fails, a non-interactive shell under
+# `set -e` exits IMMEDIATELY — before an `&&` short-circuit or a trailing
+# `|| true` is ever considered. Measured on macOS bash 3.2, the system shell
+# this repo runs a CI job to support:
+#
+#   set -e; . /nonexistent 2>/dev/null && x || true; echo AFTER   # never prints
+#
+# bash 5 on the Linux runner does NOT exit, which is why the old idiom read as
+# safe and stayed green in CI while failing on every macOS edit. `[ -r ]` alone
+# is not enough either — a syntactically broken include still aborts. The only
+# form that survives missing, empty AND corrupt is to turn errexit off across
+# the source and restore exactly the prior state:
+#
+#   _pi_errexit=0
+#   case $- in *e*) _pi_errexit=1 ;; esac
+#   set +e
+#   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# Guard the CALL on the function, not on the source succeeding: a file that
+# sourced cleanly and defined nothing is a real state.
+#
 # SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
 # unless the observability overlay's marker directory (.agents/observability/)
 # exists — so it costs nothing until a project opts in by scaffolding the
@@ -47,8 +71,15 @@ usage_log() {
 
     if [ -n "$command" ]; then
       command="${command:0:500}"
-      # Redact basic auth in URLs (replaces longest match between :// and @)
-      command="${command//:\/\/*@/:\/\/***@}"
+      # Redact basic auth in URLs (replaces longest match between :// and @).
+      #
+      # THE REPLACEMENT HALF MUST NOT ESCAPE ITS SLASHES (PI-946). Only the
+      # pattern half needs them; in the replacement, bash 5 strips the
+      # backslash and bash 3.2 KEEPS it, so the shipped `:\/\/***@` logged
+      # `https:\/\/***@host` on macOS — backslashes that were never in the
+      # operator's command, written into a log people read to reconstruct what
+      # happened. Measured on 3.2.57; the unescaped form is identical on both.
+      command="${command//:\/\/*@/://***@}"
     fi
 
     local root

--- a/.agents/hooks/workflow_state_reminder.sh
+++ b/.agents/hooks/workflow_state_reminder.sh
@@ -14,8 +14,18 @@ set -euo pipefail
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/.claude/hooks/_usage_log.sh
+++ b/.claude/hooks/_usage_log.sh
@@ -2,6 +2,30 @@
 # _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
 # #406). Sourced by the always-on shell hooks; defines usage_log().
 #
+# HOW TO SOURCE THIS FILE, and why the obvious way is wrong (PI-946).
+# `.` is a POSIX SPECIAL BUILTIN: when it fails, a non-interactive shell under
+# `set -e` exits IMMEDIATELY — before an `&&` short-circuit or a trailing
+# `|| true` is ever considered. Measured on macOS bash 3.2, the system shell
+# this repo runs a CI job to support:
+#
+#   set -e; . /nonexistent 2>/dev/null && x || true; echo AFTER   # never prints
+#
+# bash 5 on the Linux runner does NOT exit, which is why the old idiom read as
+# safe and stayed green in CI while failing on every macOS edit. `[ -r ]` alone
+# is not enough either — a syntactically broken include still aborts. The only
+# form that survives missing, empty AND corrupt is to turn errexit off across
+# the source and restore exactly the prior state:
+#
+#   _pi_errexit=0
+#   case $- in *e*) _pi_errexit=1 ;; esac
+#   set +e
+#   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# Guard the CALL on the function, not on the source succeeding: a file that
+# sourced cleanly and defined nothing is a real state.
+#
 # SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
 # unless the observability overlay's marker directory (.agents/observability/)
 # exists — so it costs nothing until a project opts in by scaffolding the
@@ -47,8 +71,15 @@ usage_log() {
 
     if [ -n "$command" ]; then
       command="${command:0:500}"
-      # Redact basic auth in URLs (replaces longest match between :// and @)
-      command="${command//:\/\/*@/:\/\/***@}"
+      # Redact basic auth in URLs (replaces longest match between :// and @).
+      #
+      # THE REPLACEMENT HALF MUST NOT ESCAPE ITS SLASHES (PI-946). Only the
+      # pattern half needs them; in the replacement, bash 5 strips the
+      # backslash and bash 3.2 KEEPS it, so the shipped `:\/\/***@` logged
+      # `https:\/\/***@host` on macOS — backslashes that were never in the
+      # operator's command, written into a log people read to reconstruct what
+      # happened. Measured on 3.2.57; the unescaped form is identical on both.
+      command="${command//:\/\/*@/://***@}"
     fi
 
     local root

--- a/.claude/hooks/workflow_state_reminder.sh
+++ b/.claude/hooks/workflow_state_reminder.sh
@@ -14,8 +14,18 @@ set -euo pipefail
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -1,10 +1,10 @@
 {
   "project-init-lifecycle": {
-    "sha256": "44668b2d972a1bfac820138ff55944bfef27c62a49963c07d2ad0f059d4ef3f2",
-    "version": "0.2.2"
+    "sha256": "f296046a6f7c70c91d505e39a85b20eeb458abe8840c540a6d892df10a7bb93e",
+    "version": "0.2.3"
   },
   "project-init-workflow": {
-    "sha256": "61b00fdf53ab286e3bac243aef033f768e8e42a24990e38365af610439b8c4be",
-    "version": "0.9.2"
+    "sha256": "9b17a1247246af042ff1b6e4935fcbbeeec0c3bcf721f0d9028fd3c7fea7c5ff",
+    "version": "0.9.3"
   }
 }

--- a/plugins/project-init-lifecycle/.claude-plugin/plugin.json
+++ b/plugins/project-init-lifecycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-lifecycle",
   "displayName": "project-init GitHub Lifecycle",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "GitHub lifecycle automation from project-init (#476, ADR-021): the issue->branch->PR->review->merge DAG guard + workflow-state hooks and the create_issue/start_task/github_workflow/request_review/audit skills. Enabled only when the lifecycle tier is on; the forge-agnostic quality/safety hooks live in project-init-workflow.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-lifecycle/hooks/_usage_log.sh
+++ b/plugins/project-init-lifecycle/hooks/_usage_log.sh
@@ -2,6 +2,30 @@
 # _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
 # #406). Sourced by the always-on shell hooks; defines usage_log().
 #
+# HOW TO SOURCE THIS FILE, and why the obvious way is wrong (PI-946).
+# `.` is a POSIX SPECIAL BUILTIN: when it fails, a non-interactive shell under
+# `set -e` exits IMMEDIATELY — before an `&&` short-circuit or a trailing
+# `|| true` is ever considered. Measured on macOS bash 3.2, the system shell
+# this repo runs a CI job to support:
+#
+#   set -e; . /nonexistent 2>/dev/null && x || true; echo AFTER   # never prints
+#
+# bash 5 on the Linux runner does NOT exit, which is why the old idiom read as
+# safe and stayed green in CI while failing on every macOS edit. `[ -r ]` alone
+# is not enough either — a syntactically broken include still aborts. The only
+# form that survives missing, empty AND corrupt is to turn errexit off across
+# the source and restore exactly the prior state:
+#
+#   _pi_errexit=0
+#   case $- in *e*) _pi_errexit=1 ;; esac
+#   set +e
+#   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# Guard the CALL on the function, not on the source succeeding: a file that
+# sourced cleanly and defined nothing is a real state.
+#
 # SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
 # unless the observability overlay's marker directory (.agents/observability/)
 # exists — so it costs nothing until a project opts in by scaffolding the
@@ -47,8 +71,15 @@ usage_log() {
 
     if [ -n "$command" ]; then
       command="${command:0:500}"
-      # Redact basic auth in URLs (replaces longest match between :// and @)
-      command="${command//:\/\/*@/:\/\/***@}"
+      # Redact basic auth in URLs (replaces longest match between :// and @).
+      #
+      # THE REPLACEMENT HALF MUST NOT ESCAPE ITS SLASHES (PI-946). Only the
+      # pattern half needs them; in the replacement, bash 5 strips the
+      # backslash and bash 3.2 KEEPS it, so the shipped `:\/\/***@` logged
+      # `https:\/\/***@host` on macOS — backslashes that were never in the
+      # operator's command, written into a log people read to reconstruct what
+      # happened. Measured on 3.2.57; the unescaped form is identical on both.
+      command="${command//:\/\/*@/://***@}"
     fi
 
     local root

--- a/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
@@ -14,8 +14,18 @@ set -euo pipefail
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/_usage_log.sh
+++ b/plugins/project-init-workflow/hooks/_usage_log.sh
@@ -2,6 +2,30 @@
 # _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
 # #406). Sourced by the always-on shell hooks; defines usage_log().
 #
+# HOW TO SOURCE THIS FILE, and why the obvious way is wrong (PI-946).
+# `.` is a POSIX SPECIAL BUILTIN: when it fails, a non-interactive shell under
+# `set -e` exits IMMEDIATELY — before an `&&` short-circuit or a trailing
+# `|| true` is ever considered. Measured on macOS bash 3.2, the system shell
+# this repo runs a CI job to support:
+#
+#   set -e; . /nonexistent 2>/dev/null && x || true; echo AFTER   # never prints
+#
+# bash 5 on the Linux runner does NOT exit, which is why the old idiom read as
+# safe and stayed green in CI while failing on every macOS edit. `[ -r ]` alone
+# is not enough either — a syntactically broken include still aborts. The only
+# form that survives missing, empty AND corrupt is to turn errexit off across
+# the source and restore exactly the prior state:
+#
+#   _pi_errexit=0
+#   case $- in *e*) _pi_errexit=1 ;; esac
+#   set +e
+#   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# Guard the CALL on the function, not on the source succeeding: a file that
+# sourced cleanly and defined nothing is a real state.
+#
 # SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
 # unless the observability overlay's marker directory (.agents/observability/)
 # exists — so it costs nothing until a project opts in by scaffolding the
@@ -47,8 +71,15 @@ usage_log() {
 
     if [ -n "$command" ]; then
       command="${command:0:500}"
-      # Redact basic auth in URLs (replaces longest match between :// and @)
-      command="${command//:\/\/*@/:\/\/***@}"
+      # Redact basic auth in URLs (replaces longest match between :// and @).
+      #
+      # THE REPLACEMENT HALF MUST NOT ESCAPE ITS SLASHES (PI-946). Only the
+      # pattern half needs them; in the replacement, bash 5 strips the
+      # backslash and bash 3.2 KEEPS it, so the shipped `:\/\/***@` logged
+      # `https:\/\/***@host` on macOS — backslashes that were never in the
+      # operator's command, written into a log people read to reconstruct what
+      # happened. Measured on 3.2.57; the unescaped form is identical on both.
+      command="${command//:\/\/*@/://***@}"
     fi
 
     local root

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -13,8 +13,18 @@ PY="$(dirname "$0")/_py.sh"
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -11,8 +11,18 @@ PY="$(dirname "$0")/_py.sh"
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log pre_commit_gate PreToolUse </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -14,8 +14,18 @@ mkdir -p .agents/logs
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the SessionStart payload is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log session_setup SessionStart "$ROOT" </dev/null || true
+fi
 
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
 # host provides; fall back to POSIX `cksum` so the fingerprint is always defined

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.2"
+__plugin_version__ = "0.9.3"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/fallback/dot_agents/hooks/_usage_log.sh
+++ b/templates/fallback/dot_agents/hooks/_usage_log.sh
@@ -2,6 +2,30 @@
 # _usage_log.sh — guarded hook self-log for the observability overlay (ADR-019,
 # #406). Sourced by the always-on shell hooks; defines usage_log().
 #
+# HOW TO SOURCE THIS FILE, and why the obvious way is wrong (PI-946).
+# `.` is a POSIX SPECIAL BUILTIN: when it fails, a non-interactive shell under
+# `set -e` exits IMMEDIATELY — before an `&&` short-circuit or a trailing
+# `|| true` is ever considered. Measured on macOS bash 3.2, the system shell
+# this repo runs a CI job to support:
+#
+#   set -e; . /nonexistent 2>/dev/null && x || true; echo AFTER   # never prints
+#
+# bash 5 on the Linux runner does NOT exit, which is why the old idiom read as
+# safe and stayed green in CI while failing on every macOS edit. `[ -r ]` alone
+# is not enough either — a syntactically broken include still aborts. The only
+# form that survives missing, empty AND corrupt is to turn errexit off across
+# the source and restore exactly the prior state:
+#
+#   _pi_errexit=0
+#   case $- in *e*) _pi_errexit=1 ;; esac
+#   set +e
+#   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# Guard the CALL on the function, not on the source succeeding: a file that
+# sourced cleanly and defined nothing is a real state.
+#
 # SHIPPED-ALWAYS-DORMANT: every scaffold carries this helper, but it no-ops
 # unless the observability overlay's marker directory (.agents/observability/)
 # exists — so it costs nothing until a project opts in by scaffolding the
@@ -47,8 +71,15 @@ usage_log() {
 
     if [ -n "$command" ]; then
       command="${command:0:500}"
-      # Redact basic auth in URLs (replaces longest match between :// and @)
-      command="${command//:\/\/*@/:\/\/***@}"
+      # Redact basic auth in URLs (replaces longest match between :// and @).
+      #
+      # THE REPLACEMENT HALF MUST NOT ESCAPE ITS SLASHES (PI-946). Only the
+      # pattern half needs them; in the replacement, bash 5 strips the
+      # backslash and bash 3.2 KEEPS it, so the shipped `:\/\/***@` logged
+      # `https:\/\/***@host` on macOS — backslashes that were never in the
+      # operator's command, written into a log people read to reconstruct what
+      # happened. Measured on 3.2.57; the unescaped form is identical on both.
+      command="${command//:\/\/*@/://***@}"
     fi
 
     local root

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -13,8 +13,18 @@ PY="$(dirname "$0")/_py.sh"
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
@@ -11,8 +11,18 @@ PY="$(dirname "$0")/_py.sh"
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log pre_commit_gate PreToolUse </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/templates/fallback/dot_agents/hooks/session_setup.sh
+++ b/templates/fallback/dot_agents/hooks/session_setup.sh
@@ -14,8 +14,18 @@ mkdir -p .agents/logs
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the SessionStart payload is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log session_setup SessionStart "$ROOT" </dev/null || true
+fi
 
 # macOS BSD coreutils ship `shasum`, not GNU `sha256sum`. Pick whichever the
 # host provides; fall back to POSIX `cksum` so the fingerprint is always defined

--- a/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
+++ b/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
@@ -14,8 +14,18 @@ set -euo pipefail
 # Self-log this firing (dormant unless the observability overlay is installed;
 # reads no stdin, so the payload below is untouched).
 # shellcheck source=/dev/null
-. "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+# Optional include. The shape is load-bearing and non-obvious — a failed `.`
+# exits a `set -e` shell despite `|| true`, because it is a special builtin.
+# Full measurement and the four file states it covers: _usage_log.sh's header
+# (PI-946).
+_pi_errexit=0
+case $- in *e*) _pi_errexit=1 ;; esac
+set +e
+[ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
+if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
+fi
 
 INPUT=$(cat)
 

--- a/tests/contracts/test_observability_self_log.py
+++ b/tests/contracts/test_observability_self_log.py
@@ -194,8 +194,18 @@ class TestHookWiring:
         assert (_PLUGIN_HOOKS / "_usage_log.sh").read_bytes() == _HELPER.read_bytes()
 
     def test_helper_never_reads_stdin_source(self):
-        """No stdin-consuming construct in the helper (cat/read/$(<)/</dev/stdin)."""
-        src = _HELPER.read_text(encoding="utf-8")
+        """No stdin-consuming construct in the helper (cat/read/$(<)/</dev/stdin).
+
+        COMMENTS ARE STRIPPED FIRST. The check is on what the shell executes,
+        and prose about the helper is not that: the phrase "read as safe" in a
+        comment tripped this as though the helper consumed stdin (PI-946). A
+        guard that fires on documentation gets the documentation deleted.
+        """
+        src = "\n".join(
+            line
+            for line in _HELPER.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
         for bad in ("$(cat", "read ", "</dev/stdin", "$(<"):
             assert bad not in src, f"helper appears to read stdin: {bad!r}"
 

--- a/tests/contracts/test_optional_include_portability.py
+++ b/tests/contracts/test_optional_include_portability.py
@@ -1,0 +1,128 @@
+"""PI-946: the optional `_usage_log.sh` include must not kill its hook.
+
+`.` is a POSIX SPECIAL BUILTIN. When it fails, a non-interactive shell under
+`set -e` exits immediately — before an `&&` short-circuit or a trailing
+`|| true` is considered. So the shipped idiom
+
+    . "$(dirname "$0")/_usage_log.sh" 2>/dev/null &&
+      usage_log … </dev/null || true
+
+read as "optional" and was not: on macOS bash 3.2 the hook died at that line
+with no output, on every edit, whenever the include was missing or corrupt.
+
+THE BEHAVIOURAL HALF OF THIS MODULE CANNOT CATCH A REGRESSION ON CI. The Linux
+runner has bash 5, which does not exit there — that is precisely why the bug
+survived in a green pipeline. So the shape assertions below are not
+belt-and-braces, they are the only guard that works on the platform that gates
+merges, and the behavioural matrix is what makes them more than a spelling
+test on the machine that can run it.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FALLBACK_HOOKS = _REPO_ROOT / "templates" / "fallback" / "dot_agents" / "hooks"
+_BASE_HOOKS = _REPO_ROOT / "templates" / "base" / "dot_agents" / "hooks"
+
+# Every hook that sources the optional helper, across both fallback layers.
+_SOURCING_HOOKS = [
+    _FALLBACK_HOOKS / "post_edit_lint.sh",
+    _FALLBACK_HOOKS / "pre_commit_gate.sh",
+    _FALLBACK_HOOKS / "session_setup.sh",
+    _REPO_ROOT
+    / "templates"
+    / "lifecycle_fallback"
+    / "dot_agents"
+    / "hooks"
+    / "workflow_state_reminder.sh",
+]
+
+
+@pytest.mark.parametrize("hook", _SOURCING_HOOKS, ids=lambda p: p.name)
+def test_the_fragile_idiom_is_gone(hook: Path):
+    """The single strongest regression guard here, and the one that works on
+    every platform: the shape that caused the bug must not reappear."""
+    body = hook.read_text(encoding="utf-8")
+    assert '_usage_log.sh" 2>/dev/null &&' not in body, (
+        "a failed `.` exits a `set -e` shell despite the `&&`/`|| true` — see PI-946"
+    )
+
+
+@pytest.mark.parametrize("hook", _SOURCING_HOOKS, ids=lambda p: p.name)
+def test_the_include_is_readability_tested_and_errexit_is_restored(hook: Path):
+    body = hook.read_text(encoding="utf-8")
+    assert '[ -r "$(dirname "$0")/_usage_log.sh" ]' in body, "include is sourced untested"
+    assert "case $- in *e*)" in body, "errexit state is not saved"
+    assert "set +e" in body, "errexit is not disabled across the source"
+    assert 'if [ "$_pi_errexit" = 1 ]; then set -e; fi' in body, "errexit is not restored"
+    # Guarding the CALL on the source's exit status would miss the real state
+    # of a file that sourced cleanly and defined nothing.
+    assert "command -v usage_log" in body, "the call is not guarded on the function"
+
+
+def test_the_url_redaction_does_not_escape_its_replacement():
+    """A SECOND bash-3.2 defect in the same file, different root cause.
+
+    Only the PATTERN half of `${x//pat/rep}` needs escaped slashes. In the
+    replacement, bash 5 strips the backslash and bash 3.2 keeps it — so the
+    shipped `:\\/\\/***@` logged `https:\\/\\/***@host` on macOS: backslashes
+    that were never in the operator's command, written into a log people read
+    to reconstruct what happened.
+    """
+    body = (_FALLBACK_HOOKS / "_usage_log.sh").read_text(encoding="utf-8")
+    assert "://***@}" in body, "the replacement half should use plain slashes"
+    assert "/:\\/\\/***@}" not in body, (
+        "escaped slashes in the replacement corrupt logs on bash 3.2"
+    )
+
+
+def _run_hook_with_include(tmp_path: Path, state: str) -> int:
+    """Run the real post_edit_lint.sh with the include in *state*."""
+    hooks = tmp_path / ".agents" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    shutil.copy(_FALLBACK_HOOKS / "post_edit_lint.sh", hooks / "post_edit_lint.sh")
+    shutil.copy(_BASE_HOOKS / "_py.sh", hooks / "_py.sh")
+    include = hooks / "_usage_log.sh"
+
+    if state == "present":
+        shutil.copy(_FALLBACK_HOOKS / "_usage_log.sh", include)
+    elif state == "empty":
+        include.write_text("")
+    elif state == "corrupt":
+        include.write_text("if then fi (\n")
+    elif state == "missing":
+        include.unlink(missing_ok=True)
+    else:  # pragma: no cover - guards the parametrisation itself
+        raise AssertionError(f"unknown state {state}")
+
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    target = src / "m.py"
+    target.write_text("x: int = 1\n")
+
+    return subprocess.run(
+        ["bash", str(hooks / "post_edit_lint.sh")],
+        input=json.dumps({"tool_input": {"file_path": str(target)}}),
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=120,
+        check=False,
+    ).returncode
+
+
+@pytest.mark.parametrize("state", ["present", "empty", "corrupt", "missing"])
+def test_the_hook_survives_every_state_of_its_optional_include(tmp_path: Path, state: str):
+    """Pre-fix, on bash 3.2: corrupt exited 2 and missing exited 1, both with
+    no output at all. A PostToolUse hook that dies silently on every edit is
+    the worst shape a failure can take."""
+    assert _run_hook_with_include(tmp_path, state) == 0, (
+        f"hook died with the include {state} — see PI-946"
+    )


### PR DESCRIPTION
Closes #946

**The full suite is green on macOS for the first time: 2982 passed, 0 failed.** The standing set of six "expected" failures is gone.

## The mechanism, measured rather than reasoned

`.` is a POSIX **special builtin**. When it fails, a non-interactive shell under `set -e` exits immediately — before the `&&` short-circuit or the trailing `|| true` is ever considered. On `/bin/bash` 3.2.57 (macOS system shell, which this repo runs a CI job to support):

```
set -euo pipefail, . missing && x || true    DIED     (rc=1)
set -e only,       . missing && x || true    DIED     (rc=1)
set -euo pipefail, . missing || true         DIED     (rc=1)     <- `|| true` alone does NOT help
no set -e,         . missing && x || true    survived (rc=0)     <- it is errexit, not -u/pipefail
set -euo pipefail, [ -r ] guard              survived (rc=0)
```

`[ -r ]` alone is not sufficient either — a **corrupt** include still aborts. The only form that survives every state is to disable errexit across the source and restore exactly the prior state.

## Four sites, not one

The ticket asked for a grep rather than a point fix. Four hooks carried the idiom: `post_edit_lint.sh`, `pre_commit_gate.sh`, `session_setup.sh`, `workflow_state_reminder.sh`. Three run under `set -e` and were affected; `session_setup.sh` deliberately omits `-e` and was **not** broken, but is fixed anyway — leaving one copy of a fragile idiom in place is how it gets copied again, and the save/restore reads its `$-` so its deliberate choice is preserved.

The rationale lives once, in `_usage_log.sh`'s own header — the file being sourced — with a pointer at each call site, rather than four copies of the same paragraph.

## A second defect, same file, different root cause

Found while fixing the first, and reported as its own thing rather than folded in silently:

```sh
command="${command//:\/\/*@/:\/\/***@}"    # the URL-redaction
```

Only the **pattern** half of `${x//pat/rep}` needs escaped slashes. In the replacement, bash 5 strips the backslash and **bash 3.2 keeps it** — so macOS logged `https:\/\/***@host`: backslashes that were never in the operator's command, written into a log people read to reconstruct what happened. Measured both ways; the unescaped form is identical on bash 5 and correct on 3.2.

## And a false positive of the guard-fires-on-documentation kind

`test_helper_never_reads_stdin_source` greps the helper's source for `"read "`. My comment explaining that the old idiom *"read as safe"* tripped it, as though the helper consumed stdin. The test now strips comment lines first: the check is on what the shell executes, and a guard that fires on documentation gets the documentation deleted.

## Evidence

Acceptance matrix from the ticket, run against a **real `--no-plugin` scaffold** on bash 3.2, hook invoked with JSON on stdin:

```
include state     after this PR     on main (pre-fix)
present               0                   0
empty                 0                   0
corrupt               0                   2      <- died
missing               0                   1      <- died
```

```
new portability tests   13 passed
full suite              2982 passed, 0 failed, 6 skipped
                        (was 2963 passed / 6 failed on main, same machine)
lint                    ruff check + format --check rc=0; shellcheck --severity=warning clean
plugins                 workflow 0.9.2 -> 0.9.3, lifecycle 0.2.2 -> 0.2.3, both relocked
```

**6 mutants, 0 survivors** — the pre-fix idiom restored wholesale (9 tests red), the readability test removed, the errexit disable removed, the restore removed, the function guard removed, and the escaped replacement put back. All five touched files restored byte-identical afterwards, asserted.

## One thing about the new tests worth flagging

**The behavioural half cannot catch a regression on CI.** The Linux runner has bash 5, which does not exit there — that is exactly why this bug lived in a green pipeline. So the shape assertions are not belt-and-braces; they are the only guard that works on the platform that gates merges, and `test_the_fragile_idiom_is_gone` is the strongest of them. The module's docstring says this, so nobody later "simplifies" the shape tests away as redundant with the behavioural ones.

## Why this mattered beyond six red lines

A standing set of expected failures is corrosive in a way the count understates: it trains you to skim the failure list. I introduced two real regressions earlier today and both were briefly invisible inside exactly that list.
