### PR TITLE
chore: mkdocs-material 9.7.6 -> 9.7.7 (CVE-2026-73295)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -479,7 +479,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -494,9 +494,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pip-audit` is failing on **every open PR in this repo**, and on none of them for a
reason the PR introduced.

`mkdocs-material` is pinned `>=9.7.6` in `pyproject.toml` and locked at exactly
9.7.6. CVE-2026-73295 was published after main's last CI run — 2026-08-23, green —
so `just audit` went red on the calendar, not on a commit. #966 and #969 are both
red for this and nothing else.

## Verified, PRISTINE vs patched, same command

```
locked 9.7.6   Name            Version ID             Fix Versions
               --------------- ------- -------------- ------------
               mkdocs-material 9.7.6   CVE-2026-73295 9.7.7
               error: recipe `audit` failed on line 72 with exit code 1

locked 9.7.7   No known vulnerabilities found
```

Green alone would not have been evidence here — a passing audit is also what a
broken audit command looks like — so the red was reproduced on the unpatched lock
first, with the same `just audit`, in the same worktree.

## Scope

Lock-only, 3 lines. `pyproject.toml`'s floor already admits 9.7.7, so the declared
dependency does not change, and `uv lock --upgrade-package mkdocs-material` moved
no other package.

**Merge this before the other open PRs** — it is what unblocks their CI gate.

https://claude.ai/code/session_01TgA39zvovy76w4HP6ZVVXd
