### PR TITLE
fix: a Codex review asked for by mention left the gate at "Awaiting review"

### DIFF
--- a/templates/lifecycle/dot_github/workflows/review-status.yml
+++ b/templates/lifecycle/dot_github/workflows/review-status.yml
@@ -104,11 +104,40 @@ jobs:
                   pullRequest(number:$number) {
                     reviews(first:1) { totalCount }
                     reviewThreads(first:100) { nodes { isResolved } }
+                    comments(last:50) { nodes { author { login } body } }
                   }
                 }
               }')
+          # A CODEX REVIEW ARRIVES BY TWO DIFFERENT DOORS AND ONLY ONE OF THEM
+          # IS A REVIEW. Codex posts a formal pull request review when it picks
+          # the PR up automatically on `opened`, but a review asked for with an
+          # `@codex review` comment comes back as a PLAIN ISSUE COMMENT — same
+          # analysis, same verdict, no review object. `reviews.totalCount` sees
+          # only the first, so a PR the bot skipped on open and reviewed on
+          # request sat at "Awaiting review" for ever.
+          #
+          # That is PI-715 reopened through a different door: the check goes
+          # permanently pending, and the only way out is the `--admin` override
+          # this gate was written to eliminate. Measured on projects-orchestrator
+          # 2026-09-06: five PRs picked up automatically all carried a review
+          # object; the two the bot skipped were reviewed on request, came back
+          # clean, and both read `reviews.totalCount == 0`.
+          #
+          # This does NOT loosen the gate. Findings from a requested review
+          # arrive as review threads exactly as they do from an automatic one,
+          # so UNRESOLVED below still fails the check on an open comment — what
+          # changes is only whether a review that DID happen is visible to the
+          # count. The author's own comments cannot satisfy it: the body must
+          # be the bot's own "Codex Review:" preamble, which only the connector
+          # writes.
+          CODEX_REVIEWS=$(printf '%s' "$REVIEW_DATA" \
+            | jq '[.data.repository.pullRequest.comments.nodes[]
+                   | select(.author.login == "chatgpt-codex-connector")
+                   | select(.body | ascii_downcase | startswith("codex review:"))]
+                  | length')
           REVIEWS=$(printf '%s' "$REVIEW_DATA" \
             | jq '.data.repository.pullRequest.reviews.totalCount')
+          REVIEWS=$((REVIEWS + CODEX_REVIEWS))
           UNRESOLVED=$(printf '%s' "$REVIEW_DATA" \
             | jq '[.data.repository.pullRequest.reviewThreads.nodes[]
                    | select(.isResolved == false)] | length')

--- a/templates/lifecycle/dot_github/workflows/review-status.yml
+++ b/templates/lifecycle/dot_github/workflows/review-status.yml
@@ -104,7 +104,7 @@ jobs:
                   pullRequest(number:$number) {
                     reviews(first:1) { totalCount }
                     reviewThreads(first:100) { nodes { isResolved } }
-                    comments(last:50) { nodes { author { login } body } }
+                    comments(last:100) { nodes { author { login } body } }
                   }
                 }
               }')
@@ -130,10 +130,20 @@ jobs:
           # count. The author's own comments cannot satisfy it: the body must
           # be the bot's own "Codex Review:" preamble, which only the connector
           # writes.
+          #
+          # `last:100` is GitHub's maximum page size, not a guess: the review
+          # comment is on the LAST page only while the thread is short, and a
+          # busy PR pushes it off a smaller window — which would put the check
+          # straight back to "Awaiting review" for exactly the PRs most likely
+          # to need it. The leading-whitespace strip is the same argument: the
+          # connector's preamble is first in the body today, and a match anchored
+          # to byte zero turns a stray newline into a lost review. Neither
+          # loosens anything — the author check is what carries the security.
           CODEX_REVIEWS=$(printf '%s' "$REVIEW_DATA" \
             | jq '[.data.repository.pullRequest.comments.nodes[]
                    | select(.author.login == "chatgpt-codex-connector")
-                   | select(.body | ascii_downcase | startswith("codex review:"))]
+                   | select(.body | sub("^[[:space:]]+"; "")
+                            | ascii_downcase | startswith("codex review:"))]
                   | length')
           REVIEWS=$(printf '%s' "$REVIEW_DATA" \
             | jq '.data.repository.pullRequest.reviews.totalCount')

--- a/tests/contracts/test_lifecycle_byte_identity.py
+++ b/tests/contracts/test_lifecycle_byte_identity.py
@@ -162,6 +162,15 @@ permissions: block sets unlisted scopes to none. Public repos resolved it
 anyway, so the defect was invisible in this repo's own CI. Only that one
 hash was re-pinned, after confirming it was the sole key that drifted in all
 eight fixtures.
+
+Exception (mention-triggered Codex reviews): the same workflow gained a count of
+Codex review COMMENTS alongside `reviews.totalCount`. A review Codex posts on
+its own initiative is a pull request review object; one asked for with an
+`@codex review` comment is a plain issue comment carrying the same verdict, so
+the gate saw no review at all and sat at "Awaiting review" for ever — PI-715
+reopened through a different door. A deliberate gate fix, not move-drift. Only
+that one hash was re-pinned, and the failure named it as the sole drifted key in
+all four fixtures before the re-pin.
 """
 
 from __future__ import annotations

--- a/tests/contracts/test_memory_byte_identity.py
+++ b/tests/contracts/test_memory_byte_identity.py
@@ -152,6 +152,15 @@ permissions: block sets unlisted scopes to none. Public repos resolved it
 anyway, so the defect was invisible in this repo's own CI. Only that one
 hash was re-pinned, after confirming it was the sole key that drifted in all
 eight fixtures.
+
+Exception (mention-triggered Codex reviews): the same workflow gained a count of
+Codex review COMMENTS alongside `reviews.totalCount`. A review Codex posts on
+its own initiative is a pull request review object; one asked for with an
+`@codex review` comment is a plain issue comment carrying the same verdict, so
+the gate saw no review at all and sat at "Awaiting review" for ever — PI-715
+reopened through a different door. A deliberate gate fix, not move-drift. Only
+that one hash was re-pinned, and the failure named it as the sole drifted key in
+all four fixtures before the re-pin.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -106,7 +106,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__no_plugin.json
@@ -106,7 +106,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -85,7 +85,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-graphify__plugin.json
@@ -85,7 +85,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -103,7 +103,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__no_plugin.json
@@ -103,7 +103,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -82,7 +82,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/lifecycle_baseline/obsidian-only__plugin.json
@@ -82,7 +82,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -107,7 +107,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__no_plugin.json
@@ -107,7 +107,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -86,7 +86,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-graphify__plugin.json
@@ -86,7 +86,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "dc481c86e9e6f52620fb2db17059c67a60869d8f7fa213ecea4cd76c5280f945",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -104,7 +104,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__no_plugin.json
@@ -104,7 +104,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -83,7 +83,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
+  ".github/workflows/review-status.yml": "e4cbaeab31048cacc3bd83766bd32540accd8e1c92f6b900943e5be09affc050",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",

--- a/tests/fixtures/memory_baseline/obsidian-only__plugin.json
+++ b/tests/fixtures/memory_baseline/obsidian-only__plugin.json
@@ -83,7 +83,7 @@
   ".github/workflows/ci.yml": "8f8f9f679bd2982c9dc9bcc0763399ad8fba4f70ab99006d2bf8a59cff6994b0",
   ".github/workflows/issue-validation.yml": "3ee7d49bce460fd45ab0c8d522fa84765aee28b5ddd7644c6cfa989f49d293af",
   ".github/workflows/project-init-upgrade.yml": "545f69f5a65e35e6fa1c5817822d515d2f193db4bf787fde4a4c945065139aeb",
-  ".github/workflows/review-status.yml": "5c8b923e5191270bafb9acf5b8a831c261e3db44ee3a762610c975ef97b980d1",
+  ".github/workflows/review-status.yml": "af8adbca14aa6ba16ff585786ba183d32174ef10dab7b0c2a3f8935f9ceffa03",
   ".github/workflows/validate-pr.yml": "75b44f457a2343817f8ffd4e871883bddf49db988c62d37d803c8967c0369d7b",
   ".gitignore": "9c6fe30037f649ab472dea10a15bd055352c5df64b3415c0fe55fcc35f8721dc",
   ".gitleaks.toml": "c72157e4c90735439355e5f8804c3694da807085471502809c574078d9b2c155",


### PR DESCRIPTION
## The defect

A Codex review arrives by two different doors and only one of them is a review.

| how the review was triggered | what Codex posts | `reviews.totalCount` sees it |
|---|---|---|
| automatic, on `opened` | a pull request **review** object | yes |
| asked for with `@codex review` | a plain **issue comment**, same verdict | **no** |

`review-status.yml` counts only the first, so a PR the connector skips on open and that is then reviewed on request reads zero reviews and sits at **"Awaiting review" for ever**.

That is **PI-715 reopened through a different door**. The gate was rewritten because it could only go green on `APPROVED` — which no bot submits and no author may self-submit — so every merge became an `--admin` override. This puts the same permanent-pending state back for any PR the connector does not pick up automatically.

## Measured, not reasoned about

On `projects-orchestrator` today: five PRs picked up automatically each carried a review object and went green. Two the bot skipped on open (#224, #229) were reviewed on request, came back clean, and both still read `reviews.totalCount == 0` with no path to green.

Run against live PR data before shipping:

| PR | formal reviews | Codex comments counted | total after fix |
|---|---|---|---|
| #229 | 0 | 1 | **1** |
| #224 | 0 | 1 | **1** |
| #230 | 2 | 0 | 2 (unchanged) |
| forged: author comment with a `Codex Review:` body | — | **0** | — |

## This does not loosen the gate

Findings from a requested review arrive as review **threads** exactly as they do from an automatic one, so the unresolved-threads branch still fails the check while any comment is open. What changes is only whether a review that *did* happen is visible to the count.

Two conditions must both hold for a comment to count: the author is `chatgpt-codex-connector`, and the body opens with the connector's own `Codex Review:` preamble. An author's own comment cannot satisfy it — proven by the forged-comment row above.

## Baselines

Both byte-identity contracts re-pin this one workflow hash, following the procedure each already records for its previous change to the same file. The failure named `.github/workflows/review-status.yml` as the **sole** drifted key in all four fixtures of each contract before the re-pin, and each exception is documented in the contract's docstring.

Suite: **3158 passed, 6 skipped** — the same total as `main`.

## Not verified here

The workflow does not run locally, so the YAML is proven by the query and the jq against live PR data, not by an Actions run. It closes on the first review event after this merges.

## Left for the operator

- **This repo's own `.github/workflows/review-status.yml` still carries the old logic.** It is a manual mirror of the template (`sync-agents` does not cover `.github/`), and both the floor guard and the permission layer refuse writes into `.github/workflows/` — deliberately. Copying the template over it is a one-line change that needs a human hand.
- **project-init's `Review status` runs are separately blocked**, and this PR does not fix that: every `pull_request_review` and `pull_request_review_comment` event triggered by **Copilot** lands in `action_required` and never executes, so the status is not refreshed after a Copilot review either. `projects-orchestrator`, which uses Codex only, has no such runs. That is a repository Actions setting, not a file.
