### PR TITLE
fix(PI-949): the scaffolded payload cites nothing a reader cannot open

### DIFF
--- a/docs/development/repo-reference.md
+++ b/docs/development/repo-reference.md
@@ -56,10 +56,29 @@ For that one the remedy is a plain PR comment, which re-triggers
 `review-status.yml`; `monitor_pr.sh` now posts it automatically when the
 review gate has passed and the status has not caught up.
 
-The approval policy itself is a repository setting (Settings → Actions →
-General) and is **not readable or writable over the REST API for a public
-repo** — `/actions/permissions/access` answers 422. Narrowing it there is the
-only fix that removes the problem rather than working around it.
+The approval policy itself **is** readable and writable over REST, and the
+one-liner below is the fix that removes the problem rather than working
+around it:
+
+```sh
+gh api repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval
+# {"approval_policy":"first_time_contributors"}
+
+gh api --method PUT repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval \
+  -f approval_policy=first_time_contributors_new_to_github
+```
+
+Allowed values are `first_time_contributors_new_to_github`,
+`first_time_contributors` and `all_external_contributors`; there is no
+"never require approval", so the first is the loosest. A bot actor counts as
+a first-time contributor under the middle tier, which is what queued the runs.
+
+An earlier revision of this page said the setting was **not** reachable over
+REST, on the strength of `/actions/permissions/access` answering 422. That is
+a *different* setting — workflow access from other repositories — and it is
+genuinely 422 for a public repo. Recording the mistake rather than quietly
+deleting it: the wrong endpoint returning a plausible error is exactly how a
+one-command fix turns into a documented dead end.
 
 ## What this repo does NOT include
 

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "65a3742b3cb04290ebc0aa21064c06b4ddb4ec12085bc04583b12746fd7c53be",
-    "version": "0.9.4"
+    "sha256": "4ceb8d047194119a3314a5c98559022732a5c99f57589c46e545982e64858687",
+    "version": "0.9.5"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas Čepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -507,15 +507,17 @@ def _exposes_secret(command: str) -> str | None:
 _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
-# harbor#4 H1 / CONTRACTS/marker.md — `context: ambient` is the owner opting a
+# THE MARKER CONTRACT (PI-901) — `context: ambient` is the owner opting a
 # repo back in to the ambient (global) agent layer. Anchored at column 0: a
 # top-level YAML key cannot be indented, and matching an indented one would let
 # a `context: ambient` nested under some unrelated block opt the whole repo out.
 # Quoted keys/values and a space before the colon ARE valid top-level YAML, and
 # project-init's own `_CONTEXT_KEY_RE` preserves exactly those spellings on
 # upgrade — a spelling the writer keeps but the reader misses is an opt-out that
-# survives in the file and is then ignored. KEEP IN STEP with harbor's
-# `floor_in_repo`, which reads the same key with the same tolerances.
+# survives in the file and is then ignored. KEEP IN STEP with the ambient
+# layer's own marker reader, which reads the same key with the same
+# tolerances — two readers of one contract that disagree is the failure the
+# contract exists to prevent.
 #
 # A COMMENT NEEDS WHITESPACE BEFORE IT (PR #927 review). `#` only begins a YAML
 # comment when preceded by whitespace; otherwise it is part of the plain scalar.
@@ -548,8 +550,8 @@ def _declares_ambient(config: Path) -> bool:
 def _find_config(start: Path) -> Path | None:
     """Walk up from *start* to the project's .agents/config.yaml, if any.
 
-    A SYMLINKED marker is refused and the walk continues (PI-903; harbor#4 M13,
-    harbor CONTRACTS/marker.md). ``is_file()`` follows symlinks, so this used to
+    A SYMLINKED marker is refused and the walk continues (PI-903; the marker
+    contract). ``is_file()`` follows symlinks, so this used to
     accept an ``.agents/`` — or an ``.agents/config.yaml`` — pointing anywhere on
     disk. That matters more here than it does for a boundary verdict: this
     function locates the file ``safety.allow`` is read from, so a link planted
@@ -558,13 +560,13 @@ def _find_config(start: Path) -> Path | None:
     repo's own review, which is exactly what the guard is defending.
 
     Refusing is the safe direction (no allowlist ⇒ keep guarding), and it makes
-    this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
-    markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
+    this walk agree with the ambient layer's own marker reader, which has
+    refused symlinked markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
     disagreement while it existed.
 
     Two further rules from the same frozen contract:
 
-    ``context: ambient`` (harbor#4 H1, M18/M19) — the owner declaring that this
+    ``context: ambient`` (the marker contract) — the owner declaring that this
     repo does NOT govern itself and the ambient layer keeps acting here. A repo
     that has opted out of governed status does not get to relax the deny table
     with its own ``safety.allow``, so the declaration returns None (no
@@ -574,7 +576,7 @@ def _find_config(start: Path) -> Path | None:
     overruled by an outer repo's config. A symlink is refused because it is
     forged; an ``ambient`` value is honoured because it is the owner speaking.
 
-    ``$HOME`` (harbor#4 M14) — the walk stops before it. A marker sitting in
+    ``$HOME`` (the marker contract) — the walk stops before it. A marker sitting in
     the home directory itself otherwise supplies an allowlist to every command
     run anywhere beneath it, and it is written by accident rather than by
     attack: project-init run once in the wrong cwd scaffolds one there. Paths

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.4"
+__plugin_version__ = "0.9.5"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/upgrade.py
+++ b/src/project_init/upgrade.py
@@ -1305,7 +1305,8 @@ def _ensure_ci_block(text: str) -> str:
 
 
 _CONTEXT_BLOCK = (
-    "# Detect-and-defer boundary marker (PI-901; harbor#4 H1). repo = this project\n"
+    "# Detect-and-defer boundary marker (PI-901; the ambient-layer marker\n"
+    "# contract). repo = this project\n"
     "# governs itself, so an ambient/global agent layer stands down inside it;\n"
     "# ambient = opt out. Not `governance:` — that name is already a boolean.\n"
     "context: repo\n"
@@ -1326,14 +1327,14 @@ _CONTEXT_ANCHOR_RE = re.compile(r"(?m)^project:")
 # revoking the opt-out; stricter ones reject the descriptor outright (PR #902
 # review). Still anchored at column 0: `context` is top-level, and one indented
 # under another block is a different key that happens to share a name.
-# KEEP IN STEP with harbor's floor_in_repo, which reads the same key — a
-# spelling the writer preserves but the reader misses is an opt-out that
-# survives upgrade and is then ignored.
+# KEEP IN STEP with the ambient layer's own marker reader, which reads the
+# same key — a spelling the writer preserves but the reader misses is an
+# opt-out that survives upgrade and is then ignored.
 _CONTEXT_KEY_RE = re.compile(r"""(?m)^(?:context|"context"|'context')[ \t]*:""")
 
 
 def _ensure_context_key(text: str) -> str:
-    """Backfill the detect-and-defer marker into a pre-PI-901 config (harbor#4 H1).
+    """Backfill the detect-and-defer marker into a pre-PI-901 config (PI-901).
 
     config.yaml is never re-rendered wholesale on upgrade, so the template line
     alone would only ever reach *fresh* scaffolds — every already-scaffolded

--- a/templates/base/dot_agents/config.yaml.tmpl
+++ b/templates/base/dot_agents/config.yaml.tmpl
@@ -1,7 +1,7 @@
 # project-init: record of choices made at init time.
 # Safe to hand-edit; re-running `project-init` will reconcile with this file.
 
-# Detect-and-defer boundary marker (PI-901; harbor#4 H1, harbor CONTRACTS/marker.md).
+# Detect-and-defer boundary marker (PI-901; the ambient-layer marker contract).
 # Declares to every layer ABOVE this repo — a root orchestrator, a global agent
 # environment, any hook that would otherwise write a machine-wide log — that this
 # project governs itself.

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -507,15 +507,17 @@ def _exposes_secret(command: str) -> str | None:
 _AUTONOMOUS_MODES = {"bypassPermissions", "dangerouslySkipPermissions"}
 
 
-# harbor#4 H1 / CONTRACTS/marker.md — `context: ambient` is the owner opting a
+# THE MARKER CONTRACT (PI-901) — `context: ambient` is the owner opting a
 # repo back in to the ambient (global) agent layer. Anchored at column 0: a
 # top-level YAML key cannot be indented, and matching an indented one would let
 # a `context: ambient` nested under some unrelated block opt the whole repo out.
 # Quoted keys/values and a space before the colon ARE valid top-level YAML, and
 # project-init's own `_CONTEXT_KEY_RE` preserves exactly those spellings on
 # upgrade — a spelling the writer keeps but the reader misses is an opt-out that
-# survives in the file and is then ignored. KEEP IN STEP with harbor's
-# `floor_in_repo`, which reads the same key with the same tolerances.
+# survives in the file and is then ignored. KEEP IN STEP with the ambient
+# layer's own marker reader, which reads the same key with the same
+# tolerances — two readers of one contract that disagree is the failure the
+# contract exists to prevent.
 #
 # A COMMENT NEEDS WHITESPACE BEFORE IT (PR #927 review). `#` only begins a YAML
 # comment when preceded by whitespace; otherwise it is part of the plain scalar.
@@ -548,8 +550,8 @@ def _declares_ambient(config: Path) -> bool:
 def _find_config(start: Path) -> Path | None:
     """Walk up from *start* to the project's .agents/config.yaml, if any.
 
-    A SYMLINKED marker is refused and the walk continues (PI-903; harbor#4 M13,
-    harbor CONTRACTS/marker.md). ``is_file()`` follows symlinks, so this used to
+    A SYMLINKED marker is refused and the walk continues (PI-903; the marker
+    contract). ``is_file()`` follows symlinks, so this used to
     accept an ``.agents/`` — or an ``.agents/config.yaml`` — pointing anywhere on
     disk. That matters more here than it does for a boundary verdict: this
     function locates the file ``safety.allow`` is read from, so a link planted
@@ -558,13 +560,13 @@ def _find_config(start: Path) -> Path | None:
     repo's own review, which is exactly what the guard is defending.
 
     Refusing is the safe direction (no allowlist ⇒ keep guarding), and it makes
-    this walk agree with harbor's ``floor_in_repo``, which has refused symlinked
-    markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
+    this walk agree with the ambient layer's own marker reader, which has
+    refused symlinked markers since the 2026-07-24 marker-forgery finding. Nothing surfaced the
     disagreement while it existed.
 
     Two further rules from the same frozen contract:
 
-    ``context: ambient`` (harbor#4 H1, M18/M19) — the owner declaring that this
+    ``context: ambient`` (the marker contract) — the owner declaring that this
     repo does NOT govern itself and the ambient layer keeps acting here. A repo
     that has opted out of governed status does not get to relax the deny table
     with its own ``safety.allow``, so the declaration returns None (no
@@ -574,7 +576,7 @@ def _find_config(start: Path) -> Path | None:
     overruled by an outer repo's config. A symlink is refused because it is
     forged; an ``ambient`` value is honoured because it is the owner speaking.
 
-    ``$HOME`` (harbor#4 M14) — the walk stops before it. A marker sitting in
+    ``$HOME`` (the marker contract) — the walk stops before it. A marker sitting in
     the home directory itself otherwise supplies an allowlist to every command
     run anywhere beneath it, and it is written by accident rather than by
     attack: project-init run once in the wrong cwd scaffolds one there. Paths

--- a/tests/contracts/test_no_private_tracker_references.py
+++ b/tests/contracts/test_no_private_tracker_references.py
@@ -1,0 +1,102 @@
+"""PI-949: nothing that lands on a scaffolded user's disk cites a private tracker.
+
+This repo is public and the scaffold it produces goes to other people's
+machines. A comment pointing at an issue tracker or a contract file that only
+one laptop can reach is worse than no citation: it reads as verifiable
+provenance and cannot be verified, so the rule it explains ends up with no
+reachable justification at all.
+
+SCOPE IS THE SHIPPED PAYLOAD, deliberately, and the scope is the interesting
+part. `templates/` and `plugins/` are copied onto a user's disk verbatim. So is
+the text `upgrade.py` *writes into* their `config.yaml` — a fact that made the
+first cut of this fix incomplete: the template was cleaned while the upgrade
+path went on emitting the old comment, so any upgrade would have restored what
+the template no longer said. Two writers of one file, cleaned one at a time.
+
+`src/`, `tests/` and `docs/` still carry references and are NOT covered here.
+Some of them name a genuine integration seam whose module is called after it,
+and renaming a public module is a different change with a different blast
+radius. Counted rather than hand-waved: see the PI-949 PR body.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The shipped payload: copied to a user's disk, or written into their files.
+_SHIPPED_DIRS = ["templates", "plugins"]
+_SHIPPED_FILES = ["src/project_init/upgrade.py"]
+
+# Lowercased substrings that name the private system or its internals. Kept as
+# a list so a second one can be added without reshaping the test.
+_PRIVATE_NAMES = ["harbor"]
+
+_SKIP_SUFFIXES = {".pyc", ".png", ".svg", ".ico", ".lock"}
+
+
+def _shipped_paths() -> list[Path]:
+    out: list[Path] = []
+    for d in _SHIPPED_DIRS:
+        for p in sorted((_REPO_ROOT / d).rglob("*")):
+            if not p.is_file() or p.suffix in _SKIP_SUFFIXES or "__pycache__" in p.parts:
+                continue
+            out.append(p)
+    out.extend(_REPO_ROOT / f for f in _SHIPPED_FILES)
+    return out
+
+
+@pytest.mark.parametrize("name", _PRIVATE_NAMES)
+def test_the_shipped_payload_names_no_private_tracker(name: str):
+    hits: list[str] = []
+    pattern = re.compile(re.escape(name), re.IGNORECASE)
+    for path in _shipped_paths():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if pattern.search(line):
+                hits.append(f"{path.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()[:90]}")
+    assert not hits, (
+        f"{len(hits)} reference(s) to a private tracker in the shipped payload:\n" + "\n".join(hits)
+    )
+
+
+def test_the_scan_actually_reaches_the_files_it_claims_to():
+    """A filter that skips its own subject reports green forever.
+
+    The scan above is a negative assertion, so it needs a positive control: if
+    a glob or a skip rule silently excluded everything, it would pass just as
+    loudly. Pin the two files the defect actually lived in.
+    """
+    scanned = {p.relative_to(_REPO_ROOT).as_posix() for p in _shipped_paths()}
+    for required in (
+        "templates/base/dot_agents/hooks/prod_guard.py",
+        "templates/base/dot_agents/config.yaml.tmpl",
+        "plugins/project-init-workflow/hooks/prod_guard.py",
+        "src/project_init/upgrade.py",
+    ):
+        assert required in scanned, f"the scan does not reach {required}"
+    assert len(scanned) > 100, f"only {len(scanned)} files scanned — the walk is not working"
+
+
+def test_the_reasoning_those_comments_carried_is_still_there():
+    """Only the unreachable citations were meant to go. The hard-won substance
+    — why an indented key must not match, why a symlinked marker is refused —
+    is the reason the comments exist and must survive the cleanup."""
+    guard = (
+        _REPO_ROOT / "templates" / "base" / "dot_agents" / "hooks" / "prod_guard.py"
+    ).read_text(encoding="utf-8")
+    for kept in (
+        "A COMMENT NEEDS WHITESPACE BEFORE IT",
+        "A SYMLINKED marker is refused",
+        "marker-forgery finding",
+        "the walk stops before it",
+        "KEEP IN STEP",
+    ):
+        assert kept in guard, f"the cleanup removed reasoning, not just a citation: {kept!r}"


### PR DESCRIPTION
Closes #949

Every comment in the scaffolded payload that cited an external private tracker now describes the same contract in words a reader can actually use.

## The count was wrong, and the shape of the miss matters

The ticket said 8 references in two files. The shipped payload had **more**, in a third place nobody had looked:

```
templates/          8   ->  0
plugins/            7   ->  0   (the synced mirror of the same file)
src/…/upgrade.py    3   ->  0   (the emitter — see below)
```

`upgrade.py` **writes the marker comment into the user's `config.yaml`**. Cleaning the template alone would have been undone by the next `project-init upgrade`, which went on emitting the old text — two writers of one file, and the fix touched one of them. That is not a cosmetic miss: it is the difference between a fix and a fix that reverts itself.

## What changed, and what deliberately did not

Citations become descriptions of the same contract — "the marker contract", "the ambient layer's own marker reader". The surrounding prose already used that vocabulary ("the ambient layer", "every layer ABOVE this repo"), so this is a vocabulary change, not a rewrite.

**Every `PI-NNN` stays.** Those resolve here. **All of the reasoning stays** — why an indented `context:` key must not match, why `ambient#typo` is not `ambient`, why a symlinked marker is refused, why the walk stops before `$HOME`. That is the hard-won part and the reason the comments exist at all; a test now asserts five of those phrases survive, so a future "tidy the comments" cannot quietly take the substance with the citation.

## Why this was a defect rather than untidiness

A citation pointing at a tracker no reader can open is **worse than no citation**: it reads as verifiable provenance and cannot be verified, so the rule it explains ends up with no reachable justification. And it propagates — the payload is copied verbatim into every project ever scaffolded, so the count grows with adoption.

## Scope, stated rather than implied

`src/` (6 remaining), `tests/` (12) and `docs/` (2) are **not** covered. Most of the `src/` ones are `box_profile.py`, a genuine integration seam whose module is *named* after the external system; renaming a public module, its imports, its CODE_MAP entry and its tests is a different change with a different blast radius, and it belongs in its own ticket rather than riding along here. The new test's docstring says exactly this, so the narrow scope is a recorded decision and not an oversight someone has to rediscover.

## Also in here: a factual correction to `repo-reference.md`

That page claimed the Actions approval policy is "not readable or writable over the REST API for a public repo", on the strength of `/actions/permissions/access` answering 422. **That is a different setting.** The policy itself is readable and writable:

```
GET  …/actions/permissions/fork-pr-contributor-approval  →  {"approval_policy":"first_time_contributors"}
PUT  …  -f approval_policy=first_time_contributors_new_to_github
```

I wrote the wrong claim in PI-939's PR, so I am correcting it rather than leaving a documented dead end where a one-liner exists. The page now records the mistake too: a wrong endpoint returning a plausible error is exactly how a one-command fix becomes folklore.

## Evidence

```
new contract tests   3 passed
full suite           2987 passed, 0 failed, 6 skipped
lint                 ruff check + format --check, rc=0
plugin               0.9.4 -> 0.9.5, synced and relocked
```

**4 mutants, 0 survivors:** a reference put back in a template, a reference put back in the emitter, the scan narrowed to nothing, and the reasoning stripped while the citation stayed gone. Each turned the suite red; files restored afterwards.

The third of those is the positive control. A negative assertion — "this string appears nowhere" — passes just as loudly when the walk reaches no files, so the test also pins the four paths the defect actually lived in and asserts it scanned more than 100 files.
