### PR TITLE
fix(PI-946): restore errexit in both directions, not just one

### DIFF
--- a/.agents/hooks/_usage_log.sh
+++ b/.agents/hooks/_usage_log.sh
@@ -20,8 +20,16 @@
 #   case $- in *e*) _pi_errexit=1 ;; esac
 #   set +e
 #   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 #   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# RESTORE BOTH DIRECTIONS (PR #947 review). A one-way `if …; then set -e; fi`
+# restores an errexit that was ON and silently keeps one the INCLUDE turned on.
+# `session_setup.sh` runs `set -uo pipefail` without `-e` on purpose — its
+# fingerprint pipeline returns nonzero routinely, because it probes manifests
+# that need not exist — so a leaked errexit exits the hook before bootstrap.
+# Measured on bash 3.2 with an include containing `set -e`: one-way leaves
+# errexit ON, two-way leaves it off and the hook reaches bootstrap.
 #
 # Guard the CALL on the function, not on the source succeeding: a file that
 # sourced cleanly and defined nothing is a real state.

--- a/.agents/hooks/workflow_state_reminder.sh
+++ b/.agents/hooks/workflow_state_reminder.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
 fi

--- a/.claude/hooks/_usage_log.sh
+++ b/.claude/hooks/_usage_log.sh
@@ -20,8 +20,16 @@
 #   case $- in *e*) _pi_errexit=1 ;; esac
 #   set +e
 #   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 #   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# RESTORE BOTH DIRECTIONS (PR #947 review). A one-way `if …; then set -e; fi`
+# restores an errexit that was ON and silently keeps one the INCLUDE turned on.
+# `session_setup.sh` runs `set -uo pipefail` without `-e` on purpose — its
+# fingerprint pipeline returns nonzero routinely, because it probes manifests
+# that need not exist — so a leaked errexit exits the hook before bootstrap.
+# Measured on bash 3.2 with an include containing `set -e`: one-way leaves
+# errexit ON, two-way leaves it off and the hook reaches bootstrap.
 #
 # Guard the CALL on the function, not on the source succeeding: a file that
 # sourced cleanly and defined nothing is a real state.

--- a/.claude/hooks/workflow_state_reminder.sh
+++ b/.claude/hooks/workflow_state_reminder.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
 fi

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -1,10 +1,10 @@
 {
   "project-init-lifecycle": {
-    "sha256": "f296046a6f7c70c91d505e39a85b20eeb458abe8840c540a6d892df10a7bb93e",
-    "version": "0.2.3"
+    "sha256": "78b96ba18ce0dc9dbf155a4df09360c2d22ffa80c665614369a3326784665933",
+    "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "9b17a1247246af042ff1b6e4935fcbbeeec0c3bcf721f0d9028fd3c7fea7c5ff",
-    "version": "0.9.3"
+    "sha256": "65a3742b3cb04290ebc0aa21064c06b4ddb4ec12085bc04583b12746fd7c53be",
+    "version": "0.9.4"
   }
 }

--- a/plugins/project-init-lifecycle/.claude-plugin/plugin.json
+++ b/plugins/project-init-lifecycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-lifecycle",
   "displayName": "project-init GitHub Lifecycle",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "GitHub lifecycle automation from project-init (#476, ADR-021): the issue->branch->PR->review->merge DAG guard + workflow-state hooks and the create_issue/start_task/github_workflow/request_review/audit skills. Enabled only when the lifecycle tier is on; the forge-agnostic quality/safety hooks live in project-init-workflow.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-lifecycle/hooks/_usage_log.sh
+++ b/plugins/project-init-lifecycle/hooks/_usage_log.sh
@@ -20,8 +20,16 @@
 #   case $- in *e*) _pi_errexit=1 ;; esac
 #   set +e
 #   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 #   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# RESTORE BOTH DIRECTIONS (PR #947 review). A one-way `if …; then set -e; fi`
+# restores an errexit that was ON and silently keeps one the INCLUDE turned on.
+# `session_setup.sh` runs `set -uo pipefail` without `-e` on purpose — its
+# fingerprint pipeline returns nonzero routinely, because it probes manifests
+# that need not exist — so a leaked errexit exits the hook before bootstrap.
+# Measured on bash 3.2 with an include containing `set -e`: one-way leaves
+# errexit ON, two-way leaves it off and the hook reaches bootstrap.
 #
 # Guard the CALL on the function, not on the source succeeding: a file that
 # sourced cleanly and defined nothing is a real state.

--- a/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
+++ b/plugins/project-init-lifecycle/hooks/workflow_state_reminder.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
 fi

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/_usage_log.sh
+++ b/plugins/project-init-workflow/hooks/_usage_log.sh
@@ -20,8 +20,16 @@
 #   case $- in *e*) _pi_errexit=1 ;; esac
 #   set +e
 #   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 #   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# RESTORE BOTH DIRECTIONS (PR #947 review). A one-way `if …; then set -e; fi`
+# restores an errexit that was ON and silently keeps one the INCLUDE turned on.
+# `session_setup.sh` runs `set -uo pipefail` without `-e` on purpose — its
+# fingerprint pipeline returns nonzero routinely, because it probes manifests
+# that need not exist — so a leaked errexit exits the hook before bootstrap.
+# Measured on bash 3.2 with an include containing `set -e`: one-way leaves
+# errexit ON, two-way leaves it off and the hook reaches bootstrap.
 #
 # Guard the CALL on the function, not on the source succeeding: a file that
 # sourced cleanly and defined nothing is a real state.

--- a/plugins/project-init-workflow/hooks/post_edit_lint.sh
+++ b/plugins/project-init-workflow/hooks/post_edit_lint.sh
@@ -21,7 +21,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
 fi

--- a/plugins/project-init-workflow/hooks/pre_commit_gate.sh
+++ b/plugins/project-init-workflow/hooks/pre_commit_gate.sh
@@ -19,7 +19,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log pre_commit_gate PreToolUse </dev/null || true
 fi

--- a/plugins/project-init-workflow/hooks/session_setup.sh
+++ b/plugins/project-init-workflow/hooks/session_setup.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log session_setup SessionStart "$ROOT" </dev/null || true
 fi

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.3"
+__plugin_version__ = "0.9.4"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/fallback/dot_agents/hooks/_usage_log.sh
+++ b/templates/fallback/dot_agents/hooks/_usage_log.sh
@@ -20,8 +20,16 @@
 #   case $- in *e*) _pi_errexit=1 ;; esac
 #   set +e
 #   [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-#   if [ "$_pi_errexit" = 1 ]; then set -e; fi
+#   if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 #   if command -v usage_log >/dev/null 2>&1; then usage_log <hook> <event>; fi
+#
+# RESTORE BOTH DIRECTIONS (PR #947 review). A one-way `if …; then set -e; fi`
+# restores an errexit that was ON and silently keeps one the INCLUDE turned on.
+# `session_setup.sh` runs `set -uo pipefail` without `-e` on purpose — its
+# fingerprint pipeline returns nonzero routinely, because it probes manifests
+# that need not exist — so a leaked errexit exits the hook before bootstrap.
+# Measured on bash 3.2 with an include containing `set -e`: one-way leaves
+# errexit ON, two-way leaves it off and the hook reaches bootstrap.
 #
 # Guard the CALL on the function, not on the source succeeding: a file that
 # sourced cleanly and defined nothing is a real state.

--- a/templates/fallback/dot_agents/hooks/post_edit_lint.sh
+++ b/templates/fallback/dot_agents/hooks/post_edit_lint.sh
@@ -21,7 +21,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log post_edit_lint PostToolUse "$ROOT" </dev/null || true
 fi

--- a/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
+++ b/templates/fallback/dot_agents/hooks/pre_commit_gate.sh
@@ -19,7 +19,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log pre_commit_gate PreToolUse </dev/null || true
 fi

--- a/templates/fallback/dot_agents/hooks/session_setup.sh
+++ b/templates/fallback/dot_agents/hooks/session_setup.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log session_setup SessionStart "$ROOT" </dev/null || true
 fi

--- a/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
+++ b/templates/lifecycle_fallback/dot_agents/hooks/workflow_state_reminder.sh
@@ -22,7 +22,7 @@ _pi_errexit=0
 case $- in *e*) _pi_errexit=1 ;; esac
 set +e
 [ -r "$(dirname "$0")/_usage_log.sh" ] && . "$(dirname "$0")/_usage_log.sh"
-if [ "$_pi_errexit" = 1 ]; then set -e; fi
+if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi
 if command -v usage_log >/dev/null 2>&1; then
   usage_log workflow_state_reminder UserPromptSubmit </dev/null || true
 fi

--- a/tests/contracts/test_optional_include_portability.py
+++ b/tests/contracts/test_optional_include_portability.py
@@ -61,7 +61,12 @@ def test_the_include_is_readability_tested_and_errexit_is_restored(hook: Path):
     assert '[ -r "$(dirname "$0")/_usage_log.sh" ]' in body, "include is sourced untested"
     assert "case $- in *e*)" in body, "errexit state is not saved"
     assert "set +e" in body, "errexit is not disabled across the source"
-    assert 'if [ "$_pi_errexit" = 1 ]; then set -e; fi' in body, "errexit is not restored"
+    # BOTH directions. A one-way restore keeps an errexit that the INCLUDE
+    # turned on, which breaks the one hook that deliberately runs without it
+    # (PR #947 review).
+    assert 'if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi' in body, (
+        "errexit is not restored in both directions"
+    )
     # Guarding the CALL on the source's exit status would miss the real state
     # of a file that sourced cleanly and defined nothing.
     assert "command -v usage_log" in body, "the call is not guarded on the function"
@@ -125,4 +130,56 @@ def test_the_hook_survives_every_state_of_its_optional_include(tmp_path: Path, s
     the worst shape a failure can take."""
     assert _run_hook_with_include(tmp_path, state) == 0, (
         f"hook died with the include {state} — see PI-946"
+    )
+
+
+def test_an_include_that_enables_errexit_does_not_leak_it(tmp_path: Path):
+    """PR #947 review: the restore must run in BOTH directions.
+
+    A one-way `if [ "$_pi_errexit" = 1 ]; then set -e; fi` puts back an errexit
+    that was on, and silently keeps one the INCLUDE switched on. That breaks
+    `session_setup.sh`, which runs `set -uo pipefail` deliberately WITHOUT
+    `-e` because its fingerprint pipeline returns nonzero routinely — it
+    probes manifests that need not exist. A leaked errexit exits the hook
+    before bootstrap.
+
+    Exercised against the real snippet in the frame that hook runs in, rather
+    than against the hook itself: the failure is about shell option state, and
+    a scaffolded bootstrap would drown it in unrelated work.
+    """
+    include = tmp_path / "_usage_log.sh"
+    include.write_text("set -e\nusage_log() { :; }\n")
+
+    snippet = (
+        "_pi_errexit=0\n"
+        "case $- in *e*) _pi_errexit=1 ;; esac\n"
+        "set +e\n"
+        f'[ -r "{include}" ] && . "{include}"\n'
+        'if [ "$_pi_errexit" = 1 ]; then set -e; else set +e; fi\n'
+    )
+    # `set -uo pipefail` with NO -e is session_setup.sh's deliberate frame.
+    script = (
+        "set -uo pipefail\n"
+        + snippet
+        + "case $- in *e*) echo LEAKED ;; *) echo clean ;; esac\n"
+        + "false\n"
+        + "echo REACHED_BOOTSTRAP\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60, check=False
+    )
+    assert "LEAKED" not in result.stdout, "the include's `set -e` escaped the restore"
+    assert "REACHED_BOOTSTRAP" in result.stdout, (
+        "a nonzero command after the include killed the hook — errexit leaked"
+    )
+
+
+def test_the_hook_that_runs_without_errexit_still_does(tmp_path: Path):
+    """The same property, asserted on the shipped file rather than a snippet:
+    session_setup.sh must not have quietly acquired `set -e`."""
+    body = (_FALLBACK_HOOKS / "session_setup.sh").read_text(encoding="utf-8")
+    set_lines = [ln for ln in body.splitlines() if ln.startswith("set -")]
+    assert set_lines, "no `set` line at all"
+    assert not any("e" in ln.split("#")[0].split()[1].lstrip("-") for ln in set_lines[:1]), (
+        f"session_setup.sh opted out of errexit on purpose; found {set_lines[0]!r}"
     )


### PR DESCRIPTION
Closes #946

Follow-up to #947, which merged before its review landed. The finding is correct and it is a **regression I introduced in that PR** — in the one file that was not broken to begin with.

## What was wrong

The errexit restore ran in one direction only:

```sh
if [ "$_pi_errexit" = 1 ]; then set -e; fi
```

That puts back an errexit that was on. It silently **keeps** one the include switched on. `session_setup.sh` runs `set -uo pipefail` deliberately *without* `-e` — its fingerprint pipeline returns nonzero routinely, because it probes manifests that need not exist — so a leaked errexit exits the hook before bootstrap.

Reproduced in that hook's exact frame, with an include containing `set -e`:

```
bash 3.2.57   (frame: set -uo pipefail, errexit deliberately OFF)
  as merged    LEAKED-ERREXIT
  both ways    errexit-still-off  REACHED-BOOTSTRAP
```

The fix is `else set +e`, applied at all four sites.

## The uncomfortable part, stated plainly

#947 fixed three hooks that were genuinely broken and touched `session_setup.sh` **only for uniformity** — I said so in that PR: "not broken but fixed anyway, because leaving one copy of a fragile idiom in place is how it gets copied again." That reasoning still holds, and the change I made in its name is the one that introduced a hazard in the file that had none. Uniformity is worth having; it is not worth having carelessly, and "this file is fine, I am only making it match" is exactly the frame in which a bug gets waved through.

## Evidence

```
portability tests   15 passed  (was 13)
full suite          2984 passed, 0 failed, 6 skipped
lint                ruff check + format --check rc=0; shellcheck --severity=warning clean
plugins             workflow 0.9.3 -> 0.9.4, lifecycle 0.2.3 -> 0.2.4, both relocked
```

Two mutants, both caught: the one-way restore put back in all four hooks (4 tests red), and put back in the behavioural test's own snippet (1 red). That second one matters — it proves the new behavioural test is exercising shell option state rather than re-reading the same file the shape assertion already reads. Files restored byte-identical, asserted.

The new test runs the snippet in `session_setup.sh`'s frame and asserts two things: the include's `set -e` does not survive the restore, and a nonzero command afterwards does not kill the shell. A companion test asserts the shipped `session_setup.sh` has not quietly acquired `-e` itself.

**This one is catchable on CI**, unlike most of #947 — it is about option state, not about bash 3.2's special-builtin behaviour, so bash 5 fails it too.
