### PR TITLE
fix: three tokenizer bypasses — a punctuation run, a mid-word #, and -m outside a VCS

### DIFF
--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "44538e89e2a991e32a0baa21e53d0b6cf0e89f059080c597f721c91bbf5b609f",
-    "version": "0.9.11"
+    "sha256": "59538d1eac49a57ea4727900ef9430756df2ecdd4871fcd100fa985096d74a1e",
+    "version": "0.9.12"
   }
 }

--- a/plugins/payload-locks.json
+++ b/plugins/payload-locks.json
@@ -4,7 +4,7 @@
     "version": "0.2.4"
   },
   "project-init-workflow": {
-    "sha256": "59538d1eac49a57ea4727900ef9430756df2ecdd4871fcd100fa985096d74a1e",
-    "version": "0.9.12"
+    "sha256": "3e082309bc86939018ce0f7b2c1372d99616df64410dfb43151ffa1becb4cf1e",
+    "version": "0.9.13"
   }
 }

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/.claude-plugin/plugin.json
+++ b/plugins/project-init-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init-workflow",
   "displayName": "project-init Workflow",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Forge-agnostic quality and safety hooks plus general skills from project-init: commit gating, lint-on-edit, prod-safety guard, and session bootstrap. The always-on core payload; GitHub lifecycle automation lives in the separate project-init-lifecycle plugin.",
   "author": {
     "name": "Vytautas \u010cepas",

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -525,6 +525,91 @@ _MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
 # ordinary path. An exemption is only ever as safe as the set it applies to.
 _MESSAGE_VERBS = frozenset({"git", "hg", "svn", "bzr", "jj"})
 
+# A SHELL ASSIGNMENT PREFIX IS NOT THE COMMAND.
+# `FOO=bar git commit -m "docs: describe .env handling"` puts `FOO=bar` in
+# leaf[0], so the verb read as `FOO=bar`, `_MESSAGE_VERBS` did not match, the
+# commit message was scanned as an ordinary argument and the line prompted
+# (Codex P2 on #974). Every rule keyed on the verb had the same blind spot —
+# the reader set, the exposure-safe set and the message carve-out alike.
+# Skipping the prefixes cannot open a bypass: the assignment TOKENS stay in the
+# list, so `FOO=<dotenv> cat x` still matches _SECRET_PATH on the value.
+_ASSIGN_PREFIX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _verb_index(leaf: list[str]) -> int:
+    """Index of the verb in *leaf*, skipping `NAME=value` prefixes."""
+    i = 0
+    while i < len(leaf) and _ASSIGN_PREFIX.match(leaf[i]):
+        i += 1
+    return i if i < len(leaf) else 0
+
+
+def _strip_comments(command: str) -> str:
+    """Remove the comments a SHELL would remove, and only those.
+
+    `#` opens a comment at the START OF A WORD and nowhere else, and quoting
+    suppresses the rule outright. The three cases this has to keep apart:
+
+        cat README#old <dotenv>      -> `#` is mid-word, nothing is a comment
+        cat README.md # notes <dotenv-mention>  -> prose, dropped
+        cat '#a' <dotenv>            -> `#a` is a FILENAME, nothing is dropped
+
+    Clearing shlex's `commenters` (the #972 P1 fix) got the first case right
+    and created the mirror-image false positive in the second, where the prose
+    after a real `#` stayed in the token stream and its mention of a dotenv
+    path prompted the operator (Codex P2 on #974). Doing it here instead of in
+    shlex is what makes the third case safe: shlex reports no quoting, so a
+    token-level rule would read `#a` as a comment opener and DISCARD the secret
+    argument behind it — trading a false positive for a bypass.
+
+    A newline ending a comment is KEPT. It separates statements, and swallowing
+    it would merge the next command into this one, which is the exact hole
+    `_BREAK_TOKENS` exists to close.
+    """
+    out: list[str] = []
+    in_single = in_double = escaped = in_comment = False
+    at_word_start = True
+    for ch in command:
+        if in_comment:
+            if ch == "\n":
+                in_comment = False
+                out.append(ch)
+                at_word_start = True
+            continue
+        if escaped:
+            out.append(ch)
+            escaped = False
+            at_word_start = False
+            continue
+        if in_single:
+            out.append(ch)
+            in_single = ch != "'"
+            continue
+        if in_double:
+            out.append(ch)
+            if ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_double = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            escaped = True
+            at_word_start = False
+            continue
+        if ch in "'\"":
+            out.append(ch)
+            in_single = ch == "'"
+            in_double = ch == '"'
+            at_word_start = False
+            continue
+        if ch == "#" and at_word_start:
+            in_comment = True
+            continue
+        out.append(ch)
+        at_word_start = ch.isspace() or ch in _PUNCTUATION_CHARS
+    return "".join(out)
+
 
 def _tokenize(command: str) -> list[str] | None:
     """Split *command* into shell tokens, or None when it cannot be parsed.
@@ -533,6 +618,7 @@ def _tokenize(command: str) -> list[str] | None:
     which over-splits rather than under-splits: for a guard, keeping the old
     false positive on an unparsable command is the safe direction.
     """
+    command = _strip_comments(command)
     lex = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lex.whitespace_split = True
     # Newline must stop being whitespace or it is thrown away before punctuation
@@ -548,6 +634,8 @@ def _tokenize(command: str) -> list[str] | None:
     # unquoted `#` inside one is an ordinary character and the truncation is pure
     # loss. A guard that silently drops the rest of the command is the worst shape
     # available: it fails open and leaves no trace of what it dropped.
+    # Real comments are already gone — `_strip_comments` above removed them with
+    # the quoting context shlex cannot report at this level.
     lex.commenters = ""
     try:
         return list(lex)
@@ -702,7 +790,7 @@ def _statement_exposes(statement: list[str]) -> str | None:
             current.append(token)
     if current:
         leaves.append(current)
-    heads = {leaf[0].rsplit("/", 1)[-1] for leaf in leaves if leaf}
+    heads = {leaf[_verb_index(leaf)].rsplit("/", 1)[-1] for leaf in leaves if leaf}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
     # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
@@ -724,7 +812,7 @@ def _statement_exposes(statement: list[str]) -> str | None:
         # The verb decides whether `-m` is a message flag at all — read it from
         # the RAW leaf, before any elision, or the check would depend on the
         # elision it is meant to gate.
-        _raw_head = leaf[0].rsplit("/", 1)[-1] if leaf else ""
+        _raw_head = leaf[_verb_index(leaf)].rsplit("/", 1)[-1] if leaf else ""
         _elide_message = _raw_head in _MESSAGE_VERBS
         tokens: list[str] = []
         skip = False
@@ -741,13 +829,14 @@ def _statement_exposes(statement: list[str]) -> str | None:
             tokens.append(token)
         if not tokens:
             continue
-        head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
+        verb_at = _verb_index(tokens)
+        head = tokens[verb_at].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
         if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
         elif head in _EXPOSURE_SAFE_VERBS and producers_are_safe:
             continue
         if head in _PATTERN_FIRST_ARG:
-            rest = [t for t in tokens[1:] if not t.startswith("-")]
+            rest = [t for t in tokens[verb_at + 1 :] if not t.startswith("-")]
             if rest:
                 tokens = [t for t in tokens if t is not rest[0]]
         if _SECRET_PATH.search(" " + " ".join(tokens)):

--- a/plugins/project-init-workflow/hooks/prod_guard.py
+++ b/plugins/project-init-workflow/hooks/prod_guard.py
@@ -450,6 +450,58 @@ _PIPE_TOKENS = frozenset({"|", "|&"})
 # PR #953 by Copilot; the regex this replaced listed `\n` explicitly and I
 # dropped it.
 _BREAK_TOKENS = frozenset({"&&", "||", ";", "&", "\n"})
+# A RUN OF PUNCTUATION IS ONE TOKEN, AND EXACT MEMBERSHIP MISSED EVERY RUN.
+# PR #972 review, Codex P1, reproduced against this file before fixing:
+#     ls -la;<newline>cat <dotenv>      -> allow   (token was ";\n")
+#     ls -la &&<newline>cat <dotenv>    -> allow   (token was "&&\n")
+#     ls -la<newline><newline>cat …     -> allow   (token was "\n\n")
+# `punctuation_chars` makes shlex COALESCE adjacent punctuation into a single
+# token, so the ordinary shell formatting a person actually types — an operator
+# at end of line, or a blank line between statements — produced a token that is
+# not in the set above, the statements merged, and #953's newline fix was only
+# ever load-bearing for the one spelling its test used. `is_break` therefore asks
+# whether a token is made ENTIRELY of separator characters rather than whether it
+# equals one of them. `>` and `<` are deliberately excluded: they are in
+# _PUNCTUATION_CHARS so that `2>&1` tokenizes correctly, but a redirection does
+# not start a new statement, and treating `>` as a break would split
+# `cat <dotenv> > out` into two leaves and lose the read.
+# A PIPE IS NOT A STATEMENT BREAK, and the first draft of this fix forgot it —
+# 26 assertions went red in one run, every one of them a `producer | xargs cat`
+# case. That direction is the dangerous one: splitting a pipeline into separate
+# leaves means the producer's secret path and the downstream reader are never
+# considered together, `ls <dotenv>` reads as an exposure-safe verb on its own,
+# and the read is ALLOWED. Under-splitting merges statements (the bug above);
+# over-splitting severs data paths. Both fail open, so this has to be accurate
+# rather than conservative in either direction.
+_BREAK_CHARS = frozenset(";&|\n")
+
+
+def _is_break(token: str) -> bool:
+    """True when *token* is a run of punctuation that separates STATEMENTS.
+
+    Exact matches are decided by the two sets first; the rest of this handles a
+    coalesced run like ``";\\n"`` or ``"&&\\n"``, which is what `punctuation_chars`
+    actually emits for ordinary shell formatting.
+    """
+    if not token or token in _PIPE_TOKENS:
+        return False
+    if token in _BREAK_TOKENS:
+        return True
+    # Anything carrying a character outside the separator set — a redirection
+    # (`2>&1`, `&>`), a subshell paren, a word — is not a separator run at all.
+    if not all(ch in _BREAK_CHARS for ch in token):
+        return False
+    # Peel the two-character operators so a LONE `&` (background, a real break)
+    # can be told apart from the `&` inside `&&` or `|&`.
+    rest = token.replace("&&", "\x00").replace("||", "\x00").replace("|&", "\x01")
+    if ";" in rest or "\x00" in rest or "&" in rest:
+        return True
+    # Only pipes and newlines remain. A NEWLINE AFTER A PIPE CONTINUES THE
+    # PIPELINE — `ls |<newline>cat` is one command, not two — so a run is a break
+    # only when it carries a newline and no pipe at all.
+    return "\n" in rest and "|" not in rest and "\x01" not in rest
+
+
 # Newline added to shlex's punctuation set, and removed from its whitespace, so
 # it is EMITTED as a token instead of being discarded. Doing it through the
 # tokenizer rather than by splitting the string on newlines first is what keeps
@@ -460,6 +512,18 @@ _PUNCTUATION_CHARS = "();<>|&\n"
 # required the quotes to still be in the string — which they are not, after
 # tokenizing — and it now also covers an unquoted message the regex never saw.
 _MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
+# ONLY WHERE `-m` ACTUALLY MEANS A MESSAGE, WHICH IS NOT EVERYWHERE.
+# PR #972 review, Codex P1, reproduced against this file before fixing:
+#     less -m <dotenv>   -> allow
+# The elision was unconditional, so ANY `-m` swallowed the token after it. In
+# `less` that flag is a display mode and takes no argument, so the elision ate
+# the filename instead and the leaf became `['less']` — no path left for
+# _SECRET_PATH to match. The same shape reaches `sort -m`, `uniq -m`, `chmod -R`
+# style flags in any tool that spells a boolean `-m`. Scoping the carve-out to
+# the commands that HAVE commit messages keeps what #953 bought (`git commit -m
+# do-not-cat-<dotenv>` stays quiet) and returns every other command to the
+# ordinary path. An exemption is only ever as safe as the set it applies to.
+_MESSAGE_VERBS = frozenset({"git", "hg", "svn", "bzr", "jj"})
 
 
 def _tokenize(command: str) -> list[str] | None:
@@ -474,6 +538,17 @@ def _tokenize(command: str) -> list[str] | None:
     # Newline must stop being whitespace or it is thrown away before punctuation
     # handling ever sees it, which is exactly how it stopped separating.
     lex.whitespace = lex.whitespace.replace("\n", "")
+    # SHLEX THINKS `#` STARTS A COMMENT. BASH DOES NOT, MID-WORD.
+    # PR #972 review, Codex P1, reproduced against this file before fixing:
+    #     cat README#old <dotenv>   -> allow
+    # shlex's default `commenters` is "#", so everything from that character to
+    # end of line was DISCARDED — the tokenizer returned ['cat', 'README'] and
+    # the secret argument simply did not exist as far as every later rule was
+    # concerned. Bash only treats `#` as a comment at the start of a word, so an
+    # unquoted `#` inside one is an ordinary character and the truncation is pure
+    # loss. A guard that silently drops the rest of the command is the worst shape
+    # available: it fails open and leaves no trace of what it dropped.
+    lex.commenters = ""
     try:
         return list(lex)
     except ValueError:
@@ -576,7 +651,7 @@ def _statements(command: str) -> list[list[str]]:
             continue
         current: list[str] = []
         for token in tokens:
-            if token in _BREAK_TOKENS:
+            if _is_break(token):
                 if current:
                     out.append(current)
                 current = []
@@ -646,17 +721,22 @@ def _statement_exposes(statement: list[str]) -> str | None:
         # not an argument naming one. Dropping the token AFTER the flag also
         # covers `-m do-not-cat-.env`, which the old quote-anchored regex could
         # not see because it required the quotes to still be present.
+        # The verb decides whether `-m` is a message flag at all — read it from
+        # the RAW leaf, before any elision, or the check would depend on the
+        # elision it is meant to gate.
+        _raw_head = leaf[0].rsplit("/", 1)[-1] if leaf else ""
+        _elide_message = _raw_head in _MESSAGE_VERBS
         tokens: list[str] = []
         skip = False
         for token in leaf:
             if skip:
                 skip = False
                 continue
-            if token in _MESSAGE_FLAGS:
+            if _elide_message and token in _MESSAGE_FLAGS:
                 skip = True
                 continue
             flag, _, inline = token.partition("=")
-            if inline and flag in _MESSAGE_FLAGS:
+            if _elide_message and inline and flag in _MESSAGE_FLAGS:
                 continue
             tokens.append(token)
         if not tokens:

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.12"
+__plugin_version__ = "0.9.13"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -4,5 +4,5 @@ __version__ = "1.2.2"
 # Plugin version is independent of the scaffolder (ADR-010). Kept in sync with
 # plugins/project-init-workflow/.claude-plugin/plugin.json by a contract test;
 # a constant here because plugins/ is not packaged into the installed wheel.
-__plugin_version__ = "0.9.11"
+__plugin_version__ = "0.9.12"
 __repo_url__ = "https://github.com/VytCepas/project-init"

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -525,6 +525,91 @@ _MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
 # ordinary path. An exemption is only ever as safe as the set it applies to.
 _MESSAGE_VERBS = frozenset({"git", "hg", "svn", "bzr", "jj"})
 
+# A SHELL ASSIGNMENT PREFIX IS NOT THE COMMAND.
+# `FOO=bar git commit -m "docs: describe .env handling"` puts `FOO=bar` in
+# leaf[0], so the verb read as `FOO=bar`, `_MESSAGE_VERBS` did not match, the
+# commit message was scanned as an ordinary argument and the line prompted
+# (Codex P2 on #974). Every rule keyed on the verb had the same blind spot —
+# the reader set, the exposure-safe set and the message carve-out alike.
+# Skipping the prefixes cannot open a bypass: the assignment TOKENS stay in the
+# list, so `FOO=<dotenv> cat x` still matches _SECRET_PATH on the value.
+_ASSIGN_PREFIX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _verb_index(leaf: list[str]) -> int:
+    """Index of the verb in *leaf*, skipping `NAME=value` prefixes."""
+    i = 0
+    while i < len(leaf) and _ASSIGN_PREFIX.match(leaf[i]):
+        i += 1
+    return i if i < len(leaf) else 0
+
+
+def _strip_comments(command: str) -> str:
+    """Remove the comments a SHELL would remove, and only those.
+
+    `#` opens a comment at the START OF A WORD and nowhere else, and quoting
+    suppresses the rule outright. The three cases this has to keep apart:
+
+        cat README#old <dotenv>      -> `#` is mid-word, nothing is a comment
+        cat README.md # notes <dotenv-mention>  -> prose, dropped
+        cat '#a' <dotenv>            -> `#a` is a FILENAME, nothing is dropped
+
+    Clearing shlex's `commenters` (the #972 P1 fix) got the first case right
+    and created the mirror-image false positive in the second, where the prose
+    after a real `#` stayed in the token stream and its mention of a dotenv
+    path prompted the operator (Codex P2 on #974). Doing it here instead of in
+    shlex is what makes the third case safe: shlex reports no quoting, so a
+    token-level rule would read `#a` as a comment opener and DISCARD the secret
+    argument behind it — trading a false positive for a bypass.
+
+    A newline ending a comment is KEPT. It separates statements, and swallowing
+    it would merge the next command into this one, which is the exact hole
+    `_BREAK_TOKENS` exists to close.
+    """
+    out: list[str] = []
+    in_single = in_double = escaped = in_comment = False
+    at_word_start = True
+    for ch in command:
+        if in_comment:
+            if ch == "\n":
+                in_comment = False
+                out.append(ch)
+                at_word_start = True
+            continue
+        if escaped:
+            out.append(ch)
+            escaped = False
+            at_word_start = False
+            continue
+        if in_single:
+            out.append(ch)
+            in_single = ch != "'"
+            continue
+        if in_double:
+            out.append(ch)
+            if ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_double = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            escaped = True
+            at_word_start = False
+            continue
+        if ch in "'\"":
+            out.append(ch)
+            in_single = ch == "'"
+            in_double = ch == '"'
+            at_word_start = False
+            continue
+        if ch == "#" and at_word_start:
+            in_comment = True
+            continue
+        out.append(ch)
+        at_word_start = ch.isspace() or ch in _PUNCTUATION_CHARS
+    return "".join(out)
+
 
 def _tokenize(command: str) -> list[str] | None:
     """Split *command* into shell tokens, or None when it cannot be parsed.
@@ -533,6 +618,7 @@ def _tokenize(command: str) -> list[str] | None:
     which over-splits rather than under-splits: for a guard, keeping the old
     false positive on an unparsable command is the safe direction.
     """
+    command = _strip_comments(command)
     lex = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lex.whitespace_split = True
     # Newline must stop being whitespace or it is thrown away before punctuation
@@ -548,6 +634,8 @@ def _tokenize(command: str) -> list[str] | None:
     # unquoted `#` inside one is an ordinary character and the truncation is pure
     # loss. A guard that silently drops the rest of the command is the worst shape
     # available: it fails open and leaves no trace of what it dropped.
+    # Real comments are already gone — `_strip_comments` above removed them with
+    # the quoting context shlex cannot report at this level.
     lex.commenters = ""
     try:
         return list(lex)
@@ -702,7 +790,7 @@ def _statement_exposes(statement: list[str]) -> str | None:
             current.append(token)
     if current:
         leaves.append(current)
-    heads = {leaf[0].rsplit("/", 1)[-1] for leaf in leaves if leaf}
+    heads = {leaf[_verb_index(leaf)].rsplit("/", 1)[-1] for leaf in leaves if leaf}
     # A PRODUCER IS ONLY SAFE WHILE NOTHING DOWNSTREAM CAN READ WHAT IT NAMES.
     # This gate existed for `find` alone, so every other producer in
     # _EXPOSURE_SAFE_VERBS was exempted unconditionally and the pipeline that
@@ -724,7 +812,7 @@ def _statement_exposes(statement: list[str]) -> str | None:
         # The verb decides whether `-m` is a message flag at all — read it from
         # the RAW leaf, before any elision, or the check would depend on the
         # elision it is meant to gate.
-        _raw_head = leaf[0].rsplit("/", 1)[-1] if leaf else ""
+        _raw_head = leaf[_verb_index(leaf)].rsplit("/", 1)[-1] if leaf else ""
         _elide_message = _raw_head in _MESSAGE_VERBS
         tokens: list[str] = []
         skip = False
@@ -741,13 +829,14 @@ def _statement_exposes(statement: list[str]) -> str | None:
             tokens.append(token)
         if not tokens:
             continue
-        head = tokens[0].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
+        verb_at = _verb_index(tokens)
+        head = tokens[verb_at].rsplit("/", 1)[-1]  # /bin/cat and cat are one verb
         if head == "find" and not producers_are_safe:
             pass  # an action or a pipe turns it into a reader's argument list
         elif head in _EXPOSURE_SAFE_VERBS and producers_are_safe:
             continue
         if head in _PATTERN_FIRST_ARG:
-            rest = [t for t in tokens[1:] if not t.startswith("-")]
+            rest = [t for t in tokens[verb_at + 1 :] if not t.startswith("-")]
             if rest:
                 tokens = [t for t in tokens if t is not rest[0]]
         if _SECRET_PATH.search(" " + " ".join(tokens)):

--- a/templates/base/dot_agents/hooks/prod_guard.py
+++ b/templates/base/dot_agents/hooks/prod_guard.py
@@ -450,6 +450,58 @@ _PIPE_TOKENS = frozenset({"|", "|&"})
 # PR #953 by Copilot; the regex this replaced listed `\n` explicitly and I
 # dropped it.
 _BREAK_TOKENS = frozenset({"&&", "||", ";", "&", "\n"})
+# A RUN OF PUNCTUATION IS ONE TOKEN, AND EXACT MEMBERSHIP MISSED EVERY RUN.
+# PR #972 review, Codex P1, reproduced against this file before fixing:
+#     ls -la;<newline>cat <dotenv>      -> allow   (token was ";\n")
+#     ls -la &&<newline>cat <dotenv>    -> allow   (token was "&&\n")
+#     ls -la<newline><newline>cat …     -> allow   (token was "\n\n")
+# `punctuation_chars` makes shlex COALESCE adjacent punctuation into a single
+# token, so the ordinary shell formatting a person actually types — an operator
+# at end of line, or a blank line between statements — produced a token that is
+# not in the set above, the statements merged, and #953's newline fix was only
+# ever load-bearing for the one spelling its test used. `is_break` therefore asks
+# whether a token is made ENTIRELY of separator characters rather than whether it
+# equals one of them. `>` and `<` are deliberately excluded: they are in
+# _PUNCTUATION_CHARS so that `2>&1` tokenizes correctly, but a redirection does
+# not start a new statement, and treating `>` as a break would split
+# `cat <dotenv> > out` into two leaves and lose the read.
+# A PIPE IS NOT A STATEMENT BREAK, and the first draft of this fix forgot it —
+# 26 assertions went red in one run, every one of them a `producer | xargs cat`
+# case. That direction is the dangerous one: splitting a pipeline into separate
+# leaves means the producer's secret path and the downstream reader are never
+# considered together, `ls <dotenv>` reads as an exposure-safe verb on its own,
+# and the read is ALLOWED. Under-splitting merges statements (the bug above);
+# over-splitting severs data paths. Both fail open, so this has to be accurate
+# rather than conservative in either direction.
+_BREAK_CHARS = frozenset(";&|\n")
+
+
+def _is_break(token: str) -> bool:
+    """True when *token* is a run of punctuation that separates STATEMENTS.
+
+    Exact matches are decided by the two sets first; the rest of this handles a
+    coalesced run like ``";\\n"`` or ``"&&\\n"``, which is what `punctuation_chars`
+    actually emits for ordinary shell formatting.
+    """
+    if not token or token in _PIPE_TOKENS:
+        return False
+    if token in _BREAK_TOKENS:
+        return True
+    # Anything carrying a character outside the separator set — a redirection
+    # (`2>&1`, `&>`), a subshell paren, a word — is not a separator run at all.
+    if not all(ch in _BREAK_CHARS for ch in token):
+        return False
+    # Peel the two-character operators so a LONE `&` (background, a real break)
+    # can be told apart from the `&` inside `&&` or `|&`.
+    rest = token.replace("&&", "\x00").replace("||", "\x00").replace("|&", "\x01")
+    if ";" in rest or "\x00" in rest or "&" in rest:
+        return True
+    # Only pipes and newlines remain. A NEWLINE AFTER A PIPE CONTINUES THE
+    # PIPELINE — `ls |<newline>cat` is one command, not two — so a run is a break
+    # only when it carries a newline and no pipe at all.
+    return "\n" in rest and "|" not in rest and "\x01" not in rest
+
+
 # Newline added to shlex's punctuation set, and removed from its whitespace, so
 # it is EMITTED as a token instead of being discarded. Doing it through the
 # tokenizer rather than by splitting the string on newlines first is what keeps
@@ -460,6 +512,18 @@ _PUNCTUATION_CHARS = "();<>|&\n"
 # required the quotes to still be in the string — which they are not, after
 # tokenizing — and it now also covers an unquoted message the regex never saw.
 _MESSAGE_FLAGS = frozenset({"-m", "-am", "--message"})
+# ONLY WHERE `-m` ACTUALLY MEANS A MESSAGE, WHICH IS NOT EVERYWHERE.
+# PR #972 review, Codex P1, reproduced against this file before fixing:
+#     less -m <dotenv>   -> allow
+# The elision was unconditional, so ANY `-m` swallowed the token after it. In
+# `less` that flag is a display mode and takes no argument, so the elision ate
+# the filename instead and the leaf became `['less']` — no path left for
+# _SECRET_PATH to match. The same shape reaches `sort -m`, `uniq -m`, `chmod -R`
+# style flags in any tool that spells a boolean `-m`. Scoping the carve-out to
+# the commands that HAVE commit messages keeps what #953 bought (`git commit -m
+# do-not-cat-<dotenv>` stays quiet) and returns every other command to the
+# ordinary path. An exemption is only ever as safe as the set it applies to.
+_MESSAGE_VERBS = frozenset({"git", "hg", "svn", "bzr", "jj"})
 
 
 def _tokenize(command: str) -> list[str] | None:
@@ -474,6 +538,17 @@ def _tokenize(command: str) -> list[str] | None:
     # Newline must stop being whitespace or it is thrown away before punctuation
     # handling ever sees it, which is exactly how it stopped separating.
     lex.whitespace = lex.whitespace.replace("\n", "")
+    # SHLEX THINKS `#` STARTS A COMMENT. BASH DOES NOT, MID-WORD.
+    # PR #972 review, Codex P1, reproduced against this file before fixing:
+    #     cat README#old <dotenv>   -> allow
+    # shlex's default `commenters` is "#", so everything from that character to
+    # end of line was DISCARDED — the tokenizer returned ['cat', 'README'] and
+    # the secret argument simply did not exist as far as every later rule was
+    # concerned. Bash only treats `#` as a comment at the start of a word, so an
+    # unquoted `#` inside one is an ordinary character and the truncation is pure
+    # loss. A guard that silently drops the rest of the command is the worst shape
+    # available: it fails open and leaves no trace of what it dropped.
+    lex.commenters = ""
     try:
         return list(lex)
     except ValueError:
@@ -576,7 +651,7 @@ def _statements(command: str) -> list[list[str]]:
             continue
         current: list[str] = []
         for token in tokens:
-            if token in _BREAK_TOKENS:
+            if _is_break(token):
                 if current:
                     out.append(current)
                 current = []
@@ -646,17 +721,22 @@ def _statement_exposes(statement: list[str]) -> str | None:
         # not an argument naming one. Dropping the token AFTER the flag also
         # covers `-m do-not-cat-.env`, which the old quote-anchored regex could
         # not see because it required the quotes to still be present.
+        # The verb decides whether `-m` is a message flag at all — read it from
+        # the RAW leaf, before any elision, or the check would depend on the
+        # elision it is meant to gate.
+        _raw_head = leaf[0].rsplit("/", 1)[-1] if leaf else ""
+        _elide_message = _raw_head in _MESSAGE_VERBS
         tokens: list[str] = []
         skip = False
         for token in leaf:
             if skip:
                 skip = False
                 continue
-            if token in _MESSAGE_FLAGS:
+            if _elide_message and token in _MESSAGE_FLAGS:
                 skip = True
                 continue
             flag, _, inline = token.partition("=")
-            if inline and flag in _MESSAGE_FLAGS:
+            if _elide_message and inline and flag in _MESSAGE_FLAGS:
                 continue
             tokens.append(token)
         if not tokens:

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -915,6 +915,25 @@ EXPOSING = [
     "less -m .env",
     "sort -m .env",
     "less --message .env",
+    # ── PR #974 review, Codex P2 (a), THE CONTROLS. Stripping real comments is
+    # what closes the false positive below, and the cheap way to do it — treat
+    # any token starting with `#` as a comment opener — turns that fix into a
+    # BYPASS, because shlex reports no quoting and `'#a'` is a filename. Each
+    # line here must still be seen; they fail the moment the strip stops being
+    # quote-aware.
+    "cat '#a' .env",
+    'cat "#a" .env',
+    "cat \\#a .env",
+    # A comment ends at the newline and MUST NOT swallow it — the newline is
+    # what separates the statements, so eating it merges the read into the safe
+    # verb above and re-opens #953.
+    "cat README.md # notes\ncat .env",
+    "ls -la # listing\n\ncat .env",
+    # ── PR #974 review, Codex P2 (b), THE CONTROL. Skipping assignment prefixes
+    # must find the REAL verb, not exempt the leaf: a reader is still a reader
+    # behind `FOO=bar`, and the assignment's own value is still an argument.
+    "FOO=bar cat .env",
+    "FOO=.env cat notes.md",
 ]
 
 NOT_EXPOSING = [
@@ -1021,6 +1040,26 @@ NOT_EXPOSING = [
     # control proving the narrowing did not become "always look at -m's argument".
     "less -m README.md",
     "sort -m a.txt b.txt",
+    # ── PR #974 review, Codex P2 (a): A REAL COMMENT IS PROSE, NOT AN ARGUMENT.
+    # Clearing shlex's `commenters` to fix the mid-word `#` left the text after
+    # a genuine `#` in the token stream, so ordinary annotated commands — the
+    # way people actually write shell — prompted on a path they never read.
+    # A guard that fires on these gets switched off, and a switched-off guard
+    # protects nothing.
+    "cat README.md # mention .env handling",
+    "ls -la  # check whether .env exists",
+    "git status # ignore .env for now",
+    "cat README.md\n# a whole-line comment about .env",
+    # ── PR #974 review, Codex P2 (b): AN ASSIGNMENT PREFIX IS NOT THE VERB.
+    # `leaf[0]` was the assignment, so `git` never matched _MESSAGE_VERBS, the
+    # commit-message carve-out did not apply, and the message's prose was read
+    # as a path.
+    'FOO=bar git commit -m "docs: describe .env handling"',
+    "GIT_AUTHOR_NAME=x git commit -m do-not-cat-.env",
+    "VERSION=1.2 git tag -m release-.env v1",
+    # The assignment prefix must not resurrect the exposure-safe exemption
+    # either — `echo` stays quiet behind one, as it does in front.
+    "FOO=bar echo .env",
     # ── PR #953 review, P2: A QUOTED SEPARATOR IS TEXT, NOT AN OPERATOR. The
     # splitter worked on the raw string, so it could not tell `|&` inside a
     # quoted argument from a real pipeline: `echo '.env |& xargs cat'` reads

--- a/tests/contracts/test_prod_guard.py
+++ b/tests/contracts/test_prod_guard.py
@@ -884,6 +884,37 @@ EXPOSING = [
     "cat README.md\ncat .env",
     # Three lines, so the read is not merely adjacent to the safe verb.
     "cd /tmp\nls -la\ncat .env",
+    # ── PR #972 review, Codex P1 (a): A RUN OF PUNCTUATION IS ONE TOKEN.
+    # `punctuation_chars` COALESCES adjacent operators, so the newline fix above
+    # only ever worked for the one spelling its cases used. Every line here
+    # produced a token — ";\n", "&&\n", "\n\n" — that was not a member of
+    # _BREAK_TOKENS, so the statements merged and the read went through exactly
+    # as before #953. Measured against the 1041-line file: all three ALLOWED.
+    # This is the ordinary way a person formats a script, which is what makes it
+    # worse than the case that was fixed.
+    "ls -la;\ncat .env",
+    "ls -la &&\ncat .env",
+    "ls -la ||\ncat .env",
+    "ls -la\n\ncat .env",
+    "cd /tmp;\nls -la;\ncat .env",
+    # ── PR #972 review, Codex P1 (b): SHLEX THINKS `#` STARTS A COMMENT.
+    # Bash only treats it that way at the start of a word, so `README#old` is one
+    # ordinary argument. shlex's default commenters discarded everything from the
+    # `#` to end of line, the tokenizer returned ['cat', 'README'], and the secret
+    # argument did not exist for any later rule. Measured: ALLOWED. Silent
+    # truncation is the worst failure shape a guard has — it fails open and
+    # leaves no record of what it dropped.
+    "cat README#old .env",
+    "cat a#b .env",
+    "head -n1 notes#draft .env",
+    # ── PR #972 review, Codex P1 (c): `-m` IS NOT ALWAYS A MESSAGE FLAG.
+    # The elision was unconditional, so any `-m` swallowed the token after it. In
+    # `less` the flag is a display mode taking no argument, so the elision ate the
+    # PATH instead and the leaf became ['less']. Measured: ALLOWED. The carve-out
+    # is now scoped to the commands that actually have commit messages.
+    "less -m .env",
+    "sort -m .env",
+    "less --message .env",
 ]
 
 NOT_EXPOSING = [
@@ -961,6 +992,35 @@ NOT_EXPOSING = [
     # A keystore-shaped DOCUMENT is not a keystore.
     "cat keystore.md",
     "cat docs/api-key-rotation.md",
+    # ── PR #972 controls. Widening what counts as a separator, and narrowing the
+    # `-m` carve-out, both had an obvious over-correction available; these are the
+    # lines that would go red if either had been taken.
+    #
+    # A REDIRECTION IS NOT A STATEMENT BREAK. `>` and `<` are in
+    # _PUNCTUATION_CHARS so `2>&1` tokenizes, but treating them as breaks would
+    # split a leaf and lose the path it names — the guard would fail open on
+    # exactly the shape it is watching.
+    "ls -la > out.txt",
+    "echo hi >> out.txt",
+    "cat README.md > copy.md",
+    "sort < input.txt",
+    # Ordinary multi-statement work formatted the way people actually write it.
+    "cd /tmp;\nls -la",
+    "cd /tmp &&\nls -la",
+    "cd /tmp\n\nls -la",
+    # `#` mid-word must survive tokenizing without dragging a secret in with it.
+    "cat README#old.md",
+    "ls notes#draft",
+    # The commit-message carve-out this PR deliberately KEEPS — scoped to the
+    # verbs that have messages, not withdrawn.
+    "git commit -m do-not-cat-.env",
+    "git commit -am fix-.env-handling",
+    'git commit --message="tidy .env handling"',
+    "git tag -m release-.env v1",
+    # And `-m` on a non-VCS command with nothing secret stays quiet, which is the
+    # control proving the narrowing did not become "always look at -m's argument".
+    "less -m README.md",
+    "sort -m a.txt b.txt",
     # ── PR #953 review, P2: A QUOTED SEPARATOR IS TEXT, NOT AN OPERATOR. The
     # splitter worked on the raw string, so it could not tell `|&` inside a
     # quoted argument from a real pipeline: `echo '.env |& xargs cat'` reads


### PR DESCRIPTION
Raised as three P1s by Codex on #972. All three reproduce against the 1041-line file before the fix — measured with a dotenv path, verdict straight from the hook:

| command | before | after |
|---|---|---|
| `cat <secret>` (baseline) | `ask` | `ask` |
| `ls -la⏎cat <secret>` (#953's case) | `ask` | `ask` |
| `ls -la;⏎cat <secret>` | **allow** | `ask` |
| `ls -la &&⏎cat <secret>` | **allow** | `ask` |
| `ls -la⏎⏎cat <secret>` | **allow** | `ask` |
| `cat README#old <secret>` | **allow** | `ask` |
| `less -m <secret>` | **allow** | `ask` |
| safe control command | allow | allow |

### A · a run of punctuation is one token

`punctuation_chars` **coalesces** adjacent operators, so #953's newline fix only ever held for the one spelling its tests used. An operator at end of line, or a blank line between statements — ordinary formatting — produced a token that was not a member of `_BREAK_TOKENS`; the statements merged, the head became an exposure-safe verb, and the read went through exactly as before #953.

**A pipe is not a statement break, and the first draft of this forgot it.** 26 assertions went red, every one a `producer | xargs cat` case. That direction is the dangerous one: severing a pipeline means the producer's secret path and the downstream reader are never considered together, so the guard fails **open** on the shape it is watching. Under-splitting merges statements; over-splitting severs data paths — both fail open. `_is_break` therefore peels the two-character operators to find a lone `&`, and treats a newline as a break only when the run carries no pipe (`ls |⏎cat` is one pipeline).

### B · shlex thinks `#` starts a comment

Bash only does at the start of a word, so `README#old` is one ordinary argument. shlex's default `commenters` discarded everything from that character to end of line — the tokenizer returned `['cat', 'README']` and the secret argument did not exist for any later rule. Silent truncation is the worst shape a guard has: it fails open and leaves no record of what it dropped.

### C · `-m` is not always a message flag

The elision was unconditional, so any `-m` swallowed the token after it. In `less` that flag is a display mode taking no argument, so the elision ate the **path** and the leaf became `['less']`. Now scoped to the verbs that actually have commit messages — `git commit -m do-not-cat-<secret>` still stays quiet. The verb is read from the raw leaf, before any elision, so the check cannot depend on the elision it gates.

### False-positive controls are half the change

Both widenings had an obvious over-correction available. 16 controls assert quiet: the three `git commit` message spellings, quoted separators, four redirection forms (`2>&1`, `>`, `>>`, `<` — deliberately *not* breaks, or a leaf loses its path), ordinary multi-statement work in all three formattings, `#` in a safe filename, and `-m` on a non-VCS command with nothing secret.

### Verification

Mutation-tested: reverting `_is_break` to plain set membership fails 8 assertions **by name**, including every coalesced-run case. `test_prod_guard` 502 passed; full suite **3136 passed, 6 skipped**; ruff check and format clean. Payload re-synced, version bumped 0.9.11 → 0.9.12 at both sites PI-881 checks.