### PR TITLE
fix: the payload hash counted gitignored bytecode, so a local hook run reddened CI's green

### DIFF
--- a/tests/contracts/test_plugin_marketplace.py
+++ b/tests/contracts/test_plugin_marketplace.py
@@ -210,6 +210,35 @@ class TestPayloadVersionLock:
             for hook in (root / "hooks").glob("*.sh"):
                 assert hook.stat().st_mode & 0o111, f"{root.name}/{hook.name} is not executable"
 
+    def test_bytecode_next_to_a_hook_does_not_move_the_hash(self, tmp_path):
+        # THE HASH IS OVER THE COMMITTED TREE, AND BYTECODE IS NOT IN IT.
+        # `hooks/prod_guard.py` is importable, so any local run of the guard
+        # writes `__pycache__/*.pyc` inside the payload dir. Measured 2026-09-06:
+        # two such files made test_lock_matches_the_committed_tree fail locally
+        # while the same SHA was green on CI, whose checkout has none. A red that
+        # ordinary local work manufactures is No.2.11's false positive, and the
+        # operator learns to ignore the one that will later be real drift.
+        (tmp_path / ".claude-plugin").mkdir()
+        (tmp_path / ".claude-plugin" / "plugin.json").write_text('{"version": "1.0.0"}')
+        hook = tmp_path / "hooks" / "h.py"
+        hook.parent.mkdir()
+        hook.write_text("x = 1\n")
+        clean = sync_plugin.payload_sha256(tmp_path)
+
+        # Both spellings the walk has to survive: a __pycache__ dir, and a stray
+        # .pyc sitting directly beside the source.
+        cache = hook.parent / "__pycache__"
+        cache.mkdir()
+        (cache / "h.cpython-314.pyc").write_bytes(b"\x00compiled")
+        (hook.parent / "h.pyc").write_bytes(b"\x00compiled")
+
+        assert sync_plugin.payload_sha256(tmp_path) == clean
+        # And the exclusion must not be a blanket one: a real payload file added
+        # in the same directory MUST still move the digest, or this test would
+        # pass just as well against a walk that returned nothing.
+        (hook.parent / "h2.py").write_text("y = 2\n")
+        assert sync_plugin.payload_sha256(tmp_path) != clean
+
 
 class TestScaffoldedSettingsWiring:
     def test_default_is_plugin_first(self, tmp_path: Path):

--- a/tests/contracts/test_plugin_marketplace.py
+++ b/tests/contracts/test_plugin_marketplace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 from pathlib import Path
 
 import pytest
@@ -238,6 +239,28 @@ class TestPayloadVersionLock:
         # pass just as well against a walk that returned nothing.
         (hook.parent / "h2.py").write_text("y = 2\n")
         assert sync_plugin.payload_sha256(tmp_path) != clean
+
+    def test_an_ancestor_named_pycache_does_not_empty_the_payload(self, tmp_path):
+        # PR #972, Codex P2. Testing `"__pycache__" in p.parts` asks about the
+        # WHOLE ABSOLUTE PATH, so a plugin root living beneath an ancestor of
+        # that name matches every candidate: the walk returns [], the digest
+        # becomes the digest of nothing, the lock agrees with itself forever and
+        # PI-881 stops detecting the stale-plugin drift it exists for. Silent,
+        # and in the unsafe direction. The exclusion must be plugin-relative.
+        root = tmp_path / "__pycache__" / "plugin"
+        (root / ".claude-plugin").mkdir(parents=True)
+        (root / ".claude-plugin" / "plugin.json").write_text('{"version": "1.0.0"}')
+        hook = root / "hooks" / "h.py"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("x = 1\n")
+
+        assert sync_plugin._payload_files(root) == [hook]
+        # The digest must be the same one the plugin gets anywhere else, so the
+        # location of the checkout cannot change what the lock records.
+        elsewhere = tmp_path / "plain" / "plugin"
+        elsewhere.mkdir(parents=True)
+        shutil.copytree(root, elsewhere, dirs_exist_ok=True)
+        assert sync_plugin.payload_sha256(root) == sync_plugin.payload_sha256(elsewhere)
 
 
 class TestScaffoldedSettingsWiring:

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -70,11 +70,31 @@ def _payload_files(plugin_root: Path) -> list[Path]:
 
     The manifest and the lock live in `.claude-plugin/`; excluding it keeps the
     hash free of self-reference (the lock records this very hash).
+
+    BYTE-COMPILED DROPPINGS ARE EXCLUDED, and the same three words appear at
+    scaffold.py:49 and scaffold.py:861 because this is the third place the walk
+    had to learn them. `plugins/project-init-workflow/hooks/prod_guard.py` is a
+    real hook: importing it — which any local run of the guard does — writes
+    `__pycache__/prod_guard.cpython-*.pyc` NEXT TO IT, inside the payload dir.
+    Those files are gitignored, so a clean CI checkout never has them and the
+    committed lock is computed without them.
+
+    MEASURED 2026-09-06 on this box: two stray `.pyc` (cpython-311 and
+    cpython-314) made `test_lock_matches_the_committed_tree` fail locally while
+    the same test at the same SHA was green on CI. Removing them turned the
+    suite green with no other change. The test's own name is the argument — it
+    asserts the lock matches the COMMITTED tree, and untracked bytecode is not
+    in it. A tripwire that fires on artefacts of running the thing it guards is
+    the false positive CLAUDE.md No.2.11 forbids: the operator learns to ignore
+    a red that will one day be real drift.
     """
     return sorted(
         p
         for p in plugin_root.rglob("*")
-        if p.is_file() and ".claude-plugin" not in p.relative_to(plugin_root).parts
+        if p.is_file()
+        and ".claude-plugin" not in p.relative_to(plugin_root).parts
+        and "__pycache__" not in p.parts
+        and p.suffix not in (".pyc", ".pyo")
     )
 
 

--- a/tools/sync_plugin.py
+++ b/tools/sync_plugin.py
@@ -71,10 +71,11 @@ def _payload_files(plugin_root: Path) -> list[Path]:
     The manifest and the lock live in `.claude-plugin/`; excluding it keeps the
     hash free of self-reference (the lock records this very hash).
 
-    BYTE-COMPILED DROPPINGS ARE EXCLUDED, and the same three words appear at
-    scaffold.py:49 and scaffold.py:861 because this is the third place the walk
-    had to learn them. `plugins/project-init-workflow/hooks/prod_guard.py` is a
-    real hook: importing it — which any local run of the guard does — writes
+    BYTE-COMPILED DROPPINGS ARE EXCLUDED, the third place this walk had to learn
+    it — `_tree_digest` and `_iter_layer_sources` in scaffold.py already do,
+    the second with `.pyo` as well, so this matches both.
+    `plugins/project-init-workflow/hooks/prod_guard.py` is a real hook:
+    importing it — which any local run of the guard does — writes
     `__pycache__/prod_guard.cpython-*.pyc` NEXT TO IT, inside the payload dir.
     Those files are gitignored, so a clean CI checkout never has them and the
     committed lock is computed without them.
@@ -87,13 +88,23 @@ def _payload_files(plugin_root: Path) -> list[Path]:
     in it. A tripwire that fires on artefacts of running the thing it guards is
     the false positive CLAUDE.md No.2.11 forbids: the operator learns to ignore
     a red that will one day be real drift.
+
+    BOTH EXCLUSIONS TEST THE PLUGIN-RELATIVE PATH, NEVER THE ABSOLUTE ONE, and
+    the first draft of the bytecode clause got this wrong (PR #972, Codex P2).
+    `"__pycache__" not in p.parts` asks about the whole absolute path, so a
+    checkout — or any caller-supplied `plugin_root` — living beneath an ancestor
+    named `__pycache__` matches on EVERY candidate, `_payload_files` returns the
+    empty list, and `payload_sha256` becomes the digest of nothing. The lock
+    then agrees with itself forever and PI-881 stops detecting the stale-plugin
+    drift it exists for. That fails silently and in the unsafe direction, which
+    is the one shape a guard must not have.
     """
     return sorted(
         p
         for p in plugin_root.rglob("*")
         if p.is_file()
         and ".claude-plugin" not in p.relative_to(plugin_root).parts
-        and "__pycache__" not in p.parts
+        and "__pycache__" not in p.relative_to(plugin_root).parts
         and p.suffix not in (".pyc", ".pyo")
     )
 


### PR DESCRIPTION
`payload_sha256` walks `plugin_root.rglob("*")` and hashes every file it finds. `plugins/project-init-workflow/hooks/prod_guard.py` is an importable module, so importing it writes `__pycache__/prod_guard.cpython-*.pyc` **inside the payload dir**. Those are gitignored, so a clean CI checkout never has them and the committed lock is computed without them.

## What was measured

On this box, 2026-09-06: two stray `.pyc` (cpython-311 and cpython-314) made `test_lock_matches_the_committed_tree` fail locally while the same test at the same SHA — 6bfe80b, whose CI run is green — passed on the runner. `rm -rf` on that one directory turned the suite green with nothing else changed.

The test's own name is the argument: it asserts the lock matches the **committed** tree, and untracked bytecode is not in it. A tripwire that fires on an artefact of running the very thing it guards is a false positive — the operator learns to ignore a red that will one day be real payload drift, which is the drift PI-881 exists to catch.

## Third place the walk had to learn this

`scaffold.py:49` and `scaffold.py:861` already carry the exclusion, the second with `.pyo` as well. This matches both, so a scaffolded project and the plugin payload now agree on what "the product" means.

## No version bump is owed

The committed lock was computed on CI without the bytecode, so this makes the local value match what is already recorded. `sync_plugin.py --check` reports `plugin payload is in sync`; `plugins/payload-locks.json` is untouched.

## Mutation-tested

With the two `and` clauses reverted, `test_bytecode_next_to_a_hook_does_not_move_the_hash` fails **by name**; restored, it passes. The test also asserts the exclusion is *not* a blanket one — adding a real `h2.py` in the same directory must still move the digest — because a walk that returned nothing would satisfy the first assertion just as well.

Verified: 3098 passed, 6 skipped; `ruff check` and `ruff format` clean.