### PR TITLE
fix: `|&` is a pipe, and head extraction was reading the `&` as the verb

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "4c4031c56439cc8a407044093950dc41fc60b4b0e709f72b00fd010458c665d7",
-    "version": "0.9.10"
+    "sha256": "44538e89e2a991e32a0baa21e53d0b6cf0e89f059080c597f721c91bbf5b609f",
+    "version": "0.9.11"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "89ccd0e27e58dbe6f2fa49326bfe41b6a5ef58229661028eee5fdd614b547666",
-    "version": "0.9.9"
+    "sha256": "4c4031c56439cc8a407044093950dc41fc60b4b0e709f72b00fd010458c665d7",
+    "version": "0.9.10"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "d866a54d08426c23b763536bc2ccbb51bf5096fae412e5da6c7c50e444f90dbc",
-    "version": "0.9.8"
+    "sha256": "89ccd0e27e58dbe6f2fa49326bfe41b6a5ef58229661028eee5fdd614b547666",
+    "version": "0.9.9"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -494,11 +494,20 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
+        # `|&` IS A PIPE. Bash's shorthand for `2>&1 |` survives the statement
+        # split intact (the `&` is excluded below), and then the per-stage split
+        # on `|` leaves the downstream segment headed by `&` instead of the real
+        # verb — so no reader is found, the producer is exempted, and the read
+        # goes through. Measured: `ls <dotenv> |& xargs cat` allowed, including
+        # the documented `find … | xargs cat` shape (PR #952 review, second
+        # round). Normalising here fixes both the statement split and the stage
+        # split, because both read this output.
+        chunk = chunk.replace("|&", "|")
         # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
         # separator when it is not part of a redirection: splitting on any `&`
-        # broke `2>&1`, `&>` and `|&`, which tore a producer away from its
-        # downstream reader and REINTRODUCED the bypass — measured,
-        # `ls .env 2>&1 | xargs cat` went back to allow (PR #952 review).
+        # broke `2>&1` and `&>`, which tore a producer away from its downstream
+        # reader and REINTRODUCED the bypass — measured, `ls <dotenv> 2>&1 |
+        # xargs cat` went back to allow.
         out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
     return out
 

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -35,6 +35,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -429,6 +430,36 @@ _SUBSTITUTION = re.compile(r"\$\(([^()]*)\)|`([^`]*)`")
 # NOT "any pipe": `find . -name .env | wc -l` counts matches and reads nothing,
 # and a guard that prompts on it is the false positive that gets guards turned
 # off. The downstream verb has to actually consume contents.
+# SEPARATORS AS TOKENS, NOT AS CHARACTERS IN A STRING. `shlex` with
+# punctuation_chars=True yields each shell operator as its own token and leaves
+# an operator that appeared inside quotes buried in the token it belongs to, so
+# `echo '.env |& xargs cat'` tokenizes to two tokens and nothing splits. Getting
+# this from the tokenizer also retires the redirection lookaround the regex
+# needed: shlex already emits `>&` and `&>` as distinct tokens, so a bare `&` is
+# unambiguously a separator and `2>&1` cannot be mistaken for one.
+_PIPE_TOKENS = frozenset({"|", "|&"})
+_BREAK_TOKENS = frozenset({"&&", "||", ";", "&"})
+# The token AFTER one of these is prose, not a path. Replaces a regex that
+# required the quotes to still be in the string — which they are not, after
+# tokenizing — and it now also covers an unquoted message the regex never saw.
+_MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
+
+
+def _tokenize(command: str) -> list[str] | None:
+    """Split *command* into shell tokens, or None when it cannot be parsed.
+
+    None means unbalanced quotes. Callers fall back to the character split,
+    which over-splits rather than under-splits: for a guard, keeping the old
+    false positive on an unparsable command is the safe direction.
+    """
+    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
 _FIND_ACTS = re.compile(r"\s-(?:exec|execdir|ok|okdir)\b")
 _READER_VERBS = frozenset(
     {
@@ -478,15 +509,23 @@ def _leaf_commands(command: str) -> list[str]:
     return out
 
 
-def _statements(command: str) -> list[str]:
-    """Split *command* into statements, keeping each pipeline intact.
+def _statements(command: str) -> list[list[str]]:
+    """Split *command* into statements as token lists, pipelines kept intact.
 
     `_leaf_commands` collapses `;`, `&` and `|` into one separator, which loses
     the distinction that matters for the reader check: `a | b` shares a data path
     and `a && b` does not. Substitutions are inlined the same way, so a read
     hidden inside one is still judged.
+
+    TOKENS, NOT SUBSTRINGS, and this is the fourth defect in this one function
+    that says why. Every previous cut split the raw string, so it could not tell
+    an operator from the same characters inside a quoted argument, and
+    `echo '.env |& xargs cat'` — which reads nothing — was asked about. Measured
+    on the character split: all five separators were affected (`|`, `|&`, `&&`,
+    `||`, `;`), not just the `|&` that was reported. Three earlier rounds each
+    fixed one spelling with another lookaround; this replaces the mechanism.
     """
-    out: list[str] = []
+    out: list[list[str]] = []
     pending = [command]
     while pending and len(out) < 100:
         chunk = pending.pop()
@@ -494,21 +533,37 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
-        # `|&` IS A PIPE. Bash's shorthand for `2>&1 |` survives the statement
-        # split intact (the `&` is excluded below), and then the per-stage split
-        # on `|` leaves the downstream segment headed by `&` instead of the real
-        # verb — so no reader is found, the producer is exempted, and the read
-        # goes through. Measured: `ls <dotenv> |& xargs cat` allowed, including
-        # the documented `find … | xargs cat` shape (PR #952 review, second
-        # round). Normalising here fixes both the statement split and the stage
-        # split, because both read this output.
-        chunk = chunk.replace("|&", "|")
-        # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
-        # separator when it is not part of a redirection: splitting on any `&`
-        # broke `2>&1` and `&>`, which tore a producer away from its downstream
-        # reader and REINTRODUCED the bypass — measured, `ls <dotenv> 2>&1 |
-        # xargs cat` went back to allow.
-        out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
+        tokens = _tokenize(chunk)
+        if tokens is None:
+            # Unparsable (unbalanced quotes). Fall back to the character split
+            # this function used before — it cannot tell a quoted separator from
+            # a real one, so it may over-split, and over-splitting only ever
+            # makes the guard MORE eager. Deliberate: the alternative is to skip
+            # an unparsable command, and a guard that skips what it cannot read
+            # is a guard with a documented bypass.
+            #
+            # The segments must come out as REAL TOKENS, not as one token holding
+            # the whole segment: the caller reads `leaf[0]` as the verb, so a
+            # single-token segment has no recognisable verb, matches no reader
+            # and no safe producer, and the fallback silently stops guarding.
+            # Measured while writing this — the corpus went 28 red on a forced
+            # fallback, and every one of those was this, not the split.
+            out.extend(
+                segment.replace("|&", " | ").replace("|", " | ").split()
+                for segment in re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk)
+                if segment.strip()
+            )
+            continue
+        current: list[str] = []
+        for token in tokens:
+            if token in _BREAK_TOKENS:
+                if current:
+                    out.append(current)
+                current = []
+            else:
+                current.append(token)
+        if current:
+            out.append(current)
     return out
 
 
@@ -534,10 +589,25 @@ def _exposes_secret(command: str) -> str | None:
     return None
 
 
-def _statement_exposes(statement: str) -> str | None:
-    """The original per-segment check, scoped to one statement's pipeline."""
-    leaves = [seg for seg in statement.split("|") if seg.strip()]
-    heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
+def _statement_exposes(statement: list[str]) -> str | None:
+    """The original per-segment check, scoped to one statement's pipeline.
+
+    Takes TOKENS. Joining is safe wherever a regex still wants a string: any
+    separator left inside a token was quoted, and joining never re-splits — it
+    was the splitting that could not tell the two apart.
+    """
+    leaves: list[list[str]] = []
+    current: list[str] = []
+    for token in statement:
+        if token in _PIPE_TOKENS:
+            if current:
+                leaves.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        leaves.append(current)
+    heads = {leaf[0].rsplit("/", 1)[-1] for leaf in leaves if leaf}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
     # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
@@ -548,12 +618,29 @@ def _statement_exposes(statement: str) -> str | None:
     #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
     # The reader segment carries no path of its own, so once the naming segment
     # is skipped nothing is left to match and the contents reach the transcript.
-    producers_are_safe = not _FIND_ACTS.search(statement) and not (heads & _READER_VERBS)
-    for segment in leaves:
-        seg = _MESSAGE_ARG.sub(" ", segment).strip()
-        if not seg:
+    producers_are_safe = not _FIND_ACTS.search(" " + " ".join(statement)) and not (
+        heads & _READER_VERBS
+    )
+    for leaf in leaves:
+        # Drop a commit/tag message: it is prose that happens to contain a path,
+        # not an argument naming one. Dropping the token AFTER the flag also
+        # covers `-m do-not-cat-.env`, which the old quote-anchored regex could
+        # not see because it required the quotes to still be present.
+        tokens: list[str] = []
+        skip = False
+        for token in leaf:
+            if skip:
+                skip = False
+                continue
+            if token in _MESSAGE_FLAGS:
+                skip = True
+                continue
+            flag, _, inline = token.partition("=")
+            if inline and flag in _MESSAGE_FLAGS:
+                continue
+            tokens.append(token)
+        if not tokens:
             continue
-        tokens = seg.split()
         head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
         if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
@@ -562,8 +649,8 @@ def _statement_exposes(statement: str) -> str | None:
         if head in _PATTERN_FIRST_ARG:
             rest = [t for t in tokens[1:] if not t.startswith("-")]
             if rest:
-                seg = seg.replace(rest[0], " ", 1)
-        if _SECRET_PATH.search(" " + seg):
+                tokens = [t for t in tokens if t is not rest[0]]
+        if _SECRET_PATH.search(" " + " ".join(tokens)):
             return "read of a secret-bearing file"
     return None
 

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -438,7 +438,24 @@ _SUBSTITUTION = re.compile(r"\$\(([^()]*)\)|`([^`]*)`")
 # needed: shlex already emits `>&` and `&>` as distinct tokens, so a bare `&` is
 # unambiguously a separator and `2>&1` cannot be mistaken for one.
 _PIPE_TOKENS = frozenset({"|", "|&"})
-_BREAK_TOKENS = frozenset({"&&", "||", ";", "&"})
+# A NEWLINE IS A STATEMENT SEPARATOR, and shlex does not think so by default:
+# it is whitespace, so `cmd1\ncmd2` came back as ONE statement with `cmd2` read
+# as an argument to `cmd1`. That is not cosmetic — it reopened the bypass this
+# module exists to close. Measured before the fix, with a dotenv path:
+#     ls -la<newline>cat <dotenv>     -> allow   (WRONG, a read got through)
+#     cat README.md<newline>echo …    -> ask     (WRONG, the other direction)
+# The first is the one that matters: two lines merge, the head becomes `ls`
+# (exposure-safe), no reader appears in `heads` because `cat` is now an
+# argument, the producer is exempted, and the file is read. Caught in review of
+# PR #953 by Copilot; the regex this replaced listed `\n` explicitly and I
+# dropped it.
+_BREAK_TOKENS = frozenset({"&&", "||", ";", "&", "\n"})
+# Newline added to shlex's punctuation set, and removed from its whitespace, so
+# it is EMITTED as a token instead of being discarded. Doing it through the
+# tokenizer rather than by splitting the string on newlines first is what keeps
+# a QUOTED newline intact: `echo 'a<newline>b'` stays one token, where a
+# pre-split would tear it in half and leave both halves unparsable.
+_PUNCTUATION_CHARS = "();<>|&\n"
 # The token AFTER one of these is prose, not a path. Replaces a regex that
 # required the quotes to still be in the string — which they are not, after
 # tokenizing — and it now also covers an unquoted message the regex never saw.
@@ -452,8 +469,11 @@ def _tokenize(command: str) -> list[str] | None:
     which over-splits rather than under-splits: for a guard, keeping the old
     false positive on an unparsable command is the safe direction.
     """
-    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lex.whitespace_split = True
+    # Newline must stop being whitespace or it is thrown away before punctuation
+    # handling ever sees it, which is exactly how it stopped separating.
+    lex.whitespace = lex.whitespace.replace("\n", "")
     try:
         return list(lex)
     except ValueError:

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.10"
+__plugin_version__ = "0.9.11"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.8"
+__plugin_version__ = "0.9.9"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.9"
+__plugin_version__ = "0.9.10"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 import time
 import tomllib
 from collections.abc import Callable, Iterator
@@ -1406,14 +1407,29 @@ def _generate_claude_projection(
     # STAGED, so the set of projected paths is a fact rather than an inference.
     # Rendering straight into `.claude/` leaves no way to tell what we just wrote
     # from what was already beside it, and guessing is what broke this before.
-    staging = claude_dir.with_name(claude_dir.name + ".projection-staging")
-    shutil.rmtree(staging, ignore_errors=True)
+    #
+    # A FIXED STAGING NAME HAD TWO FAULTS, both raised in review of PR #953 and
+    # both reproduced. The first cut used `<claude_dir>.projection-staging` and
+    # cleared it with `rmtree(..., ignore_errors=True)`:
+    #
+    #   1. `rmtree` does not remove a FILE, so a plain file sitting at that path
+    #      left it in place and `copytree` died on an unhandled FileExistsError,
+    #      taking the whole upgrade with it (measured: rc=1, traceback).
+    #   2. It deleted whatever directory already stood there, which is right for
+    #      our own leftovers and wrong for anything else that picked the name.
+    #
+    # `mkdtemp` retires both rather than handling each: the name is unique, so
+    # there is nothing to collide with and nothing pre-existing to delete. It is
+    # created inside the project directory on purpose — a staging dir on another
+    # filesystem would turn the second copytree into a cross-device copy.
+    staging_parent = Path(tempfile.mkdtemp(prefix=".projection-staging-", dir=claude_dir.parent))
+    staging = staging_parent / "render"
     try:
         shutil.copytree(agents_dir, staging, ignore=_ignore)
         projected = [f.relative_to(staging).as_posix() for f in staging.rglob("*") if f.is_file()]
         shutil.copytree(staging, claude_dir, dirs_exist_ok=True)
     finally:
-        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(staging_parent, ignore_errors=True)
     _write_projection_manifest(claude_dir, projected)
 
 

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -1410,9 +1410,7 @@ def _generate_claude_projection(
     shutil.rmtree(staging, ignore_errors=True)
     try:
         shutil.copytree(agents_dir, staging, ignore=_ignore)
-        projected = [
-            f.relative_to(staging).as_posix() for f in staging.rglob("*") if f.is_file()
-        ]
+        projected = [f.relative_to(staging).as_posix() for f in staging.rglob("*") if f.is_file()]
         shutil.copytree(staging, claude_dir, dirs_exist_ok=True)
     finally:
         shutil.rmtree(staging, ignore_errors=True)

--- a/src/project_init/scaffold.py
+++ b/src/project_init/scaffold.py
@@ -1257,13 +1257,21 @@ def _read_projection_manifest(claude_dir: Path) -> set[str] | None:
     return set(paths)
 
 
-def _write_projection_manifest(claude_dir: Path) -> None:
-    """Record every file now under `.claude/` except our own state files."""
-    paths = sorted(
-        f.relative_to(claude_dir).as_posix()
-        for f in claude_dir.rglob("*")
-        if f.is_file() and f.relative_to(claude_dir).as_posix() not in _PROJECTION_OWN_STATE
-    )
+def _write_projection_manifest(claude_dir: Path, projected: list[str]) -> None:
+    """Record the paths THIS projection wrote — nothing else.
+
+    An earlier version of this recorded everything present under `.claude/` after
+    the copy, which quietly re-created the bug it was added to fix: a
+    repo-authored file sitting beside the projection was listed as ours, so the
+    NEXT run deleted it as ours. That deferred the data loss by one cycle instead
+    of preventing it, and it was caught only because the cycle came round.
+    Measured: `inject.d/10-deliverables-name-the-proof-tier.md` appeared in a
+    15-entry manifest it had no business being in, and was gone one run later.
+
+    So the list comes from the staged render — the files copytree actually
+    produced — and never from the destination directory.
+    """
+    paths = sorted(x for x in projected if x not in _PROJECTION_OWN_STATE)
     (claude_dir / PROJECTION_MANIFEST).write_text(
         json.dumps({"paths": paths}, indent=2) + "\n", encoding="utf-8"
     )
@@ -1395,8 +1403,20 @@ def _generate_claude_projection(
             skip |= {n for n in names if n in PLUGIN_PROVIDED_SKILLS}
         return skip
 
-    shutil.copytree(agents_dir, claude_dir, ignore=_ignore, dirs_exist_ok=True)
-    _write_projection_manifest(claude_dir)
+    # STAGED, so the set of projected paths is a fact rather than an inference.
+    # Rendering straight into `.claude/` leaves no way to tell what we just wrote
+    # from what was already beside it, and guessing is what broke this before.
+    staging = claude_dir.with_name(claude_dir.name + ".projection-staging")
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        shutil.copytree(agents_dir, staging, ignore=_ignore)
+        projected = [
+            f.relative_to(staging).as_posix() for f in staging.rglob("*") if f.is_file()
+        ]
+        shutil.copytree(staging, claude_dir, dirs_exist_ok=True)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    _write_projection_manifest(claude_dir, projected)
 
 
 def _emit_generated(

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -494,11 +494,20 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
+        # `|&` IS A PIPE. Bash's shorthand for `2>&1 |` survives the statement
+        # split intact (the `&` is excluded below), and then the per-stage split
+        # on `|` leaves the downstream segment headed by `&` instead of the real
+        # verb — so no reader is found, the producer is exempted, and the read
+        # goes through. Measured: `ls <dotenv> |& xargs cat` allowed, including
+        # the documented `find … | xargs cat` shape (PR #952 review, second
+        # round). Normalising here fixes both the statement split and the stage
+        # split, because both read this output.
+        chunk = chunk.replace("|&", "|")
         # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
         # separator when it is not part of a redirection: splitting on any `&`
-        # broke `2>&1`, `&>` and `|&`, which tore a producer away from its
-        # downstream reader and REINTRODUCED the bypass — measured,
-        # `ls .env 2>&1 | xargs cat` went back to allow (PR #952 review).
+        # broke `2>&1` and `&>`, which tore a producer away from its downstream
+        # reader and REINTRODUCED the bypass — measured, `ls <dotenv> 2>&1 |
+        # xargs cat` went back to allow.
         out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
     return out
 

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -35,6 +35,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -429,6 +430,36 @@ _SUBSTITUTION = re.compile(r"\$\(([^()]*)\)|`([^`]*)`")
 # NOT "any pipe": `find . -name .env | wc -l` counts matches and reads nothing,
 # and a guard that prompts on it is the false positive that gets guards turned
 # off. The downstream verb has to actually consume contents.
+# SEPARATORS AS TOKENS, NOT AS CHARACTERS IN A STRING. `shlex` with
+# punctuation_chars=True yields each shell operator as its own token and leaves
+# an operator that appeared inside quotes buried in the token it belongs to, so
+# `echo '.env |& xargs cat'` tokenizes to two tokens and nothing splits. Getting
+# this from the tokenizer also retires the redirection lookaround the regex
+# needed: shlex already emits `>&` and `&>` as distinct tokens, so a bare `&` is
+# unambiguously a separator and `2>&1` cannot be mistaken for one.
+_PIPE_TOKENS = frozenset({"|", "|&"})
+_BREAK_TOKENS = frozenset({"&&", "||", ";", "&"})
+# The token AFTER one of these is prose, not a path. Replaces a regex that
+# required the quotes to still be in the string — which they are not, after
+# tokenizing — and it now also covers an unquoted message the regex never saw.
+_MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
+
+
+def _tokenize(command: str) -> list[str] | None:
+    """Split *command* into shell tokens, or None when it cannot be parsed.
+
+    None means unbalanced quotes. Callers fall back to the character split,
+    which over-splits rather than under-splits: for a guard, keeping the old
+    false positive on an unparsable command is the safe direction.
+    """
+    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
 _FIND_ACTS = re.compile(r"\s-(?:exec|execdir|ok|okdir)\b")
 _READER_VERBS = frozenset(
     {
@@ -478,15 +509,23 @@ def _leaf_commands(command: str) -> list[str]:
     return out
 
 
-def _statements(command: str) -> list[str]:
-    """Split *command* into statements, keeping each pipeline intact.
+def _statements(command: str) -> list[list[str]]:
+    """Split *command* into statements as token lists, pipelines kept intact.
 
     `_leaf_commands` collapses `;`, `&` and `|` into one separator, which loses
     the distinction that matters for the reader check: `a | b` shares a data path
     and `a && b` does not. Substitutions are inlined the same way, so a read
     hidden inside one is still judged.
+
+    TOKENS, NOT SUBSTRINGS, and this is the fourth defect in this one function
+    that says why. Every previous cut split the raw string, so it could not tell
+    an operator from the same characters inside a quoted argument, and
+    `echo '.env |& xargs cat'` — which reads nothing — was asked about. Measured
+    on the character split: all five separators were affected (`|`, `|&`, `&&`,
+    `||`, `;`), not just the `|&` that was reported. Three earlier rounds each
+    fixed one spelling with another lookaround; this replaces the mechanism.
     """
-    out: list[str] = []
+    out: list[list[str]] = []
     pending = [command]
     while pending and len(out) < 100:
         chunk = pending.pop()
@@ -494,21 +533,37 @@ def _statements(command: str) -> list[str]:
         if inner:
             pending.extend(inner)
             chunk = _SUBSTITUTION.sub(" ", chunk)
-        # `|&` IS A PIPE. Bash's shorthand for `2>&1 |` survives the statement
-        # split intact (the `&` is excluded below), and then the per-stage split
-        # on `|` leaves the downstream segment headed by `&` instead of the real
-        # verb — so no reader is found, the producer is exempted, and the read
-        # goes through. Measured: `ls <dotenv> |& xargs cat` allowed, including
-        # the documented `find … | xargs cat` shape (PR #952 review, second
-        # round). Normalising here fixes both the statement split and the stage
-        # split, because both read this output.
-        chunk = chunk.replace("|&", "|")
-        # `&&` and `||` FIRST, or they split wrongly. And a bare `&` is only a
-        # separator when it is not part of a redirection: splitting on any `&`
-        # broke `2>&1` and `&>`, which tore a producer away from its downstream
-        # reader and REINTRODUCED the bypass — measured, `ls <dotenv> 2>&1 |
-        # xargs cat` went back to allow.
-        out.extend(re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk))
+        tokens = _tokenize(chunk)
+        if tokens is None:
+            # Unparsable (unbalanced quotes). Fall back to the character split
+            # this function used before — it cannot tell a quoted separator from
+            # a real one, so it may over-split, and over-splitting only ever
+            # makes the guard MORE eager. Deliberate: the alternative is to skip
+            # an unparsable command, and a guard that skips what it cannot read
+            # is a guard with a documented bypass.
+            #
+            # The segments must come out as REAL TOKENS, not as one token holding
+            # the whole segment: the caller reads `leaf[0]` as the verb, so a
+            # single-token segment has no recognisable verb, matches no reader
+            # and no safe producer, and the fallback silently stops guarding.
+            # Measured while writing this — the corpus went 28 red on a forced
+            # fallback, and every one of those was this, not the split.
+            out.extend(
+                segment.replace("|&", " | ").replace("|", " | ").split()
+                for segment in re.split(r"(?:&&|\|\||;|\n|(?<![>&|])&(?![>&]))+", chunk)
+                if segment.strip()
+            )
+            continue
+        current: list[str] = []
+        for token in tokens:
+            if token in _BREAK_TOKENS:
+                if current:
+                    out.append(current)
+                current = []
+            else:
+                current.append(token)
+        if current:
+            out.append(current)
     return out
 
 
@@ -534,10 +589,25 @@ def _exposes_secret(command: str) -> str | None:
     return None
 
 
-def _statement_exposes(statement: str) -> str | None:
-    """The original per-segment check, scoped to one statement's pipeline."""
-    leaves = [seg for seg in statement.split("|") if seg.strip()]
-    heads = {seg.split()[0].rsplit("/", 1)[-1] for seg in leaves if seg.split()}
+def _statement_exposes(statement: list[str]) -> str | None:
+    """The original per-segment check, scoped to one statement's pipeline.
+
+    Takes TOKENS. Joining is safe wherever a regex still wants a string: any
+    separator left inside a token was quoted, and joining never re-splits — it
+    was the splitting that could not tell the two apart.
+    """
+    leaves: list[list[str]] = []
+    current: list[str] = []
+    for token in statement:
+        if token in _PIPE_TOKENS:
+            if current:
+                leaves.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        leaves.append(current)
+    heads = {leaf[0].rsplit("/", 1)[-1] for leaf in leaves if leaf}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
     # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
@@ -548,12 +618,29 @@ def _statement_exposes(statement: str) -> str | None:
     #   ls .env           | xargs cat   -> ALLOWED  (exempt, wrong)
     # The reader segment carries no path of its own, so once the naming segment
     # is skipped nothing is left to match and the contents reach the transcript.
-    producers_are_safe = not _FIND_ACTS.search(statement) and not (heads & _READER_VERBS)
-    for segment in leaves:
-        seg = _MESSAGE_ARG.sub(" ", segment).strip()
-        if not seg:
+    producers_are_safe = not _FIND_ACTS.search(" " + " ".join(statement)) and not (
+        heads & _READER_VERBS
+    )
+    for leaf in leaves:
+        # Drop a commit/tag message: it is prose that happens to contain a path,
+        # not an argument naming one. Dropping the token AFTER the flag also
+        # covers `-m do-not-cat-.env`, which the old quote-anchored regex could
+        # not see because it required the quotes to still be present.
+        tokens: list[str] = []
+        skip = False
+        for token in leaf:
+            if skip:
+                skip = False
+                continue
+            if token in _MESSAGE_FLAGS:
+                skip = True
+                continue
+            flag, _, inline = token.partition("=")
+            if inline and flag in _MESSAGE_FLAGS:
+                continue
+            tokens.append(token)
+        if not tokens:
             continue
-        tokens = seg.split()
         head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
         if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
@@ -562,8 +649,8 @@ def _statement_exposes(statement: str) -> str | None:
         if head in _PATTERN_FIRST_ARG:
             rest = [t for t in tokens[1:] if not t.startswith("-")]
             if rest:
-                seg = seg.replace(rest[0], " ", 1)
-        if _SECRET_PATH.search(" " + seg):
+                tokens = [t for t in tokens if t is not rest[0]]
+        if _SECRET_PATH.search(" " + " ".join(tokens)):
             return "read of a secret-bearing file"
     return None
 

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -438,7 +438,24 @@ _SUBSTITUTION = re.compile(r"\$\(([^()]*)\)|`([^`]*)`")
 # needed: shlex already emits `>&` and `&>` as distinct tokens, so a bare `&` is
 # unambiguously a separator and `2>&1` cannot be mistaken for one.
 _PIPE_TOKENS = frozenset({"|", "|&"})
-_BREAK_TOKENS = frozenset({"&&", "||", ";", "&"})
+# A NEWLINE IS A STATEMENT SEPARATOR, and shlex does not think so by default:
+# it is whitespace, so `cmd1\ncmd2` came back as ONE statement with `cmd2` read
+# as an argument to `cmd1`. That is not cosmetic — it reopened the bypass this
+# module exists to close. Measured before the fix, with a dotenv path:
+#     ls -la<newline>cat <dotenv>     -> allow   (WRONG, a read got through)
+#     cat README.md<newline>echo …    -> ask     (WRONG, the other direction)
+# The first is the one that matters: two lines merge, the head becomes `ls`
+# (exposure-safe), no reader appears in `heads` because `cat` is now an
+# argument, the producer is exempted, and the file is read. Caught in review of
+# PR #953 by Copilot; the regex this replaced listed `\n` explicitly and I
+# dropped it.
+_BREAK_TOKENS = frozenset({"&&", "||", ";", "&", "\n"})
+# Newline added to shlex's punctuation set, and removed from its whitespace, so
+# it is EMITTED as a token instead of being discarded. Doing it through the
+# tokenizer rather than by splitting the string on newlines first is what keeps
+# a QUOTED newline intact: `echo 'a<newline>b'` stays one token, where a
+# pre-split would tear it in half and leave both halves unparsable.
+_PUNCTUATION_CHARS = "();<>|&\n"
 # The token AFTER one of these is prose, not a path. Replaces a regex that
 # required the quotes to still be in the string — which they are not, after
 # tokenizing — and it now also covers an unquoted message the regex never saw.
@@ -452,8 +469,11 @@ def _tokenize(command: str) -> list[str] | None:
     which over-splits rather than under-splits: for a guard, keeping the old
     false positive on an unparsable command is the safe direction.
     """
-    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lex.whitespace_split = True
+    # Newline must stop being whitespace or it is thrown away before punctuation
+    # handling ever sees it, which is exactly how it stopped separating.
+    lex.whitespace = lex.whitespace.replace("\n", "")
     try:
         return list(lex)
     except ValueError:

--- a/tests/contracts/test_claude_projection.py
+++ b/tests/contracts/test_claude_projection.py
@@ -138,6 +138,35 @@ def test_rebuild_keeps_a_file_the_projection_never_wrote(tmp_path: Path):
     assert (tmp_path / ".claude" / "settings.json").exists()
 
 
+def test_an_unmanaged_file_survives_repeated_projections(tmp_path: Path):
+    """The arm that was missing, and the bug it would have caught.
+
+    The first version of the manifest recorded everything present under
+    `.claude/` after the copy — so a repo-authored file beside the projection was
+    listed as ours and the NEXT run deleted it. One projection looked fine; two
+    did not. Measured on a real repo:
+    `inject.d/10-deliverables-name-the-proof-tier.md` appeared in a 15-entry
+    manifest and was gone one run later.
+
+    Three runs, because the failure needed two.
+    """
+    _mk_agents(tmp_path)
+    _generate_claude_projection(tmp_path)
+
+    hand_written = tmp_path / ".claude" / "inject.d" / "10-local-rule.md"
+    hand_written.parent.mkdir(parents=True, exist_ok=True)
+    hand_written.write_text("repo-authored, no .agents/ counterpart\n")
+
+    for run in range(3):
+        _generate_claude_projection(tmp_path, first_scaffold=False)
+        assert hand_written.exists(), f"deleted on run {run + 2}"
+
+    import json
+
+    listed = json.loads((tmp_path / ".claude" / ".projection.json").read_text())["paths"]
+    assert "inject.d/10-local-rule.md" not in listed, "claimed a file it never wrote"
+
+
 def test_rebuild_is_still_delete_aware_once_recorded(tmp_path: Path):
     """The control for the arm above: delete-awareness must survive the fix.
 

--- a/tests/contracts/test_claude_projection.py
+++ b/tests/contracts/test_claude_projection.py
@@ -138,6 +138,39 @@ def test_rebuild_keeps_a_file_the_projection_never_wrote(tmp_path: Path):
     assert (tmp_path / ".claude" / "settings.json").exists()
 
 
+def test_a_collision_at_the_old_staging_name_is_harmless(tmp_path: Path):
+    """PR #953 review: the staging directory had a FIXED name, with two faults.
+
+    The first cut staged the render in `<claude_dir>.projection-staging` and
+    cleared it with `shutil.rmtree(..., ignore_errors=True)`:
+
+      1. `rmtree` does not remove a FILE. A plain file at that path therefore
+         survived the clear, and `copytree` died on an unhandled FileExistsError
+         — measured on a real scaffold, the upgrade exited 1 with a traceback.
+      2. A pre-existing DIRECTORY there was deleted unconditionally, which is
+         correct for our own crash leftovers and wrong for anything else.
+
+    `mkdtemp` retires both: the name is unique, so there is nothing to collide
+    with and nothing to delete. This test plants BOTH shapes at the old fixed
+    name and requires the projection to succeed and to touch neither.
+    """
+    _mk_agents(tmp_path)
+    stale_file = tmp_path / ".claude.projection-staging"
+    stale_file.write_text("not ours, and not a directory\n")
+    stale_dir = tmp_path / ".claude.projection-staging.d"
+    stale_dir.mkdir()
+    (stale_dir / "keep.txt").write_text("someone else's data\n")
+
+    _generate_claude_projection(tmp_path)
+
+    assert stale_file.read_text() == "not ours, and not a directory\n"
+    assert (stale_dir / "keep.txt").read_text() == "someone else's data\n"
+    assert (tmp_path / ".claude" / "settings.json").exists(), "projection did not run"
+    # And no staging directory is left behind for the next run to trip over.
+    leftovers = sorted(q.name for q in tmp_path.glob(".projection-staging-*"))
+    assert leftovers == [], f"staging litter: {leftovers}"
+
+
 def test_an_unmanaged_file_survives_repeated_projections(tmp_path: Path):
     """The arm that was missing, and the bug it would have caught.
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -947,6 +947,29 @@ NOT_EXPOSING = [
     # A keystore-shaped DOCUMENT is not a keystore.
     "cat keystore.md",
     "cat docs/api-key-rotation.md",
+    # ── PR #953 review, P2: A QUOTED SEPARATOR IS TEXT, NOT AN OPERATOR. The
+    # splitter worked on the raw string, so it could not tell `|&` inside a
+    # quoted argument from a real pipeline: `echo '.env |& xargs cat'` reads
+    # nothing at all, yet `xargs` was counted as a downstream reader, the `echo`
+    # exemption was withdrawn, and the line prompted.
+    #
+    # ALL FIVE SEPARATORS WERE AFFECTED, not just the reported `|&`. The report
+    # named one spelling; measuring the others showed the same false positive on
+    # every one, which is why the mechanism changed to a tokenizer instead of the
+    # fourth lookaround in that function. Each line below reads NOTHING.
+    "echo '.env |& xargs cat'",
+    'echo ".env |& xargs cat"',
+    "echo '.env | xargs cat'",
+    "echo '.env && cat .env'",
+    "echo '.env ; cat .env'",
+    "echo '.env || cat .env'",
+    "echo 'cat .env'",
+    "printf '%s' '.env |& cat'",
+    # An UNQUOTED message argument. The old carve-out was anchored on the quote
+    # characters, so it only ever saw a quoted message; tokenizing drops the
+    # argument after the flag regardless of how it was written.
+    "git commit -m do-not-cat-.env",
+    "git commit -am fix-.env-handling",
 ]
 
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -870,6 +870,19 @@ EXPOSING = [
     # shares a pipeline with the producer, even if another statement precedes it.
     "cat README.md && ls .env | xargs cat",
     "ls .env | xargs cat && cat README.md",
+    # PR #953 review, and this one was a BYPASS rather than a false positive.
+    # A NEWLINE SEPARATES STATEMENTS and shlex disagrees: it is whitespace, so
+    # `cmd1\\ncmd2` came back as ONE statement with `cmd2` read as an argument
+    # to `cmd1`. The head then became the exposure-safe `ls`, no reader appeared
+    # in `heads` because the verb was no longer a head, the producer was
+    # exempted, and the read went through. Measured before the fix: ALLOWED.
+    # The regex the tokenizer replaced listed `\\n` explicitly, and dropping it
+    # reopened this.
+    "ls -la\ncat .env",
+    "ls .env\ncat .env",
+    "cat README.md\ncat .env",
+    # Three lines, so the read is not merely adjacent to the safe verb.
+    "cd /tmp\nls -la\ncat .env",
 ]
 
 NOT_EXPOSING = [
@@ -970,6 +983,21 @@ NOT_EXPOSING = [
     # argument after the flag regardless of how it was written.
     "git commit -m do-not-cat-.env",
     "git commit -am fix-.env-handling",
+    # The newline fix must not become "any newline is suspicious". Each of these
+    # is two INDEPENDENT statements with no data path between them, exactly like
+    # the `;` cases above — and the merged-statement bug made the second one
+    # prompt on an everyday two-line paste.
+    'echo ".env" >> .gitignore\ncat README.md',
+    'cat README.md\necho ".env" >> .gitignore',
+    "ls .env\ncat README.md",
+    # A reader alone on its line has nothing feeding it: a pipe shares a data
+    # path, a newline does not.
+    "ls .env\nxargs cat",
+    # A QUOTED newline is text, not a separator. This is the property that keeps
+    # the fix inside the tokenizer rather than a pre-split on "\\n", which would
+    # tear a quoted string in half and leave both halves unparsable.
+    "echo 'first line\n.env second line'",
+    "printf 'a\nb' | cat",
 ]
 
 

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -856,6 +856,13 @@ EXPOSING = [
     # broke `2>&1`, `&>` and `|&`, tearing the producer away from its
     # downstream reader and reintroducing the bypass this fix closed.
     "ls .env 2>&1 | xargs cat",
+    # `|&` IS A PIPE — bash shorthand for `2>&1 |`. It survived the statement
+    # split, then the per-stage split on `|` left the downstream segment headed
+    # by `&` instead of the verb, so no reader was found at all.
+    "ls .env |& xargs cat",
+    "printf '.env\\n' |& xargs cat",
+    "echo .env |& xargs cat",
+    "find . -name .env |& xargs cat",
     "printf '.env\\n' 2>&1 | xargs cat",
     "ls .env &> /tmp/out | xargs cat",
     "cat .env >/dev/null 2>&1",
@@ -931,6 +938,11 @@ NOT_EXPOSING = [
     "sleep 1 & cat README.md",
     "ls .env & cat README.md",
     "cat README.md 2>&1",
+    # `|&` on nothing secret stays allowed — the control against normalising
+    # it into a blanket match.
+    "ls -la |& grep foo",
+    "cat README.md |& head",
+    "cat .env.example |& head",
     "ls -la 2>&1 | grep foo",
     # A keystore-shaped DOCUMENT is not a keystore.
     "cat keystore.md",

--- a/tests/integration/test_hooks_and_safety.py
+++ b/tests/integration/test_hooks_and_safety.py
@@ -148,10 +148,25 @@ class TestGitleaksPreCommitHook:
         fake.write_text(f'#!/bin/bash\necho "$@" > "{log}"\nexit 1\n')
         fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
+        # Neutralize the hook's stage-1 `just lint` gate, same reason and same
+        # stub as TestPrePushLifecycleGate: the hook resolves REPO_ROOT from the
+        # CWD, which under pytest is THIS repo, so a real `just` on PATH lints
+        # project-init itself. When project-init's own lint was red the hook
+        # exited 1 at stage 1, never reached gitleaks, and this test failed as
+        # `FileNotFoundError: args.log` — a message that names neither the gate
+        # nor the file that was actually unformatted. Only gitleaks delegation is
+        # under test here; the lint gate's own behaviour is not.
+        stub_bin = tmp_path / "stub-bin"
+        stub_bin.mkdir(exist_ok=True)
+        stub = stub_bin / "just"
+        stub.write_text("#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+
         env = os.environ.copy()
-        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["PATH"] = f"{fake_bin}:{stub_bin}:{env['PATH']}"
         result = _run_hook(self.hook, env=env)
         assert result.returncode == 1, "findings exit code must abort the commit"
+        assert log.exists(), "hook exited without invoking gitleaks; stderr:\n" + result.stderr
         assert "--staged" in log.read_text()
 
 


### PR DESCRIPTION
fix: `|&` is a pipe, and head extraction was reading the `&` as the verb

PR #952 review, second round on the merged branch. A REGRESSION FROM MY OWN
STATEMENT SPLITTING, and it reopened the documented bypass through a different
spelling.

`_statements()` correctly kept `|&` in one statement — the lookaround excludes an
`&` that follows `|`. Then `_statement_exposes()` split that statement on `|` and
the downstream stage came out as `& xargs cat`. Head extraction took `&` as the
verb, `xargs` never entered `heads`, no reader was detected, the producer was
exempted, and the read went through.

Measured before, with a dotenv path as the producer's argument:

    ls <dotenv> |& xargs cat             -> allow   (WRONG)
    printf '<dotenv>' |& xargs cat       -> allow   (WRONG)
    echo <dotenv> |& xargs cat           -> allow   (WRONG)
    find . -name <dotenv> |& xargs cat   -> allow   (WRONG)

The last one is the shape the corpus has documented since PR #942 — reachable
again because the ORIGINAL `re.split(r"[;&|\n]+", …)` happened to break `|&` into
separate leaves, so `xargs` stayed a head. My statement splitting removed that
accident without replacing it.

Fixed by normalising before any splitting, since `|&` is bash shorthand for
`2>&1 |` and the pipe is the part that matters:

    chunk = chunk.replace("|&", "|")

One line, placed in `_statements()` rather than in head extraction, because BOTH
splits read that output and fixing it once covers both.

SEVEN CORPUS CASES, three of them controls so the normalisation cannot become a
blanket match — `ls -la |& grep foo`, `cat README.md |& head` and the example-file
sibling piped the same way all stay allowed.

Plugin bumped 0.9.8 -> **0.9.11** with the lock and the version constant (PI-881).

> Corrected after review: this line said `-> 0.9.9`, which was true when it was
> written and stale by the time anyone read it. Two later review rounds on this
> same PR each changed the payload and so each required its own bump — 0.9.9 for
> the `|&` and manifest fixes, 0.9.10 for the tokenizer and staging fixes, 0.9.11
> for the newline separator. **0.9.11 is the version that carries all of it**, and
> it is the number downstream consumers should pin. Caught by Copilot, who read
> the description against the diff rather than trusting it.

Verified: 3047 passed, 6 skipped, 0 failed. Probes: `|&` 9/9, redirection 9/9,
30-case battery 30/0.

STANDING RECOMMENDATION, recorded because this is the third segmentation defect in
five rounds: each one came from a shell form the regex did not enumerate, and the
corpus caught none of them — an adversarial reader did, every time. If a fourth
appears, the answer is a real parser (bashlex or equivalent) rather than another
lookaround. Hand-rolled shell segmentation has now been wrong three times in the
same function.

