### PR TITLE
chore: bump ccr 3.0.21 → 3.0.22

### DIFF
--- a/templates/multi_model/dot_agents/scripts/setup_models.sh
+++ b/templates/multi_model/dot_agents/scripts/setup_models.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # hold every scaffolded project behind a bump PR on a fast-moving tool. It is
 # installed at upstream latest and is absent from the manifest by design.
 CCR_PKG="@musistudio/claude-code-router"
-CCR_VERSION="3.0.21"
+CCR_VERSION="3.0.22"
 CLAUDE_PKG="@anthropic-ai/claude-code"
 
 # --- paths --------------------------------------------------------------------

--- a/tools/pinned_third_party.toml
+++ b/tools/pinned_third_party.toml
@@ -10,7 +10,7 @@
 [tools.ccr]
 package = "@musistudio/claude-code-router"
 ecosystem = "npm"
-pinned = "3.0.21"
+pinned = "3.0.22"
 # The shell variable carrying this version in each used_in file (kept in lockstep
 # with `pinned` by `check_third_party_updates.py apply`).
 version_var = "CCR_VERSION"


### PR DESCRIPTION
Automated proposal to bump the vetted pin for **ccr** (`@musistudio/claude-code-router`).

- **3.0.21 → 3.0.22**
- Security scan — npm audit: 0 vulnerabilities (critical 0, high 0, moderate 0, low 0).
- Changelog: https://github.com/musistudio/claude-code-router/releases

This sits on a scaffolded project's request path, so **review the changelog/diff
before merging** (ADR-016 §5). Not auto-merged. Downstream projects inherit the
vetted pin via upgrade-as-PR (PI-241).