### PR TITLE
fix: two secret-read bypasses in prod_guard, and a fuzz gate wrong in both directions

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "d261e0d8e99140814d2e5af0c5033b7c9193de78f37c194c774690631cfa1e33",
-    "version": "0.9.7"
+    "sha256": "d866a54d08426c23b763536bc2ccbb51bf5096fae412e5da6c7c50e444f90dbc",
+    "version": "0.9.8"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "4ceb8d047194119a3314a5c98559022732a5c99f57589c46e545982e64858687",
-    "version": "0.9.5"
+    "sha256": "9e7e736053b5829bb32863e6480f3a66676cd684dd5fd16e220079fa5882af01",
+    "version": "0.9.6"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "9e7e736053b5829bb32863e6480f3a66676cd684dd5fd16e220079fa5882af01",
-    "version": "0.9.6"
+    "sha256": "d261e0d8e99140814d2e5af0c5033b7c9193de78f37c194c774690631cfa1e33",
+    "version": "0.9.7"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
-    "name": "Vytautas Čepas",
+    "name": "Vytautas \u010cepas",
     "url": "https://github.com/VytCepas"
   },
   "repository": "https://github.com/VytCepas/project-init",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -494,8 +494,12 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
-        # `&&` and `||` before the single-character forms, or they split wrongly.
-        out.extend(re.split(r"(?:&&|\|\||;|&|\n)+", chunk))
+        # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
+        # separator when it is not part of a redirection: splitting on any `&`
+        # broke `2>&1`, `&>` and `|&`, which tore a producer away from its
+        # downstream reader and REINTRODUCED the bypass — measured,
+        # `ls .env 2>&1 | xargs cat` went back to allow (PR #952 review).
+        out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
     return out
 
 

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -351,7 +351,13 @@ _SECRET_PATH = re.compile(
       | \.envrc(?![\w.-])
       | id_(?:rsa|dsa|ecdsa|ed25519)(?![\w.-])
       | \.(?:netrc|pgpass|npmrc)(?![\w.-])
-      | [\w.-]*\.(?:pem|p12|pfx|jks|keystore)(?![\w.-])
+        # `key` covers the `server.key` / `tls.key` convention. It was absent
+        # while `.gitignore` in every scaffolded repo already lists `*.key`,
+        # so the tree classified the file as a secret and the guard read it
+        # out loud: measured, `cat server.key` and `cat tls.key` were ALLOWED
+        # while `cat id_rsa` and `cat secrets.pem` asked. A false positive
+        # here costs one confirmation, which is the cheap side of the trade.
+      | [\w.-]*\.(?:pem|p12|pfx|jks|keystore|key)(?![\w.-])
       | [\w.-]*(?:service[-_]?account|credentials|client[-_]secret)[\w.-]*\.json(?![\w.-])
       | secrets?/[\w./-]+
     )
@@ -481,16 +487,26 @@ def _exposes_secret(command: str) -> str | None:
     """
     leaves = _leaf_commands(command)
     heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
-    find_is_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
+    # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
+    # This gate existed for `find` alone, so every other producer in
+    # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
+    # actually reads the file was skipped along with it. Measured before the fix:
+    #   find . -name .env | xargs cat   -> ask      (gated, correct)
+    #   printf '.env\n'   | xargs cat   -> ALLOWED  (exempt, wrong)
+    #   echo .env         | xargs cat   -> ALLOWED  (exempt, wrong)
+    #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
+    # The reader segment carries no path of its own, so once the naming segment
+    # is skipped nothing is left to match and the contents reach the transcript.
+    producers_are_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
     for segment in leaves:
         seg = _MESSAGE_ARG.sub(" ", segment).strip()
         if not seg:
             continue
         tokens = seg.split()
         head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
-        if head == "find" and not find_is_safe:
+        if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
-        elif head in _EXPOSURE_SAFE_VERBS:
+        elif head in _EXPOSURE_SAFE_VERBS and producers_are_safe:
             continue
         if head in _PATTERN_FIRST_ARG:
             rest = [t for t in tokens[1:] if not t.startswith("-")]

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -478,6 +478,27 @@ def _leaf_commands(command: str) -> list[str]:
     return out
 
 
+def _statements(command: str) -> list[str]:
+    """Split *command* into statements, keeping each pipeline intact.
+
+    `_leaf_commands` collapses `;`, `&` and `|` into one separator, which loses
+    the distinction that matters for the reader check: `a | b` shares a data path
+    and `a && b` does not. Substitutions are inlined the same way, so a read
+    hidden inside one is still judged.
+    """
+    out: list[str] = []
+    pending = [command]
+    while pending and len(out) < 100:
+        chunk = pending.pop()
+        inner = [g for match in _SUBSTITUTION.finditer(chunk) for g in match.groups() if g]
+        if inner:
+            pending.extend(inner)
+            chunk = _SUBSTITUTION.sub(" ", chunk)
+        # `&&` and `||` before the single-character forms, or they split wrongly.
+        out.extend(re.split(r"(?:&&|\|\||;|&|\n)+", chunk))
+    return out
+
+
 def _exposes_secret(command: str) -> str | None:
     """Return a label if *command* could read a secret-bearing file, else None.
 
@@ -485,7 +506,24 @@ def _exposes_secret(command: str) -> str | None:
     second one reads: a whole-string match would be decided by the harmless
     verb that happens to come first.
     """
-    leaves = _leaf_commands(command)
+    # PER STATEMENT, NOT PER COMMAND. Computing the reader set over the whole
+    # string made any reader anywhere taint every safe segment, so
+    # `cat README.md && echo ".env" >> .gitignore` was flagged as a secret read
+    # — `cat` is a reader, `echo` was therefore not exempt, and the `.env` being
+    # written INTO .gitignore matched. Prompting on that is the false positive
+    # this guard cannot afford: it is ordinary work, and a guard that blocks
+    # ordinary work gets switched off. `|` shares a data path, `&&` and `;` do
+    # not, so the reader question is only meaningful inside one pipeline.
+    for statement in _statements(command):
+        found = _statement_exposes(statement)
+        if found:
+            return found
+    return None
+
+
+def _statement_exposes(statement: str) -> str | None:
+    """The original per-segment check, scoped to one statement's pipeline."""
+    leaves = [seg for seg in statement.split("|") if seg.strip()]
     heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
@@ -497,7 +535,7 @@ def _exposes_secret(command: str) -> str | None:
     #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
     # The reader segment carries no path of its own, so once the naming segment
     # is skipped nothing is left to match and the contents reach the transcript.
-    producers_are_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
+    producers_are_safe = not _FIND_ACTS.search(statement) and not (heads & _READER_VERBS)
     for segment in leaves:
         seg = _MESSAGE_ARG.sub(" ", segment).strip()
         if not seg:

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.6"
+__plugin_version__ = "0.9.7"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.7"
+__plugin_version__ = "0.9.8"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.5"
+__plugin_version__ = "0.9.6"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import fnmatch
 import hashlib
 import json
@@ -1232,6 +1233,66 @@ def _unique_backup_dir(claude_dir: Path) -> Path:
     return candidate
 
 
+PROJECTION_MANIFEST = ".projection.json"
+#: Paths inside `.claude/` that are ours regardless of any manifest — state we
+#: write ourselves, which must never be mistaken for user content.
+_PROJECTION_OWN_STATE = frozenset({PROJECTION_MANIFEST, ".upgrade-base.json"})
+
+
+def _read_projection_manifest(claude_dir: Path) -> set[str] | None:
+    """The relative paths the last projection wrote, or ``None`` if unrecorded.
+
+    ``None`` and ``set()`` are different answers: no manifest means an older
+    version built this tree and we must not guess, while an empty manifest means
+    the last projection wrote nothing.
+    """
+    record = claude_dir / PROJECTION_MANIFEST
+    try:
+        data = json.loads(record.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    paths = data.get("paths") if isinstance(data, dict) else None
+    if not isinstance(paths, list) or not all(isinstance(x, str) for x in paths):
+        return None
+    return set(paths)
+
+
+def _write_projection_manifest(claude_dir: Path) -> None:
+    """Record every file now under `.claude/` except our own state files."""
+    paths = sorted(
+        f.relative_to(claude_dir).as_posix()
+        for f in claude_dir.rglob("*")
+        if f.is_file() and f.relative_to(claude_dir).as_posix() not in _PROJECTION_OWN_STATE
+    )
+    (claude_dir / PROJECTION_MANIFEST).write_text(
+        json.dumps({"paths": paths}, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _clear_prior_projection(claude_dir: Path, agents_dir: Path) -> None:
+    """Remove only what the previous projection wrote; keep everything else.
+
+    A blanket ``rmtree`` here deleted repo-authored files that live alongside the
+    projection (#951). The manifest makes the distinction exact. Without one, fall
+    back to "has an `.agents/` counterpart today" — which still clears the
+    plugin-mode twins (their counterpart exists, the projection skips them) while
+    keeping anything unrecognised.
+    """
+    recorded = _read_projection_manifest(claude_dir)
+    for path in sorted(claude_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        rel = path.relative_to(claude_dir).as_posix()
+        if path.is_dir():
+            with contextlib.suppress(OSError):
+                path.rmdir()  # only succeeds once emptied, so survivors keep theirs
+            continue
+        if rel in _PROJECTION_OWN_STATE:
+            continue
+        ours = rel in recorded if recorded is not None else (agents_dir / rel).exists()
+        if ours:
+            with contextlib.suppress(OSError):
+                path.unlink()
+
+
 def _generate_claude_projection(
     target: Path,
     *,
@@ -1266,8 +1327,24 @@ def _generate_claude_projection(
     that already exists is the user's own hand-written Claude config (custom
     commands/skills/settings), not our projection — so it is parked as a
     ``.claude.pre-project-init`` sibling and reported via *conflicts* instead of
-    being deleted. On any later run the dir is our own projection, so it is
-    rebuilt in place.
+    being deleted.
+
+    ON A LATER RUN THE DIRECTORY IS NOT PURELY OURS, and assuming it was cost
+    real files (#951). `rmtree` on the whole tree deleted everything without an
+    `.agents/` counterpart — repo-authored `.claude/inject.d/` rules, and a
+    project-scoped skill that a tool had installed there (`graphify install
+    --project`). Neither appears in any manifest, so nothing flagged the loss; it
+    was found by reading `git status` afterwards and recognising the filenames.
+    Measured three times on the same fleet — every re-render ate them again.
+
+    So the projection now records WHAT IT WROTE, in ``.claude/.projection.json``,
+    and on the next run deletes exactly those paths. Delete-awareness is
+    preserved — a file removed from `.agents/` was in the previous manifest, so it
+    is still cleaned — while anything we did not write is left alone. With no
+    manifest yet (a tree projected by an older version), the fallback is
+    conservative: clear only paths whose `.agents/` counterpart exists today, and
+    keep the rest. That is the migration case, and erring toward keeping is the
+    whole point.
 
     We COPY rather than symlink. A committed symlink is not portable: under git's
     default ``core.symlinks=false`` — the default on BOTH Windows (no symlink
@@ -1302,7 +1379,7 @@ def _generate_claude_projection(
     elif claude_dir.is_symlink() or claude_dir.is_file():
         claude_dir.unlink()
     elif real_dir:
-        shutil.rmtree(claude_dir)
+        _clear_prior_projection(claude_dir, agents_dir)
 
     agents_resolved = agents_dir.resolve()
 
@@ -1318,7 +1395,8 @@ def _generate_claude_projection(
             skip |= {n for n in names if n in PLUGIN_PROVIDED_SKILLS}
         return skip
 
-    shutil.copytree(agents_dir, claude_dir, ignore=_ignore)
+    shutil.copytree(agents_dir, claude_dir, ignore=_ignore, dirs_exist_ok=True)
+    _write_projection_manifest(claude_dir)
 
 
 def _emit_generated(

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -494,8 +494,12 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
-        # `&&` and `||` before the single-character forms, or they split wrongly.
-        out.extend(re.split(r"(?:&&|\|\||;|&|\n)+", chunk))
+        # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
+        # separator when it is not part of a redirection: splitting on any `&`
+        # broke `2>&1`, `&>` and `|&`, which tore a producer away from its
+        # downstream reader and REINTRODUCED the bypass — measured,
+        # `ls .env 2>&1 | xargs cat` went back to allow (PR #952 review).
+        out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
     return out
 
 

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -351,7 +351,13 @@ _SECRET_PATH = re.compile(
       | \.envrc(?![\w.-])
       | id_(?:rsa|dsa|ecdsa|ed25519)(?![\w.-])
       | \.(?:netrc|pgpass|npmrc)(?![\w.-])
-      | [\w.-]*\.(?:pem|p12|pfx|jks|keystore)(?![\w.-])
+        # `key` covers the `server.key` / `tls.key` convention. It was absent
+        # while `.gitignore` in every scaffolded repo already lists `*.key`,
+        # so the tree classified the file as a secret and the guard read it
+        # out loud: measured, `cat server.key` and `cat tls.key` were ALLOWED
+        # while `cat id_rsa` and `cat secrets.pem` asked. A false positive
+        # here costs one confirmation, which is the cheap side of the trade.
+      | [\w.-]*\.(?:pem|p12|pfx|jks|keystore|key)(?![\w.-])
       | [\w.-]*(?:service[-_]?account|credentials|client[-_]secret)[\w.-]*\.json(?![\w.-])
       | secrets?/[\w./-]+
     )
@@ -481,16 +487,26 @@ def _exposes_secret(command: str) -> str | None:
     """
     leaves = _leaf_commands(command)
     heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
-    find_is_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
+    # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
+    # This gate existed for `find` alone, so every other producer in
+    # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
+    # actually reads the file was skipped along with it. Measured before the fix:
+    #   find . -name .env | xargs cat   -> ask      (gated, correct)
+    #   printf '.env\n'   | xargs cat   -> ALLOWED  (exempt, wrong)
+    #   echo .env         | xargs cat   -> ALLOWED  (exempt, wrong)
+    #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
+    # The reader segment carries no path of its own, so once the naming segment
+    # is skipped nothing is left to match and the contents reach the transcript.
+    producers_are_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
     for segment in leaves:
         seg = _MESSAGE_ARG.sub(" ", segment).strip()
         if not seg:
             continue
         tokens = seg.split()
         head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
-        if head == "find" and not find_is_safe:
+        if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
-        elif head in _EXPOSURE_SAFE_VERBS:
+        elif head in _EXPOSURE_SAFE_VERBS and producers_are_safe:
             continue
         if head in _PATTERN_FIRST_ARG:
             rest = [t for t in tokens[1:] if not t.startswith("-")]

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -478,6 +478,27 @@ def _leaf_commands(command: str) -> list[str]:
     return out
 
 
+def _statements(command: str) -> list[str]:
+    """Split *command* into statements, keeping each pipeline intact.
+
+    `_leaf_commands` collapses `;`, `&` and `|` into one separator, which loses
+    the distinction that matters for the reader check: `a | b` shares a data path
+    and `a && b` does not. Substitutions are inlined the same way, so a read
+    hidden inside one is still judged.
+    """
+    out: list[str] = []
+    pending = [command]
+    while pending and len(out) < 100:
+        chunk = pending.pop()
+        inner = [g for match in _SUBSTITUTION.finditer(chunk) for g in match.groups() if g]
+        if inner:
+            pending.extend(inner)
+            chunk = _SUBSTITUTION.sub(" ", chunk)
+        # `&&` and `||` before the single-character forms, or they split wrongly.
+        out.extend(re.split(r"(?:&&|\|\||;|&|\n)+", chunk))
+    return out
+
+
 def _exposes_secret(command: str) -> str | None:
     """Return a label if *command* could read a secret-bearing file, else None.
 
@@ -485,7 +506,24 @@ def _exposes_secret(command: str) -> str | None:
     second one reads: a whole-string match would be decided by the harmless
     verb that happens to come first.
     """
-    leaves = _leaf_commands(command)
+    # PER STATEMENT, NOT PER COMMAND. Computing the reader set over the whole
+    # string made any reader anywhere taint every safe segment, so
+    # `cat README.md && echo ".env" >> .gitignore` was flagged as a secret read
+    # — `cat` is a reader, `echo` was therefore not exempt, and the `.env` being
+    # written INTO .gitignore matched. Prompting on that is the false positive
+    # this guard cannot afford: it is ordinary work, and a guard that blocks
+    # ordinary work gets switched off. `|` shares a data path, `&&` and `;` do
+    # not, so the reader question is only meaningful inside one pipeline.
+    for statement in _statements(command):
+        found = _statement_exposes(statement)
+        if found:
+            return found
+    return None
+
+
+def _statement_exposes(statement: str) -> str | None:
+    """The original per-segment check, scoped to one statement's pipeline."""
+    leaves = [seg for seg in statement.split("|") if seg.strip()]
     heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
@@ -497,7 +535,7 @@ def _exposes_secret(command: str) -> str | None:
     #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
     # The reader segment carries no path of its own, so once the naming segment
     # is skipped nothing is left to match and the contents reach the transcript.
-    producers_are_safe = not _FIND_ACTS.search(command) and not (heads & _READER_VERBS)
+    producers_are_safe = not _FIND_ACTS.search(statement) and not (heads & _READER_VERBS)
     for segment in leaves:
         seg = _MESSAGE_ARG.sub(" ", segment).strip()
         if not seg:

--- a/templates/base/dot_agents/settings.json.tmpl
+++ b/templates/base/dot_agents/settings.json.tmpl
@@ -20,6 +20,8 @@
       "Read(**/*.env.staging)",
       "Read(**/*.pem)",
       "Read(**/*.key)",
+      "Read(**/*.jks)",
+      "Read(**/*.keystore)",
       "Read(**/*.p12)",
       "Read(**/*.pfx)",
       "Read(**/id_rsa)",

--- a/templates/base/dot_agents/settings.json.tmpl
+++ b/templates/base/dot_agents/settings.json.tmpl
@@ -19,6 +19,7 @@
       "Read(**/*.env.prod)",
       "Read(**/*.env.staging)",
       "Read(**/*.pem)",
+      "Read(**/*.key)",
       "Read(**/*.p12)",
       "Read(**/*.pfx)",
       "Read(**/id_rsa)",

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -1138,12 +1138,28 @@ jobs:
           if [ ! -f pyproject.toml ] && [ ! -f package.json ] && [ ! -f go.mod ] && [ ! -f Cargo.toml ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "No project manifest yet — nothing to fuzz."
-          elif [ -d tests ] || [ -d test ] || find . \
+          # NO BARE DIRECTORY CHECK. `[ -d tests ]` counted an EMPTY tests/ as
+          # a test, so the gate opened and `just fuzz` then died the way this
+          # step exists to prevent: pytest exits 5 on "no tests collected", and
+          # a placeholder directory is the most common shape of a young repo.
+          # The patterns below already search tests/ recursively, so nothing is
+          # lost by requiring an actual file.
+          elif find . \
                  \( -name .git -o -name .venv -o -name node_modules \
                     -o -name target -o -name vendor \) -prune -o \
                  \( -name 'test_*.py' -o -name '*_test.py' -o -name '*_test.go' \
-                    -o -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' \) \
+                    -o -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' \
+                    -o -path '*/tests/*.rs' \) \
                  -print -quit | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          # RUST KEEPS ITS TESTS INSIDE THE SOURCE FILE. `#[cfg(test)]` modules and
+          # `proptest!` blocks live in src/*.rs, which matches none of the filename
+          # patterns above — so a Rust crate testing the conventional way scored
+          # exists=false and SILENTLY LOST nightly fuzz coverage the older
+          # manifest-based gate had given it. -F because the literal contains
+          # regex metacharacters.
+          elif [ -f Cargo.toml ] && grep -rqsF --include='*.rs' \
+                 -e '#[cfg(test)]' -e 'proptest!' src; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/templates/base/dot_github/workflows/ci.yml.tmpl
+++ b/templates/base/dot_github/workflows/ci.yml.tmpl
@@ -1149,6 +1149,8 @@ jobs:
                     -o -name target -o -name vendor \) -prune -o \
                  \( -name 'test_*.py' -o -name '*_test.py' -o -name '*_test.go' \
                     -o -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' \
+                    -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' \
+                    -o -name '*_spec.ts' -o -name '*_spec.js' \
                     -o -path '*/tests/*.rs' \) \
                  -print -quit | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -1158,8 +1160,20 @@ jobs:
           # exists=false and SILENTLY LOST nightly fuzz coverage the older
           # manifest-based gate had given it. -F because the literal contains
           # regex metacharacters.
-          elif [ -f Cargo.toml ] && grep -rqsF --include='*.rs' \
-                 -e '#[cfg(test)]' -e 'proptest!' src; then
+          # `#[test]` ALONE IS A TEST. Cargo runs a bare `#[test]` fn with no
+          # surrounding `#[cfg(test)]` module, so requiring the cfg spelling
+          # suppressed the job for a validly tested crate. The search also covers
+          # WORKSPACES via `*/src`, because a Cargo workspace keeps its crates in
+          # subdirectories and grepping only the root src/ found nothing in any of
+          # them. Deliberately NOT `.`: that would sweep target/ and any vendored
+          # crate, so a dependency's tests would open the gate for a crate with
+          # none of its own. An unmatched `*/src` glob stays literal and -s
+          # swallows the resulting error.
+          elif [ -f Cargo.toml ] && find . \
+                 \( -name target -o -name vendor -o -name .git \) -prune -o \
+                 -path '*/src/*' -name '*.rs' \
+                 -exec grep -lsF -e '#[test]' -e '#[cfg(test)]' -e 'proptest!' {} + \
+               2>/dev/null | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/tests/contracts/test_claude_projection.py
+++ b/tests/contracts/test_claude_projection.py
@@ -113,6 +113,84 @@ def test_rebuild_is_delete_aware(tmp_path: Path):
     assert (tmp_path / ".claude" / "settings.json").exists()
 
 
+def test_rebuild_keeps_a_file_the_projection_never_wrote(tmp_path: Path):
+    """#951: a blanket rmtree ate repo-authored files living beside the projection.
+
+    Measured on a real fleet three times: `.claude/inject.d/*.md` rules and a
+    project-scoped skill installed by a tool (`graphify install --project`) were
+    deleted on every re-render. Neither appears in any manifest, so nothing
+    flagged the loss.
+    """
+    _mk_agents(tmp_path)
+    _generate_claude_projection(tmp_path)
+
+    hand_written = tmp_path / ".claude" / "inject.d" / "10-local-rule.md"
+    hand_written.parent.mkdir(parents=True, exist_ok=True)
+    hand_written.write_text("a rule this repo wrote, not the scaffold\n")
+    own_skill = tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md"
+    own_skill.parent.mkdir(parents=True, exist_ok=True)
+    own_skill.write_text("installed by a tool, no .agents/ counterpart\n")
+
+    _generate_claude_projection(tmp_path, first_scaffold=False)
+
+    assert hand_written.exists(), "a repo-authored .claude/ file was deleted"
+    assert own_skill.exists(), "a tool-installed project skill was deleted"
+    assert (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_rebuild_is_still_delete_aware_once_recorded(tmp_path: Path):
+    """The control for the arm above: delete-awareness must survive the fix.
+
+    Without this, "stop deleting things" would pass by simply never deleting
+    anything, and a file removed from `.agents/` would linger in `.claude/`
+    forever — the exact split-brain the projection exists to prevent.
+    """
+    _mk_agents(tmp_path)
+    _generate_claude_projection(tmp_path)
+    assert (tmp_path / ".claude" / "skills" / "demo").exists()
+    # A second run writes the manifest that records what is ours.
+    _generate_claude_projection(tmp_path, first_scaffold=False)
+
+    shutil.rmtree(tmp_path / ".agents" / "skills" / "demo")
+    _generate_claude_projection(tmp_path, first_scaffold=False)
+
+    assert not (tmp_path / ".claude" / "skills" / "demo").exists()
+
+
+def test_unrecorded_tree_falls_back_to_the_counterpart_rule(tmp_path: Path):
+    """Migration: a tree projected by an older version has no manifest.
+
+    The fallback keeps anything without an `.agents/` counterpart and clears
+    anything with one, so an upgrade from the pre-#951 code neither loses user
+    files nor leaves the managed copies stale.
+    """
+    _mk_agents(tmp_path)
+    _generate_claude_projection(tmp_path)
+    (tmp_path / ".claude" / ".projection.json").unlink()  # as an older version left it
+
+    stray = tmp_path / ".claude" / "inject.d" / "99-stray.md"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_text("no counterpart\n")
+
+    _generate_claude_projection(tmp_path, first_scaffold=False)
+
+    assert stray.exists(), "fallback deleted a file with no .agents/ counterpart"
+    assert (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_projection_manifest_excludes_its_own_state(tmp_path: Path):
+    """The manifest must not list itself, or it becomes self-referential state."""
+    import json
+
+    _mk_agents(tmp_path)
+    _generate_claude_projection(tmp_path)
+    record = tmp_path / ".claude" / ".projection.json"
+    listed = json.loads(record.read_text())["paths"]
+    assert ".projection.json" not in listed
+    assert ".upgrade-base.json" not in listed
+    assert "settings.json" in listed
+
+
 def test_idempotent_and_reflects_edits(tmp_path: Path):
     _mk_agents(tmp_path)
     _generate_claude_projection(tmp_path)

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -235,11 +235,45 @@ class TestNightlyGuardsSkipEmptyProjects:
         assert self._run(guard, work) == "exists=false"
 
     def test_fuzz_runs_once_a_test_exists(self, tmp_path: Path):
+        # THIS TEST USED TO CREATE AN EMPTY tests/ DIRECTORY AND NOTHING ELSE,
+        # so it asserted the opposite of its own name: the gate opened on a
+        # directory holding no test, and `just fuzz` then died the way the gate
+        # exists to prevent (pytest exits 5 on "no tests collected"). The body
+        # now matches the name.
         guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
         work = tmp_path / "real"
         (work / "tests").mkdir(parents=True)
         (work / "pyproject.toml").write_text('[project]\nname = "x"\nversion = "0"\n')
+        (work / "tests" / "test_a.py").write_text("def test_a():\n    assert True\n")
         assert self._run(guard, work) == "exists=true"
+
+    def test_fuzz_skips_an_empty_tests_directory(self, tmp_path: Path):
+        """A placeholder directory is not a test — the case the old body asserted."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "placeholder"
+        (work / "tests").mkdir(parents=True)
+        (work / "pyproject.toml").write_text('[project]\nname = "x"\nversion = "0"\n')
+        assert self._run(guard, work) == "exists=false"
+
+    def test_fuzz_sees_rust_tests_inline_in_the_source(self, tmp_path: Path):
+        """`#[cfg(test)]` in src/*.rs matches no filename pattern, and is the norm."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "crate"
+        (work / "src").mkdir(parents=True)
+        (work / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+        (work / "src" / "lib.rs").write_text(
+            "pub fn a() {}\n\n#[cfg(test)]\nmod t {\n    #[test]\n    fn x() {}\n}\n"
+        )
+        assert self._run(guard, work) == "exists=true"
+
+    def test_fuzz_skips_a_rust_crate_with_no_tests(self, tmp_path: Path):
+        """Control for the arm above — the inline check must not fire on any crate."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "crate-bare"
+        (work / "src").mkdir(parents=True)
+        (work / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+        (work / "src" / "lib.rs").write_text("pub fn a() {}\n")
+        assert self._run(guard, work) == "exists=false"
 
     def test_mutmut_skips_a_pyproject_with_no_config(self, tmp_path: Path):
         guard = self._guard(

--- a/tests/contracts/test_fuzzing.py
+++ b/tests/contracts/test_fuzzing.py
@@ -275,6 +275,47 @@ class TestNightlyGuardsSkipEmptyProjects:
         (work / "src" / "lib.rs").write_text("pub fn a() {}\n")
         assert self._run(guard, work) == "exists=false"
 
+    def test_fuzz_sees_a_bare_rust_test_attribute(self, tmp_path: Path):
+        """Cargo runs `#[test]` with no surrounding `#[cfg(test)]` module."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "crate-bare-attr"
+        (work / "src").mkdir(parents=True)
+        (work / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+        (work / "src" / "lib.rs").write_text("pub fn a() {}\n\n#[test]\nfn x() {}\n")
+        assert self._run(guard, work) == "exists=true"
+
+    def test_fuzz_sees_tests_in_a_cargo_workspace(self, tmp_path: Path):
+        """A workspace keeps crates in subdirectories; a root-only search finds none."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "ws"
+        (work / "crates" / "foo" / "src").mkdir(parents=True)
+        (work / "Cargo.toml").write_text('[workspace]\nmembers = ["crates/foo"]\n')
+        (work / "crates" / "foo" / "src" / "lib.rs").write_text(
+            "#[cfg(test)]\nmod t {\n    #[test]\n    fn x() {}\n}\n"
+        )
+        assert self._run(guard, work) == "exists=true"
+
+    def test_fuzz_ignores_tests_that_belong_to_a_vendored_crate(self, tmp_path: Path):
+        """Control: a dependency's tests must not open the gate for a crate with none."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        work = tmp_path / "vendored"
+        (work / "src").mkdir(parents=True)
+        (work / "target" / "dep" / "src").mkdir(parents=True)
+        (work / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+        (work / "src" / "lib.rs").write_text("pub fn a() {}\n")
+        (work / "target" / "dep" / "src" / "lib.rs").write_text("#[test]\nfn v() {}\n")
+        assert self._run(guard, work) == "exists=false"
+
+    def test_fuzz_sees_bun_spec_spellings(self, tmp_path: Path):
+        """`bun test` runs thing.spec.ts; the patterns covered only `.test`."""
+        guard = self._guard(_scaffold(tmp_path / "p"), "fuzz", "Check for something to fuzz")
+        for name in ("thing.spec.ts", "thing_spec.ts"):
+            work = tmp_path / f"bun-{name}"
+            (work / "src").mkdir(parents=True)
+            (work / "package.json").write_text('{"name":"x"}\n')
+            (work / "src" / name).write_text("")
+            assert self._run(guard, work) == "exists=true", name
+
     def test_mutmut_skips_a_pyproject_with_no_config(self, tmp_path: Path):
         guard = self._guard(
             _scaffold(tmp_path / "p"), "mutation-tests", "Check for a mutmut configuration"

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -852,6 +852,13 @@ EXPOSING = [
     "printf '.env\\n' | xargs cat",
     "echo .env | xargs cat",
     "ls .env | xargs cat",
+    # A REDIRECTION IS NOT A SEPARATOR. Splitting statements on any `&`
+    # broke `2>&1`, `&>` and `|&`, tearing the producer away from its
+    # downstream reader and reintroducing the bypass this fix closed.
+    "ls .env 2>&1 | xargs cat",
+    "printf '.env\\n' 2>&1 | xargs cat",
+    "ls .env &> /tmp/out | xargs cat",
+    "cat .env >/dev/null 2>&1",
     # SAME PIPELINE, DIFFERENT STATEMENT. The reader must still be seen when it
     # shares a pipeline with the producer, even if another statement precedes it.
     "cat README.md && ls .env | xargs cat",
@@ -918,6 +925,13 @@ NOT_EXPOSING = [
     'echo ".env" >> .gitignore && cat README.md',
     "cat README.md; ls .env",
     "ls .env; cat README.md",
+    # A GENUINE background `&` still separates, so a reader after it is a
+    # different statement — the control that stops the redirection fix from
+    # simply never splitting on `&` at all.
+    "sleep 1 & cat README.md",
+    "ls .env & cat README.md",
+    "cat README.md 2>&1",
+    "ls -la 2>&1 | grep foo",
     # A keystore-shaped DOCUMENT is not a keystore.
     "cat keystore.md",
     "cat docs/api-key-rotation.md",

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -836,6 +836,26 @@ EXPOSING = [
     "cat ${HOME}/.netrc",
     'cat "$HOME/.ssh/id_rsa"',
     "docker run --rm -v $PWD:/w alpine cat /w/.env",
+    # ── PR #952 review: the extension list and the producer exemption ──
+    # `.key` was absent while `.gitignore` in every scaffolded repo lists
+    # `*.key` — the tree called the file a secret and the guard read it aloud.
+    "cat server.key",
+    "cat tls.key",
+    "cat certs/api.key",
+    # The Read() denylist flags these two, so the Bash side must agree; a
+    # control that exists on one surface and not the other is not a control.
+    "cat store.jks",
+    "cat app.keystore",
+    # THE EXEMPTION WAS GATED FOR `find` ALONE. Every other producer handed the
+    # path to a reader and the segment naming it was skipped — and the reader
+    # segment carries no path of its own, so nothing was left to match.
+    "printf '.env\\n' | xargs cat",
+    "echo .env | xargs cat",
+    "ls .env | xargs cat",
+    # SAME PIPELINE, DIFFERENT STATEMENT. The reader must still be seen when it
+    # shares a pipeline with the producer, even if another statement precedes it.
+    "cat README.md && ls .env | xargs cat",
+    "ls .env | xargs cat && cat README.md",
 ]
 
 NOT_EXPOSING = [
@@ -887,6 +907,20 @@ NOT_EXPOSING = [
     # mutation run showed the boundary was otherwise held by nothing, and a
     # fragment no test holds is one a later edit deletes.
     "cat docs/managing-secrets/guide.md",
+    # ── PR #952 review, P1: a reader in ANOTHER STATEMENT must not taint a safe
+    # producer. `|` shares a data path; `&&` and `;` do not. Computing the reader
+    # set over the whole command string made `cat` here poison the `echo`, so this
+    # everyday line started prompting — and in autonomous mode, denying. It is the
+    # exact false positive that gets a guard switched off, and it was reachable
+    # only by COMBINING two commands each of which the suite already covered
+    # alone, which is why nothing caught it.
+    'cat README.md && echo ".env" >> .gitignore',
+    'echo ".env" >> .gitignore && cat README.md',
+    "cat README.md; ls .env",
+    "ls .env; cat README.md",
+    # A keystore-shaped DOCUMENT is not a keystore.
+    "cat keystore.md",
+    "cat docs/api-key-rotation.md",
 ]
 
 


### PR DESCRIPTION
Four rounds, because each round's review found something the previous one introduced. Every finding was reproduced here before being fixed, and every fix carries a control arm.

**Plugin version: 0.9.5 → 0.9.8.** Three bumps, one per payload change, as PI-881 requires — Claude Code caches a plugin by version, so a payload change under an unchanged version serves the stale copy. `plugin.json`, `plugins/payload-locks.json` and `__plugin_version__` move together; the repo's own contract tests caught each coupling in turn.

## Round 1 — two secret-read bypasses

**`.key` was not a secret extension.** The pattern covered pem/p12/pfx/jks/keystore and not `key`, so the `server.key` / `tls.key` convention read straight into the transcript — while `.gitignore` in every scaffolded repo already lists `*.key`. The tree classified the file as a secret and the guard read it out loud.

**A safe producer stayed exempt with a reader downstream.** The gate existed for `find` alone, so every other producer was exempted unconditionally — and the reader segment carries no path of its own, so once the naming segment was skipped nothing was left to match.

## Round 2 — a false positive I introduced, and four gate gaps

**The reader set was computed over the whole command string**, so any reader anywhere tainted every safe producer. Adding a filename to `.gitignore` after reading a file started prompting — and in autonomous mode, denying. Worse than the bypass it came from: a guard that blocks daily work gets switched off. Reader detection is now scoped per statement, because `|` shares a data path and `&&` / `;` do not.

Why the suite missed it: both halves were *already* asserted as allowed, individually. The defect was reachable only by combining two cases the corpus already covered separately.

Also: `.jks`/`.keystore` missing from the `Read` denylist (the same one-surface asymmetry, one line away), Bun's `.spec`/`_spec_` spellings, a bare `#[test]` with no `#[cfg(test)]`, and Cargo workspaces — where my first attempt used `src */src` and still missed `crates/foo/src`. The sandbox caught that at 8/9; reading the code had not.

## Round 3 — the projection deleted files it never wrote (#951)

`.claude/` was treated as a pure mirror of `.agents/`, so every run after the first `rmtree`'d the whole directory. Repo-authored `inject.d/` rules and a tool-installed project skill were destroyed — measured three times on the same fleet, restored by hand each time, flagged by nothing.

Delete-awareness is why the `rmtree` existed, so dropping it would trade data loss for split-brain. The projection now records what it wrote in `.claude/.projection.json` and deletes exactly those paths. Trees with no manifest fall back to "has an `.agents/` counterpart today" — conservative by design.

## Round 4 — a redirection is not a statement separator

Splitting on any `&` broke `2>&1`, `&>` and `|&`, tearing a producer away from its downstream reader and **reintroducing the round-1 bypass**. Fixed with lookarounds; `&&` and `||` stay first in the alternation.

## Evidence

```
full suite            3036 passed, 6 skipped, 0 failed
guard corpus            406 passed
30-case battery          30 passed, 0 failed   (26/4 against the pre-fix guard)
redirection probe         9 passed, 0 failed
fuzz gate sandbox         9 cases, 4 of them controls
projection arms           4 arms, 1 of them a control
```

The controls are the point. Each fix here could have been faked by a wider rule — never split on `&`, never delete anything, treat every crate as tested — so each has an arm that goes red if it were.
